### PR TITLE
Implement enhanced logging and telemetry

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,950 @@
+# Logging and Telemetry Guide
+
+Complete guide to logging, metrics, and telemetry in the Originals SDK.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Quick Start](#quick-start)
+- [Configuration](#configuration)
+- [Logger](#logger)
+- [Metrics](#metrics)
+- [Event Integration](#event-integration)
+- [Best Practices](#best-practices)
+- [Export Formats](#export-formats)
+- [Performance](#performance)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+The Originals SDK provides a comprehensive logging and telemetry system that helps you:
+
+- **Monitor operations** - Track all asset lifecycle operations
+- **Debug issues** - Detailed structured logs with context
+- **Measure performance** - Built-in timing and metrics
+- **Production observability** - Export metrics to monitoring systems
+- **Track errors** - Error codes and error rates
+
+### Key Features
+
+✅ **Structured Logging** - JSON-friendly log entries with context  
+✅ **Multiple Log Levels** - debug, info, warn, error  
+✅ **Child Loggers** - Hierarchical context (e.g., SDK:Lifecycle:CreateAsset)  
+✅ **Performance Timing** - Automatic operation duration tracking  
+✅ **Metrics Collection** - Count operations, track performance, error rates  
+✅ **Event Integration** - Automatic logging of lifecycle events  
+✅ **Multiple Outputs** - Console, file, custom destinations  
+✅ **Data Sanitization** - Automatically redact sensitive data  
+✅ **Export Formats** - JSON and Prometheus formats  
+
+---
+
+## Quick Start
+
+### Basic Configuration
+
+```typescript
+import { OriginalsSDK } from '@originals/sdk';
+
+const sdk = OriginalsSDK.create({
+  network: 'mainnet',
+  defaultKeyType: 'ES256K',
+  logging: {
+    level: 'info',
+    sanitizeLogs: true
+  },
+  metrics: {
+    enabled: true
+  }
+});
+
+// Logger is available on sdk.logger
+sdk.logger.info('SDK initialized');
+
+// Metrics are available on sdk.metrics
+const metrics = sdk.metrics.getMetrics();
+console.log('Assets created:', metrics.assetsCreated);
+```
+
+### Enable Debug Logging
+
+```typescript
+const sdk = OriginalsSDK.create({
+  network: 'mainnet',
+  defaultKeyType: 'ES256K',
+  logging: {
+    level: 'debug' // Enable debug logs
+  }
+});
+```
+
+---
+
+## Configuration
+
+### Logging Configuration
+
+```typescript
+interface LoggingConfig {
+  level?: 'debug' | 'info' | 'warn' | 'error';
+  outputs?: LogOutput[];
+  includeTimestamps?: boolean;
+  includeContext?: boolean;
+  eventLogging?: EventLoggingConfig;
+  sanitizeLogs?: boolean;
+}
+```
+
+**Options:**
+
+- **`level`** - Minimum log level to output (default: `'info'`)
+- **`outputs`** - Array of log output destinations (default: console)
+- **`includeTimestamps`** - Include ISO timestamps in logs (default: `true`)
+- **`includeContext`** - Include logger context in logs (default: `true`)
+- **`eventLogging`** - Configure event logging levels
+- **`sanitizeLogs`** - Redact sensitive data like private keys (default: `true`)
+
+### Metrics Configuration
+
+```typescript
+interface MetricsConfig {
+  enabled?: boolean;
+  exportFormat?: 'json' | 'prometheus';
+  collectCache?: boolean;
+}
+```
+
+**Options:**
+
+- **`enabled`** - Enable metrics collection (default: `true`)
+- **`exportFormat`** - Default export format (default: `'json'`)
+- **`collectCache`** - Track cache hit/miss rates (default: `false`)
+
+### Complete Configuration Example
+
+```typescript
+import { ConsoleLogOutput, FileLogOutput } from '@originals/sdk';
+
+const sdk = OriginalsSDK.create({
+  network: 'mainnet',
+  defaultKeyType: 'ES256K',
+  logging: {
+    level: 'debug',
+    outputs: [
+      new ConsoleLogOutput(),
+      new FileLogOutput('./logs/sdk.log')
+    ],
+    includeTimestamps: true,
+    includeContext: true,
+    sanitizeLogs: true,
+    eventLogging: {
+      'asset:created': 'info',
+      'asset:migrated': 'info',
+      'asset:transferred': 'info',
+      'resource:published': 'debug',
+      'credential:issued': 'debug'
+    }
+  },
+  metrics: {
+    enabled: true,
+    exportFormat: 'prometheus'
+  }
+});
+```
+
+---
+
+## Logger
+
+### Basic Usage
+
+```typescript
+const sdk = OriginalsSDK.create({ /* config */ });
+
+// Log at different levels
+sdk.logger.debug('Debug information', { detail: 'value' });
+sdk.logger.info('Operation successful');
+sdk.logger.warn('Warning: rate limit approaching');
+sdk.logger.error('Operation failed', error, { context: 'data' });
+```
+
+### Log Levels
+
+Logs are filtered based on the configured minimum level:
+
+| Level | Priority | When to Use |
+|-------|----------|-------------|
+| `debug` | 0 | Detailed diagnostic information |
+| `info` | 1 | General informational messages |
+| `warn` | 2 | Warning messages, potential issues |
+| `error` | 3 | Error messages, operation failures |
+
+**Example:**
+
+```typescript
+// With level: 'info'
+sdk.logger.debug('Not shown'); // Filtered out
+sdk.logger.info('Shown');      // ✓
+sdk.logger.warn('Shown');      // ✓
+sdk.logger.error('Shown');     // ✓
+```
+
+### Child Loggers
+
+Create child loggers for hierarchical context:
+
+```typescript
+const lifecycleLogger = sdk.logger.child('Lifecycle');
+lifecycleLogger.info('Processing asset'); 
+// Context: "SDK:Lifecycle"
+
+const operationLogger = lifecycleLogger.child('CreateAsset');
+operationLogger.info('Creating asset');
+// Context: "SDK:Lifecycle:CreateAsset"
+```
+
+### Performance Timing
+
+Track operation duration automatically:
+
+```typescript
+async function performOperation() {
+  const stopTimer = sdk.logger.startTimer('myOperation');
+  
+  try {
+    // ... perform work ...
+    await doSomething();
+    
+    stopTimer(); // Logs: "myOperation completed (123.45ms)"
+  } catch (error) {
+    stopTimer(); // Still logs duration even on error
+    throw error;
+  }
+}
+```
+
+### Custom Log Outputs
+
+#### Console Output (Default)
+
+```typescript
+import { ConsoleLogOutput } from '@originals/sdk';
+
+const consoleOutput = new ConsoleLogOutput();
+```
+
+#### File Output
+
+```typescript
+import { FileLogOutput } from '@originals/sdk';
+
+const fileOutput = new FileLogOutput('./logs/app.log');
+```
+
+#### Custom Output
+
+```typescript
+import type { LogOutput, LogEntry } from '@originals/sdk';
+
+class CustomOutput implements LogOutput {
+  async write(entry: LogEntry): Promise<void> {
+    // Send to external service
+    await fetch('https://logs.example.com', {
+      method: 'POST',
+      body: JSON.stringify(entry)
+    });
+  }
+}
+
+const sdk = OriginalsSDK.create({
+  network: 'mainnet',
+  defaultKeyType: 'ES256K',
+  logging: {
+    outputs: [new CustomOutput()]
+  }
+});
+```
+
+#### Multiple Outputs
+
+```typescript
+sdk.logger.addOutput(new FileLogOutput('./logs/debug.log'));
+sdk.logger.addOutput(new CustomOutput());
+```
+
+### Data Sanitization
+
+Automatically redacts sensitive information:
+
+```typescript
+sdk.logger.info('User operation', {
+  username: 'alice',
+  privateKey: 'z6Mk...', // Will be [REDACTED]
+  operation: 'transfer'
+});
+
+// Logged as:
+// {
+//   username: 'alice',
+//   privateKey: '[REDACTED]',
+//   operation: 'transfer'
+// }
+```
+
+**Sanitized keys:**
+- `privateKey`, `private_key`
+- `secret`, `secretKey`
+- `password`, `pwd`
+- `token`, `accessToken`
+- `credential`, `credentials`
+- Any key containing "key", "secret", "password", "token", "credential"
+
+**Disable sanitization:**
+
+```typescript
+const sdk = OriginalsSDK.create({
+  network: 'mainnet',
+  defaultKeyType: 'ES256K',
+  logging: {
+    sanitizeLogs: false // Disable for development only!
+  }
+});
+```
+
+---
+
+## Metrics
+
+### Available Metrics
+
+The SDK tracks comprehensive metrics automatically:
+
+```typescript
+interface Metrics {
+  // Asset operations
+  assetsCreated: number;
+  assetsMigrated: Record<string, number>; // by layer transition
+  assetsTransferred: number;
+  
+  // Operation performance
+  operationTimes: Record<string, OperationMetrics>;
+  
+  // Error tracking
+  errors: Record<string, number>; // by error code
+  
+  // Cache statistics (optional)
+  cacheStats?: {
+    hits: number;
+    misses: number;
+    hitRate: number;
+  };
+  
+  // System metrics
+  startTime: string;
+  uptime: number; // milliseconds
+}
+```
+
+### Reading Metrics
+
+```typescript
+// Get complete metrics snapshot
+const metrics = sdk.metrics.getMetrics();
+
+console.log('Assets created:', metrics.assetsCreated);
+console.log('Migrations:', metrics.assetsMigrated);
+console.log('Errors:', metrics.errors);
+
+// Get specific operation metrics
+const createMetrics = sdk.metrics.getOperationMetrics('createAsset');
+console.log('Average duration:', createMetrics.avgTime, 'ms');
+console.log('Error rate:', createMetrics.errorCount / createMetrics.count);
+```
+
+### Operation Metrics
+
+Each operation tracks detailed statistics:
+
+```typescript
+interface OperationMetrics {
+  count: number;        // Total operations
+  totalTime: number;    // Total time (ms)
+  avgTime: number;      // Average time (ms)
+  minTime: number;      // Minimum time (ms)
+  maxTime: number;      // Maximum time (ms)
+  errorCount: number;   // Number of errors
+}
+```
+
+### Asset Lifecycle Metrics
+
+```typescript
+const metrics = sdk.metrics.getMetrics();
+
+// Asset creation count
+console.log('Total assets created:', metrics.assetsCreated);
+
+// Migration counts by layer transition
+console.log('Peer → Web:', metrics.assetsMigrated['peer→webvh']);
+console.log('Web → Bitcoin:', metrics.assetsMigrated['webvh→btco']);
+
+// Transfer count
+console.log('Total transfers:', metrics.assetsTransferred);
+```
+
+### Error Tracking
+
+```typescript
+const metrics = sdk.metrics.getMetrics();
+
+// Error counts by code
+console.log('Asset creation errors:', metrics.errors['ASSET_CREATION_FAILED']);
+console.log('Inscription errors:', metrics.errors['INSCRIPTION_FAILED']);
+
+// Calculate error rate
+const createOp = sdk.metrics.getOperationMetrics('createAsset');
+const errorRate = createOp.errorCount / createOp.count;
+console.log('Error rate:', (errorRate * 100).toFixed(2), '%');
+```
+
+### Recording Custom Metrics
+
+Access the MetricsCollector in your code:
+
+```typescript
+// Record custom operation
+const complete = sdk.metrics.startOperation('myCustomOperation');
+
+try {
+  // ... perform work ...
+  complete(true); // Success
+} catch (error) {
+  complete(false); // Failure
+  sdk.metrics.recordError('MY_ERROR_CODE');
+  throw error;
+}
+
+// Or record directly with duration
+sdk.metrics.recordOperation('operation', 123.45, true);
+```
+
+### Resetting Metrics
+
+```typescript
+// Reset all metrics (useful for testing)
+sdk.metrics.reset();
+```
+
+---
+
+## Event Integration
+
+The SDK automatically logs lifecycle events and extracts metrics from them.
+
+### Event Logging Configuration
+
+Configure which events to log and at what level:
+
+```typescript
+const sdk = OriginalsSDK.create({
+  network: 'mainnet',
+  defaultKeyType: 'ES256K',
+  logging: {
+    level: 'info',
+    eventLogging: {
+      'asset:created': 'info',
+      'asset:migrated': 'info',
+      'asset:transferred': 'warn',
+      'resource:published': 'debug',
+      'credential:issued': 'debug',
+      'verification:completed': 'info'
+    }
+  }
+});
+```
+
+### Disable Event Logging
+
+```typescript
+const sdk = OriginalsSDK.create({
+  network: 'mainnet',
+  defaultKeyType: 'ES256K',
+  logging: {
+    eventLogging: {
+      'resource:published': false, // Disable specific event
+      'credential:issued': false
+    }
+  }
+});
+```
+
+### Automatic Metrics from Events
+
+Events automatically update metrics:
+
+- **`asset:created`** → `assetsCreated++`
+- **`asset:migrated`** → `assetsMigrated[transition]++`
+- **`asset:transferred`** → `assetsTransferred++`
+
+```typescript
+// Create an asset
+const asset = await sdk.lifecycle.createAsset(resources);
+
+// Metrics are automatically updated
+const metrics = sdk.metrics.getMetrics();
+console.log(metrics.assetsCreated); // 1
+```
+
+---
+
+## Best Practices
+
+### Production Configuration
+
+```typescript
+const sdk = OriginalsSDK.create({
+  network: 'mainnet',
+  defaultKeyType: 'ES256K',
+  logging: {
+    level: 'info', // Don't use 'debug' in production
+    outputs: [
+      new FileLogOutput('./logs/app.log'),
+      new ExternalLogService() // Send to monitoring service
+    ],
+    sanitizeLogs: true, // Always sanitize in production
+    eventLogging: {
+      'asset:created': 'info',
+      'asset:migrated': 'info',
+      'asset:transferred': 'info'
+    }
+  },
+  metrics: {
+    enabled: true,
+    exportFormat: 'prometheus'
+  }
+});
+```
+
+### Development Configuration
+
+```typescript
+const sdk = OriginalsSDK.create({
+  network: 'testnet',
+  defaultKeyType: 'ES256K',
+  logging: {
+    level: 'debug', // Verbose logging for development
+    outputs: [new ConsoleLogOutput()],
+    sanitizeLogs: false, // See full data during development
+    eventLogging: {
+      'asset:created': 'debug',
+      'asset:migrated': 'debug',
+      'asset:transferred': 'debug',
+      'resource:published': 'debug',
+      'credential:issued': 'debug'
+    }
+  }
+});
+```
+
+### Structured Logging
+
+Always include relevant context in logs:
+
+```typescript
+// ✅ Good - structured data
+sdk.logger.info('Asset created', {
+  assetId: asset.id,
+  resourceCount: resources.length,
+  layer: asset.currentLayer
+});
+
+// ❌ Avoid - unstructured string
+sdk.logger.info(`Asset ${asset.id} created with ${resources.length} resources`);
+```
+
+### Error Handling
+
+```typescript
+try {
+  const asset = await sdk.lifecycle.createAsset(resources);
+  sdk.logger.info('Asset created successfully', { assetId: asset.id });
+} catch (error) {
+  sdk.logger.error('Asset creation failed', error as Error, {
+    resourceCount: resources.length,
+    attempt: retryCount
+  });
+  sdk.metrics.recordError('ASSET_CREATION_FAILED');
+  throw error;
+}
+```
+
+### Performance Monitoring
+
+```typescript
+async function complexOperation() {
+  const stopTimer = sdk.logger.startTimer('complexOperation');
+  const complete = sdk.metrics.startOperation('complexOperation');
+  
+  try {
+    // Perform operation
+    const result = await performWork();
+    
+    stopTimer();
+    complete(true);
+    
+    sdk.logger.info('Operation completed', { resultSize: result.length });
+    return result;
+    
+  } catch (error) {
+    stopTimer();
+    complete(false);
+    
+    sdk.logger.error('Operation failed', error as Error);
+    sdk.metrics.recordError('OPERATION_FAILED');
+    throw error;
+  }
+}
+```
+
+---
+
+## Export Formats
+
+### JSON Export
+
+```typescript
+const json = sdk.metrics.export('json');
+console.log(json);
+```
+
+**Output:**
+
+```json
+{
+  "assetsCreated": 42,
+  "assetsMigrated": {
+    "peer→webvh": 30,
+    "webvh→btco": 12
+  },
+  "assetsTransferred": 8,
+  "operationTimes": {
+    "createAsset": {
+      "count": 42,
+      "totalTime": 5250.5,
+      "avgTime": 125.0,
+      "minTime": 95.2,
+      "maxTime": 180.7,
+      "errorCount": 2
+    }
+  },
+  "errors": {
+    "ASSET_CREATION_FAILED": 2,
+    "INSCRIPTION_FAILED": 1
+  },
+  "startTime": "2025-10-06T12:00:00.000Z",
+  "uptime": 3600000
+}
+```
+
+### Prometheus Export
+
+```typescript
+const prometheus = sdk.metrics.export('prometheus');
+console.log(prometheus);
+```
+
+**Output:**
+
+```prometheus
+# HELP originals_assets_created_total Total number of assets created
+# TYPE originals_assets_created_total counter
+originals_assets_created_total 42
+
+# HELP originals_assets_migrated_total Total number of assets migrated by layer transition
+# TYPE originals_assets_migrated_total counter
+originals_assets_migrated_total{from="peer",to="webvh"} 30
+originals_assets_migrated_total{from="webvh",to="btco"} 12
+
+# HELP originals_operation_createAsset_total Total number of createAsset operations
+# TYPE originals_operation_createAsset_total counter
+originals_operation_createAsset_total 42
+
+# HELP originals_operation_createAsset_duration_milliseconds Duration of createAsset operations
+# TYPE originals_operation_createAsset_duration_milliseconds summary
+originals_operation_createAsset_duration_milliseconds{quantile="0.0"} 95.2
+originals_operation_createAsset_duration_milliseconds{quantile="0.5"} 125.0
+originals_operation_createAsset_duration_milliseconds{quantile="1.0"} 180.7
+originals_operation_createAsset_duration_milliseconds_sum 5250.5
+originals_operation_createAsset_duration_milliseconds_count 42
+
+# HELP originals_errors_total Total number of errors by code
+# TYPE originals_errors_total counter
+originals_errors_total{code="ASSET_CREATION_FAILED"} 2
+
+# HELP originals_uptime_milliseconds SDK uptime in milliseconds
+# TYPE originals_uptime_milliseconds gauge
+originals_uptime_milliseconds 3600000
+```
+
+### Integration with Monitoring Systems
+
+#### Prometheus + Grafana
+
+```typescript
+import express from 'express';
+
+const app = express();
+
+app.get('/metrics', (req, res) => {
+  const metrics = sdk.metrics.export('prometheus');
+  res.set('Content-Type', 'text/plain');
+  res.send(metrics);
+});
+
+app.listen(9090);
+```
+
+#### DataDog
+
+```typescript
+import type { LogOutput, LogEntry } from '@originals/sdk';
+
+class DataDogOutput implements LogOutput {
+  async write(entry: LogEntry): Promise<void> {
+    await fetch('https://http-intake.logs.datadoghq.com/v1/input', {
+      method: 'POST',
+      headers: {
+        'DD-API-KEY': process.env.DATADOG_API_KEY,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        service: 'originals-sdk',
+        level: entry.level,
+        message: entry.message,
+        ...entry.data
+      })
+    });
+  }
+}
+```
+
+#### CloudWatch
+
+```typescript
+import { CloudWatchLogs } from 'aws-sdk';
+
+class CloudWatchOutput implements LogOutput {
+  private client = new CloudWatchLogs();
+  
+  async write(entry: LogEntry): Promise<void> {
+    await this.client.putLogEvents({
+      logGroupName: '/originals-sdk',
+      logStreamName: 'application',
+      logEvents: [{
+        timestamp: new Date(entry.timestamp).getTime(),
+        message: JSON.stringify(entry)
+      }]
+    }).promise();
+  }
+}
+```
+
+---
+
+## Performance
+
+### Overhead Benchmarks
+
+The telemetry system is designed for production use with minimal overhead:
+
+| Operation | Average Time | Target |
+|-----------|--------------|--------|
+| Log entry (info) | ~0.3ms | <1ms |
+| Log entry (filtered) | ~0.01ms | <0.1ms |
+| Metrics recording | ~0.05ms | <0.1ms |
+| Event logging | ~0.4ms | <0.5ms |
+| Timer operation | ~0.3ms | <1ms |
+| JSON export | ~10ms | <50ms |
+| Prometheus export | ~30ms | <100ms |
+
+### Memory Efficiency
+
+- **Logger**: No memory leaks, logs are written immediately
+- **Metrics**: Aggregate data only, not individual records
+- **Events**: No event history stored, processed on-the-fly
+
+### Performance Tips
+
+1. **Use appropriate log levels** - Don't use `debug` in production
+2. **Filter early** - Set `level` to filter before processing
+3. **Batch metrics exports** - Export periodically, not per-operation
+4. **Async outputs** - Use non-blocking log outputs for I/O
+5. **Sanitization** - Keep enabled in production (minimal overhead)
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+#### Logs Not Appearing
+
+**Problem**: Logs are not showing up
+
+**Solutions**:
+1. Check log level - ensure configured level includes your logs
+2. Verify outputs are configured
+3. Check console/file permissions
+
+```typescript
+// Verify configuration
+console.log('Log level:', sdk.logger); // Should show logger instance
+```
+
+#### Memory Usage Growing
+
+**Problem**: Application memory increasing over time
+
+**Solutions**:
+1. Don't store log entries in memory
+2. Use appropriate log levels (avoid debug in production)
+3. Ensure file outputs are flushing correctly
+
+```typescript
+// ✅ Good - logs are written immediately
+sdk.logger.info('Message');
+
+// ❌ Bad - storing logs in memory
+const logs = [];
+sdk.logger.addOutput({ 
+  write: (entry) => logs.push(entry) // Memory leak!
+});
+```
+
+#### Sensitive Data in Logs
+
+**Problem**: Private keys visible in logs
+
+**Solution**: Ensure sanitization is enabled
+
+```typescript
+const sdk = OriginalsSDK.create({
+  network: 'mainnet',
+  defaultKeyType: 'ES256K',
+  logging: {
+    sanitizeLogs: true // Must be true!
+  }
+});
+```
+
+#### Metrics Not Updating
+
+**Problem**: Metrics show zero or outdated values
+
+**Solutions**:
+1. Ensure metrics are enabled
+2. Check that operations are completing
+3. Verify event integration is active
+
+```typescript
+const metrics = sdk.metrics.getMetrics();
+console.log('Metrics:', JSON.stringify(metrics, null, 2));
+```
+
+### Debug Mode
+
+Enable maximum verbosity for troubleshooting:
+
+```typescript
+const sdk = OriginalsSDK.create({
+  network: 'testnet',
+  defaultKeyType: 'ES256K',
+  logging: {
+    level: 'debug',
+    outputs: [
+      new ConsoleLogOutput(),
+      new FileLogOutput('./debug.log')
+    ],
+    sanitizeLogs: false,
+    includeTimestamps: true,
+    includeContext: true,
+    eventLogging: {
+      'asset:created': 'debug',
+      'asset:migrated': 'debug',
+      'asset:transferred': 'debug',
+      'resource:published': 'debug',
+      'credential:issued': 'debug',
+      'verification:completed': 'debug'
+    }
+  }
+});
+```
+
+---
+
+## API Reference
+
+### Logger
+
+```typescript
+class Logger {
+  debug(message: string, data?: any): void;
+  info(message: string, data?: any): void;
+  warn(message: string, data?: any): void;
+  error(message: string, error?: Error, data?: any): void;
+  
+  startTimer(operation: string): () => void;
+  child(context: string): Logger;
+  setOutput(output: LogOutput): void;
+  addOutput(output: LogOutput): void;
+}
+```
+
+### MetricsCollector
+
+```typescript
+class MetricsCollector {
+  recordOperation(operation: string, duration: number, success: boolean): void;
+  startOperation(operation: string): (success?: boolean) => void;
+  
+  recordAssetCreated(): void;
+  recordMigration(from: LayerType, to: LayerType): void;
+  recordTransfer(): void;
+  recordError(code: string, operation?: string): void;
+  
+  recordCacheHit(): void;
+  recordCacheMiss(): void;
+  
+  getMetrics(): Metrics;
+  getOperationMetrics(operation: string): OperationMetrics | null;
+  
+  reset(): void;
+  export(format: 'json' | 'prometheus'): string;
+}
+```
+
+---
+
+## Examples
+
+See the test files for comprehensive examples:
+
+- **Unit Tests**: `tests/unit/utils/Logger.test.ts`, `tests/unit/utils/MetricsCollector.test.ts`
+- **Integration Tests**: `tests/integration/TelemetryIntegration.test.ts`
+- **Performance Tests**: `tests/performance/logging.perf.test.ts`
+
+---
+
+## Support
+
+For questions or issues:
+- **GitHub Issues**: [Report an issue](https://github.com/aviarytech/originals-sdk/issues)
+- **Documentation**: [Full SDK docs](./README.md)
+- **Events**: [Event system docs](./EVENTS.md)
+
+---
+
+**Telemetry system is production-ready! 📊**
+

--- a/src/lifecycle/LifecycleManager.ts
+++ b/src/lifecycle/LifecycleManager.ts
@@ -439,11 +439,21 @@ export class LifecycleManager {
       transactionId: revealTxId
     });
     
-    // Note: asset.currentLayer is updated after migrate() call above
-    // Migration should be from the layer before migration (webvh or peer) to btco
-    // Since we already migrated, we need to infer the fromLayer
-    // The inscribeOnBitcoin validation ensures currentLayer is webvh or peer before migration
-    this.metrics.recordMigration('did:webvh', 'did:btco');
+     const usedFeeRate = typeof inscription.feeRate === 'number' ? inscription.feeRate : feeRate;
+ 
+    // Capture the layer before migration for accurate metrics
+    const fromLayer = asset.currentLayer;
+ 
+     await asset.migrate('did:btco', {
+       transactionId: revealTxId,
+       inscriptionId: inscription.inscriptionId,
+     });
+ 
+     // Note: asset.currentLayer is updated after migrate() call above
+     // Migration should be from the layer before migration (webvh or peer) to btco
+     // Since we already migrated, we need to infer the fromLayer
+     // The inscribeOnBitcoin validation ensures currentLayer is webvh or peer before migration
+    this.metrics.recordMigration(fromLayer, 'did:btco');
     
     return asset;
     } catch (error) {

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,5 +1,7 @@
 import { StorageAdapter, FeeOracleAdapter, OrdinalsProvider } from '../adapters';
 import { TelemetryHooks } from '../utils/telemetry';
+import type { LogLevel, LogOutput } from '../utils/Logger';
+import type { EventLoggingConfig } from '../utils/EventLogger';
 
 // Base types for the Originals protocol
 export type LayerType = 'did:peer' | 'did:webvh' | 'did:btco';
@@ -16,6 +18,21 @@ export interface OriginalsConfig {
   ordinalsProvider?: OrdinalsProvider;
   // Optional telemetry hooks
   telemetry?: TelemetryHooks;
+  // Enhanced logging configuration
+  logging?: {
+    level?: LogLevel;
+    outputs?: LogOutput[];
+    includeTimestamps?: boolean;
+    includeContext?: boolean;
+    eventLogging?: EventLoggingConfig;
+    sanitizeLogs?: boolean; // Remove sensitive data
+  };
+  // Metrics configuration
+  metrics?: {
+    enabled?: boolean;
+    exportFormat?: 'json' | 'prometheus';
+    collectCache?: boolean;
+  };
 }
 
 export interface AssetResource {

--- a/src/utils/EventLogger.ts
+++ b/src/utils/EventLogger.ts
@@ -1,0 +1,227 @@
+/**
+ * Event Logger - Integration between Event System and Logger
+ * 
+ * Features:
+ * - Auto-subscribe to EventEmitter events
+ * - Configurable logging levels per event type
+ * - Automatic metrics extraction from events
+ * - Performance tracking
+ */
+
+import type { EventEmitter } from '../events/EventEmitter';
+import type { OriginalsEvent, EventTypeMap } from '../events/types';
+import type { Logger, LogLevel } from './Logger';
+import type { MetricsCollector } from './MetricsCollector';
+
+/**
+ * Event logging configuration
+ */
+export interface EventLoggingConfig {
+  'asset:created'?: LogLevel | false;
+  'asset:migrated'?: LogLevel | false;
+  'asset:transferred'?: LogLevel | false;
+  'resource:published'?: LogLevel | false;
+  'credential:issued'?: LogLevel | false;
+  'verification:completed'?: LogLevel | false;
+}
+
+/**
+ * Default event logging configuration
+ */
+const DEFAULT_EVENT_CONFIG: EventLoggingConfig = {
+  'asset:created': 'info',
+  'asset:migrated': 'info',
+  'asset:transferred': 'info',
+  'resource:published': 'info',
+  'credential:issued': 'info',
+  'verification:completed': 'info'
+};
+
+/**
+ * EventLogger class for integrating events with logging and metrics
+ */
+export class EventLogger {
+  private config: EventLoggingConfig;
+  private unsubscribeFns: Array<() => void> = [];
+  
+  constructor(
+    private logger: Logger,
+    private metricsCollector: MetricsCollector
+  ) {
+    this.config = { ...DEFAULT_EVENT_CONFIG };
+  }
+  
+  /**
+   * Subscribe to all events from an EventEmitter
+   */
+  subscribeToEvents(eventEmitter: EventEmitter): void {
+    // Subscribe to each event type
+    const eventTypes: Array<keyof EventTypeMap> = [
+      'asset:created',
+      'asset:migrated',
+      'asset:transferred',
+      'resource:published',
+      'credential:issued',
+      'verification:completed'
+    ];
+    
+    for (const eventType of eventTypes) {
+      const unsubscribe = eventEmitter.on(eventType, (event) => {
+        this.handleEvent(event);
+      });
+      
+      this.unsubscribeFns.push(unsubscribe);
+    }
+  }
+  
+  /**
+   * Configure which events to log at which levels
+   */
+  configureEventLogging(config: EventLoggingConfig): void {
+    this.config = { ...this.config, ...config };
+  }
+  
+  /**
+   * Unsubscribe from all events
+   */
+  unsubscribe(): void {
+    for (const unsubscribe of this.unsubscribeFns) {
+      unsubscribe();
+    }
+    this.unsubscribeFns = [];
+  }
+  
+  /**
+   * Handle an event - log and extract metrics
+   */
+  private handleEvent(event: OriginalsEvent): void {
+    const eventType = event.type;
+    const logLevel = this.config[eventType];
+    
+    // Always extract metrics from the event (even if logging is disabled)
+    this.extractMetrics(event);
+    
+    // Skip logging if disabled for this event type
+    if (logLevel === false) {
+      return;
+    }
+    
+    // Log the event
+    if (logLevel) {
+      this.logEvent(event, logLevel);
+    }
+  }
+  
+  /**
+   * Log an event at the specified level
+   */
+  private logEvent(event: OriginalsEvent, level: LogLevel): void {
+    let message: string;
+    let data: Record<string, any>;
+    
+    switch (event.type) {
+      case 'asset:created':
+        message = 'Asset created';
+        data = {
+          assetId: event.asset.id,
+          layer: event.asset.layer,
+          resourceCount: event.asset.resourceCount
+        };
+        break;
+        
+      case 'asset:migrated':
+        message = 'Asset migrated';
+        data = {
+          assetId: event.asset.id,
+          fromLayer: event.asset.fromLayer,
+          toLayer: event.asset.toLayer,
+          details: event.details
+        };
+        break;
+        
+      case 'asset:transferred':
+        message = 'Asset transferred';
+        data = {
+          assetId: event.asset.id,
+          layer: event.asset.layer,
+          from: event.from,
+          to: event.to,
+          transactionId: event.transactionId
+        };
+        break;
+        
+      case 'resource:published':
+        message = 'Resource published';
+        data = {
+          assetId: event.asset.id,
+          resourceId: event.resource.id,
+          url: event.resource.url,
+          domain: event.domain
+        };
+        break;
+        
+      case 'credential:issued':
+        message = 'Credential issued';
+        data = {
+          assetId: event.asset.id,
+          credentialType: event.credential.type,
+          issuer: event.credential.issuer
+        };
+        break;
+        
+      case 'verification:completed':
+        message = 'Verification completed';
+        data = {
+          assetId: event.asset.id,
+          result: event.result,
+          checks: event.checks
+        };
+        break;
+        
+      default:
+        return; // Unknown event type
+    }
+    
+    // Call the appropriate log method based on level
+    switch (level) {
+      case 'debug':
+        this.logger.debug(message, data);
+        break;
+      case 'info':
+        this.logger.info(message, data);
+        break;
+      case 'warn':
+        this.logger.warn(message, data);
+        break;
+      case 'error':
+        this.logger.error(message, undefined, data);
+        break;
+    }
+  }
+  
+  /**
+   * Extract metrics from an event
+   */
+  private extractMetrics(event: OriginalsEvent): void {
+    switch (event.type) {
+      case 'asset:created':
+        this.metricsCollector.recordAssetCreated();
+        break;
+        
+      case 'asset:migrated':
+        this.metricsCollector.recordMigration(
+          event.asset.fromLayer,
+          event.asset.toLayer
+        );
+        break;
+        
+      case 'asset:transferred':
+        this.metricsCollector.recordTransfer();
+        break;
+        
+      // Other events don't need explicit metric recording
+      // as they're tracked elsewhere
+    }
+  }
+}
+

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -89,6 +89,10 @@ export class FileLogOutput implements LogOutput {
     }
   }
   
+// At the top of src/utils/Logger.ts
+import { appendFile } from 'node:fs/promises';
+import type { OriginalsConfig } from '../types';
+
   private async flush(): Promise<void> {
     if (this.buffer.length === 0) {
       return;
@@ -98,23 +102,25 @@ export class FileLogOutput implements LogOutput {
     this.buffer = [];
     this.flushTimeout = null;
     
+-    try {
+-      // Use Bun's file API for efficient file writing
+-      const file = Bun.file(this.filePath);
+-      const exists = await file.exists();
+-      
+-      if (exists) {
+-        // Append to existing file
+-        const content = await file.text();
+-        await Bun.write(this.filePath, content + lines);
+-      } else {
+-        // Create new file
+-        await Bun.write(this.filePath, lines);
+-      }
     try {
-      // Use Bun's file API for efficient file writing
-      const file = Bun.file(this.filePath);
-      const exists = await file.exists();
-      
-      if (exists) {
-        // Append to existing file
-        const content = await file.text();
-        await Bun.write(this.filePath, content + lines);
-      } else {
-        // Create new file
-        await Bun.write(this.filePath, lines);
-      }
+      await appendFile(this.filePath, lines);
     } catch (err) {
-      // Fallback to console on file write error
-      console.error('Failed to write log file:', err);
-    }
+       // Fallback to console on file write error
+       console.error('Failed to write log file:', err);
+     }
   }
 }
 

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -1,0 +1,322 @@
+/**
+ * Enhanced Logger for Originals SDK
+ * 
+ * Features:
+ * - Multiple log levels (debug, info, warn, error)
+ * - Child loggers with hierarchical context
+ * - Performance timing with startTimer
+ * - Multiple output destinations
+ * - Data sanitization for sensitive information
+ * - Async-safe operations
+ */
+
+import type { OriginalsConfig } from '../types';
+
+/**
+ * Log level type
+ */
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+/**
+ * Structured log entry
+ */
+export interface LogEntry {
+  timestamp: string;
+  level: LogLevel;
+  context: string;
+  message: string;
+  data?: any;
+  duration?: number; // For performance tracking
+  traceId?: string; // For request correlation
+}
+
+/**
+ * Log output interface for custom outputs
+ */
+export interface LogOutput {
+  write(entry: LogEntry): void | Promise<void>;
+}
+
+/**
+ * Console log output implementation
+ */
+export class ConsoleLogOutput implements LogOutput {
+  write(entry: LogEntry): void {
+    const timestamp = entry.timestamp;
+    const level = entry.level.toUpperCase().padEnd(5);
+    const context = entry.context;
+    const message = entry.message;
+    const durationStr = entry.duration !== undefined ? ` (${entry.duration.toFixed(2)}ms)` : '';
+    const dataStr = entry.data ? ` ${JSON.stringify(entry.data)}` : '';
+    
+    const logMessage = `[${timestamp}] ${level} [${context}] ${message}${durationStr}${dataStr}`;
+    
+    switch (entry.level) {
+      case 'debug':
+        console.debug(logMessage);
+        break;
+      case 'info':
+        console.info(logMessage);
+        break;
+      case 'warn':
+        console.warn(logMessage);
+        break;
+      case 'error':
+        console.error(logMessage);
+        break;
+    }
+  }
+}
+
+/**
+ * File log output implementation (async)
+ */
+export class FileLogOutput implements LogOutput {
+  private buffer: string[] = [];
+  private flushTimeout: any = null;
+  private readonly flushInterval = 1000; // Flush every 1 second
+  
+  constructor(private filePath: string) {}
+  
+  async write(entry: LogEntry): Promise<void> {
+    // Format as JSON line
+    const line = JSON.stringify(entry) + '\n';
+    this.buffer.push(line);
+    
+    // Schedule flush
+    if (!this.flushTimeout) {
+      this.flushTimeout = setTimeout(() => this.flush(), this.flushInterval);
+    }
+  }
+  
+  private async flush(): Promise<void> {
+    if (this.buffer.length === 0) {
+      return;
+    }
+    
+    const lines = this.buffer.join('');
+    this.buffer = [];
+    this.flushTimeout = null;
+    
+    try {
+      // Use Bun's file API for efficient file writing
+      const file = Bun.file(this.filePath);
+      const exists = await file.exists();
+      
+      if (exists) {
+        // Append to existing file
+        const content = await file.text();
+        await Bun.write(this.filePath, content + lines);
+      } else {
+        // Create new file
+        await Bun.write(this.filePath, lines);
+      }
+    } catch (err) {
+      // Fallback to console on file write error
+      console.error('Failed to write log file:', err);
+    }
+  }
+}
+
+/**
+ * Main Logger class
+ */
+export class Logger {
+  private outputs: LogOutput[] = [];
+  private minLevel: LogLevel;
+  private includeTimestamps: boolean;
+  private includeContext: boolean;
+  private sanitizeLogs: boolean;
+  
+  // Log level priorities
+  private static readonly LEVEL_PRIORITY: Record<LogLevel, number> = {
+    debug: 0,
+    info: 1,
+    warn: 2,
+    error: 3
+  };
+  
+  constructor(
+    private context: string,
+    config: OriginalsConfig
+  ) {
+    this.minLevel = config.logging?.level || 'info';
+    this.includeTimestamps = config.logging?.includeTimestamps !== false;
+    this.includeContext = config.logging?.includeContext !== false;
+    this.sanitizeLogs = config.logging?.sanitizeLogs !== false;
+    
+    // Set up default outputs
+    if (config.logging?.outputs && config.logging.outputs.length > 0) {
+      this.outputs = [...config.logging.outputs];
+    } else {
+      // Default to console output
+      this.outputs = [new ConsoleLogOutput()];
+    }
+  }
+  
+  /**
+   * Log a debug message
+   */
+  debug(message: string, data?: any): void {
+    this.log('debug', message, data);
+  }
+  
+  /**
+   * Log an info message
+   */
+  info(message: string, data?: any): void {
+    this.log('info', message, data);
+  }
+  
+  /**
+   * Log a warning message
+   */
+  warn(message: string, data?: any): void {
+    this.log('warn', message, data);
+  }
+  
+  /**
+   * Log an error message
+   */
+  error(message: string, error?: Error, data?: any): void {
+    const errorData = error ? {
+      ...data,
+      error: {
+        name: error.name,
+        message: error.message,
+        stack: error.stack
+      }
+    } : data;
+    
+    this.log('error', message, errorData);
+  }
+  
+  /**
+   * Start a timer for performance tracking
+   * Returns a function that stops the timer and logs the duration
+   */
+  startTimer(operation: string): () => void {
+    const startTime = performance.now();
+    
+    return () => {
+      const duration = performance.now() - startTime;
+      this.log('debug', `${operation} completed`, undefined, duration);
+    };
+  }
+  
+  /**
+   * Create a child logger with nested context
+   */
+  child(childContext: string): Logger {
+    const newLogger = Object.create(Logger.prototype);
+    newLogger.context = `${this.context}:${childContext}`;
+    newLogger.outputs = this.outputs;
+    newLogger.minLevel = this.minLevel;
+    newLogger.includeTimestamps = this.includeTimestamps;
+    newLogger.includeContext = this.includeContext;
+    newLogger.sanitizeLogs = this.sanitizeLogs;
+    return newLogger;
+  }
+  
+  /**
+   * Set a single output (replaces existing outputs)
+   */
+  setOutput(output: LogOutput): void {
+    this.outputs = [output];
+  }
+  
+  /**
+   * Add an output to the existing outputs
+   */
+  addOutput(output: LogOutput): void {
+    this.outputs.push(output);
+  }
+  
+  /**
+   * Internal log method
+   */
+  private log(level: LogLevel, message: string, data?: any, duration?: number): void {
+    // Check if we should log this level
+    if (Logger.LEVEL_PRIORITY[level] < Logger.LEVEL_PRIORITY[this.minLevel]) {
+      return;
+    }
+    
+    // Sanitize data if needed
+    const sanitizedData = this.sanitizeLogs ? this.sanitize(data) : data;
+    
+    // Create log entry
+    const entry: LogEntry = {
+      timestamp: this.includeTimestamps ? new Date().toISOString() : '',
+      level,
+      context: this.includeContext ? this.context : '',
+      message,
+      data: sanitizedData,
+      duration
+    };
+    
+    // Write to all outputs (fire and forget for async outputs)
+    for (const output of this.outputs) {
+      try {
+        const result = output.write(entry);
+        // If result is a promise, don't await it (non-blocking)
+        if (result instanceof Promise) {
+          result.catch(err => {
+            // Silently fail for async outputs to avoid blocking
+            if (typeof console !== 'undefined' && console.error) {
+              console.error('Log output error:', err);
+            }
+          });
+        }
+      } catch (err) {
+        // Continue even if one output fails
+        if (typeof console !== 'undefined' && console.error) {
+          console.error('Log output error:', err);
+        }
+      }
+    }
+  }
+  
+  /**
+   * Sanitize sensitive data from logs
+   */
+  private sanitize(data: any): any {
+    if (!data) {
+      return data;
+    }
+    
+    // Handle arrays
+    if (Array.isArray(data)) {
+      return data.map(item => this.sanitize(item));
+    }
+    
+    // Handle objects
+    if (typeof data === 'object') {
+      const sanitized: any = {};
+      
+      for (const [key, value] of Object.entries(data)) {
+        const lowerKey = key.toLowerCase();
+        
+        // Sanitize sensitive keys
+        if (
+          lowerKey.includes('private') ||
+          lowerKey.includes('key') ||
+          lowerKey.includes('secret') ||
+          lowerKey.includes('password') ||
+          lowerKey.includes('token') ||
+          lowerKey.includes('credential')
+        ) {
+          sanitized[key] = '[REDACTED]';
+        } else {
+          // Recursively sanitize nested objects
+          sanitized[key] = this.sanitize(value);
+        }
+      }
+      
+      return sanitized;
+    }
+    
+    // Return primitive values as-is
+    return data;
+  }
+}
+

--- a/src/utils/MetricsCollector.ts
+++ b/src/utils/MetricsCollector.ts
@@ -1,0 +1,358 @@
+/**
+ * Metrics Collector for Originals SDK
+ * 
+ * Features:
+ * - Track operation counts and performance
+ * - Asset lifecycle metrics (created, migrated, transferred)
+ * - Error tracking by error code
+ * - Cache statistics (optional)
+ * - Export in JSON and Prometheus formats
+ * - Memory-efficient storage
+ */
+
+import type { LayerType } from '../types';
+
+/**
+ * Operation-specific metrics
+ */
+export interface OperationMetrics {
+  count: number;
+  totalTime: number;
+  avgTime: number;
+  minTime: number;
+  maxTime: number;
+  errorCount: number;
+}
+
+/**
+ * Complete metrics snapshot
+ */
+export interface Metrics {
+  // Asset operations
+  assetsCreated: number;
+  assetsMigrated: Record<string, number>; // by layer transition (e.g., "peer→webvh": 5)
+  assetsTransferred: number;
+  
+  // Operation performance
+  operationTimes: Record<string, OperationMetrics>;
+  
+  // Error tracking
+  errors: Record<string, number>; // by error code
+  
+  // Cache statistics (if caching is implemented)
+  cacheStats?: {
+    hits: number;
+    misses: number;
+    hitRate: number;
+  };
+  
+  // System metrics
+  startTime: string;
+  uptime: number; // milliseconds
+}
+
+/**
+ * MetricsCollector class
+ */
+export class MetricsCollector {
+  private assetsCreatedCount = 0;
+  private assetsMigratedMap: Map<string, number> = new Map();
+  private assetsTransferredCount = 0;
+  
+  private operationMetrics: Map<string, {
+    count: number;
+    totalTime: number;
+    minTime: number;
+    maxTime: number;
+    errorCount: number;
+  }> = new Map();
+  
+  private errorCounts: Map<string, number> = new Map();
+  
+  private cacheHits = 0;
+  private cacheMisses = 0;
+  
+  private readonly startTime: string;
+  
+  constructor() {
+    this.startTime = new Date().toISOString();
+  }
+  
+  /**
+   * Record an operation with timing and success status
+   */
+  recordOperation(operation: string, duration: number, success: boolean): void {
+    if (!this.operationMetrics.has(operation)) {
+      this.operationMetrics.set(operation, {
+        count: 0,
+        totalTime: 0,
+        minTime: Infinity,
+        maxTime: -Infinity,
+        errorCount: 0
+      });
+    }
+    
+    const metrics = this.operationMetrics.get(operation)!;
+    metrics.count++;
+    metrics.totalTime += duration;
+    metrics.minTime = Math.min(metrics.minTime, duration);
+    metrics.maxTime = Math.max(metrics.maxTime, duration);
+    
+    if (!success) {
+      metrics.errorCount++;
+    }
+  }
+  
+  /**
+   * Start tracking an operation, returns completion function
+   */
+  startOperation(operation: string): () => void {
+    const startTime = performance.now();
+    
+    return (success: boolean = true) => {
+      const duration = performance.now() - startTime;
+      this.recordOperation(operation, duration, success);
+    };
+  }
+  
+  /**
+   * Record an asset creation
+   */
+  recordAssetCreated(): void {
+    this.assetsCreatedCount++;
+  }
+  
+  /**
+   * Record an asset migration between layers
+   */
+  recordMigration(from: LayerType, to: LayerType): void {
+    // Create transition key
+    const fromShort = from.split(':')[1]; // "peer", "webvh", "btco"
+    const toShort = to.split(':')[1];
+    const transitionKey = `${fromShort}→${toShort}`;
+    
+    const current = this.assetsMigratedMap.get(transitionKey) || 0;
+    this.assetsMigratedMap.set(transitionKey, current + 1);
+  }
+  
+  /**
+   * Record an asset transfer
+   */
+  recordTransfer(): void {
+    this.assetsTransferredCount++;
+  }
+  
+  /**
+   * Record an error by error code
+   */
+  recordError(code: string, operation?: string): void {
+    // Track error by code
+    const current = this.errorCounts.get(code) || 0;
+    this.errorCounts.set(code, current + 1);
+    
+    // If operation is provided, increment its error count
+    if (operation && this.operationMetrics.has(operation)) {
+      this.operationMetrics.get(operation)!.errorCount++;
+    }
+  }
+  
+  /**
+   * Record a cache hit
+   */
+  recordCacheHit(): void {
+    this.cacheHits++;
+  }
+  
+  /**
+   * Record a cache miss
+   */
+  recordCacheMiss(): void {
+    this.cacheMisses++;
+  }
+  
+  /**
+   * Get a snapshot of all metrics
+   */
+  getMetrics(): Metrics {
+    const operationTimes: Record<string, OperationMetrics> = {};
+    
+    for (const [operation, metrics] of this.operationMetrics.entries()) {
+      operationTimes[operation] = {
+        count: metrics.count,
+        totalTime: metrics.totalTime,
+        avgTime: metrics.count > 0 ? metrics.totalTime / metrics.count : 0,
+        minTime: metrics.minTime === Infinity ? 0 : metrics.minTime,
+        maxTime: metrics.maxTime === -Infinity ? 0 : metrics.maxTime,
+        errorCount: metrics.errorCount
+      };
+    }
+    
+    const assetsMigrated: Record<string, number> = {};
+    for (const [key, count] of this.assetsMigratedMap.entries()) {
+      assetsMigrated[key] = count;
+    }
+    
+    const errors: Record<string, number> = {};
+    for (const [code, count] of this.errorCounts.entries()) {
+      errors[code] = count;
+    }
+    
+    const totalCacheRequests = this.cacheHits + this.cacheMisses;
+    const cacheStats = totalCacheRequests > 0 ? {
+      hits: this.cacheHits,
+      misses: this.cacheMisses,
+      hitRate: this.cacheHits / totalCacheRequests
+    } : undefined;
+    
+    return {
+      assetsCreated: this.assetsCreatedCount,
+      assetsMigrated,
+      assetsTransferred: this.assetsTransferredCount,
+      operationTimes,
+      errors,
+      cacheStats,
+      startTime: this.startTime,
+      uptime: Date.now() - new Date(this.startTime).getTime()
+    };
+  }
+  
+  /**
+   * Get metrics for a specific operation
+   */
+  getOperationMetrics(operation: string): OperationMetrics | null {
+    const metrics = this.operationMetrics.get(operation);
+    
+    if (!metrics) {
+      return null;
+    }
+    
+    return {
+      count: metrics.count,
+      totalTime: metrics.totalTime,
+      avgTime: metrics.count > 0 ? metrics.totalTime / metrics.count : 0,
+      minTime: metrics.minTime === Infinity ? 0 : metrics.minTime,
+      maxTime: metrics.maxTime === -Infinity ? 0 : metrics.maxTime,
+      errorCount: metrics.errorCount
+    };
+  }
+  
+  /**
+   * Reset all metrics
+   */
+  reset(): void {
+    this.assetsCreatedCount = 0;
+    this.assetsMigratedMap.clear();
+    this.assetsTransferredCount = 0;
+    this.operationMetrics.clear();
+    this.errorCounts.clear();
+    this.cacheHits = 0;
+    this.cacheMisses = 0;
+  }
+  
+  /**
+   * Export metrics in the specified format
+   */
+  export(format: 'json' | 'prometheus'): string {
+    if (format === 'json') {
+      return this.exportJSON();
+    } else if (format === 'prometheus') {
+      return this.exportPrometheus();
+    }
+    
+    throw new Error(`Unsupported export format: ${format}`);
+  }
+  
+  /**
+   * Export metrics as JSON
+   */
+  private exportJSON(): string {
+    return JSON.stringify(this.getMetrics(), null, 2);
+  }
+  
+  /**
+   * Export metrics in Prometheus format
+   */
+  private exportPrometheus(): string {
+    const lines: string[] = [];
+    const metrics = this.getMetrics();
+    
+    // Asset metrics
+    lines.push('# HELP originals_assets_created_total Total number of assets created');
+    lines.push('# TYPE originals_assets_created_total counter');
+    lines.push(`originals_assets_created_total ${metrics.assetsCreated}`);
+    lines.push('');
+    
+    lines.push('# HELP originals_assets_transferred_total Total number of assets transferred');
+    lines.push('# TYPE originals_assets_transferred_total counter');
+    lines.push(`originals_assets_transferred_total ${metrics.assetsTransferred}`);
+    lines.push('');
+    
+    // Migration metrics
+    lines.push('# HELP originals_assets_migrated_total Total number of assets migrated by layer transition');
+    lines.push('# TYPE originals_assets_migrated_total counter');
+    for (const [transition, count] of Object.entries(metrics.assetsMigrated)) {
+      const [from, to] = transition.split('→');
+      lines.push(`originals_assets_migrated_total{from="${from}",to="${to}"} ${count}`);
+    }
+    lines.push('');
+    
+    // Operation metrics
+    for (const [operation, opMetrics] of Object.entries(metrics.operationTimes)) {
+      const safeOpName = operation.replace(/[^a-zA-Z0-9_]/g, '_');
+      
+      lines.push(`# HELP originals_operation_${safeOpName}_total Total number of ${operation} operations`);
+      lines.push(`# TYPE originals_operation_${safeOpName}_total counter`);
+      lines.push(`originals_operation_${safeOpName}_total ${opMetrics.count}`);
+      lines.push('');
+      
+      lines.push(`# HELP originals_operation_${safeOpName}_duration_milliseconds Duration of ${operation} operations`);
+      lines.push(`# TYPE originals_operation_${safeOpName}_duration_milliseconds summary`);
+      lines.push(`originals_operation_${safeOpName}_duration_milliseconds{quantile="0.0"} ${opMetrics.minTime}`);
+      lines.push(`originals_operation_${safeOpName}_duration_milliseconds{quantile="0.5"} ${opMetrics.avgTime}`);
+      lines.push(`originals_operation_${safeOpName}_duration_milliseconds{quantile="1.0"} ${opMetrics.maxTime}`);
+      lines.push(`originals_operation_${safeOpName}_duration_milliseconds_sum ${opMetrics.totalTime}`);
+      lines.push(`originals_operation_${safeOpName}_duration_milliseconds_count ${opMetrics.count}`);
+      lines.push('');
+      
+      lines.push(`# HELP originals_operation_${safeOpName}_errors_total Total number of errors in ${operation} operations`);
+      lines.push(`# TYPE originals_operation_${safeOpName}_errors_total counter`);
+      lines.push(`originals_operation_${safeOpName}_errors_total ${opMetrics.errorCount}`);
+      lines.push('');
+    }
+    
+    // Error metrics
+    lines.push('# HELP originals_errors_total Total number of errors by code');
+    lines.push('# TYPE originals_errors_total counter');
+    for (const [code, count] of Object.entries(metrics.errors)) {
+      lines.push(`originals_errors_total{code="${code}"} ${count}`);
+    }
+    lines.push('');
+    
+    // Cache metrics
+    if (metrics.cacheStats) {
+      lines.push('# HELP originals_cache_hits_total Total number of cache hits');
+      lines.push('# TYPE originals_cache_hits_total counter');
+      lines.push(`originals_cache_hits_total ${metrics.cacheStats.hits}`);
+      lines.push('');
+      
+      lines.push('# HELP originals_cache_misses_total Total number of cache misses');
+      lines.push('# TYPE originals_cache_misses_total counter');
+      lines.push(`originals_cache_misses_total ${metrics.cacheStats.misses}`);
+      lines.push('');
+      
+      lines.push('# HELP originals_cache_hit_rate Cache hit rate');
+      lines.push('# TYPE originals_cache_hit_rate gauge');
+      lines.push(`originals_cache_hit_rate ${metrics.cacheStats.hitRate}`);
+      lines.push('');
+    }
+    
+    // System metrics
+    lines.push('# HELP originals_uptime_milliseconds SDK uptime in milliseconds');
+    lines.push('# TYPE originals_uptime_milliseconds gauge');
+    lines.push(`originals_uptime_milliseconds ${metrics.uptime}`);
+    lines.push('');
+    
+    return lines.join('\n');
+  }
+}
+

--- a/tests/integration/TelemetryIntegration.test.ts
+++ b/tests/integration/TelemetryIntegration.test.ts
@@ -1,0 +1,395 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { OriginalsSDK } from '../../src/core/OriginalsSDK';
+import type { OriginalsConfig } from '../../src/types';
+import type { LogOutput, LogEntry } from '../../src/utils/Logger';
+
+describe('Telemetry Integration', () => {
+  let logEntries: LogEntry[];
+  let mockOutput: LogOutput;
+  let config: OriginalsConfig;
+  
+  beforeEach(() => {
+    logEntries = [];
+    mockOutput = {
+      write: (entry: LogEntry) => {
+        logEntries.push(entry);
+      }
+    };
+    
+    config = {
+      network: 'testnet',
+      defaultKeyType: 'ES256K',
+      logging: {
+        level: 'debug',
+        outputs: [mockOutput]
+      },
+      metrics: {
+        enabled: true
+      }
+    };
+  });
+  
+  describe('SDK initialization', () => {
+    test('should log SDK initialization', () => {
+      const sdk = new OriginalsSDK(config);
+      
+      // Should have logged initialization
+      const initLogs = logEntries.filter(e => e.message.includes('Initializing'));
+      expect(initLogs.length).toBeGreaterThan(0);
+      
+      const successLogs = logEntries.filter(e => e.message.includes('initialized successfully'));
+      expect(successLogs.length).toBeGreaterThan(0);
+    });
+    
+    test('should have logger and metrics accessible', () => {
+      const sdk = new OriginalsSDK(config);
+      
+      expect(sdk.logger).toBeDefined();
+      expect(sdk.metrics).toBeDefined();
+    });
+  });
+  
+  describe('lifecycle operations with logging', () => {
+    test('should log asset creation', async () => {
+      const sdk = OriginalsSDK.create({
+        network: 'testnet',
+        defaultKeyType: 'ES256K',
+        logging: {
+          level: 'info',
+          outputs: [mockOutput]
+        }
+      });
+      
+      const resources = [
+        {
+          id: 'test-resource',
+          type: 'text',
+          contentType: 'text/plain',
+          hash: 'abc123',
+          content: 'Hello World'
+        }
+      ];
+      
+      logEntries = []; // Reset log entries
+      
+      const asset = await sdk.lifecycle.createAsset(resources);
+      
+      // Should have logged asset creation
+      const creationLogs = logEntries.filter(e => e.message.includes('Creating asset'));
+      expect(creationLogs.length).toBeGreaterThan(0);
+      
+      const successLogs = logEntries.filter(e => e.message.includes('Asset created successfully'));
+      expect(successLogs.length).toBeGreaterThan(0);
+      
+      // Check that metrics were recorded
+      const lifecycleMetrics = (sdk.lifecycle as any).metrics.getMetrics();
+      expect(lifecycleMetrics.assetsCreated).toBeGreaterThan(0);
+    });
+    
+    test('should log with performance timing', async () => {
+      const sdk = OriginalsSDK.create({
+        network: 'testnet',
+        defaultKeyType: 'ES256K',
+        logging: {
+          level: 'debug',
+          outputs: [mockOutput]
+        }
+      });
+      
+      const resources = [
+        {
+          id: 'test-resource',
+          type: 'text',
+          contentType: 'text/plain',
+          hash: 'abc123',
+          content: 'Hello World'
+        }
+      ];
+      
+      logEntries = [];
+      
+      await sdk.lifecycle.createAsset(resources);
+      
+      // Should have logged with duration
+      const timedLogs = logEntries.filter(e => 
+        e.message.includes('completed') && e.duration !== undefined
+      );
+      expect(timedLogs.length).toBeGreaterThan(0);
+      
+      // Duration should be reasonable
+      const duration = timedLogs[0].duration!;
+      expect(duration).toBeGreaterThan(0);
+      expect(duration).toBeLessThan(10000); // Less than 10 seconds
+    });
+  });
+  
+  describe('event logging integration', () => {
+    test('should automatically log events', async () => {
+      const sdk = OriginalsSDK.create({
+        network: 'testnet',
+        defaultKeyType: 'ES256K',
+        logging: {
+          level: 'info',
+          outputs: [mockOutput],
+          eventLogging: {
+            'asset:created': 'info'
+          }
+        }
+      });
+      
+      const resources = [
+        {
+          id: 'test-resource',
+          type: 'text',
+          contentType: 'text/plain',
+          hash: 'abc123',
+          content: 'Hello World'
+        }
+      ];
+      
+      logEntries = [];
+      
+      const asset = await sdk.lifecycle.createAsset(resources);
+      
+      // Wait for microtask (event is deferred)
+      await new Promise(resolve => setTimeout(resolve, 10));
+      
+      // Should have logged the asset:created event
+      const eventLogs = logEntries.filter(e => e.context.includes('Events'));
+      expect(eventLogs.length).toBeGreaterThan(0);
+    });
+  });
+  
+  describe('metrics collection', () => {
+    test('should collect metrics from lifecycle operations', async () => {
+      const sdk = OriginalsSDK.create({
+        network: 'testnet',
+        defaultKeyType: 'ES256K',
+        metrics: {
+          enabled: true
+        }
+      });
+      
+      const resources = [
+        {
+          id: 'test-resource',
+          type: 'text',
+          contentType: 'text/plain',
+          hash: 'abc123',
+          content: 'Hello World'
+        }
+      ];
+      
+      await sdk.lifecycle.createAsset(resources);
+      await sdk.lifecycle.createAsset(resources);
+      
+      // Get metrics from LifecycleManager
+      const lifecycleMetrics = (sdk.lifecycle as any).metrics.getMetrics();
+      
+      expect(lifecycleMetrics.assetsCreated).toBe(2);
+    });
+    
+    test('should export metrics in JSON format', async () => {
+      const sdk = OriginalsSDK.create({
+        network: 'testnet',
+        defaultKeyType: 'ES256K'
+      });
+      
+      const resources = [
+        {
+          id: 'test-resource',
+          type: 'text',
+          contentType: 'text/plain',
+          hash: 'abc123',
+          content: 'Hello World'
+        }
+      ];
+      
+      await sdk.lifecycle.createAsset(resources);
+      
+      const lifecycleMetrics = (sdk.lifecycle as any).metrics;
+      const json = lifecycleMetrics.export('json');
+      
+      expect(() => JSON.parse(json)).not.toThrow();
+      
+      const parsed = JSON.parse(json);
+      expect(parsed.assetsCreated).toBeGreaterThan(0);
+    });
+    
+    test('should export metrics in Prometheus format', async () => {
+      const sdk = OriginalsSDK.create({
+        network: 'testnet',
+        defaultKeyType: 'ES256K'
+      });
+      
+      const resources = [
+        {
+          id: 'test-resource',
+          type: 'text',
+          contentType: 'text/plain',
+          hash: 'abc123',
+          content: 'Hello World'
+        }
+      ];
+      
+      await sdk.lifecycle.createAsset(resources);
+      
+      const lifecycleMetrics = (sdk.lifecycle as any).metrics;
+      const prometheus = lifecycleMetrics.export('prometheus');
+      
+      expect(prometheus).toContain('originals_assets_created_total');
+    });
+  });
+  
+  describe('error logging', () => {
+    test('should log errors during operations', async () => {
+      const sdk = OriginalsSDK.create({
+        network: 'testnet',
+        defaultKeyType: 'ES256K',
+        logging: {
+          level: 'error',
+          outputs: [mockOutput]
+        }
+      });
+      
+      logEntries = [];
+      
+      // Try to create asset with invalid resources
+      try {
+        await sdk.lifecycle.createAsset([]);
+      } catch (error) {
+        // Expected to fail
+      }
+      
+      // Should have logged the error
+      const errorLogs = logEntries.filter(e => e.level === 'error');
+      expect(errorLogs.length).toBeGreaterThan(0);
+    });
+    
+    test('should record error metrics', async () => {
+      const sdk = OriginalsSDK.create({
+        network: 'testnet',
+        defaultKeyType: 'ES256K'
+      });
+      
+      // Try to create asset with invalid resources
+      try {
+        await sdk.lifecycle.createAsset([]);
+      } catch (error) {
+        // Expected to fail
+      }
+      
+      const lifecycleMetrics = (sdk.lifecycle as any).metrics.getMetrics();
+      
+      // Should have recorded an error
+      expect(Object.keys(lifecycleMetrics.errors).length).toBeGreaterThan(0);
+    });
+  });
+  
+  describe('child loggers', () => {
+    test('should use hierarchical context in logs', async () => {
+      const sdk = OriginalsSDK.create({
+        network: 'testnet',
+        defaultKeyType: 'ES256K',
+        logging: {
+          level: 'info',
+          outputs: [mockOutput]
+        }
+      });
+      
+      const childLogger = sdk.logger.child('TestModule');
+      
+      logEntries = [];
+      childLogger.info('Test message');
+      
+      expect(logEntries.length).toBe(1);
+      expect(logEntries[0].context).toBe('SDK:TestModule');
+    });
+  });
+  
+  describe('configuration options', () => {
+    test('should respect log level configuration', () => {
+      const sdk = new OriginalsSDK({
+        network: 'testnet',
+        defaultKeyType: 'ES256K',
+        logging: {
+          level: 'warn',
+          outputs: [mockOutput]
+        }
+      });
+      
+      logEntries = [];
+      
+      sdk.logger.debug('Debug message');
+      sdk.logger.info('Info message');
+      sdk.logger.warn('Warn message');
+      
+      // Only warn and above should be logged
+      expect(logEntries.length).toBe(1);
+      expect(logEntries[0].level).toBe('warn');
+    });
+    
+    test('should support custom event logging configuration', async () => {
+      const sdk = OriginalsSDK.create({
+        network: 'testnet',
+        defaultKeyType: 'ES256K',
+        logging: {
+          level: 'info',
+          outputs: [mockOutput],
+          eventLogging: {
+            'asset:created': 'info',
+            'asset:migrated': false // Disable migration logging
+          }
+        }
+      });
+      
+      const resources = [
+        {
+          id: 'test-resource',
+          type: 'text',
+          contentType: 'text/plain',
+          hash: 'abc123',
+          content: 'Hello World'
+        }
+      ];
+      
+      logEntries = [];
+      
+      await sdk.lifecycle.createAsset(resources);
+      
+      // Wait for events
+      await new Promise(resolve => setTimeout(resolve, 10));
+      
+      // Should have logs (configuration doesn't crash)
+      expect(logEntries.length).toBeGreaterThan(0);
+    });
+  });
+  
+  describe('data sanitization', () => {
+    test('should sanitize sensitive data in logs', () => {
+      const sdk = new OriginalsSDK({
+        network: 'testnet',
+        defaultKeyType: 'ES256K',
+        logging: {
+          level: 'info',
+          outputs: [mockOutput],
+          sanitizeLogs: true
+        }
+      });
+      
+      logEntries = [];
+      
+      sdk.logger.info('User operation', {
+        username: 'alice',
+        privateKey: 'z6Mk...',
+        operation: 'create'
+      });
+      
+      expect(logEntries.length).toBe(1);
+      expect(logEntries[0].data.username).toBe('alice');
+      expect(logEntries[0].data.privateKey).toBe('[REDACTED]');
+      expect(logEntries[0].data.operation).toBe('create');
+    });
+  });
+});
+

--- a/tests/performance/logging.perf.test.ts
+++ b/tests/performance/logging.perf.test.ts
@@ -1,0 +1,336 @@
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { Logger, type LogOutput, type LogEntry } from '../../src/utils/Logger';
+import { MetricsCollector } from '../../src/utils/MetricsCollector';
+import { EventLogger } from '../../src/utils/EventLogger';
+import { EventEmitter } from '../../src/events/EventEmitter';
+import type { OriginalsConfig, AssetCreatedEvent } from '../../src/types';
+
+describe('Logging Performance Benchmarks', () => {
+  let config: OriginalsConfig;
+  let noOpOutput: LogOutput;
+  
+  beforeEach(() => {
+    noOpOutput = {
+      write: () => {} // No-op for performance testing
+    };
+    
+    config = {
+      network: 'mainnet',
+      defaultKeyType: 'ES256K',
+      logging: {
+        level: 'info',
+        outputs: [noOpOutput]
+      }
+    };
+  });
+  
+  describe('Logger performance', () => {
+    test('should log with <1ms overhead per call', () => {
+      const logger = new Logger('Test', config);
+      
+      const iterations = 1000;
+      const start = performance.now();
+      
+      for (let i = 0; i < iterations; i++) {
+        logger.info('Test message', { iteration: i });
+      }
+      
+      const duration = performance.now() - start;
+      const avgDuration = duration / iterations;
+      
+      console.log(`Logger average time per call: ${avgDuration.toFixed(3)}ms`);
+      
+      expect(avgDuration).toBeLessThan(1);
+    });
+    
+    test('should handle child logger creation efficiently', () => {
+      const logger = new Logger('Test', config);
+      
+      const iterations = 1000;
+      const start = performance.now();
+      
+      for (let i = 0; i < iterations; i++) {
+        const child = logger.child(`Child${i}`);
+        child.info('Test message');
+      }
+      
+      const duration = performance.now() - start;
+      const avgDuration = duration / iterations;
+      
+      console.log(`Child logger + log average time: ${avgDuration.toFixed(3)}ms`);
+      
+      expect(avgDuration).toBeLessThan(2);
+    });
+    
+    test('should handle timer operations efficiently', () => {
+      const logger = new Logger('Test', config);
+      config.logging!.level = 'debug'; // Enable debug to see timer logs
+      
+      const iterations = 1000;
+      const start = performance.now();
+      
+      for (let i = 0; i < iterations; i++) {
+        const stopTimer = logger.startTimer(`operation${i}`);
+        stopTimer();
+      }
+      
+      const duration = performance.now() - start;
+      const avgDuration = duration / iterations;
+      
+      console.log(`Timer operation average time: ${avgDuration.toFixed(3)}ms`);
+      
+      expect(avgDuration).toBeLessThan(1);
+    });
+    
+    test('should filter log levels efficiently', () => {
+      const logger = new Logger('Test', config);
+      config.logging!.level = 'error'; // High threshold
+      
+      const iterations = 10000;
+      const start = performance.now();
+      
+      for (let i = 0; i < iterations; i++) {
+        logger.debug('Debug message'); // Should be filtered
+        logger.info('Info message');   // Should be filtered
+        logger.warn('Warn message');   // Should be filtered
+      }
+      
+      const duration = performance.now() - start;
+      const avgDuration = duration / (iterations * 3);
+      
+      console.log(`Filtered log average time: ${avgDuration.toFixed(3)}ms`);
+      
+      // Filtered logs should be even faster
+      expect(avgDuration).toBeLessThan(0.1);
+    });
+  });
+  
+  describe('MetricsCollector performance', () => {
+    test('should record operations efficiently', () => {
+      const metrics = new MetricsCollector();
+      
+      const iterations = 10000;
+      const start = performance.now();
+      
+      for (let i = 0; i < iterations; i++) {
+        metrics.recordOperation('testOp', Math.random() * 100, true);
+      }
+      
+      const duration = performance.now() - start;
+      const avgDuration = duration / iterations;
+      
+      console.log(`MetricsCollector record average time: ${avgDuration.toFixed(3)}ms`);
+      
+      expect(avgDuration).toBeLessThan(0.1);
+    });
+    
+    test('should handle concurrent metric types efficiently', () => {
+      const metrics = new MetricsCollector();
+      
+      const iterations = 1000;
+      const start = performance.now();
+      
+      for (let i = 0; i < iterations; i++) {
+        metrics.recordAssetCreated();
+        metrics.recordMigration('did:peer', 'did:webvh');
+        metrics.recordTransfer();
+        metrics.recordError('ERR_001');
+        metrics.recordCacheHit();
+        metrics.recordCacheMiss();
+      }
+      
+      const duration = performance.now() - start;
+      const avgDuration = duration / (iterations * 6);
+      
+      console.log(`Multiple metric types average time: ${avgDuration.toFixed(3)}ms`);
+      
+      expect(avgDuration).toBeLessThan(0.1);
+    });
+    
+    test('should export large metric sets efficiently', () => {
+      const metrics = new MetricsCollector();
+      
+      // Generate large metric set
+      for (let i = 0; i < 1000; i++) {
+        metrics.recordOperation(`op${i % 10}`, Math.random() * 100, true);
+        metrics.recordAssetCreated();
+        metrics.recordMigration('did:peer', 'did:webvh');
+      }
+      
+      // Test JSON export
+      const jsonStart = performance.now();
+      const json = metrics.export('json');
+      const jsonDuration = performance.now() - jsonStart;
+      
+      console.log(`JSON export time: ${jsonDuration.toFixed(3)}ms`);
+      
+      expect(jsonDuration).toBeLessThan(50);
+      
+      // Test Prometheus export
+      const promStart = performance.now();
+      const prom = metrics.export('prometheus');
+      const promDuration = performance.now() - promStart;
+      
+      console.log(`Prometheus export time: ${promDuration.toFixed(3)}ms`);
+      
+      expect(promDuration).toBeLessThan(100);
+    });
+  });
+  
+  describe('EventLogger performance', () => {
+    test('should handle event logging with <0.5ms overhead', async () => {
+      const logger = new Logger('Test', config);
+      const metrics = new MetricsCollector();
+      const eventLogger = new EventLogger(logger, metrics);
+      const eventEmitter = new EventEmitter();
+      
+      eventLogger.subscribeToEvents(eventEmitter);
+      
+      const event: AssetCreatedEvent = {
+        type: 'asset:created',
+        timestamp: new Date().toISOString(),
+        asset: {
+          id: 'did:peer:test123',
+          layer: 'did:peer',
+          resourceCount: 1,
+          createdAt: new Date().toISOString()
+        }
+      };
+      
+      const iterations = 100;
+      const start = performance.now();
+      
+      for (let i = 0; i < iterations; i++) {
+        await eventEmitter.emit(event);
+      }
+      
+      const duration = performance.now() - start;
+      const avgDuration = duration / iterations;
+      
+      console.log(`EventLogger average time per event: ${avgDuration.toFixed(3)}ms`);
+      
+      expect(avgDuration).toBeLessThan(0.5);
+    });
+  });
+  
+  describe('Memory efficiency', () => {
+    test('should not leak memory with many log calls', () => {
+      const logger = new Logger('Test', config);
+      
+      // Create a buffer to store some references
+      const beforeMemory = (process as any).memoryUsage?.() || { heapUsed: 0 };
+      
+      for (let i = 0; i < 10000; i++) {
+        logger.info('Test message', { 
+          iteration: i,
+          data: { key: 'value', nested: { deep: 'data' } }
+        });
+      }
+      
+      // Force garbage collection if available
+      if (global.gc) {
+        global.gc();
+      }
+      
+      const afterMemory = (process as any).memoryUsage?.() || { heapUsed: 0 };
+      
+      // Memory increase should be minimal (less than 10MB)
+      const memoryIncrease = (afterMemory.heapUsed - beforeMemory.heapUsed) / 1024 / 1024;
+      
+      console.log(`Memory increase after 10k logs: ${memoryIncrease.toFixed(2)}MB`);
+      
+      expect(memoryIncrease).toBeLessThan(10);
+    });
+    
+    test('should not leak memory in metrics collection', () => {
+      const metrics = new MetricsCollector();
+      
+      const beforeMemory = (process as any).memoryUsage?.() || { heapUsed: 0 };
+      
+      // Record many operations
+      for (let i = 0; i < 50000; i++) {
+        metrics.recordOperation(`op${i % 20}`, Math.random() * 100, true);
+      }
+      
+      if (global.gc) {
+        global.gc();
+      }
+      
+      const afterMemory = (process as any).memoryUsage?.() || { heapUsed: 0 };
+      
+      const memoryIncrease = (afterMemory.heapUsed - beforeMemory.heapUsed) / 1024 / 1024;
+      
+      console.log(`Memory increase after 50k metrics: ${memoryIncrease.toFixed(2)}MB`);
+      
+      // Should only store aggregated data for 20 operations, not 50k entries
+      expect(memoryIncrease).toBeLessThan(5);
+    });
+  });
+  
+  describe('Sanitization performance', () => {
+    test('should sanitize data efficiently', () => {
+      config.logging!.sanitizeLogs = true;
+      const logger = new Logger('Test', config);
+      
+      const sensitiveData = {
+        username: 'alice',
+        privateKey: 'z6Mk...',
+        publicKey: 'z6Mk...',
+        data: {
+          nested: {
+            secret: 'top-secret',
+            password: 'password123'
+          }
+        }
+      };
+      
+      const iterations = 1000;
+      const start = performance.now();
+      
+      for (let i = 0; i < iterations; i++) {
+        logger.info('User data', sensitiveData);
+      }
+      
+      const duration = performance.now() - start;
+      const avgDuration = duration / iterations;
+      
+      console.log(`Sanitization average time: ${avgDuration.toFixed(3)}ms`);
+      
+      // Sanitization should add minimal overhead
+      expect(avgDuration).toBeLessThan(2);
+    });
+  });
+  
+  describe('Overall telemetry impact', () => {
+    test('should have minimal impact on SDK operations', async () => {
+      const logger = new Logger('SDK', config);
+      const metrics = new MetricsCollector();
+      
+      // Simulate SDK operation with full logging
+      const iterations = 100;
+      const start = performance.now();
+      
+      for (let i = 0; i < iterations; i++) {
+        const childLogger = logger.child('Operation');
+        const stopTimer = childLogger.startTimer('fullOperation');
+        
+        childLogger.info('Starting operation', { iteration: i });
+        
+        // Simulate work
+        metrics.recordOperation('work', Math.random() * 10, true);
+        
+        childLogger.info('Operation completed', { iteration: i });
+        stopTimer();
+      }
+      
+      const duration = performance.now() - start;
+      const avgDuration = duration / iterations;
+      
+      console.log(`Full telemetry stack average time: ${avgDuration.toFixed(3)}ms`);
+      
+      // Total overhead should be less than 2ms per operation
+      expect(avgDuration).toBeLessThan(2);
+    });
+  });
+});
+

--- a/tests/unit/utils/EventIntegration.test.ts
+++ b/tests/unit/utils/EventIntegration.test.ts
@@ -1,0 +1,384 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { EventLogger } from '../../../src/utils/EventLogger';
+import { Logger, type LogOutput } from '../../../src/utils/Logger';
+import { MetricsCollector } from '../../../src/utils/MetricsCollector';
+import { EventEmitter } from '../../../src/events/EventEmitter';
+import type { AssetCreatedEvent, AssetMigratedEvent, AssetTransferredEvent } from '../../../src/events/types';
+import type { OriginalsConfig } from '../../../src/types';
+
+describe('EventIntegration', () => {
+  let eventEmitter: EventEmitter;
+  let logger: Logger;
+  let metricsCollector: MetricsCollector;
+  let eventLogger: EventLogger;
+  let config: OriginalsConfig;
+  let logOutput: any;
+  
+  beforeEach(() => {
+    eventEmitter = new EventEmitter();
+    metricsCollector = new MetricsCollector();
+    
+    logOutput = mock(() => {});
+    const mockOutput: LogOutput = {
+      write: logOutput
+    };
+    
+    config = {
+      network: 'mainnet',
+      defaultKeyType: 'ES256K',
+      logging: {
+        level: 'info',
+        outputs: [mockOutput]
+      }
+    };
+    
+    logger = new Logger('Test', config);
+    eventLogger = new EventLogger(logger, metricsCollector);
+  });
+  
+  describe('event subscription', () => {
+    test('should subscribe to all event types', () => {
+      eventLogger.subscribeToEvents(eventEmitter);
+      
+      // Check that event emitter has listeners
+      expect(eventEmitter.hasListeners('asset:created')).toBe(true);
+      expect(eventEmitter.hasListeners('asset:migrated')).toBe(true);
+      expect(eventEmitter.hasListeners('asset:transferred')).toBe(true);
+      expect(eventEmitter.hasListeners('resource:published')).toBe(true);
+      expect(eventEmitter.hasListeners('credential:issued')).toBe(true);
+      expect(eventEmitter.hasListeners('verification:completed')).toBe(true);
+    });
+    
+    test('should unsubscribe from all events', () => {
+      eventLogger.subscribeToEvents(eventEmitter);
+      eventLogger.unsubscribe();
+      
+      expect(eventEmitter.hasListeners('asset:created')).toBe(false);
+      expect(eventEmitter.hasListeners('asset:migrated')).toBe(false);
+      expect(eventEmitter.hasListeners('asset:transferred')).toBe(false);
+    });
+  });
+  
+  describe('event logging', () => {
+    beforeEach(() => {
+      eventLogger.subscribeToEvents(eventEmitter);
+    });
+    
+    test('should log asset:created events', async () => {
+      const event: AssetCreatedEvent = {
+        type: 'asset:created',
+        timestamp: new Date().toISOString(),
+        asset: {
+          id: 'did:peer:123',
+          layer: 'did:peer',
+          resourceCount: 2,
+          createdAt: new Date().toISOString()
+        }
+      };
+      
+      await eventEmitter.emit(event);
+      
+      expect(logOutput).toHaveBeenCalled();
+      const logEntry = logOutput.mock.calls[0][0];
+      expect(logEntry.message).toBe('Asset created');
+      expect(logEntry.data.assetId).toBe('did:peer:123');
+      expect(logEntry.data.resourceCount).toBe(2);
+    });
+    
+    test('should log asset:migrated events', async () => {
+      const event: AssetMigratedEvent = {
+        type: 'asset:migrated',
+        timestamp: new Date().toISOString(),
+        asset: {
+          id: 'did:peer:123',
+          fromLayer: 'did:peer',
+          toLayer: 'did:webvh'
+        },
+        details: {
+          transactionId: 'tx123'
+        }
+      };
+      
+      await eventEmitter.emit(event);
+      
+      expect(logOutput).toHaveBeenCalled();
+      const logEntry = logOutput.mock.calls[0][0];
+      expect(logEntry.message).toBe('Asset migrated');
+      expect(logEntry.data.fromLayer).toBe('did:peer');
+      expect(logEntry.data.toLayer).toBe('did:webvh');
+    });
+    
+    test('should log asset:transferred events', async () => {
+      const event: AssetTransferredEvent = {
+        type: 'asset:transferred',
+        timestamp: new Date().toISOString(),
+        asset: {
+          id: 'did:btco:123',
+          layer: 'did:btco'
+        },
+        from: 'alice',
+        to: 'bc1q...',
+        transactionId: 'tx456'
+      };
+      
+      await eventEmitter.emit(event);
+      
+      expect(logOutput).toHaveBeenCalled();
+      const logEntry = logOutput.mock.calls[0][0];
+      expect(logEntry.message).toBe('Asset transferred');
+      expect(logEntry.data.from).toBe('alice');
+      expect(logEntry.data.to).toBe('bc1q...');
+    });
+  });
+  
+  describe('metrics extraction', () => {
+    beforeEach(() => {
+      eventLogger.subscribeToEvents(eventEmitter);
+    });
+    
+    test('should extract metrics from asset:created events', async () => {
+      const event: AssetCreatedEvent = {
+        type: 'asset:created',
+        timestamp: new Date().toISOString(),
+        asset: {
+          id: 'did:peer:123',
+          layer: 'did:peer',
+          resourceCount: 1,
+          createdAt: new Date().toISOString()
+        }
+      };
+      
+      await eventEmitter.emit(event);
+      
+      const metrics = metricsCollector.getMetrics();
+      expect(metrics.assetsCreated).toBe(1);
+    });
+    
+    test('should extract metrics from asset:migrated events', async () => {
+      const event: AssetMigratedEvent = {
+        type: 'asset:migrated',
+        timestamp: new Date().toISOString(),
+        asset: {
+          id: 'did:peer:123',
+          fromLayer: 'did:peer',
+          toLayer: 'did:webvh'
+        }
+      };
+      
+      await eventEmitter.emit(event);
+      
+      const metrics = metricsCollector.getMetrics();
+      expect(metrics.assetsMigrated['peer→webvh']).toBe(1);
+    });
+    
+    test('should extract metrics from asset:transferred events', async () => {
+      const event: AssetTransferredEvent = {
+        type: 'asset:transferred',
+        timestamp: new Date().toISOString(),
+        asset: {
+          id: 'did:btco:123',
+          layer: 'did:btco'
+        },
+        from: 'alice',
+        to: 'bc1q...',
+        transactionId: 'tx456'
+      };
+      
+      await eventEmitter.emit(event);
+      
+      const metrics = metricsCollector.getMetrics();
+      expect(metrics.assetsTransferred).toBe(1);
+    });
+    
+    test('should track multiple events', async () => {
+      const events = [
+        {
+          type: 'asset:created' as const,
+          timestamp: new Date().toISOString(),
+          asset: {
+            id: 'did:peer:1',
+            layer: 'did:peer' as const,
+            resourceCount: 1,
+            createdAt: new Date().toISOString()
+          }
+        },
+        {
+          type: 'asset:created' as const,
+          timestamp: new Date().toISOString(),
+          asset: {
+            id: 'did:peer:2',
+            layer: 'did:peer' as const,
+            resourceCount: 1,
+            createdAt: new Date().toISOString()
+          }
+        },
+        {
+          type: 'asset:migrated' as const,
+          timestamp: new Date().toISOString(),
+          asset: {
+            id: 'did:peer:1',
+            fromLayer: 'did:peer' as const,
+            toLayer: 'did:webvh' as const
+          }
+        }
+      ];
+      
+      for (const event of events) {
+        await eventEmitter.emit(event);
+      }
+      
+      const metrics = metricsCollector.getMetrics();
+      expect(metrics.assetsCreated).toBe(2);
+      expect(metrics.assetsMigrated['peer→webvh']).toBe(1);
+    });
+  });
+  
+  describe('event logging configuration', () => {
+    test('should respect custom log levels', async () => {
+      eventLogger.configureEventLogging({
+        'asset:created': 'debug',
+        'asset:migrated': 'warn'
+      });
+      
+      eventLogger.subscribeToEvents(eventEmitter);
+      
+      const event: AssetCreatedEvent = {
+        type: 'asset:created',
+        timestamp: new Date().toISOString(),
+        asset: {
+          id: 'did:peer:123',
+          layer: 'did:peer',
+          resourceCount: 1,
+          createdAt: new Date().toISOString()
+        }
+      };
+      
+      // With default info level, debug logs won't appear
+      await eventEmitter.emit(event);
+      
+      // Log should not appear because debug is below info threshold
+      // (Logger is configured with 'info' level)
+      // This is a smoke test to ensure configuration doesn't crash
+      expect(logOutput.mock.calls.length).toBeGreaterThanOrEqual(0);
+    });
+    
+    test('should disable logging for specific events', async () => {
+      eventLogger.configureEventLogging({
+        'asset:created': false
+      });
+      
+      eventLogger.subscribeToEvents(eventEmitter);
+      
+      const createdEvent: AssetCreatedEvent = {
+        type: 'asset:created',
+        timestamp: new Date().toISOString(),
+        asset: {
+          id: 'did:peer:123',
+          layer: 'did:peer',
+          resourceCount: 1,
+          createdAt: new Date().toISOString()
+        }
+      };
+      
+      const migratedEvent: AssetMigratedEvent = {
+        type: 'asset:migrated',
+        timestamp: new Date().toISOString(),
+        asset: {
+          id: 'did:peer:123',
+          fromLayer: 'did:peer',
+          toLayer: 'did:webvh'
+        }
+      };
+      
+      await eventEmitter.emit(createdEvent);
+      const callsAfterCreated = logOutput.mock.calls.length;
+      
+      await eventEmitter.emit(migratedEvent);
+      const callsAfterMigrated = logOutput.mock.calls.length;
+      
+      // asset:created should not log, asset:migrated should log
+      expect(callsAfterMigrated).toBeGreaterThan(callsAfterCreated);
+    });
+    
+    test('should still extract metrics even when logging is disabled', async () => {
+      eventLogger.configureEventLogging({
+        'asset:created': false
+      });
+      
+      eventLogger.subscribeToEvents(eventEmitter);
+      
+      const event: AssetCreatedEvent = {
+        type: 'asset:created',
+        timestamp: new Date().toISOString(),
+        asset: {
+          id: 'did:peer:123',
+          layer: 'did:peer',
+          resourceCount: 1,
+          createdAt: new Date().toISOString()
+        }
+      };
+      
+      await eventEmitter.emit(event);
+      
+      // Metrics should still be recorded
+      const metrics = metricsCollector.getMetrics();
+      expect(metrics.assetsCreated).toBe(1);
+    });
+  });
+  
+  describe('performance', () => {
+    test('should have minimal overhead (<1ms per event)', async () => {
+      eventLogger.subscribeToEvents(eventEmitter);
+      
+      const event: AssetCreatedEvent = {
+        type: 'asset:created',
+        timestamp: new Date().toISOString(),
+        asset: {
+          id: 'did:peer:123',
+          layer: 'did:peer',
+          resourceCount: 1,
+          createdAt: new Date().toISOString()
+        }
+      };
+      
+      const start = performance.now();
+      for (let i = 0; i < 100; i++) {
+        await eventEmitter.emit(event);
+      }
+      const duration = performance.now() - start;
+      
+      const avgDuration = duration / 100;
+      
+      // Each event should add less than 1ms overhead
+      expect(avgDuration).toBeLessThan(1);
+    });
+  });
+  
+  describe('error handling', () => {
+    test('should not throw if metrics recording fails', async () => {
+      // Create a spy that throws
+      const brokenMetrics = new MetricsCollector();
+      (brokenMetrics as any).recordAssetCreated = () => {
+        throw new Error('Metrics error');
+      };
+      
+      const brokenEventLogger = new EventLogger(logger, brokenMetrics);
+      brokenEventLogger.subscribeToEvents(eventEmitter);
+      
+      const event: AssetCreatedEvent = {
+        type: 'asset:created',
+        timestamp: new Date().toISOString(),
+        asset: {
+          id: 'did:peer:123',
+          layer: 'did:peer',
+          resourceCount: 1,
+          createdAt: new Date().toISOString()
+        }
+      };
+      
+      // Should not throw even if metrics recording fails
+      await expect(eventEmitter.emit(event)).resolves.toBeUndefined();
+    });
+  });
+});
+

--- a/tests/unit/utils/Logger.test.ts
+++ b/tests/unit/utils/Logger.test.ts
@@ -1,0 +1,473 @@
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { Logger, ConsoleLogOutput, FileLogOutput, type LogEntry, type LogOutput } from '../../../src/utils/Logger';
+import type { OriginalsConfig } from '../../../src/types';
+
+describe('Logger', () => {
+  let config: OriginalsConfig;
+  
+  beforeEach(() => {
+    config = {
+      network: 'mainnet',
+      defaultKeyType: 'ES256K',
+      logging: {
+        level: 'info'
+      }
+    };
+  });
+  
+  describe('log levels', () => {
+    test('should log at debug level', () => {
+      const output = mock(() => {});
+      const mockOutput: LogOutput = {
+        write: output
+      };
+      
+      config.logging!.level = 'debug';
+      config.logging!.outputs = [mockOutput];
+      config.logging!.sanitizeLogs = false; // Disable sanitization for this test
+      
+      const logger = new Logger('Test', config);
+      logger.debug('Debug message', { testField: 'value' });
+      
+      expect(output).toHaveBeenCalledTimes(1);
+      const entry = output.mock.calls[0][0] as LogEntry;
+      expect(entry.level).toBe('debug');
+      expect(entry.message).toBe('Debug message');
+      expect(entry.data).toEqual({ testField: 'value' });
+    });
+    
+    test('should log at info level', () => {
+      const output = mock(() => {});
+      const mockOutput: LogOutput = {
+        write: output
+      };
+      
+      config.logging!.outputs = [mockOutput];
+      
+      const logger = new Logger('Test', config);
+      logger.info('Info message');
+      
+      expect(output).toHaveBeenCalledTimes(1);
+      const entry = output.mock.calls[0][0] as LogEntry;
+      expect(entry.level).toBe('info');
+      expect(entry.message).toBe('Info message');
+    });
+    
+    test('should log at warn level', () => {
+      const output = mock(() => {});
+      const mockOutput: LogOutput = {
+        write: output
+      };
+      
+      config.logging!.outputs = [mockOutput];
+      
+      const logger = new Logger('Test', config);
+      logger.warn('Warning message');
+      
+      expect(output).toHaveBeenCalledTimes(1);
+      const entry = output.mock.calls[0][0] as LogEntry;
+      expect(entry.level).toBe('warn');
+      expect(entry.message).toBe('Warning message');
+    });
+    
+    test('should log at error level with error object', () => {
+      const output = mock(() => {});
+      const mockOutput: LogOutput = {
+        write: output
+      };
+      
+      config.logging!.outputs = [mockOutput];
+      
+      const logger = new Logger('Test', config);
+      const error = new Error('Test error');
+      logger.error('Error occurred', error);
+      
+      expect(output).toHaveBeenCalledTimes(1);
+      const entry = output.mock.calls[0][0] as LogEntry;
+      expect(entry.level).toBe('error');
+      expect(entry.message).toBe('Error occurred');
+      expect(entry.data.error.message).toBe('Test error');
+      expect(entry.data.error.name).toBe('Error');
+    });
+  });
+  
+  describe('log level filtering', () => {
+    test('should filter out debug logs when level is info', () => {
+      const output = mock(() => {});
+      const mockOutput: LogOutput = {
+        write: output
+      };
+      
+      config.logging!.level = 'info';
+      config.logging!.outputs = [mockOutput];
+      
+      const logger = new Logger('Test', config);
+      logger.debug('Should not appear');
+      logger.info('Should appear');
+      
+      expect(output).toHaveBeenCalledTimes(1);
+      const entry = output.mock.calls[0][0] as LogEntry;
+      expect(entry.level).toBe('info');
+    });
+    
+    test('should filter out info and debug when level is warn', () => {
+      const output = mock(() => {});
+      const mockOutput: LogOutput = {
+        write: output
+      };
+      
+      config.logging!.level = 'warn';
+      config.logging!.outputs = [mockOutput];
+      
+      const logger = new Logger('Test', config);
+      logger.debug('Should not appear');
+      logger.info('Should not appear');
+      logger.warn('Should appear');
+      logger.error('Should appear');
+      
+      expect(output).toHaveBeenCalledTimes(2);
+    });
+    
+    test('should only log errors when level is error', () => {
+      const output = mock(() => {});
+      const mockOutput: LogOutput = {
+        write: output
+      };
+      
+      config.logging!.level = 'error';
+      config.logging!.outputs = [mockOutput];
+      
+      const logger = new Logger('Test', config);
+      logger.debug('Should not appear');
+      logger.info('Should not appear');
+      logger.warn('Should not appear');
+      logger.error('Should appear');
+      
+      expect(output).toHaveBeenCalledTimes(1);
+    });
+  });
+  
+  describe('child loggers', () => {
+    test('should create child logger with nested context', () => {
+      const output = mock(() => {});
+      const mockOutput: LogOutput = {
+        write: output
+      };
+      
+      config.logging!.outputs = [mockOutput];
+      
+      const parentLogger = new Logger('Parent', config);
+      const childLogger = parentLogger.child('Child');
+      
+      childLogger.info('Message from child');
+      
+      expect(output).toHaveBeenCalledTimes(1);
+      const entry = output.mock.calls[0][0] as LogEntry;
+      expect(entry.context).toBe('Parent:Child');
+    });
+    
+    test('should support multiple levels of nesting', () => {
+      const output = mock(() => {});
+      const mockOutput: LogOutput = {
+        write: output
+      };
+      
+      config.logging!.outputs = [mockOutput];
+      
+      const logger = new Logger('SDK', config);
+      const child1 = logger.child('Lifecycle');
+      const child2 = child1.child('CreateAsset');
+      
+      child2.info('Deeply nested message');
+      
+      expect(output).toHaveBeenCalledTimes(1);
+      const entry = output.mock.calls[0][0] as LogEntry;
+      expect(entry.context).toBe('SDK:Lifecycle:CreateAsset');
+    });
+    
+    test('should inherit log level from parent', () => {
+      const output = mock(() => {});
+      const mockOutput: LogOutput = {
+        write: output
+      };
+      
+      config.logging!.level = 'warn';
+      config.logging!.outputs = [mockOutput];
+      
+      const parentLogger = new Logger('Parent', config);
+      const childLogger = parentLogger.child('Child');
+      
+      childLogger.info('Should not appear');
+      childLogger.warn('Should appear');
+      
+      expect(output).toHaveBeenCalledTimes(1);
+    });
+  });
+  
+  describe('timer functionality', () => {
+    test('should track operation duration', () => {
+      const output = mock(() => {});
+      const mockOutput: LogOutput = {
+        write: output
+      };
+      
+      config.logging!.level = 'debug';
+      config.logging!.outputs = [mockOutput];
+      
+      const logger = new Logger('Test', config);
+      const stopTimer = logger.startTimer('testOperation');
+      
+      // Simulate some work
+      const start = Date.now();
+      while (Date.now() - start < 10) {
+        // Wait 10ms
+      }
+      
+      stopTimer();
+      
+      expect(output).toHaveBeenCalledTimes(1);
+      const entry = output.mock.calls[0][0] as LogEntry;
+      expect(entry.duration).toBeDefined();
+      expect(entry.duration!).toBeGreaterThanOrEqual(9); // Allow for timing variance
+    });
+    
+    test('should log timer completion with operation name', () => {
+      const output = mock(() => {});
+      const mockOutput: LogOutput = {
+        write: output
+      };
+      
+      config.logging!.level = 'debug';
+      config.logging!.outputs = [mockOutput];
+      
+      const logger = new Logger('Test', config);
+      const stopTimer = logger.startTimer('myOperation');
+      stopTimer();
+      
+      expect(output).toHaveBeenCalledTimes(1);
+      const entry = output.mock.calls[0][0] as LogEntry;
+      expect(entry.message).toBe('myOperation completed');
+    });
+  });
+  
+  describe('multiple outputs', () => {
+    test('should write to multiple outputs', () => {
+      const output1 = mock(() => {});
+      const output2 = mock(() => {});
+      
+      const mockOutput1: LogOutput = { write: output1 };
+      const mockOutput2: LogOutput = { write: output2 };
+      
+      config.logging!.outputs = [mockOutput1, mockOutput2];
+      
+      const logger = new Logger('Test', config);
+      logger.info('Test message');
+      
+      expect(output1).toHaveBeenCalledTimes(1);
+      expect(output2).toHaveBeenCalledTimes(1);
+    });
+    
+    test('should continue if one output fails', () => {
+      const output1 = mock(() => {
+        throw new Error('Output 1 failed');
+      });
+      const output2 = mock(() => {});
+      
+      const mockOutput1: LogOutput = { write: output1 };
+      const mockOutput2: LogOutput = { write: output2 };
+      
+      config.logging!.outputs = [mockOutput1, mockOutput2];
+      
+      const logger = new Logger('Test', config);
+      
+      // Should not throw
+      expect(() => logger.info('Test message')).not.toThrow();
+      
+      // Both outputs should be called
+      expect(output1).toHaveBeenCalledTimes(1);
+      expect(output2).toHaveBeenCalledTimes(1);
+    });
+    
+    test('should support addOutput to add additional outputs', () => {
+      const output1 = mock(() => {});
+      const output2 = mock(() => {});
+      
+      const mockOutput1: LogOutput = { write: output1 };
+      const mockOutput2: LogOutput = { write: output2 };
+      
+      config.logging!.outputs = [mockOutput1];
+      
+      const logger = new Logger('Test', config);
+      logger.addOutput(mockOutput2);
+      
+      logger.info('Test message');
+      
+      expect(output1).toHaveBeenCalledTimes(1);
+      expect(output2).toHaveBeenCalledTimes(1);
+    });
+    
+    test('should support setOutput to replace outputs', () => {
+      const output1 = mock(() => {});
+      const output2 = mock(() => {});
+      
+      const mockOutput1: LogOutput = { write: output1 };
+      const mockOutput2: LogOutput = { write: output2 };
+      
+      config.logging!.outputs = [mockOutput1];
+      
+      const logger = new Logger('Test', config);
+      logger.setOutput(mockOutput2);
+      
+      logger.info('Test message');
+      
+      expect(output1).not.toHaveBeenCalled();
+      expect(output2).toHaveBeenCalledTimes(1);
+    });
+  });
+  
+  describe('data sanitization', () => {
+    test('should sanitize private keys', () => {
+      const output = mock(() => {});
+      const mockOutput: LogOutput = {
+        write: output
+      };
+      
+      config.logging!.outputs = [mockOutput];
+      config.logging!.sanitizeLogs = true;
+      
+      const logger = new Logger('Test', config);
+      logger.info('User data', {
+        username: 'alice',
+        privateKey: 'z6Mk...',
+        publicKey: 'z6Mk...'
+      });
+      
+      expect(output).toHaveBeenCalledTimes(1);
+      const entry = output.mock.calls[0][0] as LogEntry;
+      expect(entry.data.username).toBe('alice');
+      expect(entry.data.privateKey).toBe('[REDACTED]');
+      expect(entry.data.publicKey).toBe('[REDACTED]');
+    });
+    
+    test('should sanitize nested sensitive data', () => {
+      const output = mock(() => {});
+      const mockOutput: LogOutput = {
+        write: output
+      };
+      
+      config.logging!.outputs = [mockOutput];
+      config.logging!.sanitizeLogs = true;
+      
+      const logger = new Logger('Test', config);
+      logger.info('Nested data', {
+        user: {
+          name: 'alice',
+          secret: 'top-secret',
+          credentials: { token: 'abc123' }
+        }
+      });
+      
+      expect(output).toHaveBeenCalledTimes(1);
+      const entry = output.mock.calls[0][0] as LogEntry;
+      expect(entry.data.user.name).toBe('alice');
+      expect(entry.data.user.secret).toBe('[REDACTED]');
+      expect(entry.data.user.credentials).toBe('[REDACTED]');
+    });
+    
+    test('should not sanitize when sanitizeLogs is false', () => {
+      const output = mock(() => {});
+      const mockOutput: LogOutput = {
+        write: output
+      };
+      
+      config.logging!.outputs = [mockOutput];
+      config.logging!.sanitizeLogs = false;
+      
+      const logger = new Logger('Test', config);
+      logger.info('User data', {
+        privateKey: 'z6Mk...'
+      });
+      
+      expect(output).toHaveBeenCalledTimes(1);
+      const entry = output.mock.calls[0][0] as LogEntry;
+      expect(entry.data.privateKey).toBe('z6Mk...');
+    });
+  });
+  
+  describe('ConsoleLogOutput', () => {
+    test('should format log entries correctly', () => {
+      const consoleOutput = new ConsoleLogOutput();
+      const entry: LogEntry = {
+        timestamp: '2025-10-06T12:00:00.000Z',
+        level: 'info',
+        context: 'Test',
+        message: 'Test message',
+        data: { key: 'value' }
+      };
+      
+      // Should not throw
+      expect(() => consoleOutput.write(entry)).not.toThrow();
+    });
+  });
+  
+  describe('performance', () => {
+    test('should have minimal overhead (<1ms per log call)', () => {
+      const output = mock(() => {});
+      const mockOutput: LogOutput = {
+        write: output
+      };
+      
+      config.logging!.outputs = [mockOutput];
+      
+      const logger = new Logger('Test', config);
+      
+      const start = performance.now();
+      for (let i = 0; i < 100; i++) {
+        logger.info('Test message', { iteration: i });
+      }
+      const duration = performance.now() - start;
+      
+      const avgDuration = duration / 100;
+      
+      // Each log call should take less than 1ms on average
+      expect(avgDuration).toBeLessThan(1);
+    });
+  });
+  
+  describe('configuration options', () => {
+    test('should respect includeTimestamps option', () => {
+      const output = mock(() => {});
+      const mockOutput: LogOutput = {
+        write: output
+      };
+      
+      config.logging!.outputs = [mockOutput];
+      config.logging!.includeTimestamps = false;
+      
+      const logger = new Logger('Test', config);
+      logger.info('Test message');
+      
+      expect(output).toHaveBeenCalledTimes(1);
+      const entry = output.mock.calls[0][0] as LogEntry;
+      expect(entry.timestamp).toBe('');
+    });
+    
+    test('should respect includeContext option', () => {
+      const output = mock(() => {});
+      const mockOutput: LogOutput = {
+        write: output
+      };
+      
+      config.logging!.outputs = [mockOutput];
+      config.logging!.includeContext = false;
+      
+      const logger = new Logger('Test', config);
+      logger.info('Test message');
+      
+      expect(output).toHaveBeenCalledTimes(1);
+      const entry = output.mock.calls[0][0] as LogEntry;
+      expect(entry.context).toBe('');
+    });
+  });
+});
+

--- a/tests/unit/utils/MetricsCollector.test.ts
+++ b/tests/unit/utils/MetricsCollector.test.ts
@@ -1,0 +1,358 @@
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { MetricsCollector } from '../../../src/utils/MetricsCollector';
+
+describe('MetricsCollector', () => {
+  let metrics: MetricsCollector;
+  
+  beforeEach(() => {
+    metrics = new MetricsCollector();
+  });
+  
+  describe('operation recording', () => {
+    test('should record operation with duration and success', () => {
+      metrics.recordOperation('testOp', 100, true);
+      
+      const opMetrics = metrics.getOperationMetrics('testOp');
+      
+      expect(opMetrics).not.toBeNull();
+      expect(opMetrics!.count).toBe(1);
+      expect(opMetrics!.totalTime).toBe(100);
+      expect(opMetrics!.avgTime).toBe(100);
+      expect(opMetrics!.minTime).toBe(100);
+      expect(opMetrics!.maxTime).toBe(100);
+      expect(opMetrics!.errorCount).toBe(0);
+    });
+    
+    test('should record multiple operations and calculate statistics', () => {
+      metrics.recordOperation('testOp', 50, true);
+      metrics.recordOperation('testOp', 100, true);
+      metrics.recordOperation('testOp', 150, true);
+      
+      const opMetrics = metrics.getOperationMetrics('testOp');
+      
+      expect(opMetrics!.count).toBe(3);
+      expect(opMetrics!.totalTime).toBe(300);
+      expect(opMetrics!.avgTime).toBe(100);
+      expect(opMetrics!.minTime).toBe(50);
+      expect(opMetrics!.maxTime).toBe(150);
+    });
+    
+    test('should track errors in operations', () => {
+      metrics.recordOperation('testOp', 50, true);
+      metrics.recordOperation('testOp', 100, false);
+      metrics.recordOperation('testOp', 75, false);
+      
+      const opMetrics = metrics.getOperationMetrics('testOp');
+      
+      expect(opMetrics!.count).toBe(3);
+      expect(opMetrics!.errorCount).toBe(2);
+    });
+    
+    test('should return null for non-existent operation', () => {
+      const opMetrics = metrics.getOperationMetrics('nonExistent');
+      
+      expect(opMetrics).toBeNull();
+    });
+  });
+  
+  describe('startOperation helper', () => {
+    test('should track operation duration automatically', () => {
+      const complete = metrics.startOperation('autoOp');
+      
+      // Simulate work
+      const start = Date.now();
+      while (Date.now() - start < 10) {
+        // Wait 10ms
+      }
+      
+      complete(true);
+      
+      const opMetrics = metrics.getOperationMetrics('autoOp');
+      
+      expect(opMetrics!.count).toBe(1);
+      expect(opMetrics!.totalTime).toBeGreaterThanOrEqual(9);
+    });
+    
+    test('should record success or failure', () => {
+      const complete1 = metrics.startOperation('op1');
+      complete1(true);
+      
+      const complete2 = metrics.startOperation('op1');
+      complete2(false);
+      
+      const opMetrics = metrics.getOperationMetrics('op1');
+      
+      expect(opMetrics!.count).toBe(2);
+      expect(opMetrics!.errorCount).toBe(1);
+    });
+  });
+  
+  describe('asset lifecycle metrics', () => {
+    test('should record asset creations', () => {
+      metrics.recordAssetCreated();
+      metrics.recordAssetCreated();
+      metrics.recordAssetCreated();
+      
+      const allMetrics = metrics.getMetrics();
+      
+      expect(allMetrics.assetsCreated).toBe(3);
+    });
+    
+    test('should record migrations by layer transition', () => {
+      metrics.recordMigration('did:peer', 'did:webvh');
+      metrics.recordMigration('did:peer', 'did:webvh');
+      metrics.recordMigration('did:webvh', 'did:btco');
+      
+      const allMetrics = metrics.getMetrics();
+      
+      expect(allMetrics.assetsMigrated['peer→webvh']).toBe(2);
+      expect(allMetrics.assetsMigrated['webvh→btco']).toBe(1);
+    });
+    
+    test('should record asset transfers', () => {
+      metrics.recordTransfer();
+      metrics.recordTransfer();
+      
+      const allMetrics = metrics.getMetrics();
+      
+      expect(allMetrics.assetsTransferred).toBe(2);
+    });
+  });
+  
+  describe('error tracking', () => {
+    test('should track errors by code', () => {
+      metrics.recordError('ERR_001');
+      metrics.recordError('ERR_001');
+      metrics.recordError('ERR_002');
+      
+      const allMetrics = metrics.getMetrics();
+      
+      expect(allMetrics.errors['ERR_001']).toBe(2);
+      expect(allMetrics.errors['ERR_002']).toBe(1);
+    });
+    
+    test('should increment operation error count when operation is provided', () => {
+      // First create some operations
+      metrics.recordOperation('testOp', 100, true);
+      
+      // Then record errors for that operation
+      metrics.recordError('ERR_001', 'testOp');
+      metrics.recordError('ERR_002', 'testOp');
+      
+      const opMetrics = metrics.getOperationMetrics('testOp');
+      
+      expect(opMetrics!.errorCount).toBe(2);
+    });
+  });
+  
+  describe('cache statistics', () => {
+    test('should track cache hits and misses', () => {
+      metrics.recordCacheHit();
+      metrics.recordCacheHit();
+      metrics.recordCacheMiss();
+      
+      const allMetrics = metrics.getMetrics();
+      
+      expect(allMetrics.cacheStats).toBeDefined();
+      expect(allMetrics.cacheStats!.hits).toBe(2);
+      expect(allMetrics.cacheStats!.misses).toBe(1);
+      expect(allMetrics.cacheStats!.hitRate).toBeCloseTo(2 / 3);
+    });
+    
+    test('should return undefined cache stats when no cache operations', () => {
+      const allMetrics = metrics.getMetrics();
+      
+      expect(allMetrics.cacheStats).toBeUndefined();
+    });
+    
+    test('should calculate hit rate correctly', () => {
+      // 80% hit rate
+      for (let i = 0; i < 8; i++) {
+        metrics.recordCacheHit();
+      }
+      for (let i = 0; i < 2; i++) {
+        metrics.recordCacheMiss();
+      }
+      
+      const allMetrics = metrics.getMetrics();
+      
+      expect(allMetrics.cacheStats!.hitRate).toBe(0.8);
+    });
+  });
+  
+  describe('system metrics', () => {
+    test('should track start time', () => {
+      const allMetrics = metrics.getMetrics();
+      
+      expect(allMetrics.startTime).toBeDefined();
+      expect(new Date(allMetrics.startTime).getTime()).toBeLessThanOrEqual(Date.now());
+    });
+    
+    test('should track uptime', async () => {
+      await new Promise(resolve => setTimeout(resolve, 10));
+      
+      const allMetrics = metrics.getMetrics();
+      
+      expect(allMetrics.uptime).toBeGreaterThanOrEqual(9);
+    });
+  });
+  
+  describe('reset functionality', () => {
+    test('should reset all metrics', () => {
+      // Record various metrics
+      metrics.recordAssetCreated();
+      metrics.recordMigration('did:peer', 'did:webvh');
+      metrics.recordTransfer();
+      metrics.recordOperation('testOp', 100, true);
+      metrics.recordError('ERR_001');
+      metrics.recordCacheHit();
+      metrics.recordCacheMiss();
+      
+      // Reset
+      metrics.reset();
+      
+      const allMetrics = metrics.getMetrics();
+      
+      expect(allMetrics.assetsCreated).toBe(0);
+      expect(Object.keys(allMetrics.assetsMigrated).length).toBe(0);
+      expect(allMetrics.assetsTransferred).toBe(0);
+      expect(Object.keys(allMetrics.operationTimes).length).toBe(0);
+      expect(Object.keys(allMetrics.errors).length).toBe(0);
+      expect(allMetrics.cacheStats).toBeUndefined();
+    });
+  });
+  
+  describe('export formats', () => {
+    beforeEach(() => {
+      // Set up some test metrics
+      metrics.recordAssetCreated();
+      metrics.recordAssetCreated();
+      metrics.recordMigration('did:peer', 'did:webvh');
+      metrics.recordTransfer();
+      metrics.recordOperation('createAsset', 150, true);
+      metrics.recordOperation('createAsset', 200, true);
+      metrics.recordOperation('createAsset', 250, false);
+      metrics.recordError('ERR_001');
+      metrics.recordCacheHit();
+      metrics.recordCacheMiss();
+    });
+    
+    test('should export as JSON', () => {
+      const json = metrics.export('json');
+      
+      expect(() => JSON.parse(json)).not.toThrow();
+      
+      const parsed = JSON.parse(json);
+      expect(parsed.assetsCreated).toBe(2);
+      expect(parsed.assetsMigrated['peer→webvh']).toBe(1);
+      expect(parsed.assetsTransferred).toBe(1);
+    });
+    
+    test('should export as Prometheus format', () => {
+      const prometheus = metrics.export('prometheus');
+      
+      // Check for expected Prometheus metrics
+      expect(prometheus).toContain('originals_assets_created_total');
+      expect(prometheus).toContain('originals_assets_transferred_total');
+      expect(prometheus).toContain('originals_assets_migrated_total');
+      expect(prometheus).toContain('originals_operation_createAsset_total');
+      expect(prometheus).toContain('originals_operation_createAsset_duration_milliseconds');
+      expect(prometheus).toContain('originals_errors_total');
+      expect(prometheus).toContain('originals_cache_hits_total');
+      expect(prometheus).toContain('originals_uptime_milliseconds');
+    });
+    
+    test('should format Prometheus metrics correctly', () => {
+      const prometheus = metrics.export('prometheus');
+      
+      // Check specific values
+      expect(prometheus).toContain('originals_assets_created_total 2');
+      expect(prometheus).toContain('originals_assets_transferred_total 1');
+      expect(prometheus).toContain('originals_assets_migrated_total{from="peer",to="webvh"} 1');
+    });
+    
+    test('should include operation statistics in Prometheus format', () => {
+      const prometheus = metrics.export('prometheus');
+      
+      // Check for operation metrics
+      expect(prometheus).toContain('originals_operation_createAsset_total 3');
+      expect(prometheus).toContain('originals_operation_createAsset_errors_total 1');
+      
+      // Check for duration quantiles
+      expect(prometheus).toContain('originals_operation_createAsset_duration_milliseconds{quantile="0.0"}');
+      expect(prometheus).toContain('originals_operation_createAsset_duration_milliseconds{quantile="0.5"}');
+      expect(prometheus).toContain('originals_operation_createAsset_duration_milliseconds{quantile="1.0"}');
+    });
+    
+    test('should throw error for unsupported format', () => {
+      expect(() => metrics.export('xml' as any)).toThrow('Unsupported export format');
+    });
+  });
+  
+  describe('comprehensive metrics snapshot', () => {
+    test('should provide complete metrics snapshot', () => {
+      // Set up comprehensive metrics
+      metrics.recordAssetCreated();
+      metrics.recordMigration('did:peer', 'did:webvh');
+      metrics.recordMigration('did:webvh', 'did:btco');
+      metrics.recordTransfer();
+      metrics.recordOperation('op1', 100, true);
+      metrics.recordOperation('op2', 200, false);
+      metrics.recordError('ERR_001');
+      metrics.recordCacheHit();
+      
+      const allMetrics = metrics.getMetrics();
+      
+      // Verify structure
+      expect(allMetrics).toHaveProperty('assetsCreated');
+      expect(allMetrics).toHaveProperty('assetsMigrated');
+      expect(allMetrics).toHaveProperty('assetsTransferred');
+      expect(allMetrics).toHaveProperty('operationTimes');
+      expect(allMetrics).toHaveProperty('errors');
+      expect(allMetrics).toHaveProperty('cacheStats');
+      expect(allMetrics).toHaveProperty('startTime');
+      expect(allMetrics).toHaveProperty('uptime');
+      
+      // Verify values
+      expect(allMetrics.assetsCreated).toBe(1);
+      expect(allMetrics.assetsMigrated['peer→webvh']).toBe(1);
+      expect(allMetrics.assetsMigrated['webvh→btco']).toBe(1);
+      expect(allMetrics.assetsTransferred).toBe(1);
+      expect(allMetrics.operationTimes['op1']).toBeDefined();
+      expect(allMetrics.operationTimes['op2']).toBeDefined();
+      expect(allMetrics.errors['ERR_001']).toBe(1);
+    });
+  });
+  
+  describe('memory efficiency', () => {
+    test('should not leak memory with many operations', () => {
+      // Record a large number of operations
+      for (let i = 0; i < 10000; i++) {
+        metrics.recordOperation(`op${i % 10}`, Math.random() * 100, Math.random() > 0.1);
+      }
+      
+      // Should only have 10 unique operations
+      const allMetrics = metrics.getMetrics();
+      expect(Object.keys(allMetrics.operationTimes).length).toBe(10);
+      
+      // Each operation should have correct count
+      expect(allMetrics.operationTimes['op0'].count).toBe(1000);
+    });
+    
+    test('should handle many error codes efficiently', () => {
+      // Record many different error codes
+      for (let i = 0; i < 1000; i++) {
+        metrics.recordError(`ERR_${i % 50}`);
+      }
+      
+      const allMetrics = metrics.getMetrics();
+      
+      // Should have 50 unique error codes
+      expect(Object.keys(allMetrics.errors).length).toBe(50);
+      
+      // Each error code should appear 20 times
+      expect(allMetrics.errors['ERR_0']).toBe(20);
+    });
+  });
+});
+


### PR DESCRIPTION
Implement a comprehensive logging and telemetry system to enhance SDK observability and integrate with the event system.

The existing SDK lacked structured logging, metrics, and event integration, making production debugging and monitoring challenging. This PR introduces a robust system for structured logs, performance metrics, and automatic event-driven telemetry, crucial for production-ready observability.

---
<a href="https://cursor.com/background-agent?bcId=bc-9ec1a775-0350-44d3-8567-5b3ea6a76169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9ec1a775-0350-44d3-8567-5b3ea6a76169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added structured logging with levels, timers, multiple outputs, and child loggers; fully configurable in SDK settings.
  - Introduced metrics collection with JSON and Prometheus export; tracks operations, errors, cache stats, and uptime.
  - Integrated event logging for lifecycle events with per-event level control and optional disabling.
  - Enabled data sanitization to redact sensitive fields in logs.

- Documentation
  - Added a comprehensive Telemetry and Logging guide with configuration, examples, best practices, and troubleshooting.

- Tests
  - Added unit, integration, and performance tests for logging, metrics, events, and sanitization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->