### PR TITLE
Add 100% test coverage for telemetry, retry, and eddsa

### DIFF
--- a/tests/utils/retry.test.ts
+++ b/tests/utils/retry.test.ts
@@ -1,0 +1,105 @@
+import { retry, RetryError } from '../../src/utils/retry';
+
+describe('utils/retry', () => {
+  jest.setTimeout(10000);
+
+  test('succeeds immediately without retries', async () => {
+    const op = jest.fn(async () => 42);
+    const result = await retry(op, { retries: 3, initialDelayMs: 1, jitter: false });
+    expect(result).toBe(42);
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  test('succeeds with completely default options (no second arg)', async () => {
+    const op = jest.fn(async () => 5);
+    const result = await retry(op);
+    expect(result).toBe(5);
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  test('retries on failure then succeeds', async () => {
+    let calls = 0;
+    const op = jest.fn(async () => {
+      calls += 1;
+      if (calls < 3) throw new Error('fail');
+      return 'ok';
+    });
+    const result = await retry(op, { retries: 5, initialDelayMs: 1, backoffFactor: 2, jitter: false });
+    expect(result).toBe('ok');
+    expect(op).toHaveBeenCalledTimes(3);
+  });
+
+  test('honors shouldRetry false to stop early', async () => {
+    const op = jest.fn(async () => { throw new Error('fail'); });
+    await expect(retry(op, { retries: 5, initialDelayMs: 1, jitter: false, shouldRetry: () => false }))
+      .rejects.toThrow(RetryError);
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  test('exhausts retries and throws RetryError with attempts', async () => {
+    const op = jest.fn(async () => { throw new Error('always'); });
+    try {
+      await retry(op, { retries: 2, initialDelayMs: 1, backoffFactor: 3, maxDelayMs: 5, jitter: false });
+      fail('expected throw');
+    } catch (e: any) {
+      expect(e).toBeInstanceOf(RetryError);
+      expect(e.name).toBe('RetryError');
+      // attempts is retries+1 executions
+      expect(e.attempts).toBe(3);
+      expect(e.cause).toBeInstanceOf(Error);
+      expect((e.cause as Error).message).toBe('always');
+    }
+    expect(op).toHaveBeenCalledTimes(3);
+  });
+
+  test('respects jitter option true/false without throwing', async () => {
+    // Case 1: jitter=true and no retry needed
+    const opNoRetry = jest.fn(async () => 7);
+    await expect(retry(opNoRetry, { jitter: true })).resolves.toBe(7);
+    // Case 2: jitter=false and no retry needed
+    const opNoRetry2 = jest.fn(async () => 7);
+    await expect(retry(opNoRetry2, { jitter: false })).resolves.toBe(7);
+
+    // Case 3: jitter=true with at least one retry to exercise addJitter path
+    let attempts = 0;
+    const opRetry = jest.fn(async () => {
+      attempts += 1;
+      if (attempts < 2) throw new Error('transient');
+      return 9;
+    });
+    const result = await retry(opRetry, { retries: 2, initialDelayMs: 1, jitter: true, shouldRetry: () => true });
+    expect(result).toBe(9);
+    expect(opRetry).toHaveBeenCalledTimes(2);
+
+    // Case 4: jitter=false with a retry to hit non-jitter sleep path
+    let tries = 0;
+    const opRetryNoJitter = jest.fn(async () => {
+      tries += 1;
+      if (tries < 2) throw new Error('once');
+      return 10;
+    });
+    const resultNoJitter = await retry(opRetryNoJitter, { retries: 2, initialDelayMs: 1, jitter: false });
+    expect(resultNoJitter).toBe(10);
+    expect(opRetryNoJitter).toHaveBeenCalledTimes(2);
+  });
+
+  test('defaults jitter=true when unspecified and performs retry', async () => {
+    let n = 0;
+    const op = jest.fn(async () => {
+      n += 1;
+      if (n < 2) throw new Error('once');
+      return 'done';
+    });
+    const res = await retry(op, { retries: 1, initialDelayMs: 1 });
+    expect(res).toBe('done');
+    expect(op).toHaveBeenCalledTimes(2);
+  });
+
+  test('skips loop when retries < 0 and throws RetryError immediately', async () => {
+    const op = jest.fn(async () => 1);
+    await expect(retry(op, { retries: -1 })).rejects.toBeInstanceOf(RetryError);
+    // operation never called because loop condition fails
+    expect(op).not.toHaveBeenCalled();
+  });
+});
+

--- a/tests/utils/telemetry.test.ts
+++ b/tests/utils/telemetry.test.ts
@@ -1,0 +1,51 @@
+import { emitTelemetry, emitError, StructuredError } from '../../src/utils/telemetry';
+
+describe('utils/telemetry', () => {
+  test('emitTelemetry invokes onEvent with default level info', () => {
+    const onEvent = jest.fn();
+    emitTelemetry({ onEvent }, { name: 'event-1' });
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    const arg = onEvent.mock.calls[0][0];
+    expect(arg.name).toBe('event-1');
+    expect(arg.level).toBe('info');
+  });
+
+  test('emitTelemetry respects provided level', () => {
+    const onEvent = jest.fn();
+    emitTelemetry({ onEvent }, { name: 'event-2', level: 'debug' });
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent.mock.calls[0][0].level).toBe('debug');
+  });
+
+  test('emitTelemetry is no-op when hooks missing or handler absent', () => {
+    expect(() => emitTelemetry(undefined, { name: 'noop' })).not.toThrow();
+    expect(() => emitTelemetry({}, { name: 'noop' })).not.toThrow();
+  });
+
+  test('emitTelemetry swallows handler exceptions', () => {
+    const onEvent = jest.fn(() => { throw new Error('boom'); });
+    expect(() => emitTelemetry({ onEvent }, { name: 'err' })).not.toThrow();
+  });
+
+  test('StructuredError holds code, message, and optional details', () => {
+    const err = new StructuredError('E_TEST', 'message', { a: 1 });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('StructuredError');
+    expect(err.code).toBe('E_TEST');
+    expect(err.message).toBe('message');
+    expect(err.details).toEqual({ a: 1 });
+  });
+
+  test('emitError calls onError and swallows handler exceptions', () => {
+    const onErrorOk = jest.fn();
+    const se = new StructuredError('E', 'm');
+    emitError({ onError: onErrorOk }, se);
+    expect(onErrorOk).toHaveBeenCalledWith(se);
+
+    const onErrorThrow = jest.fn(() => { throw new Error('boom'); });
+    expect(() => emitError({ onError: onErrorThrow }, se)).not.toThrow();
+    expect(() => emitError(undefined, se)).not.toThrow();
+    expect(() => emitError({}, se)).not.toThrow();
+  });
+});
+

--- a/tests/vc/cryptosuites/eddsa.coverage-extra.test.ts
+++ b/tests/vc/cryptosuites/eddsa.coverage-extra.test.ts
@@ -1,0 +1,85 @@
+import { EdDSACryptosuiteManager } from '../../../src/vc/cryptosuites/eddsa';
+import { multikey } from '../../../src/crypto/Multikey';
+
+describe('EdDSA coverage extras', () => {
+  const goodContext = ['https://www.w3.org/ns/credentials/v2'];
+
+  test('createProofConfiguration defaults proofPurpose to assertionMethod', async () => {
+    const sk = new Uint8Array(32).fill(1);
+    const pkMb = multikey.encodePublicKey(new Uint8Array(32).fill(2), 'Ed25519');
+    const vm = 'did:ex#vm';
+    const loader = async (iri: string) => {
+      if (iri.includes('#')) {
+        return { document: { '@context': goodContext, id: iri, publicKeyMultibase: pkMb }, documentUrl: iri, contextUrl: null };
+      }
+      return { document: { '@context': { '@version': 1.1 } }, documentUrl: iri, contextUrl: null } as any;
+    };
+    const doc: any = { '@context': goodContext, id: 'urn:doc-default-purpose' };
+    const proof = await EdDSACryptosuiteManager.createProof(doc, { verificationMethod: vm, privateKey: sk, cryptosuite: 'eddsa-rdfc-2022', documentLoader: loader });
+    // The method deletes @context before returning, so we assert the purpose value
+    expect(proof.proofPurpose).toBe('assertionMethod');
+  });
+
+  test('createProof includes only challenge when provided', async () => {
+    const sk = new Uint8Array(32).fill(7);
+    const pkMb = multikey.encodePublicKey(new Uint8Array(32).fill(6), 'Ed25519');
+    const vm = 'did:ex#vm-chal';
+    const loader = async (iri: string) => {
+      if (iri.includes('#')) {
+        return { document: { '@context': goodContext, id: iri, publicKeyMultibase: pkMb }, documentUrl: iri, contextUrl: null };
+      }
+      return { document: { '@context': { '@version': 1.1 } }, documentUrl: iri, contextUrl: null } as any;
+    };
+    const proof = await EdDSACryptosuiteManager.createProof({ '@context': goodContext, id: 'urn:chal' }, { verificationMethod: vm, privateKey: sk, cryptosuite: 'eddsa-rdfc-2022', challenge: '123', documentLoader: loader });
+    expect((proof as any).challenge).toBe('123');
+    expect((proof as any).domain).toBeUndefined();
+  });
+
+  test('createProof includes only domain when provided', async () => {
+    const sk = new Uint8Array(32).fill(9);
+    const pkMb = multikey.encodePublicKey(new Uint8Array(32).fill(8), 'Ed25519');
+    const vm = 'did:ex#vm-domain';
+    const loader = async (iri: string) => {
+      if (iri.includes('#')) {
+        return { document: { '@context': goodContext, id: iri, publicKeyMultibase: pkMb }, documentUrl: iri, contextUrl: null };
+      }
+      return { document: { '@context': { '@version': 1.1 } }, documentUrl: iri, contextUrl: null } as any;
+    };
+    const proof = await EdDSACryptosuiteManager.createProof({ '@context': goodContext, id: 'urn:domain' }, { verificationMethod: vm, privateKey: sk, cryptosuite: 'eddsa-rdfc-2022', domain: 'ex.org', documentLoader: loader });
+    expect((proof as any).domain).toBe('ex.org');
+    expect((proof as any).challenge).toBeUndefined();
+  });
+
+  test('verifyProof returns error message on thrown exception path', async () => {
+    const pkMb = multikey.encodePublicKey(new Uint8Array(32).fill(3), 'Ed25519');
+    const loader = async (iri: string) => {
+      if (iri.includes('#')) {
+        return { document: { '@context': goodContext, id: iri, publicKeyMultibase: pkMb }, documentUrl: iri, contextUrl: null };
+      }
+      return { document: { '@context': { '@version': 1.1 } }, documentUrl: iri, contextUrl: null } as any;
+    };
+    const doc: any = { '@context': goodContext, id: 'urn:doc' };
+    const badProof: any = { type: 'DataIntegrityProof', cryptosuite: 'eddsa-rdfc-2022', verificationMethod: 'did:ex#k', proofPurpose: 'assertionMethod', proofValue: 'not-multibase' };
+    const res = await EdDSACryptosuiteManager.verifyProof(doc, badProof, { documentLoader: loader });
+    expect(res.verified).toBe(false);
+    expect(Array.isArray(res.errors)).toBe(true);
+    expect(typeof res.errors![0]).toBe('string');
+  });
+
+  test('verifyProof uses Unknown verification error when thrown value lacks message', async () => {
+    const pkMb = multikey.encodePublicKey(new Uint8Array(32).fill(4), 'Ed25519');
+    const doc: any = { '@context': goodContext, id: 'urn:doc-unknown' };
+    const proof: any = { type: 'DataIntegrityProof', cryptosuite: 'eddsa-rdfc-2022', verificationMethod: 'did:ex#vm-unknown', proofPurpose: 'assertionMethod', proofValue: 'z1L' };
+    const loader = async (iri: string) => {
+      if (iri.includes('#')) {
+        // Throw a primitive string (no message property) only on VM fetch, after transform/hash succeeded
+        throw '';
+      }
+      return { document: { '@context': { '@version': 1.1 } }, documentUrl: iri, contextUrl: null } as any;
+    };
+    const res = await EdDSACryptosuiteManager.verifyProof(doc, proof, { documentLoader: loader });
+    expect(res.verified).toBe(false);
+    expect(res.errors?.[0]).toBe('Unknown verification error');
+  });
+});
+


### PR DESCRIPTION
Add 100% coverage tests for `telemetry` and `retry` utilities, and expand `eddsa` cryptosuite tests.

---
<a href="https://cursor.com/background-agent?bcId=bc-0b267d42-9b71-411a-999d-12a135e4c5b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0b267d42-9b71-411a-999d-12a135e4c5b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

