### PR TITLE
Implement pluggable storage and publication credentials

### DIFF
--- a/tests/integration/WebVhPublish.test.ts
+++ b/tests/integration/WebVhPublish.test.ts
@@ -23,5 +23,19 @@ describe('WebVH publish end-to-end', () => {
 
     const resolved = await sdk.did.resolveDID(webBinding!);
     expect(resolved?.id).toBe(webBinding);
+
+    // Assert resources have stable URLs
+    expect(Array.isArray(published.resources)).toBe(true);
+    for (const r of published.resources) {
+      expect(typeof r.url).toBe('string');
+      expect((r.url as string).includes('.well-known/webvh/')).toBe(true);
+    }
+
+    // Assert a publication credential was attached
+    const creds = (published as any).credentials || [];
+    expect(Array.isArray(creds)).toBe(true);
+    expect(creds.length).toBeGreaterThan(0);
+    const hasPublication = creds.some((c: any) => Array.isArray(c.type) && (c.type.includes('ResourceMigrated') || c.type.includes('ResourceCreated')));
+    expect(hasPublication).toBe(true);
   });
 });


### PR DESCRIPTION
Complete the WebVH publish flow by integrating a pluggable `StorageAdapter`, publishing resources to deterministic URLs, and attaching a signed publication credential.

---
<a href="https://cursor.com/background-agent?bcId=bc-a95dea66-f3ba-4f3a-a400-2b435ab85180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a95dea66-f3ba-4f3a-a400-2b435ab85180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

