### PR TITLE
Remove bitcoin mock fallback logic

### DIFF
--- a/src/bitcoin/BitcoinManager.ts
+++ b/src/bitcoin/BitcoinManager.ts
@@ -89,18 +89,12 @@ export class BitcoinManager {
     const effectiveFeeRate = await this.resolveFeeRate(1, feeRate);
 
     if (!this.ord) {
-      return {
-        satoshi: 'mock-sat',
-        inscriptionId: 'mock-inscription',
-        content: data,
-        contentType,
-        txid: 'mock-txid',
-        vout: 0,
-        // Provide deterministic defaults so tests can assert presence
-        blockHeight: undefined as any,
-        // @ts-ignore augment for tests
-        feeRate: typeof effectiveFeeRate === 'number' && Number.isFinite(effectiveFeeRate) ? effectiveFeeRate : 10
-      };
+      throw new StructuredError(
+        'ORD_PROVIDER_REQUIRED',
+        'Ordinals provider must be configured to inscribe data on Bitcoin. ' +
+        'Please provide an ordinalsProvider in your SDK configuration. ' +
+        'For testing, use OrdMockProvider from @originals/sdk/adapters/providers.'
+      );
     }
 
     if (typeof this.ord.createInscription !== 'function') {
@@ -205,13 +199,12 @@ export class BitcoinManager {
     const effectiveFeeRate = await this.resolveFeeRate(1);
 
     if (!this.ord) {
-      const value = Math.max(DUST_LIMIT_SATS, 546);
-      return {
-        txid: 'mock-transfer-txid',
-        vin: [{ txid: inscription.txid, vout: inscription.vout }],
-        vout: [{ value, scriptPubKey: 'script', address: toAddress }],
-        fee: 100
-      };
+      throw new StructuredError(
+        'ORD_PROVIDER_REQUIRED',
+        'Ordinals provider must be configured to transfer inscriptions on Bitcoin. ' +
+        'Please provide an ordinalsProvider in your SDK configuration. ' +
+        'For testing, use OrdMockProvider from @originals/sdk/adapters/providers.'
+      );
     }
 
     if (typeof this.ord.transferInscription !== 'function') {

--- a/tests/bitcoin/BitcoinManager.test.ts
+++ b/tests/bitcoin/BitcoinManager.test.ts
@@ -233,4 +233,45 @@ describe('BitcoinManager integration with providers', () => {
     const res: any = await sdk.bitcoin.inscribeData(Buffer.from('hello'), 'text/plain', 2);
     expect(res.feeRate).toBe(9);
   });
+
+  test('inscribeData throws ORD_PROVIDER_REQUIRED when provider not configured', async () => {
+    const sdk = OriginalsSDK.create({ network: 'regtest' });
+    try {
+      await sdk.bitcoin.inscribeData(Buffer.from('data'), 'text/plain');
+      throw new Error('Expected error to be thrown');
+    } catch (error: any) {
+      expect(error.code).toBe('ORD_PROVIDER_REQUIRED');
+      expect(error.message).toContain('Ordinals provider must be configured');
+    }
+  });
+
+  test('transferInscription throws ORD_PROVIDER_REQUIRED when provider not configured', async () => {
+    const sdk = OriginalsSDK.create({ network: 'regtest' });
+    const mockInscription = {
+      inscriptionId: 'test-id',
+      satoshi: 'sat-123',
+      content: Buffer.from('test'),
+      contentType: 'text/plain',
+      txid: 'tx-123',
+      vout: 0
+    };
+    try {
+      await sdk.bitcoin.transferInscription(mockInscription, 'bc1qtest');
+      throw new Error('Expected error to be thrown');
+    } catch (error: any) {
+      expect(error.code).toBe('ORD_PROVIDER_REQUIRED');
+      expect(error.message).toContain('Ordinals provider must be configured');
+    }
+  });
+
+  test('validateBitcoinConfig throws when ordinalsProvider not configured', () => {
+    const sdk = OriginalsSDK.create({ network: 'regtest' });
+    expect(() => sdk.validateBitcoinConfig()).toThrow('Bitcoin operations require an ordinalsProvider');
+  });
+
+  test('validateBitcoinConfig passes when ordinalsProvider is configured', () => {
+    const provider = createMockProvider();
+    const sdk = OriginalsSDK.create({ network: 'regtest', ordinalsProvider: provider } as any);
+    expect(() => sdk.validateBitcoinConfig()).not.toThrow();
+  });
 });

--- a/tests/integration/CompleteLifecycle.e2e.test.ts
+++ b/tests/integration/CompleteLifecycle.e2e.test.ts
@@ -278,7 +278,7 @@ describe('E2E Integration: Complete Lifecycle Flow', () => {
           id: 'resource-direct',
           type: 'data',
           contentType: 'application/json',
-          hash: 'direct123456789abcdef1234567890abcdef1234567890abcdef1234567890',
+          hash: 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
           content: '{"test": "data"}'
         }
       ];
@@ -515,11 +515,8 @@ describe('E2E Integration: Complete Lifecycle Flow', () => {
     });
 
     test('handles empty resources array', async () => {
-      const asset = await sdk.lifecycle.createAsset([]);
-      
-      expect(asset).toBeInstanceOf(OriginalsAsset);
-      expect(asset.resources).toHaveLength(0);
-      expect(asset.currentLayer).toBe('did:peer');
+      // Empty resources should throw an error per validation rules
+      await expect(sdk.lifecycle.createAsset([])).rejects.toThrow('At least one resource is required');
     });
 
     test('handles multiple resources with different content types', async () => {

--- a/tests/integration/Lifecycle.transfer.btco.integration.test.ts
+++ b/tests/integration/Lifecycle.transfer.btco.integration.test.ts
@@ -1,9 +1,11 @@
 /* istanbul ignore file */
 declare const describe: any, test: any, expect: any;
 import { OriginalsSDK, OriginalsAsset } from '../../src';
+import { MockOrdinalsProvider } from '../mocks/adapters';
 
 describe('Integration: Lifecycle.transferOwnership for did:btco', () => {
-  const sdk = OriginalsSDK.create({ network: 'regtest', bitcoinRpcUrl: 'http://ord' });
+  const provider = new MockOrdinalsProvider();
+  const sdk = OriginalsSDK.create({ network: 'regtest', bitcoinRpcUrl: 'http://ord', ordinalsProvider: provider } as any);
 
   test('returns txid and records provenance transfer', async () => {
     const asset = new OriginalsAsset(

--- a/tests/integration/LifecycleManager.test.ts
+++ b/tests/integration/LifecycleManager.test.ts
@@ -2,13 +2,15 @@
 
 /** Inlined from LifecycleManager.btco.integration.part.ts */
 import { OriginalsSDK } from '../../src';
+import { MockOrdinalsProvider } from '../mocks/adapters';
 
 // Ensure Jest types are available
 declare const expect: any;
 
 describe('Integration: Lifecycle inscribe updates provenance and btco layer', () => {
   test('provenance updated and layer becomes did:btco', async () => {
-    const sdk = OriginalsSDK.create({ network: 'regtest', bitcoinRpcUrl: 'http://ord' });
+    const provider = new MockOrdinalsProvider();
+    const sdk = OriginalsSDK.create({ network: 'regtest', bitcoinRpcUrl: 'http://ord', ordinalsProvider: provider } as any);
     const asset = await sdk.lifecycle.createAsset([
       { id: 'res1', type: 'text', contentType: 'text/plain', hash: 'deadbeef' }
     ]);

--- a/tests/lifecycle/LifecycleManager.prov.test.ts
+++ b/tests/lifecycle/LifecycleManager.prov.test.ts
@@ -1,8 +1,10 @@
 import { OriginalsSDK } from '../../src';
+import { MockOrdinalsProvider } from '../mocks/adapters';
 
 describe('LifecycleManager provenance fallback', () => {
   test('inscribeOnBitcoin initializes provenance when missing', async () => {
-    const sdk = OriginalsSDK.create({ network: 'regtest' });
+    const provider = new MockOrdinalsProvider();
+    const sdk = OriginalsSDK.create({ network: 'regtest', ordinalsProvider: provider } as any);
     const asset = await sdk.lifecycle.createAsset([{ id: 'r', type: 'text', contentType: 'text/plain', hash: 'aa' }]);
     // ensure provenance exists but is empty (migrations/transfers arrays present)
     (asset as any).provenance = { createdAt: new Date().toISOString(), creator: asset.id, migrations: [], transfers: [] };

--- a/tests/lifecycle/LifecycleManager.transfer.unit.test.ts
+++ b/tests/lifecycle/LifecycleManager.transfer.unit.test.ts
@@ -1,9 +1,11 @@
 /* istanbul ignore file */
 declare const describe: any, test: any, expect: any;
 import { OriginalsSDK, OriginalsAsset } from '../../src';
+import { MockOrdinalsProvider } from '../mocks/adapters';
 
 describe('LifecycleManager.transferOwnership unit edge cases', () => {
-  const sdk = OriginalsSDK.create({ network: 'regtest' });
+  const provider = new MockOrdinalsProvider();
+  const sdk = OriginalsSDK.create({ network: 'regtest', ordinalsProvider: provider } as any);
 
   test('throws if not on btco layer', async () => {
     const asset = new OriginalsAsset(


### PR DESCRIPTION
Remove mock/test fallback logic from BitcoinManager production code to prevent accidental use of mocks and ensure clear error handling.

This change prevents production code from returning mock data when `ordinalsProvider` is not configured, instead throwing a `StructuredError`. It also adds configuration validation in `OriginalsSDK`, updates all relevant tests to explicitly use mock providers, and enhances the `README.md` with comprehensive configuration examples.

---
<a href="https://cursor.com/background-agent?bcId=bc-80227cf4-8d40-4109-9e10-885075266ffb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-80227cf4-8d40-4109-9e10-885075266ffb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

