### PR TITLE
Test ordinals client provider adapter negative paths

### DIFF
--- a/tests/did/providers/OrdinalsClientProviderAdapter.test.ts
+++ b/tests/did/providers/OrdinalsClientProviderAdapter.test.ts
@@ -1,0 +1,148 @@
+import { OrdinalsClient } from '../../../src/bitcoin/OrdinalsClient';
+import { OrdinalsClientProviderAdapter } from '../../../src/did/providers/OrdinalsClientProviderAdapter';
+
+describe('OrdinalsClientProviderAdapter.resolveInscription', () => {
+  const inscriptionId = 'insc123';
+  const originalFetch = global.fetch as any;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  afterEach(() => {
+    (global as any).fetch = originalFetch;
+  });
+
+  test('throws when baseUrl is missing/empty', async () => {
+    const client = new OrdinalsClient('http://rpc', 'mainnet');
+    const adapter = new OrdinalsClientProviderAdapter(client, '');
+    const fetchSpy = jest.spyOn(globalThis, 'fetch' as any);
+    await expect(adapter.resolveInscription(inscriptionId)).rejects.toThrow('OrdinalsClientProviderAdapter requires a baseUrl');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test('throws when inscription endpoint returns non-OK', async () => {
+    const client = new OrdinalsClient('http://rpc', 'mainnet');
+    const adapter = new OrdinalsClientProviderAdapter(client, 'https://api.example.com/');
+
+    const fetchMock = jest.fn().mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
+    (globalThis as any).fetch = fetchMock;
+
+    await expect(adapter.resolveInscription(inscriptionId)).rejects.toThrow(`Failed to resolve inscription: ${inscriptionId}`);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example.com/inscription/insc123',
+      { headers: { Accept: 'application/json' } }
+    );
+  });
+
+  test('maps fields correctly when JSON has explicit values and numeric sat', async () => {
+    const client = new OrdinalsClient('http://rpc', 'mainnet');
+    const adapter = new OrdinalsClientProviderAdapter(client, 'https://ord.example');
+
+    const apiResponse = {
+      inscription_id: 'abc123',
+      sat: 42,
+      content_type: 'image/png',
+      content_url: 'https://cdn.example/abc123.png'
+    };
+
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true, json: async () => apiResponse });
+    (globalThis as any).fetch = fetchMock;
+
+    const result = await adapter.resolveInscription(inscriptionId);
+
+    expect(result).toEqual({
+      id: 'abc123',
+      sat: 42,
+      content_type: 'image/png',
+      content_url: 'https://cdn.example/abc123.png'
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://ord.example/inscription/insc123',
+      { headers: { Accept: 'application/json' } }
+    );
+  });
+
+  test('applies fallbacks and coerces string sat to number', async () => {
+    const client = new OrdinalsClient('http://rpc', 'mainnet');
+    const adapter = new OrdinalsClientProviderAdapter(client, 'https://api.example.com/');
+
+    const apiResponse = {
+      sat: '007'
+      // missing inscription_id, content_type, content_url
+    } as any;
+
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true, json: async () => apiResponse });
+    (globalThis as any).fetch = fetchMock;
+
+    const result = await adapter.resolveInscription(inscriptionId);
+
+    expect(result).toEqual({
+      id: 'insc123',
+      sat: 7,
+      content_type: 'text/plain',
+      content_url: 'https://api.example.com/content/insc123'
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example.com/inscription/insc123',
+      { headers: { Accept: 'application/json' } }
+    );
+  });
+
+  test('applies default sat=0 when sat is missing', async () => {
+    const client = new OrdinalsClient('http://rpc', 'mainnet');
+    const adapter = new OrdinalsClientProviderAdapter(client, 'https://api.example.com/');
+
+    const apiResponse = { } as any;
+
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true, json: async () => apiResponse });
+    (globalThis as any).fetch = fetchMock;
+
+    const result = await adapter.resolveInscription(inscriptionId);
+
+    expect(result).toEqual({
+      id: 'insc123',
+      sat: 0,
+      content_type: 'text/plain',
+      content_url: 'https://api.example.com/content/insc123'
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example.com/inscription/insc123',
+      { headers: { Accept: 'application/json' } }
+    );
+  });
+
+  test('getSatInfo proxies to client.getSatInfo', async () => {
+    const mockClient = {
+      getSatInfo: jest.fn(async (n: string) => ({ inscription_ids: ['a', 'b'] })),
+      getMetadata: jest.fn()
+    } as unknown as OrdinalsClient;
+
+    const adapter = new OrdinalsClientProviderAdapter(mockClient, 'https://x');
+    const result = await adapter.getSatInfo('12345');
+    expect(result).toEqual({ inscription_ids: ['a', 'b'] });
+    expect((mockClient as any).getSatInfo).toHaveBeenCalledWith('12345');
+  });
+
+  test('getMetadata proxies to client.getMetadata', async () => {
+    const expected = { hello: 'world' };
+    const mockClient = {
+      getSatInfo: jest.fn(),
+      getMetadata: jest.fn(async (id: string) => expected)
+    } as unknown as OrdinalsClient;
+
+    const adapter = new OrdinalsClientProviderAdapter(mockClient, 'https://x');
+    const result = await adapter.getMetadata('iid');
+    expect(result).toBe(expected);
+    expect((mockClient as any).getMetadata).toHaveBeenCalledWith('iid');
+  });
+});
+


### PR DESCRIPTION
Add comprehensive tests for `OrdinalsClientProviderAdapter` to ensure 100% branch coverage and validate error handling and data mapping.

---
<a href="https://cursor.com/background-agent?bcId=bc-92f77383-82d6-4aca-bc93-9cad2326af6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-92f77383-82d6-4aca-bc93-9cad2326af6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

