### PR TITLE
Remove bbs-signatures dependency and stub functions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,6 @@
     "": {
       "name": "sdk",
       "dependencies": {
-        "@digitalbazaar/bbs-signatures": "^3.0.0",
         "@noble/curves": "^1.6.0",
         "@noble/ed25519": "^2.0.0",
         "@noble/hashes": "^2.0.1",
@@ -243,8 +242,6 @@
     "@babel/types": ["@babel/types@7.28.4", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q=="],
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@0.2.3", "", {}, "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="],
-
-    "@digitalbazaar/bbs-signatures": ["@digitalbazaar/bbs-signatures@3.0.0", "", { "dependencies": { "@noble/curves": "^1.3.0" } }, "sha512-mQMCMnCWAraVSswJg1kJK/qmUrb3jMoWB9c8kOmztsWfnMZJcyYAcavuF8jgrVZ5cl/ZRNMK61ZbIvkqd6BE6g=="],
 
     "@digitalbazaar/http-client": ["@digitalbazaar/http-client@3.4.1", "", { "dependencies": { "ky": "^0.33.3", "ky-universal": "^0.11.0", "undici": "^5.21.2" } }, "sha512-Ahk1N+s7urkgj7WvvUND5f8GiWEPfUw0D41hdElaqLgu8wZScI8gdI0q+qWw5N1d35x7GCRH2uk9mi+Uzo9M3g=="],
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "url": "https://github.com/aviarytech/originals-sdk"
   },
   "dependencies": {
-    "@digitalbazaar/bbs-signatures": "^3.0.0",
     "@noble/curves": "^1.6.0",
     "@noble/ed25519": "^2.0.0",
     "@noble/hashes": "^2.0.1",

--- a/src/types/external-shims.d.ts
+++ b/src/types/external-shims.d.ts
@@ -12,22 +12,7 @@ declare module 'multiformats/bases/base64' {
   };
 }
 
-declare module '@digitalbazaar/bbs-signatures' {
-  export function sign(args: {
-    ciphersuite: string;
-    secretKey: Uint8Array;
-    publicKey: Uint8Array;
-    header: Uint8Array;
-    messages: Uint8Array[];
-  }): Promise<Uint8Array>;
-  export function verifySignature(args: {
-    ciphersuite: string;
-    publicKey: Uint8Array;
-    signature: Uint8Array;
-    header: Uint8Array;
-    messages: Uint8Array[];
-  }): Promise<boolean>;
-}
+// Removed: @digitalbazaar/bbs-signatures declarations no longer needed
 
 declare module 'jsonld';
 

--- a/src/types/external-shims.d.ts
+++ b/src/types/external-shims.d.ts
@@ -12,8 +12,6 @@ declare module 'multiformats/bases/base64' {
   };
 }
 
-// Removed: @digitalbazaar/bbs-signatures declarations no longer needed
-
 declare module 'jsonld';
 
 // Global shims for non-DOM/node test environments

--- a/src/vc/cryptosuites/bbsSimple.ts
+++ b/src/vc/cryptosuites/bbsSimple.ts
@@ -1,4 +1,3 @@
-import * as bbs from '@digitalbazaar/bbs-signatures';
 import { sha256 } from '@noble/hashes/sha2.js';
 
 export type BbsKeyPair = {
@@ -11,24 +10,12 @@ export class BbsSimple {
 
   static async sign(messages: Uint8Array[], keypair: BbsKeyPair, header?: Uint8Array): Promise<Uint8Array> {
     const headerBytes = header ?? new Uint8Array(sha256(new Uint8Array(0)));
-    return await bbs.sign({
-      ciphersuite: BbsSimple.CIPHERSUITE,
-      secretKey: keypair.privateKey,
-      publicKey: keypair.publicKey,
-      header: headerBytes,
-      messages
-    });
+    throw new Error('BbsSimple.sign is not implemented');
   }
 
   static async verify(messages: Uint8Array[], signature: Uint8Array, publicKey: Uint8Array, header?: Uint8Array): Promise<boolean> {
     const headerBytes = header ?? new Uint8Array(sha256(new Uint8Array(0)));
-    return await bbs.verifySignature({
-      ciphersuite: BbsSimple.CIPHERSUITE,
-      publicKey,
-      signature,
-      header: headerBytes,
-      messages
-    });
+    throw new Error('BbsSimple.verify is not implemented');
   }
 }
 

--- a/tests/vc/bbs.simple.test.ts
+++ b/tests/vc/bbs.simple.test.ts
@@ -2,7 +2,7 @@ import { BbsSimple } from '../../src';
 import { bls12_381 as bls } from '@noble/curves/bls12-381';
 
 describe('BbsSimple e2e', () => {
-  test('sign/verify baseline with header', async () => {
+  test('sign/verify not implemented with header', async () => {
     const sk = bls.utils.randomPrivateKey();
     const pk = bls.getPublicKey(sk);
     const keypair = { privateKey: sk, publicKey: pk };
@@ -13,17 +13,11 @@ describe('BbsSimple e2e', () => {
       new TextEncoder().encode('msg3')
     ];
 
-    const sig = await BbsSimple.sign(messages, keypair, header);
-    await expect(BbsSimple.verify(messages, sig, pk, header)).resolves.toBe(true);
-    const messages2 = [
-      new TextEncoder().encode('msg1'),
-      new TextEncoder().encode('DIFF'),
-      new TextEncoder().encode('msg3')
-    ];
-    await expect(BbsSimple.verify(messages2, sig, pk, header)).resolves.toBe(false);
+    await expect(BbsSimple.sign(messages, keypair, header)).rejects.toThrow(/not implemented/i);
+    await expect(BbsSimple.verify(messages, new Uint8Array([0]), pk, header)).rejects.toThrow(/not implemented/i);
   });
 
-  test('sign/verify baseline with default header', async () => {
+  test('sign/verify not implemented with default header', async () => {
     const sk = bls.utils.randomPrivateKey();
     const pk = bls.getPublicKey(sk);
     const keypair = { privateKey: sk, publicKey: pk };
@@ -31,8 +25,8 @@ describe('BbsSimple e2e', () => {
       new TextEncoder().encode('a'),
       new TextEncoder().encode('b')
     ];
-    const sig = await BbsSimple.sign(messages, keypair);
-    await expect(BbsSimple.verify(messages, sig, pk)).resolves.toBe(true);
+    await expect(BbsSimple.sign(messages, keypair)).rejects.toThrow(/not implemented/i);
+    await expect(BbsSimple.verify(messages, new Uint8Array([1, 2]), pk)).rejects.toThrow(/not implemented/i);
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -901,13 +901,6 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@digitalbazaar/bbs-signatures@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/@digitalbazaar/bbs-signatures/-/bbs-signatures-3.0.0.tgz"
-  integrity sha512-mQMCMnCWAraVSswJg1kJK/qmUrb3jMoWB9c8kOmztsWfnMZJcyYAcavuF8jgrVZ5cl/ZRNMK61ZbIvkqd6BE6g==
-  dependencies:
-    "@noble/curves" "^1.3.0"
-
 "@digitalbazaar/http-client@^3.4.1":
   version "3.4.1"
   resolved "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-3.4.1.tgz"
@@ -1255,7 +1248,7 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@noble/curves@^1.3.0", "@noble/curves@^1.6.0":
+"@noble/curves@^1.6.0":
   version "1.9.7"
   resolved "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz"
   integrity sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==


### PR DESCRIPTION
Remove `@digitalbazaar/bbs-signatures` dependency and mark `BbsSimple.sign`/`verify` as not implemented.

---
<a href="https://cursor.com/background-agent?bcId=bc-90a9f756-c4f8-47c0-93f1-da6633f81f5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-90a9f756-c4f8-47c0-93f1-da6633f81f5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

