### PR TITLE
Migrate from server-auth to node library

### DIFF
--- a/apps/originals-explorer/package.json
+++ b/apps/originals-explorer/package.json
@@ -18,7 +18,7 @@
     "@neondatabase/serverless": "^0.10.4",
     "@originals/sdk": "file:../..",
     "@privy-io/react-auth": "^2.24.0",
-    "@privy-io/server-auth": "^1.32.2",
+    "@privy-io/node": "^0.2.0",
     "@radix-ui/react-accordion": "^1.2.4",
     "@radix-ui/react-alert-dialog": "^1.1.7",
     "@radix-ui/react-aspect-ratio": "^1.1.3",

--- a/apps/originals-explorer/server/did-webvh-service.ts
+++ b/apps/originals-explorer/server/did-webvh-service.ts
@@ -1,4 +1,4 @@
-import { PrivyClient } from "@privy-io/server-auth";
+import { PrivyClient } from "@privy-io/node";
 import { convertToMultibase, extractPublicKeyFromWallet } from "./key-utils";
 import { resolveDID } from "didwebvh-ts";
 import { originalsSdk } from "./originals";

--- a/apps/originals-explorer/server/privy-signer.ts
+++ b/apps/originals-explorer/server/privy-signer.ts
@@ -5,7 +5,7 @@
  * keys while maintaining compatibility with the didwebvh-ts library.
  */
 
-import { PrivyClient } from "@privy-io/server-auth";
+import { PrivyClient } from "@privy-io/node";
 import { ExternalSigner, ExternalVerifier } from "@originals/sdk";
 import { multikey } from "@originals/sdk";
 import { extractPublicKeyFromWallet, convertToMultibase } from "./key-utils";

--- a/apps/originals-explorer/server/routes.ts
+++ b/apps/originals-explorer/server/routes.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import QRCode from "qrcode";
 import crypto from "crypto";
 import { OAuth2Client } from "google-auth-library";
-import { PrivyClient } from "@privy-io/server-auth";
+import { PrivyClient } from "@privy-io/node";
 import { originalsSdk } from "./originals";
 import { createUserDIDWebVH } from "./did-webvh-service";
 import multer from "multer";

--- a/apps/originals-explorer/server/signing-service.ts
+++ b/apps/originals-explorer/server/signing-service.ts
@@ -1,4 +1,4 @@
-import { PrivyClient } from "@privy-io/server-auth";
+import { PrivyClient } from "@privy-io/node";
 import { storage } from "./storage";
 
 export type KeyPurpose = 'authentication' | 'assertion' | 'update';


### PR DESCRIPTION
Migrate from the deprecated `@privy-io/server-auth` library to `@privy-io/node` for updated features and support.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc222a33-0f9e-4292-b411-683b71e3070b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bc222a33-0f9e-4292-b411-683b71e3070b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

