### PR TITLE
Extend ordinals client and add cbor utils

### DIFF
--- a/src/bitcoin/OrdinalsClient.ts
+++ b/src/bitcoin/OrdinalsClient.ts
@@ -45,6 +45,36 @@ export class OrdinalsClient {
   async estimateFee(blocks: number = 1): Promise<number> {
     return Math.max(1, blocks) * 10;
   }
+
+  // Added provider-like helper methods commonly expected by higher-level resolvers
+  // Minimal placeholder implementations suitable for unit testing
+
+  async getSatInfo(satoshi: string): Promise<{ inscription_ids: string[] }> {
+    // Simulate that a satoshi may have zero or one inscription id linked
+    const has = Boolean(satoshi && satoshi !== '0');
+    return { inscription_ids: has ? [`insc-${satoshi}`] : [] };
+  }
+
+  async resolveInscription(identifier: string): Promise<OrdinalsInscription | null> {
+    // Accept either an inscription id or a satoshi number and resolve to an inscription
+    if (!identifier) return null;
+    const isInscId = identifier.startsWith('insc-');
+    const satoshi = isInscId ? identifier.replace(/^insc-/, '') : identifier;
+    return {
+      satoshi,
+      inscriptionId: `insc-${satoshi}`,
+      content: Buffer.from(''),
+      contentType: 'text/plain',
+      txid: 'txid',
+      vout: 0
+    };
+  }
+
+  async getMetadata(inscriptionId: string): Promise<Record<string, unknown> | null> {
+    // For tests we simply return a deterministic object keyed by the id
+    if (!inscriptionId) return null;
+    return { id: inscriptionId, type: 'BTCO.DID', network: this.network } as Record<string, unknown>;
+  }
 }
 
 

--- a/src/utils/cbor.ts
+++ b/src/utils/cbor.ts
@@ -1,0 +1,12 @@
+import * as cbor from 'cbor-js';
+
+export function encode(input: unknown): Uint8Array {
+  const encoded: any = (cbor as any).encode(input);
+  return new Uint8Array(encoded);
+}
+
+export function decode<T = unknown>(bytes: Uint8Array | ArrayBuffer | Buffer): T {
+  const view = new Uint8Array(bytes as any);
+  return (cbor as any).decode(view.buffer) as T;
+}
+

--- a/tests/bitcoin/OrdinalsClient.test.ts
+++ b/tests/bitcoin/OrdinalsClient.test.ts
@@ -36,6 +36,46 @@ describe('OrdinalsClient', () => {
   test('estimateFee clamps non-positive blocks to minimum', async () => {
     await expect(client.estimateFee(0)).resolves.toBeGreaterThanOrEqual(10);
   });
+
+  test('getSatInfo returns inscription ids when satoshi is non-zero', async () => {
+    const info = await client.getSatInfo('123');
+    expect(Array.isArray(info.inscription_ids)).toBe(true);
+    expect(info.inscription_ids[0]).toBe('insc-123');
+  });
+
+  test('getSatInfo returns empty for zero-like input', async () => {
+    const info = await client.getSatInfo('0');
+    expect(info.inscription_ids).toEqual([]);
+  });
+
+  test('resolveInscription by inscription id yields inscription', async () => {
+    const insc = await client.resolveInscription('insc-777');
+    expect(insc).not.toBeNull();
+    expect(insc!.inscriptionId).toBe('insc-777');
+    expect(insc!.satoshi).toBe('777');
+  });
+
+  test('resolveInscription by satoshi yields inscription', async () => {
+    const insc = await client.resolveInscription('888');
+    expect(insc).not.toBeNull();
+    expect(insc!.inscriptionId).toBe('insc-888');
+    expect(insc!.satoshi).toBe('888');
+  });
+
+  test('getMetadata returns deterministic object keyed by id', async () => {
+    const meta = await client.getMetadata('insc-abc');
+    expect(meta).toEqual(expect.objectContaining({ id: 'insc-abc' }));
+  });
+
+  test('resolveInscription returns null for empty identifier', async () => {
+    const insc = await client.resolveInscription('');
+    expect(insc).toBeNull();
+  });
+
+  test('getMetadata returns null for empty id', async () => {
+    const meta = await client.getMetadata('');
+    expect(meta).toBeNull();
+  });
 });
 
 

--- a/tests/utils/cbor.test.ts
+++ b/tests/utils/cbor.test.ts
@@ -1,0 +1,34 @@
+import { encode, decode } from '../../src/utils/cbor';
+
+describe('utils/cbor', () => {
+  test('encode returns Uint8Array', () => {
+    const input = { a: 1, b: 'two' };
+    const out = encode(input);
+    expect(out).toBeInstanceOf(Uint8Array);
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  test('decode roundtrips object', () => {
+    const input = { a: 1, b: 'two', nested: { ok: true } };
+    const encoded = encode(input);
+    const decoded = decode<typeof input>(encoded);
+    expect(decoded).toEqual(input);
+  });
+
+  test('decode accepts Buffer', () => {
+    const input = [1, 2, 3];
+    const encoded = encode(input);
+    const buf = Buffer.from(encoded);
+    const decoded = decode<number[]>(buf);
+    expect(decoded).toEqual(input);
+  });
+
+  test('decode accepts ArrayBuffer', () => {
+    const input = { hello: 'world' };
+    const encoded = encode(input);
+    const ab = encoded.buffer.slice(encoded.byteOffset, encoded.byteOffset + encoded.byteLength) as ArrayBuffer;
+    const decoded = decode<typeof input>(ab as ArrayBuffer);
+    expect(decoded).toEqual(input);
+  });
+});
+


### PR DESCRIPTION
Add provider helper methods to OrdinalsClient and CBOR utilities for BTCO DID document metadata.

---
<a href="https://cursor.com/background-agent?bcId=bc-052573e6-a4ae-4660-b501-d29952c2be66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-052573e6-a4ae-4660-b501-d29952c2be66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

