### PR TITLE
Update provenance with latest transaction id

### DIFF
--- a/src/lifecycle/OriginalsAsset.ts
+++ b/src/lifecycle/OriginalsAsset.ts
@@ -8,6 +8,7 @@ import {
 export interface ProvenanceChain {
   createdAt: string;
   creator: string;
+  txid?: string;
   migrations: Array<{
     from: LayerType;
     to: LayerType;
@@ -86,6 +87,9 @@ export class OriginalsAsset {
       revealTxId: details?.revealTxId,
       feeRate: details?.feeRate
     });
+    if (details?.transactionId) {
+      this.provenance.txid = details.transactionId;
+    }
     this.currentLayer = toLayer;
   }
 
@@ -100,6 +104,7 @@ export class OriginalsAsset {
       timestamp: new Date().toISOString(),
       transactionId
     });
+    this.provenance.txid = transactionId;
   }
 
   async verify(): Promise<boolean> {


### PR DESCRIPTION
Add a top-level `txid` to asset provenance to reflect the latest on-chain transaction, satisfying integration test expectations.

---
<a href="https://cursor.com/background-agent?bcId=bc-9ab0f99a-7d11-4906-bc38-49ac7eda8bd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9ab0f99a-7d11-4906-bc38-49ac7eda8bd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

