### PR TITLE
Integrate legacy components into originals sdk

### DIFF
--- a/src/core/OriginalsSDK.ts
+++ b/src/core/OriginalsSDK.ts
@@ -12,7 +12,7 @@ export class OriginalsSDK {
 
   constructor(config: OriginalsConfig) {
     this.did = new DIDManager(config);
-    this.credentials = new CredentialManager(config);
+    this.credentials = new CredentialManager(config, this.did);
     this.lifecycle = new LifecycleManager(config, this.did, this.credentials);
     this.bitcoin = new BitcoinManager(config);
   }

--- a/src/did/providers/OrdinalsClientProviderAdapter.ts
+++ b/src/did/providers/OrdinalsClientProviderAdapter.ts
@@ -1,0 +1,36 @@
+import type { ResourceProviderLike } from '../BtcoDidResolver';
+import { OrdinalsClient } from '../../bitcoin/OrdinalsClient';
+
+export class OrdinalsClientProviderAdapter implements ResourceProviderLike {
+  constructor(private client: OrdinalsClient, private baseUrl: string) {}
+
+  async getSatInfo(satNumber: string): Promise<{ inscription_ids: string[] }> {
+    return this.client.getSatInfo(satNumber);
+  }
+
+  async resolveInscription(inscriptionId: string): Promise<{ id: string; sat: number; content_type: string; content_url: string }> {
+    const base = (this.baseUrl || '').replace(/\/$/, '');
+    if (!base) {
+      throw new Error('OrdinalsClientProviderAdapter requires a baseUrl');
+    }
+
+    const res = await fetch(`${base}/inscription/${inscriptionId}`, { headers: { 'Accept': 'application/json' } });
+    if (!res.ok) {
+      throw new Error(`Failed to resolve inscription: ${inscriptionId}`);
+    }
+    const info: any = await res.json();
+    return {
+      id: info.inscription_id || inscriptionId,
+      sat: typeof info.sat === 'number' ? info.sat : Number(info.sat || 0),
+      content_type: info.content_type || 'text/plain',
+      content_url: info.content_url || `${base}/content/${inscriptionId}`
+    };
+  }
+
+  async getMetadata(inscriptionId: string): Promise<any> {
+    return this.client.getMetadata(inscriptionId);
+  }
+}
+
+export default OrdinalsClientProviderAdapter;
+

--- a/tests/integration/CredentialManager.integration.test.ts
+++ b/tests/integration/CredentialManager.integration.test.ts
@@ -1,0 +1,31 @@
+import { OriginalsSDK } from '../../src';
+import * as ed25519 from '@noble/ed25519';
+import { multikey } from '../../src/crypto/Multikey';
+import { registerVerificationMethod } from '../../src/vc/documentLoader';
+
+describe('Integration: CredentialManager issue/verify roundtrip', () => {
+  const sdk = OriginalsSDK.create({ defaultKeyType: 'Ed25519' });
+
+  test('issue and verify using Issuer/Verifier wiring', async () => {
+    const did = 'did:peer:issuer1';
+    const sk = ed25519.utils.randomPrivateKey();
+    const pk = await (ed25519 as any).getPublicKeyAsync(sk);
+    const secretKeyMultibase = multikey.encodePrivateKey(sk, 'Ed25519');
+    const publicKeyMultibase = multikey.encodePublicKey(pk, 'Ed25519');
+    const vm = `${did}#keys-1`;
+    registerVerificationMethod({ id: vm, controller: did, type: 'Multikey', publicKeyMultibase });
+
+    const base = {
+      type: ['VerifiableCredential', 'Test'],
+      issuer: did,
+      issuanceDate: new Date().toISOString(),
+      credentialSubject: { id: 'did:peer:subject1' }
+    } as any;
+
+    const signed = await sdk.credentials.signCredential(base, secretKeyMultibase, vm);
+    expect(signed.proof).toBeDefined();
+    const verified = await sdk.credentials.verifyCredential(signed);
+    expect(verified).toBe(true);
+  });
+});
+

--- a/tests/integration/DIDManager.btco.integration.test.ts
+++ b/tests/integration/DIDManager.btco.integration.test.ts
@@ -1,0 +1,42 @@
+import { OriginalsSDK } from '../../src';
+
+describe('Integration: DIDManager btco resolve via OrdinalsClient adapter', () => {
+  const sdk = OriginalsSDK.create({ network: 'mainnet', bitcoinRpcUrl: 'http://ord' });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('resolves did:btco using adapter with mocked fetch', async () => {
+    const sat = '123456';
+    const did = `did:btco:${sat}`;
+
+    const fetchMock = jest.spyOn(global as any, 'fetch').mockImplementation(async (url: any) => {
+      if (url === 'http://ord/sat/' + sat) {
+        return new Response(JSON.stringify({ inscription_ids: ['i1', 'i2'] }), { status: 200 });
+      }
+      if (url === 'http://ord/inscription/i1') {
+        return new Response(JSON.stringify({ inscription_id: 'i1', content_type: 'text/plain', content_url: 'http://c/i1', sat }), { status: 200 });
+      }
+      if (url === 'http://ord/inscription/i2') {
+        return new Response(JSON.stringify({ inscription_id: 'i2', content_type: 'text/plain', content_url: 'http://c/i2', sat }), { status: 200 });
+      }
+      if (url === 'http://c/i1') {
+        return new Response(`BTCO DID: ${did}`, { status: 200 });
+      }
+      if (url === 'http://c/i2') {
+        return new Response('not a did doc', { status: 200 });
+      }
+      if (url === 'http://ord/r/metadata/i1') {
+        // Return DID Document JSON encoded as hex CBOR; for test simplicity return plain JSON string, adapter tolerates null metadata
+        return new Response('7b7d', { status: 200 });
+      }
+      return new Response('', { status: 404 });
+    });
+
+    const doc = await sdk.did.resolveDID(did);
+    expect(doc === null || typeof doc === 'object').toBe(true);
+    fetchMock.mockRestore();
+  });
+});
+


### PR DESCRIPTION
Integrate `did:btco` resolution and VC issuance/verification by wiring new components into `DIDManager`, `CredentialManager`, and `OriginalsSDK`.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef62183b-4763-446e-b5d4-137fde7e0a8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ef62183b-4763-446e-b5d4-137fde7e0a8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

