### PR TITLE
Implement and strengthen asset verification and validation

### DIFF
--- a/src/lifecycle/OriginalsAsset.ts
+++ b/src/lifecycle/OriginalsAsset.ts
@@ -134,7 +134,8 @@ export class OriginalsAsset {
         if (typeof res.content === 'string') {
           const data = Buffer.from(res.content, 'utf8');
           const computed = hashResource(data);
-          if (computed !== res.hash) {
+          const expected = (res.hash || '').toLowerCase();
+          if (computed.toLowerCase() !== expected) {
             return false;
           }
           continue;
@@ -146,7 +147,8 @@ export class OriginalsAsset {
             const response = await deps.fetch(res.url);
             const buf = Buffer.from(await response.arrayBuffer());
             const computed = hashResource(buf);
-            if (computed !== res.hash) {
+            const expected = (res.hash || '').toLowerCase();
+            if (computed.toLowerCase() !== expected) {
               return false;
             }
           } catch {

--- a/tests/lifecycle/OriginalsAsset.test.ts
+++ b/tests/lifecycle/OriginalsAsset.test.ts
@@ -12,9 +12,10 @@ const emptyCreds: VerifiableCredential[] = [];
 const resources: AssetResource[] = [
   {
     id: 'res1',
-    type: 'image',
-    contentType: 'image/png',
-    hash: 'abc123'
+    type: 'text',
+    content: 'hello',
+    contentType: 'text/plain',
+    hash: '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'.slice(0, 64) // sha256('hello')
   }
 ];
 
@@ -42,9 +43,62 @@ describe('OriginalsAsset', () => {
     expect(prov.createdAt).toBeDefined();
   });
 
-  test('verifies asset integrity (expected to fail until implemented)', async () => {
+  test('verifies asset integrity (inline content hash match)', async () => {
     const asset = new OriginalsAsset(resources, buildDid('did:peer:xyz'), emptyCreds);
     await expect(asset.verify()).resolves.toBe(true);
+  });
+
+  test('verify returns false on invalid DID Document', async () => {
+    const badDid: any = { '@context': ['https://www.w3.org/ns/did/v1'], id: 'did:peer:abc', controller: ['not-a-did'] };
+    const asset = new OriginalsAsset(resources, badDid, emptyCreds as any);
+    await expect(asset.verify()).resolves.toBe(false);
+  });
+
+  test('verify uses injected fetch if provided for URL resources', async () => {
+    const resWithUrl: AssetResource = {
+      id: 'r2',
+      type: 'text',
+      url: 'https://example.com/x',
+      contentType: 'text/plain',
+      hash: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' // sha256 of empty
+    };
+    const asset = new OriginalsAsset([resWithUrl], buildDid('did:peer:abc'), emptyCreds);
+    const mockFetch = async () => ({ arrayBuffer: async () => new ArrayBuffer(0) }) as any;
+    await expect(asset.verify({ fetch: mockFetch })).resolves.toBe(true);
+  });
+
+  test('verify validates attached credentials structure and returns false on bad', async () => {
+    const badVc: any = { '@context': ['https://example.com'], type: ['VerifiableCredential'], issuer: 'did:peer:x', issuanceDate: new Date().toISOString(), credentialSubject: {} };
+    const asset = new OriginalsAsset(resources, buildDid('did:peer:xyz'), [badVc]);
+    await expect(asset.verify()).resolves.toBe(false);
+  });
+
+  test('verify with credentialManager performs cryptographic verification', async () => {
+    const goodVc: any = {
+      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      type: ['VerifiableCredential'],
+      issuer: 'did:peer:issuer',
+      issuanceDate: new Date().toISOString(),
+      credentialSubject: { id: 'did:peer:xyz' },
+      proof: { type: 'DataIntegrityProof', created: new Date().toISOString(), verificationMethod: 'did:peer:issuer#key', proofPurpose: 'assertionMethod', proofValue: 'zabc' }
+    };
+    const asset = new OriginalsAsset(resources, buildDid('did:peer:xyz'), [goodVc]);
+    const { CredentialManager } = await import('../../src/vc/CredentialManager');
+    const { DIDManager } = await import('../../src/did/DIDManager');
+    const didManager = new DIDManager({} as any);
+    const cm = new CredentialManager({ defaultKeyType: 'ES256K', network: 'regtest' } as any, didManager);
+    const spy = jest.spyOn(cm, 'verifyCredential').mockResolvedValue(true);
+    await expect(asset.verify({ credentialManager: cm, didManager })).resolves.toBe(true);
+    spy.mockRestore();
+  });
+
+  test('verify does not fail if fetch throws when URL present', async () => {
+    const resWithUrl: AssetResource = {
+      id: 'r3', type: 'text', url: 'https://example.com/missing', contentType: 'text/plain', hash: resources[0].hash
+    };
+    const asset = new OriginalsAsset([resWithUrl], buildDid('did:peer:abc'), emptyCreds);
+    const failingFetch = async () => { throw new Error('network'); };
+    await expect(asset.verify({ fetch: failingFetch as any })).resolves.toBe(true);
   });
 
   test('constructor throws on unknown DID method (coverage for error path)', () => {


### PR DESCRIPTION
Implement `OriginalsAsset.verify()` and strengthen validation utilities for DIDs, credentials, and DID Documents to ensure data integrity and compliance.

The `OriginalsAsset.verify()` method was a placeholder and now performs comprehensive checks including DID Document structure, resource hash verification (with optional fetch), and credential validation. The `validateDIDDocument()` and `validateCredential()` functions have been enhanced with stricter rules for context, issuer format, issuance date, controller DIDs, and multibase key presence to align with W3C specifications and improve robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-903c0491-52d3-483f-9fb4-672dccfbb4f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-903c0491-52d3-483f-9fb4-672dccfbb4f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

