### PR TITLE
Create btco did document helper and tests

### DIFF
--- a/src/did/createBtcoDidDocument.ts
+++ b/src/did/createBtcoDidDocument.ts
@@ -1,0 +1,52 @@
+import { DIDDocument, VerificationMethod } from '../types/did';
+import { multikey, MultikeyType } from '../crypto/Multikey';
+
+export type BitcoinNetwork = 'mainnet' | 'testnet' | 'signet';
+
+interface CreateBtcoDidDocumentParams {
+	publicKey: Uint8Array;
+	keyType: MultikeyType;
+	controller?: string;
+}
+
+function getDidPrefix(network: BitcoinNetwork): string {
+	if (network === 'mainnet') return 'did:btco';
+	if (network === 'signet') return 'did:btco:sig';
+	if (network === 'testnet') return 'did:btco:test';
+	throw new Error(`Unsupported Bitcoin network: ${network}`);
+}
+
+function buildVerificationMethod(did: string, params: CreateBtcoDidDocumentParams): VerificationMethod {
+	const fragment = '#0';
+	const id = `${did}${fragment}`;
+	const controller = params.controller ?? did;
+	return {
+		id,
+		type: 'Multikey',
+		controller,
+		publicKeyMultibase: multikey.encodePublicKey(params.publicKey, params.keyType)
+	};
+}
+
+export function createBtcoDidDocument(
+	satNumber: number | string,
+	network: BitcoinNetwork,
+	params: CreateBtcoDidDocumentParams
+): DIDDocument {
+	const did = `${getDidPrefix(network)}:${String(satNumber)}`;
+	const vm = buildVerificationMethod(did, params);
+
+	const document: DIDDocument = {
+		'@context': [
+			'https://www.w3.org/ns/did/v1',
+			'https://w3id.org/security/multikey/v1'
+		],
+		id: did,
+		verificationMethod: [vm],
+		authentication: [vm.id],
+		assertionMethod: [vm.id]
+	};
+
+	return document;
+}
+

--- a/tests/did/createBtcoDidDocument.test.ts
+++ b/tests/did/createBtcoDidDocument.test.ts
@@ -1,0 +1,66 @@
+import { createBtcoDidDocument } from '../../src/did/createBtcoDidDocument';
+import { multikey } from '../../src/crypto/Multikey';
+
+function rangeBytes(len: number, start: number): Uint8Array {
+	return new Uint8Array(len).map((_, i) => (start + i) & 0xff);
+}
+
+describe('createBtcoDidDocument', () => {
+	it('creates document for mainnet with deterministic fragment and relationships', () => {
+		const pub = rangeBytes(32, 1);
+		const doc = createBtcoDidDocument('1066296127976657', 'mainnet', { publicKey: pub, keyType: 'Ed25519' });
+		expect(doc['@context']).toEqual([
+			'https://www.w3.org/ns/did/v1',
+			'https://w3id.org/security/multikey/v1'
+		]);
+		expect(doc.id).toBe('did:btco:1066296127976657');
+		expect(doc.verificationMethod?.length).toBe(1);
+		const vm = doc.verificationMethod![0];
+		expect(vm.id).toBe('did:btco:1066296127976657#0');
+		expect(vm.type).toBe('Multikey');
+		expect(vm.controller).toBe(doc.id);
+		expect(doc.authentication).toEqual([vm.id]);
+		expect(doc.assertionMethod).toEqual([vm.id]);
+		const decoded = multikey.decodePublicKey(vm.publicKeyMultibase);
+		expect(decoded.type).toBe('Ed25519');
+		expect(Array.from(decoded.key)).toEqual(Array.from(pub));
+	});
+
+	it('creates document for testnet with proper prefix', () => {
+		const pub = rangeBytes(33, 3);
+		const doc = createBtcoDidDocument(123456, 'testnet', { publicKey: pub, keyType: 'Secp256k1' });
+		expect(doc.id).toBe('did:btco:test:123456');
+		const vm = doc.verificationMethod![0];
+		expect(vm.id).toBe('did:btco:test:123456#0');
+		const decoded = multikey.decodePublicKey(vm.publicKeyMultibase);
+		expect(decoded.type).toBe('Secp256k1');
+		expect(Array.from(decoded.key)).toEqual(Array.from(pub));
+	});
+
+	it('creates document for signet with proper prefix', () => {
+		const pub = rangeBytes(96, 5);
+		const doc = createBtcoDidDocument(999, 'signet', { publicKey: pub, keyType: 'Bls12381G2' });
+		expect(doc.id).toBe('did:btco:sig:999');
+		const vm = doc.verificationMethod![0];
+		expect(vm.id).toBe('did:btco:sig:999#0');
+		const decoded = multikey.decodePublicKey(vm.publicKeyMultibase);
+		expect(decoded.type).toBe('Bls12381G2');
+		expect(Array.from(decoded.key)).toEqual(Array.from(pub));
+	});
+
+	it('supports overriding controller', () => {
+		const pub = rangeBytes(32, 7);
+		const controller = 'did:example:controller';
+		const doc = createBtcoDidDocument('42', 'mainnet', { publicKey: pub, keyType: 'Ed25519', controller });
+		expect(doc.verificationMethod![0].controller).toBe(controller);
+	});
+
+	it('throws on unsupported network', () => {
+		const pub = rangeBytes(32, 9);
+		expect(() =>
+			// @ts-expect-error testing invalid network
+			createBtcoDidDocument('1', 'regtest', { publicKey: pub, keyType: 'Ed25519' })
+		).toThrow('Unsupported Bitcoin network: regtest');
+	});
+});
+


### PR DESCRIPTION
Add `createBtcoDidDocument` helper and comprehensive unit tests to generate BTCO DID documents with Multikey verification methods and deterministic IDs.

---
<a href="https://cursor.com/background-agent?bcId=bc-c1507665-5c33-461c-a117-cf3807c1b127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c1507665-5c33-461c-a117-cf3807c1b127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

