### PR TITLE
Implement strict satoshi identifier validation

### DIFF
--- a/src/adapters/providers/OrdMockProvider.ts
+++ b/src/adapters/providers/OrdMockProvider.ts
@@ -51,7 +51,8 @@ export class OrdMockProvider implements OrdinalsProvider {
   async createInscription(params: { data: Buffer; contentType: string; feeRate?: number; }) {
     const inscriptionId = `insc-${Math.random().toString(36).slice(2)}`;
     const txid = `tx-${Math.random().toString(36).slice(2)}`;
-    const satoshi = `sat-${Math.floor(Math.random() * 1e6)}`;
+    // Generate a valid numeric satoshi identifier (not sat-123 format)
+    const satoshi = `${Math.floor(Math.random() * 1e12)}`;
     const vout = 0;
     const record = {
       inscriptionId,

--- a/src/bitcoin/BitcoinManager.ts
+++ b/src/bitcoin/BitcoinManager.ts
@@ -317,6 +317,11 @@ export class BitcoinManager {
     if (parts.length === 3) {
       satoshi = parts[2];
     } else if (parts.length === 4) {
+      // Validate network prefix - only 'test' and 'sig' are allowed
+      const network = parts[2];
+      if (network !== 'test' && network !== 'sig') {
+        return null;
+      }
       satoshi = parts[3];
     }
     

--- a/src/did/createBtcoDidDocument.ts
+++ b/src/did/createBtcoDidDocument.ts
@@ -1,5 +1,6 @@
 import { DIDDocument, VerificationMethod } from '../types/did';
 import { multikey, MultikeyType } from '../crypto/Multikey';
+import { validateSatoshiNumber } from '../utils/satoshi-validation';
 
 export type BitcoinNetwork = 'mainnet' | 'testnet' | 'signet';
 
@@ -33,6 +34,12 @@ export function createBtcoDidDocument(
 	network: BitcoinNetwork,
 	params: CreateBtcoDidDocumentParams
 ): DIDDocument {
+	// Validate satNumber parameter at entry
+	const validation = validateSatoshiNumber(satNumber);
+	if (!validation.valid) {
+		throw new Error(`Invalid satoshi number: ${validation.error}`);
+	}
+
 	const did = `${getDidPrefix(network)}:${String(satNumber)}`;
 	const vm = buildVerificationMethod(did, params);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export { Signer, ES256KSigner, Ed25519Signer, ES256Signer, Bls12381G2Signer } fr
 
 // Utility exports
 export * from './utils/validation';
+export * from './utils/satoshi-validation';
 export * from './utils/serialization';
 export * from './utils/retry';
 export * from './utils/telemetry';

--- a/src/utils/satoshi-validation.ts
+++ b/src/utils/satoshi-validation.ts
@@ -1,0 +1,196 @@
+import { StructuredError } from './telemetry';
+
+/**
+ * Maximum number of satoshis in Bitcoin's total supply (21 million BTC)
+ * 21,000,000 BTC * 100,000,000 satoshis/BTC = 2,100,000,000,000,000 satoshis
+ */
+export const MAX_SATOSHI_SUPPLY = 2_100_000_000_000_000;
+
+/**
+ * Validation result interface for satoshi number validation
+ */
+export interface SatoshiValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+/**
+ * Validates a satoshi number for use in Bitcoin ordinals and did:btco DIDs.
+ * 
+ * @param satoshi - The satoshi identifier to validate (string or number)
+ * @returns Validation result with descriptive error if invalid
+ * 
+ * @example
+ * ```typescript
+ * const result = validateSatoshiNumber('123456');
+ * if (!result.valid) {
+ *   throw new Error(result.error);
+ * }
+ * ```
+ */
+export function validateSatoshiNumber(satoshi: string | number): SatoshiValidationResult {
+  // Check for null, undefined, or empty string
+  if (satoshi === null || satoshi === undefined || satoshi === '') {
+    return {
+      valid: false,
+      error: 'Satoshi identifier cannot be null, undefined, or empty string'
+    };
+  }
+
+  // Convert to string for validation
+  const satoshiStr = String(satoshi).trim();
+
+  // Check for empty string after trimming
+  if (satoshiStr === '') {
+    return {
+      valid: false,
+      error: 'Satoshi identifier cannot be empty or whitespace-only string'
+    };
+  }
+
+  // Check for numeric format (must be all digits, no decimals, no scientific notation)
+  if (!/^[0-9]+$/.test(satoshiStr)) {
+    return {
+      valid: false,
+      error: 'Satoshi identifier must be a non-negative integer (no decimals, no scientific notation, no non-numeric characters)'
+    };
+  }
+
+  // Convert to number for range validation
+  const satoshiNum = Number(satoshiStr);
+
+  // Check for valid number conversion
+  if (!Number.isFinite(satoshiNum)) {
+    return {
+      valid: false,
+      error: 'Satoshi identifier must be a finite number'
+    };
+  }
+
+  // Check for decimals (would be truncated by Number())
+  if (satoshiNum !== Math.floor(satoshiNum)) {
+    return {
+      valid: false,
+      error: 'Satoshi identifier cannot contain decimal places'
+    };
+  }
+
+  // Check for negative numbers
+  if (satoshiNum < 0) {
+    return {
+      valid: false,
+      error: 'Satoshi identifier must be non-negative (>= 0)'
+    };
+  }
+
+  // Check for maximum supply range
+  if (satoshiNum > MAX_SATOSHI_SUPPLY) {
+    return {
+      valid: false,
+      error: `Satoshi identifier must be within Bitcoin's total supply (0 to ${MAX_SATOSHI_SUPPLY.toLocaleString()})`
+    };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Parses a satoshi identifier from various formats and validates it.
+ * 
+ * Supported formats:
+ * - Plain satoshi number: "123456"
+ * - did:btco DID: "did:btco:123456", "did:btco:test:123456", "did:btco:sig:123456"
+ * - Ordinal notation: "123456" (same as plain number, for future extensions)
+ * 
+ * @param identifier - The identifier to parse
+ * @returns The extracted satoshi number
+ * @throws {StructuredError} If the identifier format is invalid or satoshi is invalid
+ * 
+ * @example
+ * ```typescript
+ * const satoshi = parseSatoshiIdentifier('did:btco:123456');
+ * console.log(satoshi); // 123456
+ * ```
+ */
+export function parseSatoshiIdentifier(identifier: string): number {
+  if (!identifier || typeof identifier !== 'string') {
+    throw new StructuredError(
+      'INVALID_SATOSHI_IDENTIFIER',
+      'Satoshi identifier must be a non-empty string'
+    );
+  }
+
+  const trimmed = identifier.trim();
+
+  if (trimmed === '') {
+    throw new StructuredError(
+      'INVALID_SATOSHI_IDENTIFIER',
+      'Satoshi identifier cannot be empty or whitespace-only'
+    );
+  }
+
+  let satoshiStr: string;
+
+  // Check if it's a did:btco DID
+  if (trimmed.startsWith('did:btco:')) {
+    const parts = trimmed.split(':');
+    
+    // Handle different network prefixes:
+    // did:btco:123456 (mainnet)
+    // did:btco:test:123456 (testnet)
+    // did:btco:sig:123456 (signet)
+    if (parts.length === 3) {
+      // Mainnet format: did:btco:satoshi
+      satoshiStr = parts[2];
+    } else if (parts.length === 4) {
+      // Network-specific format: did:btco:network:satoshi
+      const network = parts[2];
+      if (network !== 'test' && network !== 'sig') {
+        throw new StructuredError(
+          'INVALID_SATOSHI_IDENTIFIER',
+          `Invalid did:btco DID format: unsupported network "${network}"`
+        );
+      }
+      satoshiStr = parts[3];
+    } else {
+      throw new StructuredError(
+        'INVALID_SATOSHI_IDENTIFIER',
+        'Invalid did:btco DID format: expected "did:btco:satoshi" or "did:btco:network:satoshi"'
+      );
+    }
+  } else {
+    // Assume it's a plain satoshi number
+    satoshiStr = trimmed;
+  }
+
+  // Validate the extracted satoshi
+  const validation = validateSatoshiNumber(satoshiStr);
+  if (!validation.valid) {
+    throw new StructuredError(
+      'INVALID_SATOSHI_IDENTIFIER',
+      validation.error || 'Invalid satoshi identifier'
+    );
+  }
+
+  return Number(satoshiStr);
+}
+
+/**
+ * Validates a satoshi number and throws an error if invalid.
+ * Convenience wrapper around validateSatoshiNumber for code that expects exceptions.
+ * 
+ * @param satoshi - The satoshi identifier to validate
+ * @throws {StructuredError} If the satoshi is invalid
+ * 
+ * @example
+ * ```typescript
+ * assertValidSatoshi('123456'); // OK
+ * assertValidSatoshi(''); // throws StructuredError
+ * ```
+ */
+export function assertValidSatoshi(satoshi: string | number): void {
+  const result = validateSatoshiNumber(satoshi);
+  if (!result.valid) {
+    throw new StructuredError('INVALID_SATOSHI', result.error || 'Invalid satoshi identifier');
+  }
+}

--- a/tests/bitcoin/BitcoinManager.test.ts
+++ b/tests/bitcoin/BitcoinManager.test.ts
@@ -10,12 +10,12 @@ const createMockProvider = () => {
     async createInscription({ data, contentType, feeRate }) {
       const inscriptionId = counter === 0 ? 'insc-test' : `insc-test-${counter}`;
       counter += 1;
-      inscriptions[inscriptionId] = { satoshi: 'sat-123' };
+      inscriptions[inscriptionId] = { satoshi: '123456789' };
       return {
         inscriptionId,
         revealTxId: 'tx-reveal-1',
         commitTxId: 'tx-commit-1',
-        satoshi: 'sat-123',
+        satoshi: '123456789',
         txid: 'tx-output-1',
         vout: 1,
         blockHeight: 100,
@@ -80,7 +80,7 @@ describe('BitcoinManager integration with providers', () => {
 
     const result = await sdk.bitcoin.inscribeData(Buffer.from('hello'), 'text/plain');
     expect(result.inscriptionId).toBe('insc-test');
-    expect(result.satoshi).toBe('sat-123');
+    expect(result.satoshi).toBe('123456789');
     expect((result as any).revealTxId).toBe('tx-reveal-1');
     expect((result as any).feeRate).toBe(7);
   });
@@ -90,7 +90,7 @@ describe('BitcoinManager integration with providers', () => {
     const provider: OrdinalsProvider = {
       async createInscription({ data, contentType }) {
         const inscriptionId = 'insc-no-sat';
-        inscriptions[inscriptionId] = { satoshi: 'sat-999' };
+        inscriptions[inscriptionId] = { satoshi: '999888777' };
         return {
           inscriptionId,
           revealTxId: 'tx-reveal-2',
@@ -132,7 +132,7 @@ describe('BitcoinManager integration with providers', () => {
 
     const sdk = OriginalsSDK.create({ network: 'regtest', ordinalsProvider: provider } as any);
     const result = await sdk.bitcoin.inscribeData(Buffer.from('x'), 'text/plain');
-    expect(result.satoshi).toBe('sat-999');
+    expect(result.satoshi).toBe('999888777');
   });
 
   test('inscribeData propagates provider errors', async () => {
@@ -210,8 +210,8 @@ describe('BitcoinManager integration with providers', () => {
     const provider = createMockProvider();
     const sdk = OriginalsSDK.create({ network: 'regtest', ordinalsProvider: provider } as any);
     await sdk.bitcoin.inscribeData(Buffer.from('payload'), 'text/plain');
-    await expect(sdk.bitcoin.validateBTCODID('did:btco:sat-123')).resolves.toBe(true);
-    await expect(sdk.bitcoin.validateBTCODID('did:btco:missing')).resolves.toBe(false);
+    await expect(sdk.bitcoin.validateBTCODID('did:btco:123456789')).resolves.toBe(true);
+    await expect(sdk.bitcoin.validateBTCODID('did:btco:999999999')).resolves.toBe(false);
   });
 
   test('preventFrontRunning returns false when multiple inscriptions exist on same satoshi', async () => {
@@ -219,7 +219,7 @@ describe('BitcoinManager integration with providers', () => {
     const sdk = OriginalsSDK.create({ network: 'regtest', ordinalsProvider: provider } as any);
     await sdk.bitcoin.inscribeData(Buffer.from('payload1'), 'text/plain');
     await sdk.bitcoin.inscribeData(Buffer.from('payload2'), 'text/plain');
-    const canProceed = await sdk.bitcoin.preventFrontRunning('sat-123');
+    const canProceed = await sdk.bitcoin.preventFrontRunning('123456789');
     expect(canProceed).toBe(false);
   });
 

--- a/tests/bitcoin/BitcoinManager.test.ts
+++ b/tests/bitcoin/BitcoinManager.test.ts
@@ -214,6 +214,21 @@ describe('BitcoinManager integration with providers', () => {
     await expect(sdk.bitcoin.validateBTCODID('did:btco:999999999')).resolves.toBe(false);
   });
 
+  test('validateBTCODID rejects invalid network prefixes', async () => {
+    const provider = createMockProvider();
+    const sdk = OriginalsSDK.create({ network: 'regtest', ordinalsProvider: provider } as any);
+    await sdk.bitcoin.inscribeData(Buffer.from('payload'), 'text/plain');
+    
+    // Valid networks should work
+    await expect(sdk.bitcoin.validateBTCODID('did:btco:test:123456789')).resolves.toBe(true);
+    await expect(sdk.bitcoin.validateBTCODID('did:btco:sig:123456789')).resolves.toBe(true);
+    
+    // Invalid network prefix should be rejected
+    await expect(sdk.bitcoin.validateBTCODID('did:btco:invalid:123456789')).resolves.toBe(false);
+    await expect(sdk.bitcoin.validateBTCODID('did:btco:mainnet:123456789')).resolves.toBe(false);
+    await expect(sdk.bitcoin.validateBTCODID('did:btco:regtest:123456789')).resolves.toBe(false);
+  });
+
   test('preventFrontRunning returns false when multiple inscriptions exist on same satoshi', async () => {
     const provider = createMockProvider();
     const sdk = OriginalsSDK.create({ network: 'regtest', ordinalsProvider: provider } as any);

--- a/tests/utils/satoshi-validation.test.ts
+++ b/tests/utils/satoshi-validation.test.ts
@@ -1,0 +1,323 @@
+import { 
+  validateSatoshiNumber, 
+  parseSatoshiIdentifier, 
+  assertValidSatoshi,
+  MAX_SATOSHI_SUPPLY 
+} from '../../src/utils/satoshi-validation';
+import { StructuredError } from '../../src/utils/telemetry';
+
+describe('satoshi-validation', () => {
+  describe('validateSatoshiNumber', () => {
+    describe('valid satoshi numbers', () => {
+      test('accepts zero', () => {
+        const result = validateSatoshiNumber(0);
+        expect(result.valid).toBe(true);
+        expect(result.error).toBeUndefined();
+      });
+
+      test('accepts one', () => {
+        const result = validateSatoshiNumber(1);
+        expect(result.valid).toBe(true);
+        expect(result.error).toBeUndefined();
+      });
+
+      test('accepts valid positive number', () => {
+        const result = validateSatoshiNumber(123456789);
+        expect(result.valid).toBe(true);
+        expect(result.error).toBeUndefined();
+      });
+
+      test('accepts string representation of valid number', () => {
+        const result = validateSatoshiNumber('123456789');
+        expect(result.valid).toBe(true);
+        expect(result.error).toBeUndefined();
+      });
+
+      test('accepts maximum supply', () => {
+        const result = validateSatoshiNumber(MAX_SATOSHI_SUPPLY);
+        expect(result.valid).toBe(true);
+        expect(result.error).toBeUndefined();
+      });
+
+      test('accepts maximum supply as string', () => {
+        const result = validateSatoshiNumber(String(MAX_SATOSHI_SUPPLY));
+        expect(result.valid).toBe(true);
+        expect(result.error).toBeUndefined();
+      });
+
+      test('accepts large valid ordinal number', () => {
+        const result = validateSatoshiNumber('1066296127976657');
+        expect(result.valid).toBe(true);
+        expect(result.error).toBeUndefined();
+      });
+    });
+
+    describe('invalid formats', () => {
+      test('rejects null', () => {
+        const result = validateSatoshiNumber(null as any);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('cannot be null, undefined, or empty string');
+      });
+
+      test('rejects undefined', () => {
+        const result = validateSatoshiNumber(undefined as any);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('cannot be null, undefined, or empty string');
+      });
+
+      test('rejects empty string', () => {
+        const result = validateSatoshiNumber('');
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('cannot be null, undefined, or empty string');
+      });
+
+      test('rejects whitespace-only string', () => {
+        const result = validateSatoshiNumber('   ');
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('cannot be empty or whitespace-only string');
+      });
+
+      test('rejects negative number', () => {
+        const result = validateSatoshiNumber(-1);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('non-negative integer');
+      });
+
+      test('rejects negative string', () => {
+        const result = validateSatoshiNumber('-123');
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('non-negative integer');
+      });
+
+      test('rejects decimal number', () => {
+        const result = validateSatoshiNumber(123.456);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('non-negative integer');
+      });
+
+      test('rejects decimal string', () => {
+        const result = validateSatoshiNumber('123.456');
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('non-negative integer');
+      });
+
+      test('rejects scientific notation', () => {
+        const result = validateSatoshiNumber('1e5');
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('non-negative integer');
+      });
+
+      test('rejects non-numeric string', () => {
+        const result = validateSatoshiNumber('abc');
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('non-negative integer');
+      });
+
+      test('rejects alphanumeric string', () => {
+        const result = validateSatoshiNumber('123abc');
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('non-negative integer');
+      });
+
+      test('rejects string with spaces', () => {
+        const result = validateSatoshiNumber('123 456');
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('non-negative integer');
+      });
+
+      test('rejects infinity', () => {
+        const result = validateSatoshiNumber(Infinity);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('non-negative integer');
+      });
+
+      test('rejects NaN', () => {
+        const result = validateSatoshiNumber(NaN);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('non-negative integer');
+      });
+    });
+
+    describe('range validation', () => {
+      test('rejects value exceeding maximum supply', () => {
+        const result = validateSatoshiNumber(MAX_SATOSHI_SUPPLY + 1);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain("within Bitcoin's total supply");
+      });
+
+      test('rejects extremely large value', () => {
+        const result = validateSatoshiNumber('999999999999999999');
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain("within Bitcoin's total supply");
+      });
+
+      test('accepts value at boundary', () => {
+        const result = validateSatoshiNumber(MAX_SATOSHI_SUPPLY);
+        expect(result.valid).toBe(true);
+      });
+
+      test('accepts value just below boundary', () => {
+        const result = validateSatoshiNumber(MAX_SATOSHI_SUPPLY - 1);
+        expect(result.valid).toBe(true);
+      });
+    });
+  });
+
+  describe('parseSatoshiIdentifier', () => {
+    describe('plain satoshi numbers', () => {
+      test('parses valid plain number string', () => {
+        const result = parseSatoshiIdentifier('123456');
+        expect(result).toBe(123456);
+      });
+
+      test('parses zero', () => {
+        const result = parseSatoshiIdentifier('0');
+        expect(result).toBe(0);
+      });
+
+      test('parses large ordinal', () => {
+        const result = parseSatoshiIdentifier('1066296127976657');
+        expect(result).toBe(1066296127976657);
+      });
+    });
+
+    describe('did:btco DIDs', () => {
+      test('extracts satoshi from mainnet DID', () => {
+        const result = parseSatoshiIdentifier('did:btco:123456');
+        expect(result).toBe(123456);
+      });
+
+      test('extracts satoshi from testnet DID', () => {
+        const result = parseSatoshiIdentifier('did:btco:test:123456');
+        expect(result).toBe(123456);
+      });
+
+      test('extracts satoshi from signet DID', () => {
+        const result = parseSatoshiIdentifier('did:btco:sig:789012');
+        expect(result).toBe(789012);
+      });
+
+      test('extracts large ordinal from DID', () => {
+        const result = parseSatoshiIdentifier('did:btco:1066296127976657');
+        expect(result).toBe(1066296127976657);
+      });
+
+      test('handles whitespace around DID', () => {
+        const result = parseSatoshiIdentifier('  did:btco:123456  ');
+        expect(result).toBe(123456);
+      });
+    });
+
+    describe('error handling', () => {
+      test('throws on empty string', () => {
+        expect(() => parseSatoshiIdentifier('')).toThrow(StructuredError);
+        expect(() => parseSatoshiIdentifier('')).toThrow('non-empty string');
+      });
+
+      test('throws on whitespace-only string', () => {
+        expect(() => parseSatoshiIdentifier('   ')).toThrow(StructuredError);
+        expect(() => parseSatoshiIdentifier('   ')).toThrow('cannot be empty');
+      });
+
+      test('throws on null', () => {
+        expect(() => parseSatoshiIdentifier(null as any)).toThrow(StructuredError);
+        expect(() => parseSatoshiIdentifier(null as any)).toThrow('must be a non-empty string');
+      });
+
+      test('throws on invalid satoshi in DID', () => {
+        expect(() => parseSatoshiIdentifier('did:btco:-123')).toThrow(StructuredError);
+        expect(() => parseSatoshiIdentifier('did:btco:-123')).toThrow('non-negative integer');
+      });
+
+      test('throws on invalid satoshi format', () => {
+        expect(() => parseSatoshiIdentifier('abc')).toThrow(StructuredError);
+        expect(() => parseSatoshiIdentifier('abc')).toThrow('non-negative integer');
+      });
+
+      test('throws on decimal satoshi', () => {
+        expect(() => parseSatoshiIdentifier('123.456')).toThrow(StructuredError);
+        expect(() => parseSatoshiIdentifier('123.456')).toThrow('non-negative integer');
+      });
+
+      test('throws on satoshi exceeding max supply', () => {
+        const tooLarge = String(MAX_SATOSHI_SUPPLY + 1);
+        expect(() => parseSatoshiIdentifier(tooLarge)).toThrow(StructuredError);
+        expect(() => parseSatoshiIdentifier(tooLarge)).toThrow("within Bitcoin's total supply");
+      });
+
+      test('throws on invalid did:btco format with too few parts', () => {
+        expect(() => parseSatoshiIdentifier('did:btco')).toThrow(StructuredError);
+        expect(() => parseSatoshiIdentifier('did:btco')).toThrow('non-negative integer');
+      });
+
+      test('throws on invalid did:btco format with too many parts', () => {
+        expect(() => parseSatoshiIdentifier('did:btco:test:123:extra')).toThrow(StructuredError);
+        expect(() => parseSatoshiIdentifier('did:btco:test:123:extra')).toThrow('Invalid did:btco DID format');
+      });
+
+      test('throws on invalid network in did:btco', () => {
+        expect(() => parseSatoshiIdentifier('did:btco:invalid:123')).toThrow(StructuredError);
+        expect(() => parseSatoshiIdentifier('did:btco:invalid:123')).toThrow('unsupported network');
+      });
+    });
+
+    describe('validation integration', () => {
+      test('validates extracted satoshi', () => {
+        expect(() => parseSatoshiIdentifier('did:btco:test:-1')).toThrow();
+        expect(() => parseSatoshiIdentifier('did:btco:abc')).toThrow();
+      });
+    });
+  });
+
+  describe('assertValidSatoshi', () => {
+    test('does not throw for valid satoshi', () => {
+      expect(() => assertValidSatoshi(123456)).not.toThrow();
+      expect(() => assertValidSatoshi('123456')).not.toThrow();
+      expect(() => assertValidSatoshi(0)).not.toThrow();
+    });
+
+    test('throws StructuredError for invalid satoshi', () => {
+      expect(() => assertValidSatoshi('')).toThrow(StructuredError);
+      expect(() => assertValidSatoshi(-1)).toThrow(StructuredError);
+      expect(() => assertValidSatoshi('abc')).toThrow(StructuredError);
+    });
+
+    test('throws with error code INVALID_SATOSHI', () => {
+      try {
+        assertValidSatoshi('');
+        fail('Should have thrown');
+      } catch (error: any) {
+        expect(error).toBeInstanceOf(StructuredError);
+        expect(error.code).toBe('INVALID_SATOSHI');
+      }
+    });
+
+    test('includes descriptive error message', () => {
+      try {
+        assertValidSatoshi('');
+        fail('Should have thrown');
+      } catch (error: any) {
+        expect(error.message).toContain('cannot be null, undefined, or empty string');
+      }
+    });
+  });
+
+  describe('edge cases', () => {
+    test('handles zero correctly', () => {
+      expect(validateSatoshiNumber(0).valid).toBe(true);
+      expect(validateSatoshiNumber('0').valid).toBe(true);
+      expect(parseSatoshiIdentifier('0')).toBe(0);
+    });
+
+    test('handles very long valid number string', () => {
+      const longValid = '100000000000000';
+      expect(validateSatoshiNumber(longValid).valid).toBe(true);
+      expect(parseSatoshiIdentifier(longValid)).toBe(100000000000000);
+    });
+
+    test('trims whitespace from input', () => {
+      expect(validateSatoshiNumber('  123  ').valid).toBe(true);
+      expect(parseSatoshiIdentifier('  123  ')).toBe(123);
+    });
+  });
+});

--- a/tests/utils/satoshi-validation.test.ts
+++ b/tests/utils/satoshi-validation.test.ts
@@ -259,6 +259,17 @@ describe('satoshi-validation', () => {
         expect(() => parseSatoshiIdentifier('did:btco:invalid:123')).toThrow(StructuredError);
         expect(() => parseSatoshiIdentifier('did:btco:invalid:123')).toThrow('unsupported network');
       });
+
+      test('throws on mainnet prefix in 4-part format', () => {
+        // mainnet should use 3-part format (did:btco:123), not 4-part (did:btco:mainnet:123)
+        expect(() => parseSatoshiIdentifier('did:btco:mainnet:123')).toThrow(StructuredError);
+        expect(() => parseSatoshiIdentifier('did:btco:mainnet:123')).toThrow('unsupported network');
+      });
+
+      test('throws on regtest prefix', () => {
+        expect(() => parseSatoshiIdentifier('did:btco:regtest:123')).toThrow(StructuredError);
+        expect(() => parseSatoshiIdentifier('did:btco:regtest:123')).toThrow('unsupported network');
+      });
     });
 
     describe('validation integration', () => {


### PR DESCRIPTION
Implement strict validation for satoshi identifiers to prevent the creation of invalid `did:btco` DIDs and protocol breakage.

---
<a href="https://cursor.com/background-agent?bcId=bc-f87580e9-2034-4618-b900-3c31a269a1ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f87580e9-2034-4618-b900-3c31a269a1ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

