### PR TITLE
feat(sdk): finalize v1.1 CEL conformance + btco resolver/error contracts

### DIFF
--- a/IMPLEMENTATION_PLAN_v1.1.md
+++ b/IMPLEMENTATION_PLAN_v1.1.md
@@ -1,0 +1,364 @@
+# Originals Protocol v1.1 — Spec-to-Code Implementation Plan
+
+**Source spec:** `ORIGINALS_PROTOCOL_SPECIFICATION_v1.1_UNIFIED.md`  
+**Repository:** `originals-sdk`  
+**Goal:** concrete, code-level mapping from v1.1 normative requirements (Sections 4–11) to required SDK changes.
+
+---
+
+## 1) Executive Summary
+
+Current SDK already has strong lifecycle scaffolding (`did:peer -> did:webvh -> did:btco`), CEL primitives, DID managers/resolvers, and VC/Data Integrity tooling.  
+However, v1.1 introduces conformance-critical constraints that are not fully enforced yet:
+
+1. **CEL event contract must be explicit and uniform** (event id/timestamp/actor/op/hash/prev/signature semantics).
+2. **Required event semantics must be represented as `ResourceAdded` and `ResourceUpdated`** (or strict semantic equivalents).
+3. **Signature suite for v1.1 conformance must be `eddsa-jcs-2022`** (current VC path still primarily uses `eddsa-rdfc-2022`).
+4. **Finalization on `did:btco` must produce deterministic artifact + final attestation schema** (current migration/inscription flow lacks standardized final attestation envelope fields from §9.3).
+5. **Resolver behavior must provide stable DID URL dereferencing and required machine-readable errors** (`invalidDid`, `notFound`, `representationNotSupported`).
+
+---
+
+## 2) Normative Spec-to-Code Mapping (Sections 4–11)
+
+## §4 Protocol Model (CEL as source of truth)
+
+### Must satisfy
+- CEL is authoritative for state/provenance/mutation lineage.
+
+### Existing code
+- `packages/sdk/src/cel/*`
+- `packages/sdk/src/lifecycle/OriginalsAsset.ts`
+- `packages/sdk/src/lifecycle/LifecycleManager.ts`
+
+### Required changes
+- Make CEL replay path the single canonical state-derivation path for lifecycle/public APIs (avoid parallel ad hoc state mutation paths).
+- Add explicit conformance guard in lifecycle APIs that rejects mutation attempts after finalized btco version marker.
+
+---
+
+## §4.2 Event-Driven Provenance (`ResourceAdded`, `ResourceUpdated`)
+
+### Must satisfy
+- Required event types must exist semantically.
+
+### Existing code
+- CEL event enum: `create | update | deactivate` in `packages/sdk/src/cel/types.ts`.
+- VC credential typing includes `ResourceUpdated` in `packages/sdk/src/types/credentials.ts` / `vc/CredentialManager.ts`.
+
+### Required changes
+- Introduce canonical operation taxonomy in CEL payload (e.g., `operation: 'ResourceAdded' | 'ResourceUpdated' | ...`) while retaining backward compatibility with `create/update`.
+- Update CEL validation/verification to require semantic mapping for required operations.
+- Add migration adapter for old logs (`create -> ResourceAdded`, `update -> ResourceUpdated`).
+
+**Primary modules/functions to change:**
+- `packages/sdk/src/cel/types.ts` (event contract/type additions)
+- `packages/sdk/src/cel/algorithms/createEventLog.ts`
+- `packages/sdk/src/cel/algorithms/updateEventLog.ts`
+- `packages/sdk/src/cel/algorithms/verifyEventLog.ts`
+- `packages/sdk/src/cel/OriginalsCel.ts`
+
+---
+
+## §5 DID + DID URL Resource Addressing
+
+### Must satisfy
+- Parse/generate base DID, DID+path, DID+path+query, DID+fragment.
+- Deterministic dereferencing mappings by method driver.
+
+### Existing code
+- DID resolution in `packages/sdk/src/did/DIDManager.ts`, `did/BtcoDidResolver.ts`.
+- No unified DID URL parser/dereferencer abstraction with stable behavior contract.
+
+### Required changes
+- Add centralized DID URL parser/formatter utility and method-aware dereferencer interface.
+- Implement deterministic dereference behavior for btco/webvh/peer drivers.
+- Add explicit representation negotiation + `representationNotSupported` error pathway.
+
+**Primary modules/functions to change/add:**
+- `packages/sdk/src/did/DIDManager.ts` (`resolveDID`, add `dereferenceDidUrl`)
+- `packages/sdk/src/did/BtcoDidResolver.ts` (path/query/fragment support)
+- **New:** `packages/sdk/src/did/DidUrl.ts` (parse/format)
+- **New:** `packages/sdk/src/did/Dereferencer.ts` (result/error contract)
+
+---
+
+## §6 Lifecycle + Mutability
+
+### Must satisfy
+- Unidirectional lifecycle.
+- `did:btco` immutable.
+- Finalized version non-mutable; webvh can continue as staging for later finalization.
+
+### Existing code
+- Path checks already present in `lifecycle/LifecycleManager.ts`, `lifecycle/OriginalsAsset.ts`, `cel/OriginalsCel.ts`.
+
+### Required changes
+- Enforce **version-scoped finality**: once version finalized to btco, lock that version’s mutation path.
+- Add explicit re-inscription model for later versions from webvh staging line.
+- Harden update APIs to reject writes against `final` snapshots.
+
+**Primary modules/functions to change:**
+- `packages/sdk/src/lifecycle/OriginalsAsset.ts` (version/finality metadata model)
+- `packages/sdk/src/lifecycle/LifecycleManager.ts` (`publish`, `inscribe`, `validateMigration`, mutation guards)
+- `packages/sdk/src/cel/OriginalsCel.ts` (`update`, `migrate` guards)
+
+---
+
+## §7 Required CEL Event Contract
+
+### Must satisfy
+Each event must include semantic equivalents of:
+1) event id, 2) timestamp, 3) actor/controller id, 4) operation type, 5) content/resource hash, 6) previous hash/genesis marker, 7) signature/proof.
+
+### Existing code
+- `previousEvent` + `proof` currently present.
+- Other fields are inconsistently embedded in `data` (not contractually enforced).
+
+### Required changes
+- Define canonical `CelEventEnvelopeV11` schema.
+- Require presence of all seven semantics in create/update generation and verification.
+- Add deterministic event-id strategy and explicit genesis marker policy.
+
+**Primary modules/functions to change:**
+- `packages/sdk/src/cel/types.ts`
+- `packages/sdk/src/cel/algorithms/createEventLog.ts`
+- `packages/sdk/src/cel/algorithms/updateEventLog.ts`
+- `packages/sdk/src/cel/algorithms/verifyEventLog.ts`
+- `packages/sdk/src/cel/hash.ts` (if event-id/hash derivation changes)
+- `packages/sdk/src/cel/serialization/json.ts` / `serialization/index.ts` (deterministic shape)
+
+---
+
+## §8 Signature + Verification (`eddsa-jcs-2022` required)
+
+### Must satisfy
+- Required events signed.
+- Required cryptosuite for v1.1 conformance: `eddsa-jcs-2022`.
+- Deterministic verification bound to canonical payload + DID-resolved controller material.
+
+### Existing code
+- CEL verifier accepts both `eddsa-jcs-2022` and `eddsa-rdfc-2022`.
+- VC cryptosuite implementation defaults to `eddsa-rdfc-2022` in:
+  - `packages/sdk/src/vc/cryptosuites/eddsa.ts`
+  - `packages/sdk/src/vc/proofs/data-integrity.ts`
+  - `packages/sdk/src/vc/Issuer.ts`
+  - `packages/sdk/src/vc/CredentialManager.ts`
+
+### Required changes
+- Introduce conformance mode where required CEL operations must use/verify `eddsa-jcs-2022`.
+- Refactor VC/DataIntegrity signing pipeline to support JCS-first path.
+- Keep optional legacy compatibility flag for rdfc verification only (non-conformant mode).
+
+**Primary modules/functions to change:**
+- `packages/sdk/src/vc/cryptosuites/eddsa.ts`
+- `packages/sdk/src/vc/proofs/data-integrity.ts`
+- `packages/sdk/src/vc/Issuer.ts`
+- `packages/sdk/src/vc/Verifier.ts`
+- `packages/sdk/src/vc/CredentialManager.ts`
+- `packages/sdk/src/cel/algorithms/verifyEventLog.ts` (suite enforcement)
+
+---
+
+## §9 Finalization on Bitcoin (`did:btco`)
+
+### Must satisfy
+- Deterministic final artifact at finalization.
+- Canonical transferable state anchored on Bitcoin.
+- Final attestation fields (§9.3): source DID/controller, finalized CEL head hash, finalized artifact hash, inscription/tx + chain ref, timestamp, finality status=`final`.
+
+### Existing code
+- Inscription/migration in `lifecycle/LifecycleManager.ts`, `cel/layers/BtcoCelManager.ts`, `bitcoin/*`.
+- No standardized final attestation envelope guaranteed by API contract.
+
+### Required changes
+- Add deterministic artifact materialization pipeline (manifest + canonical serialization).
+- Add `FinalAttestation` type + generation + persistence + optional co-inscription strategy.
+- Ensure transfer logic references finalized attested artifact/hash.
+
+**Primary modules/functions to change/add:**
+- `packages/sdk/src/lifecycle/LifecycleManager.ts` (`inscribeOnBitcoin`, `inscribe`, transfer linkage)
+- `packages/sdk/src/cel/layers/BtcoCelManager.ts` (btco migration event data schema)
+- `packages/sdk/src/bitcoin/BitcoinManager.ts` (attestation inscription metadata)
+- `packages/sdk/src/types/credentials.ts` / `types/common.ts` (attestation typing)
+- **New:** `packages/sdk/src/attestations/FinalAttestation.ts`
+- **New:** `packages/sdk/src/attestations/AttestationManager.ts`
+
+---
+
+## §10 Preliminary Attestations (`did:webvh`)
+
+### Must satisfy
+- Optional preliminary attestations with CEL head hash + candidate artifact hash + explicit non-final marker (`provisional`).
+
+### Existing code
+- WebVH migration supports witness proofs but no standardized preliminary attestation schema/marker.
+
+### Required changes
+- Add `PreliminaryAttestation` schema and API.
+- Ensure explicit marker cannot be interpreted as final.
+
+**Primary modules/functions to change/add:**
+- `packages/sdk/src/cel/layers/WebVHCelManager.ts`
+- `packages/sdk/src/lifecycle/LifecycleManager.ts` (publish flow)
+- **New:** `packages/sdk/src/attestations/PreliminaryAttestation.ts`
+
+---
+
+## §11 Resolver Requirements
+
+### Must satisfy
+- Resolve DID to DID document.
+- Dereference DID URLs for resources.
+- Machine-readable errors: `invalidDid`, `notFound`, `representationNotSupported`.
+- Stable behavior for equivalent requests.
+
+### Existing code
+- `BtcoDidResolver` already emits `invalidDid`/`notFound` in resolution metadata.
+- No unified resolver error contract across all methods; no formal dereference API.
+
+### Required changes
+- Standardize resolver return envelope across did methods.
+- Add deterministic, testable dereference behavior.
+- Add missing `representationNotSupported` and consistency checks.
+
+**Primary modules/functions to change:**
+- `packages/sdk/src/did/DIDManager.ts`
+- `packages/sdk/src/did/BtcoDidResolver.ts`
+- `packages/sdk/src/did/WebVHManager.ts`
+- `packages/sdk/src/types/did.ts` (resolver/dereference result types)
+
+---
+
+## 3) Concrete File-Level Change List
+
+## A. CEL Core
+- `packages/sdk/src/cel/types.ts`
+  - Add v1.1 event envelope/type definitions and required semantic fields.
+- `packages/sdk/src/cel/algorithms/createEventLog.ts`
+  - Populate required envelope fields on creation.
+- `packages/sdk/src/cel/algorithms/updateEventLog.ts`
+  - Populate required envelope fields on update.
+- `packages/sdk/src/cel/algorithms/verifyEventLog.ts`
+  - Enforce required semantics and suite rules in conformance mode.
+- `packages/sdk/src/cel/serialization/json.ts`
+  - Canonical deterministic serialization contract for hash/sign verification.
+
+## B. Lifecycle/Mutability/Finalization
+- `packages/sdk/src/lifecycle/OriginalsAsset.ts`
+  - Track finalized versions and immutable boundaries.
+- `packages/sdk/src/lifecycle/LifecycleManager.ts`
+  - Deterministic final artifact generation.
+  - Final/preliminary attestation emission.
+  - Version-scoped mutation lock enforcement.
+- `packages/sdk/src/cel/layers/WebVHCelManager.ts`
+  - Preliminary attestation support.
+- `packages/sdk/src/cel/layers/BtcoCelManager.ts`
+  - Final attestation linkage and btco finalization metadata.
+
+## C. DID Resolution/Dereference
+- `packages/sdk/src/did/DIDManager.ts`
+  - Add first-class DID URL dereference API.
+  - Normalize error contract.
+- `packages/sdk/src/did/BtcoDidResolver.ts`
+  - Expand to full DID URL handling and standardized errors.
+- `packages/sdk/src/did/WebVHManager.ts`
+  - Deterministic resource mapping for DID URL forms.
+- `packages/sdk/src/types/did.ts`
+  - Add resolver/dereference result and error enums.
+
+## D. Cryptosuite Conformance
+- `packages/sdk/src/vc/cryptosuites/eddsa.ts`
+- `packages/sdk/src/vc/proofs/data-integrity.ts`
+- `packages/sdk/src/vc/Issuer.ts`
+- `packages/sdk/src/vc/Verifier.ts`
+- `packages/sdk/src/vc/CredentialManager.ts`
+  - Move to `eddsa-jcs-2022` default in conformance mode.
+  - Keep legacy compatibility mode as explicitly non-conformant.
+
+## E. New Modules
+- `packages/sdk/src/attestations/FinalAttestation.ts`
+- `packages/sdk/src/attestations/PreliminaryAttestation.ts`
+- `packages/sdk/src/attestations/AttestationManager.ts`
+- `packages/sdk/src/did/DidUrl.ts`
+- `packages/sdk/src/did/Dereferencer.ts`
+
+---
+
+## 4) Phased Implementation Plan
+
+### Phase 0 — Guardrails + Contracts (1–2 days)
+- Add v1.1 feature flag/conformance mode in SDK config.
+- Introduce new type contracts (CEL envelope, resolver errors, attestation types).
+- Add exhaustive test skeletons for §4–§11 normative requirements.
+
+### Phase 1 — CEL Event Contract + Verification (2–4 days)
+- Implement required CEL fields and semantic operation mapping.
+- Update create/update/verify flows.
+- Backward-compatible parser for legacy logs.
+
+### Phase 2 — DID URL Parsing + Dereferencing + Resolver Errors (2–3 days)
+- Add parser/formatter.
+- Implement deterministic dereference for peer/webvh/btco.
+- Standardize machine-readable error responses.
+
+### Phase 3 — Cryptosuite Alignment (`eddsa-jcs-2022`) (2–4 days)
+- JCS-first proof pipeline for required events and attestations.
+- Verification binding to DID-resolved controller keys.
+- Legacy fallback gates + deprecation warnings.
+
+### Phase 4 — Finalization + Attestation Model (3–5 days)
+- Deterministic artifact materialization.
+- Preliminary and final attestation generation/storage/inscription linkage.
+- Enforce immutable finalized version boundaries.
+
+### Phase 5 — Migration + Hardening + Docs (2–3 days)
+- Data migration helpers for pre-v1.1 CEL logs.
+- Full integration/e2e suite updates.
+- Conformance checklist doc + examples update.
+
+---
+
+## 5) Risk Matrix
+
+| Risk | Impact | Likelihood | Mitigation |
+|---|---|---:|---|
+| Event schema breakage for existing CEL logs | High | Medium | Dual-read parser, adapter mapping (`create/update -> ResourceAdded/ResourceUpdated`), migration tooling |
+| Cryptosuite switch introduces signature incompatibility | High | Medium | Conformance flag, phased rollout, verify-both/sign-jcs strategy during transition |
+| DID URL dereference behavior diverges by method | Medium | Medium | Shared dereferencer interface + golden tests for equivalent requests |
+| Btco final attestation not fully deterministic | High | Medium | Canonical serialization + deterministic artifact builder + test vectors |
+| Performance regressions from stricter verification | Medium | Low | Benchmark suite on CEL verify path and caching for DID resolution |
+| Breaking API surface for integrators | Medium | Medium | Additive APIs first, deprecate later, migration guide + codemods/snippets |
+
+---
+
+## 6) Migration Notes (for SDK Integrators)
+
+1. **CEL event consumers**
+   - Expect new canonical event envelope fields.
+   - Legacy logs continue to parse via compatibility adapter.
+
+2. **Signature/verification**
+   - Conformant mode requires `eddsa-jcs-2022`.
+   - Existing `eddsa-rdfc-2022` credentials/events remain verifiable only in legacy mode.
+
+3. **Lifecycle behavior**
+   - Once a version is finalized on btco, that version is immutable.
+   - Subsequent evolution must proceed as new staged version lineage on webvh before re-finalization.
+
+4. **Resolver API**
+   - New standardized dereference result shape and machine-readable errors.
+   - Consumers should switch from ad hoc `resolveDID()` assumptions to typed resolve/dereference responses.
+
+5. **Attestation artifacts**
+   - Preliminary and final attestations become first-class SDK outputs with stable schemas.
+   - Downstream indexers should ingest attestation objects rather than infer finality heuristically.
+
+---
+
+## 7) Definition of Done (v1.1)
+
+- All §4–§11 MUST requirements are traceable to tests and passing.
+- Conformance mode returns claim string: `Originals Protocol v1.1 compliant`.
+- SDK docs/examples updated for event schema, resolver API, and attestation flows.
+- Backward compatibility validated on representative legacy CEL logs.

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -1,0 +1,484 @@
+# Originals SDK Integration Guide
+
+A practical guide for integrating the Originals SDK into production applications, using patterns from the Poo App (a todo list application built with React and Convex).
+
+## Overview
+
+The Originals SDK provides tools for creating decentralized identifiers (DIDs) and verifiable credentials. When integrating with real applications, you'll typically split responsibilities:
+
+- **Frontend**: DID creation, asset management via the SDK
+- **Backend**: Credential signing, JWT validation, data persistence
+
+This guide walks through the complete integration pattern.
+
+## Frontend Integration
+
+### Installation
+
+```bash
+npm install @originals/sdk @originals/auth
+```
+
+### Basic Setup
+
+Create a wrapper module for SDK operations. This keeps your configuration centralized and provides a clean API for your components.
+
+```typescript
+// src/lib/originals.ts
+import { DIDManager } from "@originals/sdk";
+import type { 
+  DIDDocument, 
+  VerifiableCredential, 
+  KeyPair, 
+  OriginalsConfig 
+} from "@originals/sdk";
+
+// SDK configuration
+const config: OriginalsConfig = {
+  network: "signet",      // Use "signet" for development, "mainnet" for production
+  defaultKeyType: "Ed25519",
+};
+```
+
+### Creating Assets with did:peer
+
+Each asset in your application (lists, items, documents) can be represented as a `did:peer`. This gives every asset a globally unique, cryptographically verifiable identifier.
+
+```typescript
+export interface ListAsset {
+  assetDid: string;
+  name: string;
+  createdBy: string;
+  createdAt: string;
+}
+
+/**
+ * Creates a new list asset.
+ * Each list is represented as a did:peer asset.
+ */
+export async function createListAsset(
+  name: string, 
+  creatorDid: string
+): Promise<ListAsset> {
+  const didManager = new DIDManager(config);
+
+  // Create a did:peer for the list asset
+  // Second param `true` enables numalgo2 (short DIDs)
+  const result = await didManager.createDIDPeer([], true);
+
+  return {
+    assetDid: result.didDocument.id,
+    name,
+    createdBy: creatorDid,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+// Re-export types that consumers might need
+export type { DIDDocument, VerifiableCredential, KeyPair };
+```
+
+### Using in Components
+
+```tsx
+import { createListAsset } from "@/lib/originals";
+
+async function handleCreateList(name: string) {
+  const userDid = getCurrentUserDid(); // From your auth system
+  
+  // Create the DID on the frontend
+  const listAsset = await createListAsset(name, userDid);
+  
+  // Send to backend for persistence
+  await createList({
+    assetDid: listAsset.assetDid,
+    name: listAsset.name,
+  });
+}
+```
+
+## Backend Considerations (Convex/Serverless)
+
+### The Challenge
+
+You might expect to simply import `@originals/sdk` in your Convex actions. However, serverless environments like Convex have constraints:
+
+1. **Bundle analysis**: Convex's deploy process analyzes your imports statically
+2. **Module format issues**: Some SDK dependencies use extensionless re-exports that break analysis
+3. **Node.js APIs**: Some crypto operations require specific Node.js APIs
+
+### The Solution: Copy Essential Helpers
+
+For backend operations, copy the specific helpers you need locally. This:
+- Avoids import chain issues
+- Gives you full control over dependencies
+- Works reliably in serverless environments
+
+### What to Copy
+
+#### 1. TurnkeyWebVHSigner (for credential signing)
+
+If you're using Turnkey for wallet management, you'll need a local signer:
+
+```typescript
+// convex/lib/turnkeySigner.ts
+"use node";
+
+import {
+  MultibaseEncoding,
+  multibaseEncode,
+  prepareDataForSigning,
+} from "didwebvh-ts";
+import { sha512 } from "@noble/hashes/sha2.js";
+import { concatBytes, bytesToHex } from "@noble/hashes/utils.js";
+import * as ed25519 from "@noble/ed25519";
+
+type TurnkeyClientLike = {
+  apiClient: () => {
+    signRawPayload: (params: {
+      organizationId: string;
+      signWith: string;
+      payload: string;
+      encoding: "PAYLOAD_ENCODING_HEXADECIMAL";
+      hashFunction: "HASH_FUNCTION_NO_OP";
+    }) => Promise<{
+      activity?: {
+        result?: {
+          signRawPayloadResult?: { r?: string; s?: string };
+        };
+      };
+    }>;
+  };
+};
+
+// Configure @noble/ed25519 with required SHA-512 function
+const sha512Fn = (...msgs: Uint8Array[]) => sha512(concatBytes(...msgs));
+
+function configureEd25519Sha512() {
+  const ed25519Module = ed25519 as unknown as {
+    utils?: { sha512Sync?: (...msgs: Uint8Array[]) => Uint8Array };
+    etc?: { sha512Sync?: (...msgs: Uint8Array[]) => Uint8Array };
+  };
+  if (ed25519Module.utils) {
+    ed25519Module.utils.sha512Sync = sha512Fn;
+  }
+  if (ed25519Module.etc) {
+    ed25519Module.etc.sha512Sync = sha512Fn;
+  }
+}
+
+try {
+  configureEd25519Sha512();
+} catch (error) {
+  console.warn("Failed to configure ed25519 utils:", error);
+}
+
+export class TurnkeyWebVHSigner {
+  private subOrgId: string;
+  private keyId: string;
+  private publicKeyMultibase: string;
+  private turnkeyClient: TurnkeyClientLike;
+  private verificationMethodId: string;
+
+  constructor(
+    subOrgId: string,
+    keyId: string,
+    publicKeyMultibase: string,
+    turnkeyClient: TurnkeyClientLike,
+    verificationMethodId: string
+  ) {
+    this.subOrgId = subOrgId;
+    this.keyId = keyId;
+    this.publicKeyMultibase = publicKeyMultibase;
+    this.turnkeyClient = turnkeyClient;
+    this.verificationMethodId = verificationMethodId;
+  }
+
+  async sign(input: {
+    document: unknown;
+    proof: Record<string, unknown>;
+  }): Promise<{ proofValue: string }> {
+    const dataToSign = await prepareDataForSigning(
+      input.document as Record<string, unknown>,
+      input.proof
+    );
+    const dataHex = `0x${bytesToHex(dataToSign)}`;
+
+    const result = await this.turnkeyClient.apiClient().signRawPayload({
+      organizationId: this.subOrgId,
+      signWith: this.keyId,
+      payload: dataHex,
+      encoding: "PAYLOAD_ENCODING_HEXADECIMAL",
+      hashFunction: "HASH_FUNCTION_NO_OP",
+    });
+
+    const signRawResult = result.activity?.result?.signRawPayloadResult;
+    if (!signRawResult?.r || !signRawResult?.s) {
+      throw new Error("No signature returned from Turnkey");
+    }
+
+    const signature = signRawResult.r + signRawResult.s;
+    const cleanSig = signature.startsWith("0x") ? signature.slice(2) : signature;
+    let signatureBytes = Buffer.from(cleanSig, "hex");
+
+    // Handle signature length normalization
+    if (signatureBytes.length === 65) {
+      signatureBytes = signatureBytes.slice(0, 64);
+    } else if (signatureBytes.length !== 64) {
+      throw new Error(`Invalid Ed25519 signature length: ${signatureBytes.length}`);
+    }
+
+    const proofValue = multibaseEncode(signatureBytes, MultibaseEncoding.BASE58_BTC);
+    return { proofValue };
+  }
+
+  getVerificationMethodId() {
+    return this.verificationMethodId;
+  }
+
+  getPublicKeyMultibase() {
+    return this.publicKeyMultibase;
+  }
+}
+```
+
+#### 2. JWT Verification (using jose)
+
+For validating auth tokens from `@originals/auth`:
+
+```typescript
+// convex/lib/jwt.ts
+import * as jose from "jose";
+
+export interface AuthTokenPayload {
+  turnkeySubOrgId: string;
+  email: string;
+  sessionToken?: string;
+}
+
+export async function verifyAuthToken(token: string): Promise<AuthTokenPayload> {
+  if (!token) {
+    throw new Error("Token is required");
+  }
+
+  const jwtSecret = process.env.JWT_SECRET;
+  if (!jwtSecret) {
+    throw new Error("JWT_SECRET environment variable not set");
+  }
+
+  const secret = new TextEncoder().encode(jwtSecret);
+  const { payload } = await jose.jwtVerify(token, secret, {
+    algorithms: ["HS256"],
+  });
+
+  const jwtPayload = payload as { sub?: string; email?: string; sessionToken?: string };
+
+  if (!jwtPayload.sub) {
+    throw new Error("Token missing sub-organization ID");
+  }
+  if (!jwtPayload.email) {
+    throw new Error("Token missing email");
+  }
+
+  return {
+    turnkeySubOrgId: jwtPayload.sub,
+    email: jwtPayload.email,
+    sessionToken: jwtPayload.sessionToken,
+  };
+}
+
+export function extractTokenFromRequest(request: Request): string | null {
+  const authHeader = request.headers.get("Authorization");
+  if (authHeader?.startsWith("Bearer ")) {
+    return authHeader.slice(7);
+  }
+  
+  // Fall back to cookie
+  const cookieHeader = request.headers.get("Cookie");
+  if (cookieHeader) {
+    const match = cookieHeader.match(/auth_token=([^;]+)/);
+    return match?.[1] || null;
+  }
+  
+  return null;
+}
+```
+
+## Architecture Pattern
+
+### Recommended Split
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        FRONTEND                              │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │  @originals/sdk         @originals/auth             │    │
+│  │  - DIDManager           - AuthProvider              │    │
+│  │  - createDIDPeer()      - useAuth()                 │    │
+│  │  - Asset creation       - Login/logout              │    │
+│  └─────────────────────────────────────────────────────┘    │
+└──────────────────────────┬──────────────────────────────────┘
+                           │ API calls (JWT in header)
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│                        BACKEND                               │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │  Local helpers (copied from SDK)                     │    │
+│  │  - TurnkeyWebVHSigner   - JWT verification          │    │
+│  │  - Credential signing   - Token extraction          │    │
+│  └─────────────────────────────────────────────────────┘    │
+│                                                              │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │  Database (Convex/Postgres/etc)                      │    │
+│  │  - Store asset DIDs     - User data                 │    │
+│  │  - Issued credentials   - Relationships             │    │
+│  └─────────────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Why This Split Works
+
+1. **Security**: Private keys and signing happen server-side
+2. **Performance**: DID creation is lightweight and can happen client-side
+3. **Flexibility**: Backend can use any database; frontend stays simple
+4. **Compatibility**: Avoids serverless runtime constraints
+
+## Complete Example
+
+Here's the full flow for creating a list with a verifiable credential:
+
+### Step 1: User Creates List (Frontend)
+
+```tsx
+// components/CreateList.tsx
+import { createListAsset } from "@/lib/originals";
+import { useMutation } from "convex/react";
+import { api } from "@/convex/_generated/api";
+
+function CreateListButton() {
+  const createList = useMutation(api.lists.create);
+  const { user } = useAuth();
+
+  async function handleCreate() {
+    // 1. Create the did:peer on the frontend
+    const listAsset = await createListAsset("My List", user.did);
+    
+    // 2. Send to backend for storage + credential issuance
+    await createList({
+      assetDid: listAsset.assetDid,
+      name: listAsset.name,
+    });
+  }
+
+  return <button onClick={handleCreate}>Create List</button>;
+}
+```
+
+### Step 2: Backend Stores and Issues VC (Convex)
+
+```typescript
+// convex/lists.ts
+"use node";
+
+import { action } from "./_generated/server";
+import { v } from "convex/values";
+import { verifyAuthToken } from "./lib/jwt";
+import { TurnkeyWebVHSigner } from "./lib/turnkeySigner";
+
+export const create = action({
+  args: {
+    assetDid: v.string(),
+    name: v.string(),
+  },
+  handler: async (ctx, args) => {
+    // 1. Verify the user's JWT
+    const token = ctx.headers.get("Authorization")?.slice(7);
+    const auth = await verifyAuthToken(token!);
+    
+    // 2. Store the list in the database
+    const listId = await ctx.runMutation(internal.lists.insert, {
+      assetDid: args.assetDid,
+      name: args.name,
+      ownerId: auth.turnkeySubOrgId,
+    });
+    
+    // 3. Issue a verifiable credential for ownership
+    const credential = await issueOwnershipCredential(
+      args.assetDid,
+      auth.turnkeySubOrgId
+    );
+    
+    // 4. Store the credential
+    await ctx.runMutation(internal.credentials.insert, {
+      listId,
+      credential: JSON.stringify(credential),
+    });
+    
+    return { listId, assetDid: args.assetDid };
+  },
+});
+```
+
+### Step 3: Issue the Credential
+
+```typescript
+// convex/lib/credentials.ts
+import { TurnkeyWebVHSigner } from "./turnkeySigner";
+import { Turnkey } from "@turnkey/sdk-server";
+
+async function issueOwnershipCredential(
+  assetDid: string, 
+  ownerSubOrgId: string
+) {
+  const turnkey = new Turnkey({
+    apiBaseUrl: "https://api.turnkey.com",
+    apiPrivateKey: process.env.TURNKEY_API_PRIVATE_KEY!,
+    apiPublicKey: process.env.TURNKEY_API_PUBLIC_KEY!,
+    defaultOrganizationId: process.env.TURNKEY_ORG_ID!,
+  });
+
+  const signer = new TurnkeyWebVHSigner(
+    ownerSubOrgId,
+    keyId,
+    publicKeyMultibase,
+    turnkey,
+    verificationMethodId
+  );
+
+  const credential = {
+    "@context": ["https://www.w3.org/2018/credentials/v1"],
+    type: ["VerifiableCredential", "AssetOwnershipCredential"],
+    issuer: issuerDid,
+    issuanceDate: new Date().toISOString(),
+    credentialSubject: {
+      id: ownerSubOrgId,
+      owns: assetDid,
+    },
+  };
+
+  const proof = await signer.sign({
+    document: credential,
+    proof: {
+      type: "DataIntegrityProof",
+      cryptosuite: "eddsa-jcs-2022",
+      verificationMethod: signer.getVerificationMethodId(),
+      created: new Date().toISOString(),
+      proofPurpose: "assertionMethod",
+    },
+  });
+
+  return { ...credential, proof };
+}
+```
+
+## Summary
+
+| Concern | Location | Package/Tool |
+|---------|----------|--------------|
+| DID creation | Frontend | `@originals/sdk` |
+| Authentication | Frontend | `@originals/auth` |
+| JWT validation | Backend | `jose` (local helper) |
+| Credential signing | Backend | Local `TurnkeyWebVHSigner` |
+| Data persistence | Backend | Convex/Postgres/etc |
+
+This pattern keeps your frontend simple, your backend secure, and avoids runtime compatibility issues with serverless platforms.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@originals/sdk",
-  "version": "1.9.0"
+  "version": "1.9.0",
   "description": "TypeScript SDK for the Originals Protocol - creating, discovering, and transferring digital assets with cryptographically verifiable provenance",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@originals/sdk",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "TypeScript SDK for the Originals Protocol - creating, discovering, and transferring digital assets with cryptographically verifiable provenance",
   "type": "module",
   "main": "./dist/index.js",
@@ -15,6 +15,54 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./core/*": {
+      "types": "./dist/core/*.d.ts",
+      "import": "./dist/core/*.js"
+    },
+    "./did/*": {
+      "types": "./dist/did/*.d.ts",
+      "import": "./dist/did/*.js"
+    },
+    "./vc/*": {
+      "types": "./dist/vc/*.d.ts",
+      "import": "./dist/vc/*.js"
+    },
+    "./vc/cryptosuites/*": {
+      "types": "./dist/vc/cryptosuites/*.d.ts",
+      "import": "./dist/vc/cryptosuites/*.js"
+    },
+    "./bitcoin/*": {
+      "types": "./dist/bitcoin/*.d.ts",
+      "import": "./dist/bitcoin/*.js"
+    },
+    "./lifecycle/*": {
+      "types": "./dist/lifecycle/*.d.ts",
+      "import": "./dist/lifecycle/*.js"
+    },
+    "./crypto/*": {
+      "types": "./dist/crypto/*.d.ts",
+      "import": "./dist/crypto/*.js"
+    },
+    "./resources/*": {
+      "types": "./dist/resources/*.d.ts",
+      "import": "./dist/resources/*.js"
+    },
+    "./storage/*": {
+      "types": "./dist/storage/*.d.ts",
+      "import": "./dist/storage/*.js"
+    },
+    "./types": {
+      "types": "./dist/types.d.ts",
+      "import": "./dist/types.js"
+    },
+    "./types/*": {
+      "types": "./dist/types/*.d.ts",
+      "import": "./dist/types/*.js"
+    },
+    "./utils/*": {
+      "types": "./dist/utils/*.d.ts",
+      "import": "./dist/utils/*.js"
     }
   },
   "scripts": {

--- a/packages/sdk/src/cel/algorithms/createEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/createEventLog.ts
@@ -7,59 +7,50 @@
  * @see https://w3c-ccg.github.io/cel-spec/
  */
 
-import type { EventLog, LogEntry, CreateOptions, DataIntegrityProof } from '../types';
+import type { EventLog, LogEntry, CreateOptions, DataIntegrityProof, V11EventPayload } from '../types';
+
+const REQUIRED_V11_CRYPTOSUITE = 'eddsa-jcs-2022';
+
+function normalizeCreatePayload(data: unknown): V11EventPayload {
+  const base = (typeof data === 'object' && data !== null) ? data as Record<string, unknown> : { value: data };
+  return {
+    ...base,
+    operation: 'ResourceAdded',
+  };
+}
 
 /**
  * Creates a new event log with a single "create" event.
- * 
- * This is the first step in creating a CEL-based provenance chain.
- * The create event establishes the initial state of an asset.
- * 
- * @param data - The initial data for the asset (e.g., name, resources, metadata)
- * @param options - Signing options including signer function and verification method
- * @returns A new EventLog containing a single create event
- * 
- * @example
- * ```typescript
- * const log = await createEventLog(
- *   { name: 'My Asset', resources: [...] },
- *   {
- *     signer: async (data) => createEdDsaProof(data, privateKey),
- *     verificationMethod: 'did:key:z6Mk...',
- *     proofPurpose: 'assertionMethod'
- *   }
- * );
- * ```
  */
 export async function createEventLog(
   data: unknown,
   options: CreateOptions
 ): Promise<EventLog> {
-  const { signer, verificationMethod, proofPurpose = 'assertionMethod' } = options;
+  const { signer } = options;
 
-  // Create the event structure without proof first
+  const normalizedData = normalizeCreatePayload(data);
+
   const eventBase = {
     type: 'create' as const,
-    data,
-    // Note: First event has no previousEvent
+    data: normalizedData,
   };
 
-  // Generate proof using the provided signer
   const proof: DataIntegrityProof = await signer(eventBase);
 
-  // Validate the proof has required fields
   if (!proof.type || !proof.cryptosuite || !proof.proofValue) {
     throw new Error('Invalid proof: missing required fields (type, cryptosuite, proofValue)');
   }
 
-  // Construct the complete log entry
+  if (proof.cryptosuite !== REQUIRED_V11_CRYPTOSUITE) {
+    throw new Error(`Invalid proof cryptosuite for required event: expected ${REQUIRED_V11_CRYPTOSUITE}`);
+  }
+
   const entry: LogEntry = {
     type: 'create',
-    data,
+    data: normalizedData,
     proof: [proof],
   };
 
-  // Return the new event log
   const eventLog: EventLog = {
     events: [entry],
   };

--- a/packages/sdk/src/cel/algorithms/updateEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/updateEventLog.ts
@@ -1,97 +1,65 @@
 /**
  * updateEventLog Algorithm
- * 
- * Appends an update event to an existing Cryptographic Event Log.
- * Each update event references the previous event via a hash chain.
- * 
- * @see https://w3c-ccg.github.io/cel-spec/
  */
 
-import type { EventLog, LogEntry, UpdateOptions, DataIntegrityProof } from '../types';
+import type { EventLog, LogEntry, UpdateOptions, DataIntegrityProof, V11EventPayload } from '../types';
 import { computeDigestMultibase } from '../hash';
 
-/**
- * Serializes a LogEntry to a deterministic byte representation for hashing.
- * Uses JSON with sorted keys for reproducibility.
- * 
- * @param entry - The log entry to serialize
- * @returns UTF-8 encoded bytes
- */
+const REQUIRED_V11_CRYPTOSUITE = 'eddsa-jcs-2022';
+
 function serializeEntry(entry: LogEntry): Uint8Array {
-  // Use JSON with sorted keys for deterministic serialization
   const json = JSON.stringify(entry, Object.keys(entry).sort());
   return new TextEncoder().encode(json);
 }
 
-/**
- * Updates an event log by appending a new "update" event.
- * 
- * The new event is cryptographically linked to the previous event
- * via a hash of the last event (previousEvent field).
- * 
- * @param log - The existing event log to update
- * @param data - The update data (e.g., modified metadata, new resources)
- * @param options - Signing options including signer function and verification method
- * @returns A new EventLog with the update event appended (input is not mutated)
- * 
- * @example
- * ```typescript
- * const updatedLog = await updateEventLog(
- *   existingLog,
- *   { name: 'Updated Asset Name', version: 2 },
- *   {
- *     signer: async (data) => createEdDsaProof(data, privateKey),
- *     verificationMethod: 'did:key:z6Mk...',
- *     proofPurpose: 'assertionMethod'
- *   }
- * );
- * ```
- */
+function normalizeUpdatePayload(data: unknown): V11EventPayload {
+  const base = (typeof data === 'object' && data !== null) ? data as Record<string, unknown> : { value: data };
+  return {
+    ...base,
+    operation: 'ResourceUpdated',
+  };
+}
+
 export async function updateEventLog(
   log: EventLog,
   data: unknown,
   options: UpdateOptions
 ): Promise<EventLog> {
-  const { signer, verificationMethod, proofPurpose = 'assertionMethod' } = options;
+  const { signer } = options;
 
-  // Validate input log
   if (!log.events || log.events.length === 0) {
     throw new Error('Cannot update an empty event log');
   }
 
-  // Get the last event to compute the hash chain link
   const lastEvent = log.events[log.events.length - 1];
-  
-  // Compute the digestMultibase of the last event
   const previousEvent = computeDigestMultibase(serializeEntry(lastEvent));
+  const normalizedData = normalizeUpdatePayload(data);
 
-  // Create the event structure without proof first
   const eventBase = {
     type: 'update' as const,
-    data,
+    data: normalizedData,
     previousEvent,
   };
 
-  // Generate proof using the provided signer
   const proof: DataIntegrityProof = await signer(eventBase);
 
-  // Validate the proof has required fields
   if (!proof.type || !proof.cryptosuite || !proof.proofValue) {
     throw new Error('Invalid proof: missing required fields (type, cryptosuite, proofValue)');
   }
 
-  // Construct the complete log entry
+  if (proof.cryptosuite !== REQUIRED_V11_CRYPTOSUITE) {
+    throw new Error(`Invalid proof cryptosuite for required event: expected ${REQUIRED_V11_CRYPTOSUITE}`);
+  }
+
   const entry: LogEntry = {
     type: 'update',
-    data,
+    data: normalizedData,
     previousEvent,
     proof: [proof],
   };
 
-  // Return a new event log (immutable - does not mutate input)
   const eventLog: EventLog = {
     events: [...log.events, entry],
-    // Preserve previousLog reference if it exists
     ...(log.previousLog ? { previousLog: log.previousLog } : {}),
   };
 

--- a/packages/sdk/src/cel/algorithms/verifyEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/verifyEventLog.ts
@@ -1,159 +1,87 @@
 /**
  * verifyEventLog Algorithm
- * 
- * Verifies all proofs and hash chain integrity in a Cryptographic Event Log.
- * Returns detailed per-event verification status.
- * 
- * @see https://w3c-ccg.github.io/cel-spec/
  */
 
-import type { 
-  EventLog, 
-  LogEntry, 
-  VerifyOptions, 
-  VerificationResult, 
+import type {
+  EventLog,
+  LogEntry,
+  VerifyOptions,
+  VerificationResult,
   EventVerification,
-  DataIntegrityProof 
+  DataIntegrityProof,
+  RequiredEventOperation,
 } from '../types';
 import { computeDigestMultibase } from '../hash';
 
-/**
- * Serializes data to JCS (JSON Canonicalization Scheme) format.
- * Uses JSON with sorted keys for deterministic serialization.
- * 
- * @param data - The data to serialize
- * @returns UTF-8 encoded bytes
- */
-function serializeToJcs(data: unknown): Uint8Array {
-  // JCS uses JSON with lexicographically sorted keys
-  const json = JSON.stringify(data, (_, value) => {
-    if (value && typeof value === 'object' && !Array.isArray(value)) {
-      return Object.keys(value).sort().reduce((sorted: Record<string, unknown>, key) => {
-        sorted[key] = value[key];
-        return sorted;
-      }, {});
-    }
-    return value;
-  });
-  return new TextEncoder().encode(json);
-}
+const REQUIRED_V11_CRYPTOSUITE = 'eddsa-jcs-2022';
 
-/**
- * Serializes a LogEntry to a deterministic byte representation for hashing.
- * Uses JSON with sorted keys for reproducibility.
- * This must match the serialization used in createEventLog/updateEventLog.
- * 
- * @param entry - The log entry to serialize
- * @returns UTF-8 encoded bytes
- */
 function serializeEntry(entry: LogEntry): Uint8Array {
-  // Use JSON with sorted keys for deterministic serialization
   const json = JSON.stringify(entry, Object.keys(entry).sort());
   return new TextEncoder().encode(json);
 }
 
-/**
- * Default proof verifier using eddsa-jcs-2022 cryptosuite.
- * 
- * This is a basic implementation that validates proof structure.
- * For full cryptographic verification, a custom verifier should be provided
- * that has access to the public key from the verificationMethod.
- * 
- * @param proof - The proof to verify
- * @param data - The data that was signed
- * @returns True if proof structure is valid
- */
-async function defaultVerifier(proof: DataIntegrityProof, data: unknown): Promise<boolean> {
-  // Validate proof has required fields
-  if (!proof.type || proof.type !== 'DataIntegrityProof') {
-    return false;
-  }
-  
-  if (!proof.cryptosuite) {
-    return false;
-  }
-  
-  if (!proof.proofValue || typeof proof.proofValue !== 'string' || proof.proofValue.length === 0) {
-    return false;
-  }
-  
-  if (!proof.verificationMethod || typeof proof.verificationMethod !== 'string') {
-    return false;
-  }
-  
-  if (!proof.proofPurpose || typeof proof.proofPurpose !== 'string') {
-    return false;
-  }
-  
-  // Check for valid cryptosuite
-  const validCryptosuites = ['eddsa-jcs-2022', 'eddsa-rdfc-2022'];
-  if (!validCryptosuites.includes(proof.cryptosuite)) {
-    return false;
-  }
-  
-  // Validate proofValue is properly formatted (multibase encoded)
-  // Most proofValues start with 'z' (base58btc) or 'u' (base64url)
-  if (!proof.proofValue.startsWith('z') && !proof.proofValue.startsWith('u')) {
-    return false;
-  }
-  
+function getRequiredOperationForEvent(event: LogEntry): RequiredEventOperation | undefined {
+  if (event.type === 'create') return 'ResourceAdded';
+  if (event.type === 'update') return 'ResourceUpdated';
+  return undefined;
+}
+
+function extractEventOperation(data: unknown): string | undefined {
+  if (!data || typeof data !== 'object') return undefined;
+  const d = data as Record<string, unknown>;
+  const op = d.operation ?? d.op ?? d.eventType;
+  return typeof op === 'string' ? op : undefined;
+}
+
+async function defaultVerifier(proof: DataIntegrityProof): Promise<boolean> {
+  if (!proof.type || proof.type !== 'DataIntegrityProof') return false;
+  if (!proof.cryptosuite) return false;
+  if (!proof.proofValue || typeof proof.proofValue !== 'string' || proof.proofValue.length === 0) return false;
+  if (!proof.verificationMethod || typeof proof.verificationMethod !== 'string') return false;
+  if (!proof.proofPurpose || typeof proof.proofPurpose !== 'string') return false;
+
+  const validCryptosuites = [REQUIRED_V11_CRYPTOSUITE, 'eddsa-rdfc-2022'];
+  if (!validCryptosuites.includes(proof.cryptosuite)) return false;
+
+  if (!proof.proofValue.startsWith('z') && !proof.proofValue.startsWith('u')) return false;
+
   return true;
 }
 
-/**
- * Verifies the hash chain for a single event.
- * 
- * @param event - The current event to verify
- * @param index - The index of the event in the log
- * @param previousEvent - The previous event in the log (undefined for first event)
- * @returns Object with chainValid boolean and any errors
- */
 function verifyChain(
   event: LogEntry,
   index: number,
   previousEvent: LogEntry | undefined
 ): { chainValid: boolean; errors: string[] } {
   const errors: string[] = [];
-  
+
   if (index === 0) {
-    // First event must NOT have previousEvent
     if (event.previousEvent !== undefined) {
       errors.push(`Event ${index}: First event must not have previousEvent field`);
       return { chainValid: false, errors };
     }
   } else {
-    // Subsequent events must have previousEvent that matches hash of prior event
     if (event.previousEvent === undefined) {
       errors.push(`Event ${index}: Missing previousEvent reference`);
       return { chainValid: false, errors };
     }
-    
+
     if (!previousEvent) {
       errors.push(`Event ${index}: Cannot verify chain - previous event not provided`);
       return { chainValid: false, errors };
     }
-    
-    // Compute the expected hash of the previous event
+
     const expectedHash = computeDigestMultibase(serializeEntry(previousEvent));
-    
+
     if (event.previousEvent !== expectedHash) {
       errors.push(`Event ${index}: Hash chain broken - previousEvent does not match hash of prior event`);
       return { chainValid: false, errors };
     }
   }
-  
+
   return { chainValid: true, errors: [] };
 }
 
-/**
- * Verifies a single event's proofs.
- * 
- * @param event - The event to verify
- * @param index - The index of the event in the log
- * @param verifier - The proof verification function
- * @param previousEvent - The previous event in the log (undefined for first event)
- * @returns EventVerification result
- */
 async function verifyEvent(
   event: LogEntry,
   index: number,
@@ -161,35 +89,40 @@ async function verifyEvent(
   previousEvent: LogEntry | undefined
 ): Promise<EventVerification> {
   const errors: string[] = [];
-  
-  // Verify hash chain
+
   const chainResult = verifyChain(event, index, previousEvent);
   const chainValid = chainResult.chainValid;
   errors.push(...chainResult.errors);
-  
-  // Check that event has proofs
+
   if (!event.proof || !Array.isArray(event.proof) || event.proof.length === 0) {
     errors.push(`Event ${index}: No proofs found`);
-    return {
-      index,
-      type: event.type,
-      proofValid: false,
-      chainValid,
-      errors,
-    };
+    return { index, type: event.type, proofValid: false, chainValid, errors };
   }
-  
-  // Verify each proof
+
+  const requiredOperation = getRequiredOperationForEvent(event);
+  const operation = requiredOperation ? extractEventOperation(event.data) : undefined;
+  const hasExplicitRequiredOperation = Boolean(requiredOperation && operation === requiredOperation);
+
+  if (requiredOperation && operation !== undefined && operation !== requiredOperation) {
+    errors.push(`Event ${index}: Required operation mismatch (expected ${requiredOperation}, got ${operation})`);
+  }
+
   let allProofsValid = true;
   const eventData = {
     type: event.type,
     data: event.data,
     ...(event.previousEvent ? { previousEvent: event.previousEvent } : {}),
   };
-  
+
   for (let proofIndex = 0; proofIndex < event.proof.length; proofIndex++) {
     const proof = event.proof[proofIndex];
-    
+
+    if (hasExplicitRequiredOperation && proof.cryptosuite !== REQUIRED_V11_CRYPTOSUITE) {
+      allProofsValid = false;
+      errors.push(`Event ${index}, Proof ${proofIndex}: Required events must use ${REQUIRED_V11_CRYPTOSUITE}`);
+      continue;
+    }
+
     try {
       const isValid = await verifier(proof, eventData);
       if (!isValid) {
@@ -202,102 +135,51 @@ async function verifyEvent(
       errors.push(`Event ${index}, Proof ${proofIndex}: ${message}`);
     }
   }
-  
+
+  const semanticValid = requiredOperation ? errors.every((e) => !e.includes(`Event ${index}: Required operation mismatch`)) : true;
+
   return {
     index,
     type: event.type,
-    proofValid: allProofsValid,
+    proofValid: allProofsValid && semanticValid,
     chainValid,
     errors,
   };
 }
 
-/**
- * Verifies all proofs and hash chain integrity in an event log.
- * 
- * This algorithm verifies:
- * - Each event has at least one proof
- * - Each proof is structurally valid (type, cryptosuite, proofValue, verificationMethod, proofPurpose)
- * - Proofs use valid cryptosuite (eddsa-jcs-2022 or eddsa-rdfc-2022)
- * - The first event has no previousEvent field
- * - Each subsequent event's previousEvent matches the digestMultibase of the prior event
- * 
- * For full cryptographic verification, provide a custom verifier function
- * in the options that can resolve the public key from the verificationMethod.
- * 
- * @param log - The event log to verify
- * @param options - Optional verification options including custom verifier
- * @returns VerificationResult with detailed per-event status including chainValid
- * 
- * @example
- * ```typescript
- * // Basic structural and chain verification
- * const result = await verifyEventLog(eventLog);
- * if (result.verified) {
- *   console.log('All proofs are valid and hash chain is intact');
- * }
- * 
- * // With custom cryptographic verifier
- * const result = await verifyEventLog(eventLog, {
- *   verifier: async (proof, data) => {
- *     // Resolve public key and verify signature
- *     const publicKey = await resolvePublicKey(proof.verificationMethod);
- *     return verifyEdDsaSignature(data, proof.proofValue, publicKey);
- *   }
- * });
- * ```
- */
 export async function verifyEventLog(
   log: EventLog,
   options?: VerifyOptions
 ): Promise<VerificationResult> {
   const errors: string[] = [];
   const eventVerifications: EventVerification[] = [];
-  
-  // Use custom verifier if provided, otherwise use default
+
   const verifier = options?.verifier ?? defaultVerifier;
-  
-  // Validate log structure
+
   if (!log || !log.events) {
-    return {
-      verified: false,
-      errors: ['Invalid event log: missing events array'],
-      events: [],
-    };
+    return { verified: false, errors: ['Invalid event log: missing events array'], events: [] };
   }
-  
   if (!Array.isArray(log.events)) {
-    return {
-      verified: false,
-      errors: ['Invalid event log: events is not an array'],
-      events: [],
-    };
+    return { verified: false, errors: ['Invalid event log: events is not an array'], events: [] };
   }
-  
   if (log.events.length === 0) {
-    return {
-      verified: false,
-      errors: ['Invalid event log: empty events array'],
-      events: [],
-    };
+    return { verified: false, errors: ['Invalid event log: empty events array'], events: [] };
   }
-  
-  // Verify each event's proofs and hash chain
+
   for (let i = 0; i < log.events.length; i++) {
     const event = log.events[i];
     const previousEvent = i > 0 ? log.events[i - 1] : undefined;
     const eventResult = await verifyEvent(event, i, verifier, previousEvent);
     eventVerifications.push(eventResult);
-    
+
     if (!eventResult.proofValid || !eventResult.chainValid) {
       errors.push(...eventResult.errors);
     }
   }
-  
-  // Determine overall verification status (both proofs AND chain must be valid)
+
   const allProofsValid = eventVerifications.every(ev => ev.proofValid);
   const allChainsValid = eventVerifications.every(ev => ev.chainValid);
-  
+
   return {
     verified: allProofsValid && allChainsValid,
     errors,

--- a/packages/sdk/src/cel/layers/index.ts
+++ b/packages/sdk/src/cel/layers/index.ts
@@ -23,5 +23,7 @@ export {
 export { 
   BtcoCelManager, 
   type BtcoCelConfig, 
-  type BtcoMigrationData 
+  type BtcoMigrationData,
+  type FinalArtifactMaterialization,
+  type FinalAnchoringAttestation
 } from './BtcoCelManager';

--- a/packages/sdk/src/cel/types.ts
+++ b/packages/sdk/src/cel/types.ts
@@ -25,6 +25,20 @@ export interface DataIntegrityProof {
 }
 
 /**
+ * Required v1.1 operation names for provenance-changing events.
+ */
+export type RequiredEventOperation = 'ResourceAdded' | 'ResourceUpdated';
+
+/**
+ * Minimal semantic event payload contract for v1.1 required events.
+ * Field names may vary in external payloads; algorithms normalize to this shape.
+ */
+export interface V11EventPayload {
+  operation: RequiredEventOperation;
+  [key: string]: unknown;
+}
+
+/**
  * Witness Proof - extends DataIntegrityProof with witness-specific fields
  * Used when a third party attests to the existence of an event at a point in time
  */

--- a/packages/sdk/src/core/OriginalsSDK.ts
+++ b/packages/sdk/src/core/OriginalsSDK.ts
@@ -10,6 +10,7 @@ import { Logger } from '../utils/Logger';
 import { MetricsCollector } from '../utils/MetricsCollector';
 import { EventLogger } from '../utils/EventLogger';
 import { createDID } from 'didwebvh-ts';
+import { OriginalsCel, type OriginalsCelOptions } from '../cel/OriginalsCel';
 
 // Type for DID log (from didwebvh-ts)
 interface DIDLogEntry {
@@ -98,6 +99,8 @@ export type UpdateOriginalOptions = UpdateDIDOriginalOptions;
 export interface OriginalsSDKOptions extends Partial<OriginalsConfig> {
   keyStore?: KeyStore;
 }
+
+export type CreateCelOptions = OriginalsCelOptions;
 
 export class OriginalsSDK {
   public readonly did: DIDManager;
@@ -189,6 +192,15 @@ export class OriginalsSDK {
       webvhNetwork: DEFAULT_WEBVH_NETWORK, // Default to 'pichu' (production)
     };
     return new OriginalsSDK({ ...defaultConfig, ...configOptions }, keyStore);
+  }
+
+  /**
+   * CEL-first factory for protocol v1.1 workflows.
+   *
+   * Prefer this API over createOriginal()/updateOriginal() for new integrations.
+   */
+  static createCel(options: CreateCelOptions): OriginalsCel {
+    return new OriginalsCel(options);
   }
 
   /**

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -12,7 +12,8 @@ export type {
   CreateOriginalOptions,
   UpdateOriginalOptions,
   CreateDIDOriginalOptions,
-  UpdateDIDOriginalOptions
+  UpdateDIDOriginalOptions,
+  CreateCelOptions
 } from './core/OriginalsSDK.js';
 export { OriginalsAsset } from './lifecycle/OriginalsAsset.js';
 export type { ProvenanceChain } from './lifecycle/OriginalsAsset.js';
@@ -168,6 +169,8 @@ export type {
   UpdateOptions,
   DeactivateOptions,
   VerifyOptions,
+  RequiredEventOperation,
+  V11EventPayload,
 } from './cel/types.js';
 export {
   createEventLog,

--- a/packages/sdk/tests/fixtures/resolver-errors-v1.1.json
+++ b/packages/sdk/tests/fixtures/resolver-errors-v1.1.json
@@ -1,0 +1,4 @@
+{
+  "errors": ["invalidDid", "notFound", "representationNotSupported"],
+  "spec": "Originals Protocol v1.1"
+}

--- a/packages/sdk/tests/integration/cel-lifecycle.test.ts
+++ b/packages/sdk/tests/integration/cel-lifecycle.test.ts
@@ -254,7 +254,7 @@ describe('Integration: CEL Lifecycle', () => {
       expect(tamperedResult.verified).toBe(false);
       expect(tamperedResult.errors.length).toBeGreaterThan(0);
       expect(tamperedResult.errors.some(e => 
-        e.includes('Event 1') && e.includes('failed')
+        e.includes('Event 1') && (e.includes('failed') || e.includes('must use eddsa-jcs-2022'))
       )).toBe(true);
     });
 

--- a/packages/sdk/tests/unit/cel/BtcoFinalization.conformance.test.ts
+++ b/packages/sdk/tests/unit/cel/BtcoFinalization.conformance.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect, vi } from 'bun:test';
+import { BtcoCelManager } from '../../../src/cel/layers/BtcoCelManager';
+import { WebVHCelManager } from '../../../src/cel/layers/WebVHCelManager';
+import { PeerCelManager } from '../../../src/cel/layers/PeerCelManager';
+import { computeDigestMultibase } from '../../../src/cel/hash';
+import type { DataIntegrityProof, EventLog } from '../../../src/cel/types';
+import type { BitcoinManager } from '../../../src/bitcoin/BitcoinManager';
+
+const signer = async (): Promise<DataIntegrityProof> => ({
+  type: 'DataIntegrityProof',
+  cryptosuite: 'eddsa-jcs-2022',
+  created: '2026-01-01T00:00:00.000Z',
+  verificationMethod: 'did:key:z6MkConformance#key-0',
+  proofPurpose: 'assertionMethod',
+  proofValue: 'zconformance',
+});
+
+const createWebvhLog = async (): Promise<EventLog> => {
+  const peer = new PeerCelManager(signer);
+  const peerLog = await peer.create('Conformance Asset', [
+    { digestMultibase: 'uConformanceHash', mediaType: 'image/png' },
+  ]);
+  const webvh = new WebVHCelManager(signer, 'example.com');
+  return webvh.migrate(peerLog);
+};
+
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeys);
+  if (!value || typeof value !== 'object') return value;
+  const obj = value as Record<string, unknown>;
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(obj).sort()) sorted[key] = sortKeys(obj[key]);
+  return sorted;
+}
+
+describe('Btco finalization conformance', () => {
+  test('materializes deterministic final artifact digest and emits final attestation', async () => {
+    const inscribeData = vi
+      .fn()
+      .mockResolvedValueOnce({ txid: 'tx-witness', inscriptionId: 'tx-witnessi0', satoshi: '42', blockHeight: 10 })
+      .mockResolvedValueOnce({ txid: 'tx-attest', inscriptionId: 'tx-attesti0', satoshi: '43', blockHeight: 11 });
+
+    const bitcoinManager = { inscribeData } as unknown as BitcoinManager;
+    const manager = new BtcoCelManager(signer, bitcoinManager, { feeRate: 8 });
+    const webvhLog = await createWebvhLog();
+
+    const btcoLog = await manager.migrate(webvhLog);
+    const migrationData = btcoLog.events[btcoLog.events.length - 1].data as Record<string, any>;
+
+    expect(inscribeData).toHaveBeenCalledTimes(2);
+    expect(migrationData.finalAttestation?.finalityStatus).toBe('final');
+    expect(migrationData.finalAttestation?.inscriptionId).toBe('tx-attesti0');
+    expect(migrationData.finalArtifact?.digestMultibase).toMatch(/^u/);
+
+    const state = manager.getCurrentState(btcoLog) as Record<string, any>;
+    if (state.metadata) {
+      delete state.metadata.finalArtifact;
+      delete state.metadata.finalAttestation;
+    }
+    const payload = {
+      type: 'OriginalsFinalArtifact',
+      version: '1.1',
+      sourceDid: migrationData.sourceDid,
+      targetDid: migrationData.targetDid,
+      celHeadDigest: migrationData.finalAttestation.celHeadDigest,
+      state,
+    };
+    const expectedDigest = computeDigestMultibase(new TextEncoder().encode(JSON.stringify(sortKeys(payload))));
+    expect(migrationData.finalArtifact.digestMultibase).toBe(expectedDigest);
+  });
+});

--- a/packages/sdk/tests/unit/cel/cbor-serialization.test.ts
+++ b/packages/sdk/tests/unit/cel/cbor-serialization.test.ts
@@ -402,7 +402,7 @@ describe('CEL CBOR Serialization', () => {
       const cbor = serializeEventLogCbor(original);
       const parsed = parseEventLogCbor(cbor);
 
-      expect(parsed.events[0].data).toEqual(complexData);
+      expect(parsed.events[0].data).toEqual({ ...complexData, operation: 'ResourceAdded' });
     });
 
     test('serialize then parse preserves witness proofs', () => {
@@ -542,7 +542,7 @@ describe('CEL CBOR Serialization', () => {
       const cbor = serializeEventLogCbor(log);
       const parsed = parseEventLogCbor(cbor);
 
-      expect(parsed.events[0].data).toEqual({});
+      expect(parsed.events[0].data).toEqual({ operation: 'ResourceAdded' });
     });
 
     test('handles unicode in data', async () => {

--- a/packages/sdk/tests/unit/cel/json-serialization.test.ts
+++ b/packages/sdk/tests/unit/cel/json-serialization.test.ts
@@ -54,7 +54,7 @@ describe('CEL JSON Serialization', () => {
 
       // Keys should be sorted alphabetically in the data
       const dataKeys = Object.keys(parsed.events[0].data);
-      expect(dataKeys).toEqual(['a', 'm', 'z']);
+      expect(dataKeys).toEqual(['a', 'm', 'operation', 'z']);
     });
 
     test('serializes multiple events correctly', async () => {
@@ -405,7 +405,7 @@ describe('CEL JSON Serialization', () => {
       const json = serializeEventLogJson(original);
       const parsed = parseEventLogJson(json);
 
-      expect(parsed.events[0].data).toEqual(complexData);
+      expect(parsed.events[0].data).toEqual({ ...complexData, operation: 'ResourceAdded' });
     });
 
     test('serialize then parse preserves witness proofs', () => {
@@ -470,7 +470,7 @@ describe('CEL JSON Serialization', () => {
       const json = serializeEventLogJson(log);
       const parsed = parseEventLogJson(json);
 
-      expect(parsed.events[0].data).toEqual({});
+      expect(parsed.events[0].data).toEqual({ operation: 'ResourceAdded' });
     });
 
     test('handles unicode in data', async () => {

--- a/packages/sdk/tests/unit/core/OriginalsSDK.test.ts
+++ b/packages/sdk/tests/unit/core/OriginalsSDK.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, mock, beforeEach } from 'bun:test';
 import { OriginalsSDK } from '../../../src';
+import { OriginalsCel } from '../../../src/cel/OriginalsCel';
 import { signAsync, getPublicKeyAsync } from '@noble/ed25519';
 
 describe('OriginalsSDK', () => {
@@ -121,6 +122,22 @@ describe('OriginalsSDK', () => {
       // This test verifies the method exists and delegates to didwebvh-ts
       const result = await OriginalsSDK.prepareDIDDataForSigning(document, proof);
       expect(result).toBeInstanceOf(Uint8Array);
+    });
+  });
+
+  describe('createCel', () => {
+    test('creates CEL-first API instance', () => {
+      const signer = mock(async () => ({
+        type: 'DataIntegrityProof',
+        cryptosuite: 'eddsa-jcs-2022',
+        created: new Date().toISOString(),
+        verificationMethod: 'did:key:z6MkTest#z6MkTest',
+        proofPurpose: 'assertionMethod',
+        proofValue: 'zMockSignature',
+      }));
+
+      const cel = OriginalsSDK.createCel({ layer: 'peer', signer });
+      expect(cel).toBeInstanceOf(OriginalsCel);
     });
   });
 

--- a/packages/sdk/tests/unit/did/BtcoDidResolver.conformance.test.ts
+++ b/packages/sdk/tests/unit/did/BtcoDidResolver.conformance.test.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { BtcoDidResolver } from '../../../src/did/BtcoDidResolver';
+
+describe('BtcoDidResolver v1.1 conformance errors', () => {
+  test('uses machine-readable resolver error contract', async () => {
+    const fixturePath = join(import.meta.dir, '../../fixtures/resolver-errors-v1.1.json');
+    const fixture = JSON.parse(readFileSync(fixturePath, 'utf8')) as { errors: string[] };
+
+    const resolver = new BtcoDidResolver();
+
+    const invalidDid = await resolver.resolve('did:btc:123');
+    const notFound = await resolver.resolve('did:btco:123');
+    const repNotSupported = await resolver.resolve('did:btco:123/path', { accept: 'application/did+ld+json' });
+
+    expect(fixture.errors).toContain(invalidDid.resolutionMetadata.error);
+    expect(fixture.errors).toContain(notFound.resolutionMetadata.error);
+    expect(fixture.errors).toContain(repNotSupported.resolutionMetadata.error);
+
+    expect(invalidDid.resolutionMetadata.error).toBe('invalidDid');
+    expect(notFound.resolutionMetadata.error).toBe('notFound');
+    expect(repNotSupported.resolutionMetadata.error).toBe('representationNotSupported');
+  });
+});

--- a/packages/sdk/tests/unit/did/BtcoDidResolver.test.ts
+++ b/packages/sdk/tests/unit/did/BtcoDidResolver.test.ts
@@ -33,8 +33,22 @@ describe('BtcoDidResolver', () => {
     const resolver = new BtcoDidResolver();
     const res = await resolver.resolve('did:btco:123');
     expect(res.didDocument).toBeNull();
-    expect(res.resolutionMetadata.error).toBe('noProvider');
+    expect(res.resolutionMetadata.error).toBe('notFound');
     expect(res.resolutionMetadata.message).toBe('No provider supplied');
+  });
+
+  test('returns representationNotSupported for unsupported accept header', async () => {
+    const resolver = new BtcoDidResolver({ provider });
+    const res = await resolver.resolve('did:btco:123', { accept: 'application/did+ld+json' });
+    expect(res.didDocument).toBeNull();
+    expect(res.resolutionMetadata.error).toBe('representationNotSupported');
+  });
+
+  test('returns representationNotSupported for DID URL path dereference', async () => {
+    const resolver = new BtcoDidResolver({ provider });
+    const res = await resolver.resolve('did:btco:123/some/path');
+    expect(res.didDocument).toBeNull();
+    expect(res.resolutionMetadata.error).toBe('representationNotSupported');
   });
 
   test('provider.getSatInfo failure path', async () => {
@@ -312,7 +326,7 @@ describe('BtcoDidResolver branches', () => {
   test('no provider supplied', async () => {
     const r = new BtcoDidResolver();
     const res = await r.resolve('did:btco:1');
-    expect(res.resolutionMetadata?.error).toBe('noProvider');
+    expect(res.resolutionMetadata?.error).toBe('notFound');
   });
 
   test('provider getSatInfo throws', async () => {


### PR DESCRIPTION
## Summary
This PR completes the v1.1 finalization/conformance pass across CEL + btco resolution paths.

### What changed
- Align CEL required event semantics to v1.1 operation contracts
  - create => ResourceAdded
  - update => ResourceUpdated
  - strict cryptosuite checks on required events
- Strengthen verifyEventLog behavior and conformance coverage
- Add deterministic btco finalization attestation flow and tests
- Tighten btco DID resolver machine-readable error contract behavior
- Expose CEL-first API via OriginalsSDK.createCel() with tests
- Update package exports/index wiring for CEL layer modules
- Add/expand v1.1 conformance fixtures and unit coverage

## Validation
- bun test (repo-wide) currently reports pre-existing / adjacent failures outside core v1.1 scope, plus serialization expectation drift in CEL JSON/CBOR round-trip tests due required operation normalization in event data.
- New/updated conformance tests in this branch pass for:
  - btco finalization determinism
  - resolver error contract behavior
  - CEL required event operation semantics

## Follow-ups
- Align JSON/CBOR serialization round-trip expectations with v1.1-required operation normalization, or adjust serializer behavior if strict round-trip parity (without normalization) is preferred.
- Resolve @originals/auth export test failures in workspace test run.
