### PR TITLE
Update user identification to did:webvh

### DIFF
--- a/apps/originals-explorer/server/__tests__/did-service.test.ts
+++ b/apps/originals-explorer/server/__tests__/did-service.test.ts
@@ -52,7 +52,7 @@ describe('DID Service', () => {
         .mockResolvedValueOnce(mockStellarWallet1)
         .mockResolvedValueOnce(mockStellarWallet2);
 
-      const userId = 'did:privy:cltest123456';
+      const userId = 'cltest123456';
       const result = await createUserDID(userId, mockPrivyClient);
 
       // Verify all three wallets were created
@@ -114,10 +114,10 @@ describe('DID Service', () => {
 
       mockPrivyClient.walletApi.createWallet.mockResolvedValue(mockWallet);
 
-      const userId = 'did:privy:cl_test@user#123';
+      const userId = 'cl_test@user#123';
       const result = await createUserDID(userId, mockPrivyClient);
 
-      // Should remove "did:privy:" prefix and sanitize special chars
+      // Should sanitize special chars
       // Domain with port should be URL-encoded
       expect(result.did).toMatch(/^did:webvh:localhost%3A5000:cl-test-user-123$/);
     });

--- a/apps/originals-explorer/server/__tests__/didwebvh-service.test.ts
+++ b/apps/originals-explorer/server/__tests__/didwebvh-service.test.ts
@@ -29,10 +29,10 @@ const mockPrivyClient = {
 describe("DID:WebVH Service", () => {
   describe("createUserDIDWebVH", () => {
     test("creates did:webvh with correct format", async () => {
-      const userId = "did:privy:cltest123";
+      const userId = "cltest123";
       const result = await createUserDIDWebVH(userId, mockPrivyClient, "localhost:5000");
 
-      expect(result.did).toBe("did:webvh:localhost%3A5000:p-cltest123");
+      expect(result.did).toBe("did:webvh:localhost%3A5000:cltest123");
       expect(result.didDocument).toBeDefined();
       expect(result.didDocument.id).toBe(result.did);
       expect(result.authWalletId).toBe("btc-wallet-1");
@@ -41,7 +41,7 @@ describe("DID:WebVH Service", () => {
     });
 
     test("creates did:webvh with proper DID document structure", async () => {
-      const userId = "did:privy:cltest123";
+      const userId = "cltest123";
       const result = await createUserDIDWebVH(userId, mockPrivyClient, "example.com");
 
       expect(result.didDocument["@context"]).toContain("https://www.w3.org/ns/did/v1");
@@ -52,7 +52,7 @@ describe("DID:WebVH Service", () => {
     });
 
     test("creates stable slug from user ID", async () => {
-      const userId = "did:privy:cltest123";
+      const userId = "cltest123";
       const result1 = await createUserDIDWebVH(userId, mockPrivyClient);
       const result2 = await createUserDIDWebVH(userId, mockPrivyClient);
 
@@ -60,15 +60,15 @@ describe("DID:WebVH Service", () => {
       const slug2 = getUserSlugFromDID(result2.did);
 
       expect(slug1).toBe(slug2);
-      expect(slug1).toBe("p-cltest123");
+      expect(slug1).toBe("cltest123");
     });
 
     test("handles special characters in user ID", async () => {
-      const userId = "did:privy:cl_test@user#123";
+      const userId = "cl_test@user#123";
       const result = await createUserDIDWebVH(userId, mockPrivyClient);
 
       const slug = getUserSlugFromDID(result.did);
-      expect(slug).toBe("p-cl-test-user-123"); // Special chars replaced with hyphens
+      expect(slug).toBe("cl-test-user-123"); // Special chars replaced with hyphens
       expect(result.did).toMatch(/^did:webvh:/);
     });
 
@@ -87,12 +87,12 @@ describe("DID:WebVH Service", () => {
 
   describe("getUserSlugFromDID", () => {
     test("extracts slug from did:webvh", () => {
-      const slug = getUserSlugFromDID("did:webvh:localhost%3A5000:p-abc123");
-      expect(slug).toBe("p-abc123");
+      const slug = getUserSlugFromDID("did:webvh:localhost%3A5000:abc123");
+      expect(slug).toBe("abc123");
     });
 
     test("returns null for invalid DID format", () => {
-      const slug = getUserSlugFromDID("did:privy:abc123");
+      const slug = getUserSlugFromDID("invalid:format:abc123");
       expect(slug).toBeNull();
     });
 
@@ -144,7 +144,7 @@ describe("DID:WebVH Service", () => {
 
   describe("Idempotency", () => {
     test("generates same slug for same user ID", async () => {
-      const userId = "did:privy:cltest123";
+      const userId = "cltest123";
 
       const result1 = await createUserDIDWebVH(userId, mockPrivyClient);
       const result2 = await createUserDIDWebVH(userId, mockPrivyClient);

--- a/apps/originals-explorer/server/did-service.ts
+++ b/apps/originals-explorer/server/did-service.ts
@@ -15,15 +15,12 @@ export interface DIDCreationResult {
 
 /**
  * Generate a sanitized user slug from Privy user ID
- * @param privyUserId - The Privy user ID (e.g., "did:privy:...")
+ * @param privyUserId - The Privy user ID (e.g., "cltest123456")
  * @returns Sanitized slug for use in did:webvh
  */
 function generateUserSlug(privyUserId: string): string {
-  // Strip "did:privy:" prefix if present
-  let slug = privyUserId.replace(/^did:privy:/, '');
-  
   // Convert to lowercase and replace invalid characters with hyphens
-  slug = slug.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+  let slug = privyUserId.toLowerCase().replace(/[^a-z0-9-]/g, '-');
   
   // Remove consecutive hyphens and trim
   slug = slug.replace(/-+/g, '-').replace(/^-|-$/g, '');

--- a/apps/originals-explorer/server/didwebvh-service.ts
+++ b/apps/originals-explorer/server/didwebvh-service.ts
@@ -17,19 +17,15 @@ export interface DIDWebVHCreationResult {
 
 /**
  * Generate a sanitized user slug from Privy user ID
- * @param privyUserId - The Privy user ID (e.g., "did:privy:123456")
- * @returns Sanitized slug for use in did:webvh (e.g., "p-123456")
+ * @param privyUserId - The Privy user ID (e.g., "cltest123456")
+ * @returns Sanitized slug for use in did:webvh (e.g., "cltest123456" or sanitized version)
  */
 function generateUserSlug(privyUserId: string): string {
-  // Extract the ID part from did:privy:123456
-  // If it's already just an ID, use it as-is
-  const id = privyUserId.replace(/^did:privy:/, '');
-  
   // Sanitize: lowercase and replace any non-alphanumeric with hyphens
-  const sanitized = id.toLowerCase().replace(/[^a-z0-9]/g, '-');
+  const sanitized = privyUserId.toLowerCase().replace(/[^a-z0-9-]/g, '-');
   
-  // Prefix with 'p-' to indicate Privy origin
-  return `p-${sanitized}`;
+  // Remove consecutive hyphens and trim
+  return sanitized.replace(/-+/g, '-').replace(/^-|-$/g, '');
 }
 
 /**


### PR DESCRIPTION
Correct `did:webvh` slug generation by removing incorrect `did:privy:` prefix stripping and `p-` prefixing from Privy user IDs.

The previous implementation incorrectly assumed Privy user IDs were DIDs (e.g., `did:privy:cltest123`) and attempted to strip a `did:privy:` prefix. It also added an unnecessary `p-` prefix to the generated `did:webvh` slugs. Privy user IDs are plain identifiers (e.g., `cltest123`), so this change ensures slugs are generated directly from the Privy ID without these erroneous transformations, resulting in cleaner and more accurate `did:webvh` identifiers.

---
<a href="https://cursor.com/background-agent?bcId=bc-f15606b8-c8f5-4882-8705-1fbc3bddd07b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f15606b8-c8f5-4882-8705-1fbc3bddd07b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More consistent user ID and DID formatting: inputs no longer require a specific prefix, special characters are sanitized, and redundant prefixes are removed for cleaner slugs.
- Bug Fixes
  - Improved handling of special characters and consecutive hyphens in generated identifiers.
- Documentation
  - Updated inline examples to reflect the new identifier format.
- Tests
  - Adjusted test cases to match the updated slug and DID generation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->