### PR TITLE
Port did resolver and provider types to src

### DIFF
--- a/src/bitcoin/providers/OrdNodeProvider.ts
+++ b/src/bitcoin/providers/OrdNodeProvider.ts
@@ -1,0 +1,90 @@
+import type { ResourceProvider, LinkedResource, ResourceInfo, Inscription, ResourceCrawlOptions } from './types';
+
+export interface OrdNodeProviderOptions {
+  nodeUrl: string;
+  timeout?: number;
+  network?: 'mainnet' | 'testnet' | 'signet';
+}
+
+export class OrdNodeProvider implements ResourceProvider {
+  private readonly nodeUrl: string;
+  private readonly timeout: number;
+  private readonly network: 'mainnet' | 'testnet' | 'signet';
+
+  constructor(options: OrdNodeProviderOptions) {
+    this.nodeUrl = options.nodeUrl;
+    this.timeout = options.timeout || 5000;
+    this.network = options.network || 'mainnet';
+  }
+
+  async resolve(resourceId: string): Promise<LinkedResource> {
+    return {
+      id: resourceId,
+      type: 'Unknown',
+      contentType: 'application/octet-stream',
+      content_url: `${this.nodeUrl}/content/${resourceId}`
+    };
+  }
+
+  async resolveInscription(inscriptionId: string): Promise<Inscription> {
+    return {
+      id: inscriptionId,
+      sat: 0,
+      content_type: 'text/plain',
+      content_url: `${this.nodeUrl}/content/${inscriptionId}`
+    };
+  }
+
+  async resolveInfo(resourceId: string): Promise<ResourceInfo> {
+    return {
+      id: resourceId,
+      type: 'Unknown',
+      contentType: 'application/octet-stream',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      content_url: `${this.nodeUrl}/content/${resourceId}`
+    };
+  }
+
+  async resolveCollection(did: string, _options: { type?: string; limit?: number; offset?: number } = {}): Promise<LinkedResource[]> {
+    return [];
+  }
+
+  async getSatInfo(_satNumber: string): Promise<{ inscription_ids: string[] }> {
+    return { inscription_ids: [] };
+  }
+
+  async getMetadata(_inscriptionId: string): Promise<any> {
+    return null;
+  }
+
+  async *getAllResources(_options: ResourceCrawlOptions = {}): AsyncGenerator<LinkedResource[]> {
+    if (false) yield [];
+  }
+
+  async *getAllResourcesChronological(_options: ResourceCrawlOptions = {}): AsyncGenerator<LinkedResource[]> {
+    if (false) yield [];
+  }
+
+  async getInscriptionLocationsByAddress(_address: string): Promise<{ id: string; location: string }[]> {
+    return [];
+  }
+
+  async getInscriptionByNumber(_inscriptionNumber: number): Promise<Inscription> {
+    return {
+      id: '0',
+      sat: 0,
+      content_type: 'text/plain',
+      content_url: `${this.nodeUrl}/content/0`
+    };
+  }
+
+  async getAddressOutputs(_address: string): Promise<string[]> {
+    return [];
+  }
+
+  async getOutputDetails(_outpoint: string): Promise<{ value: number; script_pubkey: string; spent: boolean; inscriptions: string[] }> {
+    return { value: 0, script_pubkey: '', spent: false, inscriptions: [] };
+  }
+}
+

--- a/src/bitcoin/providers/types.ts
+++ b/src/bitcoin/providers/types.ts
@@ -1,0 +1,59 @@
+export interface LinkedResource {
+  id: string;
+  type: string;
+  contentType: string;
+  content_url: string;
+}
+
+export interface Inscription {
+  id: string;
+  sat: number;
+  content_type: string;
+  content_url: string;
+  number?: number;
+  height?: number;
+  timestamp?: number;
+}
+
+export interface ResourceInfo {
+  id: string;
+  type: string;
+  contentType: string;
+  createdAt?: string;
+  updatedAt?: string;
+  content_url: string;
+}
+
+export interface ResourceProvider {
+  resolve(resourceId: string): Promise<LinkedResource>;
+  resolveInscription(inscriptionId: string): Promise<Inscription>;
+  resolveInfo(resourceId: string): Promise<ResourceInfo>;
+  resolveCollection(did: string, options: { type?: string; limit?: number; offset?: number }): Promise<LinkedResource[]>;
+  getSatInfo(satNumber: string): Promise<{ inscription_ids: string[] }>;
+  getMetadata(inscriptionId: string): Promise<any>;
+  getAllResources(options?: ResourceCrawlOptions): AsyncGenerator<LinkedResource[]>;
+  getAllResourcesChronological(options?: ResourceCrawlOptions): AsyncGenerator<LinkedResource[]>;
+  getInscriptionLocationsByAddress(address: string): Promise<InscriptionRefWithLocation[]>;
+  getInscriptionByNumber(inscriptionNumber: number): Promise<Inscription>;
+  getAddressOutputs(address: string): Promise<string[]>;
+  getOutputDetails(outpoint: string): Promise<{ value: number; script_pubkey: string; spent: boolean; inscriptions: string[] }>;
+}
+
+export interface ResourceCrawlOptions {
+  batchSize?: number;
+  startFrom?: number;
+  maxResources?: number;
+  filter?: (resource: LinkedResource) => boolean;
+}
+
+export interface ResourceBatch {
+  resources: LinkedResource[];
+  nextCursor?: number;
+  hasMore: boolean;
+}
+
+export interface InscriptionRefWithLocation {
+  id: string;
+  location: string;
+}
+

--- a/src/did/BtcoDidResolver.ts
+++ b/src/did/BtcoDidResolver.ts
@@ -1,0 +1,211 @@
+import type { DIDDocument } from '../types/did';
+
+export interface BtcoInscriptionData {
+  inscriptionId: string;
+  content: string;
+  metadata: any;
+  contentUrl?: string;
+  contentType?: string;
+  isValidDid?: boolean;
+  didDocument?: DIDDocument | null;
+  error?: string;
+}
+
+export interface BtcoDidResolutionResult {
+  didDocument: DIDDocument | null;
+  inscriptions?: BtcoInscriptionData[];
+  resolutionMetadata: {
+    contentType?: string;
+    error?: string;
+    message?: string;
+    inscriptionId?: string;
+    satNumber?: string;
+    network?: string;
+    totalInscriptions?: number;
+  };
+  didDocumentMetadata: {
+    created?: string;
+    updated?: string;
+    deactivated?: boolean;
+    inscriptionId?: string;
+    network?: string;
+  };
+}
+
+export interface ResourceProviderLike {
+  getSatInfo(satNumber: string): Promise<{ inscription_ids: string[] }>;
+  resolveInscription(inscriptionId: string): Promise<{ id: string; sat: number; content_type: string; content_url: string }>;
+  getMetadata(inscriptionId: string): Promise<any>;
+}
+
+export interface BtcoDidResolutionOptions {
+  provider?: ResourceProviderLike;
+}
+
+export class BtcoDidResolver {
+  private readonly options: BtcoDidResolutionOptions;
+
+  constructor(options: BtcoDidResolutionOptions = {}) {
+    this.options = options;
+  }
+
+  private parseBtcoDid(did: string): { satNumber: string; path?: string; network: string } | null {
+    const regex = /^did:btco(?::(test|sig))?:([0-9]+)(?:\/(.+))?$/;
+    const match = did.match(regex);
+    if (!match) return null;
+    const [, networkSuffix, satNumber, path] = match;
+    const network = networkSuffix || 'mainnet';
+    return { satNumber, path, network };
+  }
+
+  private getDidPrefix(network: string): string {
+    switch (network) {
+      case 'test':
+      case 'testnet':
+        return 'did:btco:test';
+      case 'sig':
+      case 'signet':
+        return 'did:btco:sig';
+      default:
+        return 'did:btco';
+    }
+  }
+
+  async resolve(did: string, options: BtcoDidResolutionOptions = {}): Promise<BtcoDidResolutionResult> {
+    const parsed = this.parseBtcoDid(did);
+    if (!parsed) {
+      return this.createErrorResult('invalidDid', `Invalid BTCO DID format: ${did}`);
+    }
+
+    const { satNumber, network } = parsed;
+    const provider = options.provider || this.options.provider;
+    if (!provider) {
+      return this.createErrorResult('noProvider', 'No provider supplied');
+    }
+
+    let inscriptionIds: string[] = [];
+    try {
+      const satInfo = await provider.getSatInfo(satNumber);
+      inscriptionIds = satInfo?.inscription_ids || [];
+    } catch (e: any) {
+      return this.createErrorResult('notFound', `Failed to retrieve inscriptions for satoshi ${satNumber}: ${e?.message || String(e)}`);
+    }
+
+    if (inscriptionIds.length === 0) {
+      return this.createErrorResult('notFound', `No inscriptions found on satoshi ${satNumber}`);
+    }
+
+    const expectedDid = `${this.getDidPrefix(network)}:${satNumber}`;
+    const didPattern = new RegExp(`^(?:BTCO DID: )?(${expectedDid.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'i');
+
+    const inscriptionDataList: BtcoInscriptionData[] = [];
+
+    for (const inscriptionId of inscriptionIds) {
+      const inscriptionData: BtcoInscriptionData = {
+        inscriptionId,
+        content: '',
+        metadata: null
+      };
+
+      try {
+        const inscription = await provider.resolveInscription(inscriptionId);
+        if (!inscription) {
+          inscriptionData.error = `Inscription ${inscriptionId} not found`;
+          inscriptionDataList.push(inscriptionData);
+          continue;
+        }
+
+        inscriptionData.contentUrl = inscription.content_url;
+        inscriptionData.contentType = inscription.content_type;
+
+        try {
+          const response = await fetch(inscription.content_url);
+          if (!response.ok) {
+            throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+          }
+          inscriptionData.content = await response.text();
+        } catch (err: any) {
+          inscriptionData.error = `Failed to fetch content: ${err?.message || String(err)}`;
+          inscriptionDataList.push(inscriptionData);
+          continue;
+        }
+
+        try {
+          inscriptionData.metadata = await provider.getMetadata(inscriptionId);
+        } catch (err) {
+          inscriptionData.metadata = null;
+        }
+
+        inscriptionData.isValidDid = didPattern.test(inscriptionData.content);
+
+        if (inscriptionData.isValidDid && inscriptionData.metadata) {
+          const didDocument = inscriptionData.metadata as DIDDocument;
+          if (this.isValidDidDocument(didDocument) && didDocument.id === expectedDid) {
+            inscriptionData.didDocument = didDocument;
+          } else {
+            inscriptionData.error = 'Invalid DID document structure or mismatched ID';
+          }
+        }
+
+        if (inscriptionData.content.includes('🔥')) {
+          inscriptionData.didDocument = null;
+          if (!inscriptionData.error) {
+            inscriptionData.error = 'DID has been deactivated';
+          }
+        }
+      } catch (err: any) {
+        inscriptionData.error = `Failed to process inscription: ${err?.message || String(err)}`;
+      }
+
+      inscriptionDataList.push(inscriptionData);
+    }
+
+    let latestValidDidDocument: DIDDocument | null = null;
+    let latestInscriptionId: string | undefined;
+    for (let i = inscriptionDataList.length - 1; i >= 0; i--) {
+      const data = inscriptionDataList[i];
+      if (data.didDocument && !data.error) {
+        latestValidDidDocument = data.didDocument;
+        latestInscriptionId = data.inscriptionId;
+        break;
+      }
+    }
+
+    return {
+      didDocument: latestValidDidDocument,
+      inscriptions: inscriptionDataList,
+      resolutionMetadata: {
+        inscriptionId: latestInscriptionId,
+        satNumber,
+        network,
+        totalInscriptions: inscriptionDataList.length
+      },
+      didDocumentMetadata: {
+        inscriptionId: latestInscriptionId,
+        network
+      }
+    };
+  }
+
+  private isValidDidDocument(doc: any): doc is DIDDocument {
+    if (!doc || typeof doc !== 'object') return false;
+    if (!doc.id || typeof doc.id !== 'string') return false;
+    if (!doc['@context']) return false;
+    const contexts = Array.isArray(doc['@context']) ? doc['@context'] : [doc['@context']];
+    if (!contexts.includes('https://www.w3.org/ns/did/v1') && !contexts.includes('https://w3id.org/did/v1')) {
+      return false;
+    }
+    if (doc.verificationMethod && !Array.isArray(doc.verificationMethod)) return false;
+    if (doc.authentication && !Array.isArray(doc.authentication)) return false;
+    return true;
+  }
+
+  private createErrorResult(error: string, message: string): BtcoDidResolutionResult {
+    return {
+      didDocument: null,
+      resolutionMetadata: { error, message },
+      didDocumentMetadata: {}
+    };
+  }
+}
+

--- a/tests/bitcoin/OrdNodeProvider.test.ts
+++ b/tests/bitcoin/OrdNodeProvider.test.ts
@@ -1,0 +1,12 @@
+import { OrdNodeProvider } from '../../src/bitcoin/providers/OrdNodeProvider';
+
+describe('OrdNodeProvider (stub)', () => {
+  it('constructs and returns defaults', async () => {
+    const p = new OrdNodeProvider({ nodeUrl: 'https://ord.example' });
+    const info = await p.getSatInfo('1');
+    expect(info.inscription_ids).toEqual([]);
+    const insc = await p.resolveInscription('abc');
+    expect(insc.content_url).toContain('/content/abc');
+  });
+});
+

--- a/tests/did/BtcoDidResolver.test.ts
+++ b/tests/did/BtcoDidResolver.test.ts
@@ -1,0 +1,86 @@
+import { BtcoDidResolver } from '../../src/did/BtcoDidResolver';
+
+class MockProvider {
+  constructor(private inscriptions: Record<string, { content: string; content_type?: string; metadata?: any }>, private satToIds: Record<string, string[]>) {}
+
+  async getSatInfo(satNumber: string): Promise<{ inscription_ids: string[] }> {
+    return { inscription_ids: this.satToIds[satNumber] || [] };
+  }
+  async resolveInscription(inscriptionId: string) {
+    const insc = this.inscriptions[inscriptionId];
+    if (!insc) throw new Error('not found');
+    return {
+      id: inscriptionId,
+      sat: 0,
+      content_type: insc.content_type || 'text/plain',
+      content_url: `https://example.com/${inscriptionId}`
+    };
+  }
+  async getMetadata(inscriptionId: string) {
+    return this.inscriptions[inscriptionId]?.metadata ?? null;
+  }
+}
+
+describe('BtcoDidResolver', () => {
+  it('returns error for invalid did', async () => {
+    const r = new BtcoDidResolver();
+    const res = await r.resolve('did:bad:123');
+    expect(res.didDocument).toBeNull();
+    expect(res.resolutionMetadata.error).toBe('invalidDid');
+  });
+
+  it('resolves latest valid DID document on sat', async () => {
+    const sat = '12345';
+    const did = `did:btco:${sat}`;
+    const doc = {
+      '@context': ['https://www.w3.org/ns/did/v1'],
+      id: did
+    };
+    const provider = new MockProvider(
+      {
+        a: { content: `BTCO DID: ${did}`, metadata: doc },
+        b: { content: 'not a did' }
+      },
+      { [sat]: ['b', 'a'] }
+    );
+
+    // mock global fetch
+    const originalFetch = global.fetch as any;
+    (global as any).fetch = async (url: string) => {
+      const id = url.split('/').pop() as string;
+      const content = provider['inscriptions'][id]?.content || '';
+      return { ok: true, text: async () => content } as any;
+    };
+
+    const resolver = new BtcoDidResolver({ provider });
+    const res = await resolver.resolve(did);
+
+    expect(res.didDocument?.id).toBe(did);
+    expect(res.inscriptions?.length).toBe(2);
+    expect(res.resolutionMetadata.totalInscriptions).toBe(2);
+
+    (global as any).fetch = originalFetch;
+  });
+
+  it('handles deactivated DID marker', async () => {
+    const sat = '9';
+    const did = `did:btco:${sat}`;
+    const provider = new MockProvider(
+      {
+        x: { content: `BTCO DID: ${did} 🔥`, metadata: { '@context': ['https://www.w3.org/ns/did/v1'], id: did } }
+      },
+      { [sat]: ['x'] }
+    );
+
+    const originalFetch = global.fetch as any;
+    (global as any).fetch = async () => ({ ok: true, text: async () => `BTCO DID: ${did} 🔥` }) as any;
+
+    const resolver = new BtcoDidResolver({ provider });
+    const res = await resolver.resolve(did);
+    expect(res.didDocument).toBeNull();
+    expect(res.inscriptions?.[0].error).toMatch(/deactivated/);
+
+    (global as any).fetch = originalFetch;
+  });
+});
+


### PR DESCRIPTION
Ports `BtcoDidResolver` and Bitcoin resource provider types to `src/` as isolated modules.

---
<a href="https://cursor.com/background-agent?bcId=bc-28412ee4-584d-4f7f-8d49-70f93e2a0031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-28412ee4-584d-4f7f-8d49-70f93e2a0031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

