### PR TITLE
Implement full DID key material and robust migrations

### DIFF
--- a/src/types/external-shims.d.ts
+++ b/src/types/external-shims.d.ts
@@ -14,6 +14,10 @@ declare module 'multiformats/bases/base64' {
 
 declare module 'jsonld';
 
+declare module 'didwebvh-ts' {
+  export function resolveDID(did: string): Promise<{ doc?: any } | null>;
+}
+
 // Minimal node globals for tests without @types/node
 declare const Buffer: any;
 

--- a/tests/did/DIDManager.more.test.ts
+++ b/tests/did/DIDManager.more.test.ts
@@ -34,6 +34,9 @@ describe('DIDManager additional branches', () => {
     const vm = pubDoc.verificationMethod![0];
     const doc = await dm.migrateToDIDBTCO({ '@context': ['https://www.w3.org/ns/did/v1'], id: 'did:webvh:x', verificationMethod: [vm] } as any, '456');
     expect(doc.verificationMethod?.[0].publicKeyMultibase).toBeDefined();
+    // Preserve service endpoints if provided
+    const doc2 = await dm.migrateToDIDBTCO({ '@context': ['https://www.w3.org/ns/did/v1'], id: 'did:webvh:x', verificationMethod: [vm], service: [{ id: '#s', type: 'X', serviceEndpoint: 'u' }] } as any, '789');
+    expect(doc2.service?.[0].id).toBe('#s');
   });
 });
 


### PR DESCRIPTION
Implement full DID key material for `did:peer` creation and robust migration to `did:webvh` and `did:btco`, carrying verification methods and services.

---
<a href="https://cursor.com/background-agent?bcId=bc-f7f9d105-50b6-4c3a-a66d-9ce34b1bfb62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f7f9d105-50b6-4c3a-a66d-9ce34b1bfb62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

