### PR TITLE
fix(sdk): runtime validation for deserializeDIDDocument/deserializeCredential

### DIFF
--- a/packages/sdk/src/utils/serialization.ts
+++ b/packages/sdk/src/utils/serialization.ts
@@ -1,5 +1,6 @@
 import jsonld from 'jsonld';
 import { DIDDocument, VerifiableCredential } from '../types';
+import { validateDIDDocument, validateCredential } from './validation';
 
 type DocumentLoader = (url: string) => Promise<{
   documentUrl: string;
@@ -51,12 +52,40 @@ export function serializeDIDDocument(didDoc: DIDDocument): string {
 
 export function deserializeDIDDocument(data: string): DIDDocument {
   // Parse from JSON-LD
+  let parsed: unknown;
   try {
-    const parsed: unknown = JSON.parse(data);
-    return parsed as DIDDocument;
+    parsed = JSON.parse(data);
   } catch (error) {
     throw new Error('Invalid DID Document JSON');
   }
+
+  // Runtime shape validation
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Invalid DID Document: expected a JSON object');
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  const errors: string[] = [];
+
+  // Pre-validate shape before calling validateDIDDocument (which assumes correct types)
+  if (!Array.isArray(obj['@context']) || obj['@context'].length === 0) {
+    errors.push('@context must be a non-empty array of strings');
+  } else if (!obj['@context'].every((c: unknown) => typeof c === 'string')) {
+    errors.push('@context must contain only strings');
+  }
+  if (typeof obj.id !== 'string' || obj.id === '') {
+    errors.push('id must be a valid DID string');
+  }
+  if (errors.length > 0) {
+    throw new Error(`Invalid DID Document: ${errors.join('; ')}`);
+  }
+
+  const doc = parsed as DIDDocument;
+  if (!validateDIDDocument(doc)) {
+    throw new Error('Invalid DID Document: failed validation');
+  }
+
+  return doc;
 }
 
 export function serializeCredential(vc: VerifiableCredential): string {
@@ -66,12 +95,51 @@ export function serializeCredential(vc: VerifiableCredential): string {
 
 export function deserializeCredential(data: string): VerifiableCredential {
   // Parse VC from JSON-LD
+  let parsed: unknown;
   try {
-    const parsed: unknown = JSON.parse(data);
-    return parsed as VerifiableCredential;
+    parsed = JSON.parse(data);
   } catch (error) {
     throw new Error('Invalid Verifiable Credential JSON');
   }
+
+  // Runtime shape validation
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Invalid Verifiable Credential: expected a JSON object');
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  const errors: string[] = [];
+
+  // Pre-validate shape before calling validateCredential (which assumes correct types)
+  if (!Array.isArray(obj['@context']) || obj['@context'].length === 0) {
+    errors.push('@context must be a non-empty array of strings');
+  } else if (!obj['@context'].includes('https://www.w3.org/2018/credentials/v1')) {
+    errors.push('@context must include W3C VC v1 context');
+  }
+  if (!Array.isArray(obj.type) || obj.type.length === 0) {
+    errors.push('type must be a non-empty array of strings');
+  } else if (!obj.type.includes('VerifiableCredential')) {
+    errors.push('type must include "VerifiableCredential"');
+  }
+  if (obj.issuer === undefined || obj.issuer === null) {
+    errors.push('issuer is required');
+  }
+  if (typeof obj.issuanceDate !== 'string') {
+    errors.push('issuanceDate is required');
+  }
+  if (!obj.credentialSubject || typeof obj.credentialSubject !== 'object' || Array.isArray(obj.credentialSubject)) {
+    errors.push('credentialSubject must be a non-null object');
+  }
+  if (errors.length > 0) {
+    throw new Error(`Invalid Verifiable Credential: ${errors.join('; ')}`);
+  }
+
+  const vc = parsed as VerifiableCredential;
+  if (!validateCredential(vc)) {
+    throw new Error('Invalid Verifiable Credential: failed validation');
+  }
+
+  return vc;
 }
 
 export async function canonicalizeDocument(

--- a/packages/sdk/tests/unit/utils/serialization.test.ts
+++ b/packages/sdk/tests/unit/utils/serialization.test.ts
@@ -1,17 +1,38 @@
 import { describe, test, expect } from 'bun:test';
 import { serializeDIDDocument, deserializeDIDDocument, serializeCredential, deserializeCredential, canonicalizeDocument } from '../../../src/utils/serialization';
 
+// Helper to build a valid DID Document
+function validDIDDoc(overrides: Record<string, unknown> = {}) {
+  return {
+    '@context': ['https://www.w3.org/ns/did/v1'],
+    id: 'did:peer:abc',
+    ...overrides,
+  };
+}
+
+// Helper to build a valid Verifiable Credential
+function validVC(overrides: Record<string, unknown> = {}) {
+  return {
+    '@context': ['https://www.w3.org/2018/credentials/v1'],
+    type: ['VerifiableCredential'],
+    issuer: 'did:peer:abc',
+    issuanceDate: new Date().toISOString(),
+    credentialSubject: { id: 'did:peer:abc' },
+    ...overrides,
+  };
+}
+
 describe('serialization utils', () => {
   test('serialize/deserialize DID document roundtrip', () => {
-    const doc: any = { '@context': ['https://www.w3.org/ns/did/v1'], id: 'did:peer:abc' };
-    const ser = serializeDIDDocument(doc);
+    const doc = validDIDDoc();
+    const ser = serializeDIDDocument(doc as any);
     const round = deserializeDIDDocument(ser);
     expect(round).toEqual(doc);
   });
 
   test('serialize/deserialize VC roundtrip', () => {
-    const vc: any = { '@context': ['https://www.w3.org/2018/credentials/v1'], type: ['VerifiableCredential'], issuer: 'did:peer:abc', issuanceDate: new Date().toISOString(), credentialSubject: { id: 'did:peer:abc' } };
-    const ser = serializeCredential(vc);
+    const vc = validVC();
+    const ser = serializeCredential(vc as any);
     const round = deserializeCredential(ser);
     expect(round).toEqual(vc);
   });
@@ -74,7 +95,7 @@ describe('serialization utils', () => {
     const customLoader = async (url: string) => {
       return {
         documentUrl: url,
-        document: { 
+        document: {
           '@context': {
             '@version': 1.1,
             'TestType': 'https://example.org/TestType',
@@ -94,7 +115,6 @@ describe('serialization utils', () => {
 
     const canon = await canonicalizeDocument(doc, { documentLoader: customLoader });
     expect(typeof canon).toBe('string');
-    // canonicalizeDocument might return empty string for certain contexts/documents
     expect(canon).toBeDefined();
   });
 
@@ -108,17 +128,253 @@ describe('serialization utils', () => {
   });
 
   test('canonicalizeDocument handles non-Error thrown values', async () => {
-    // This is difficult to test directly, but we can verify the error handling path exists
     const doc = {
       '@context': ['https://www.w3.org/2018/credentials/v1'],
       id: 'urn:test:1',
       type: 'TestType'
     };
 
-    // Normal case should work
     const canon = await canonicalizeDocument(doc);
     expect(typeof canon).toBe('string');
   });
 });
 
+describe('deserializeDIDDocument runtime validation', () => {
+  test('rejects JSON array', () => {
+    expect(() => deserializeDIDDocument('[]')).toThrow('expected a JSON object');
+  });
 
+  test('rejects JSON string primitive', () => {
+    expect(() => deserializeDIDDocument('"hello"')).toThrow('expected a JSON object');
+  });
+
+  test('rejects JSON number', () => {
+    expect(() => deserializeDIDDocument('42')).toThrow('expected a JSON object');
+  });
+
+  test('rejects JSON null', () => {
+    expect(() => deserializeDIDDocument('null')).toThrow('expected a JSON object');
+  });
+
+  test('rejects JSON boolean', () => {
+    expect(() => deserializeDIDDocument('true')).toThrow('expected a JSON object');
+  });
+
+  test('rejects empty object (missing required fields)', () => {
+    expect(() => deserializeDIDDocument('{}')).toThrow('Invalid DID Document');
+  });
+
+  test('rejects object missing @context', () => {
+    const doc = { id: 'did:peer:abc' };
+    expect(() => deserializeDIDDocument(JSON.stringify(doc))).toThrow('@context must be a non-empty array');
+  });
+
+  test('rejects object with non-array @context', () => {
+    const doc = { '@context': 'https://www.w3.org/ns/did/v1', id: 'did:peer:abc' };
+    expect(() => deserializeDIDDocument(JSON.stringify(doc))).toThrow('@context must be a non-empty array');
+  });
+
+  test('rejects object missing id', () => {
+    const doc = { '@context': ['https://www.w3.org/ns/did/v1'] };
+    expect(() => deserializeDIDDocument(JSON.stringify(doc))).toThrow('id must be a valid DID string');
+  });
+
+  test('rejects object with non-DID id', () => {
+    const doc = { '@context': ['https://www.w3.org/ns/did/v1'], id: 'not-a-did' };
+    expect(() => deserializeDIDDocument(JSON.stringify(doc))).toThrow('Invalid DID Document');
+  });
+
+  test('rejects object with unsupported DID method', () => {
+    const doc = { '@context': ['https://www.w3.org/ns/did/v1'], id: 'did:unsupported:abc' };
+    expect(() => deserializeDIDDocument(JSON.stringify(doc))).toThrow('Invalid DID Document');
+  });
+
+  test('rejects object with invalid verificationMethod entries', () => {
+    const doc = {
+      '@context': ['https://www.w3.org/ns/did/v1'],
+      id: 'did:peer:abc',
+      verificationMethod: [{ id: 'key-1' }],
+    };
+    expect(() => deserializeDIDDocument(JSON.stringify(doc))).toThrow('Invalid DID Document');
+  });
+
+  test('accepts valid DID document with verificationMethod', () => {
+    const doc = validDIDDoc({
+      verificationMethod: [{
+        id: 'did:peer:abc#key-1',
+        type: 'Ed25519VerificationKey2020',
+        controller: 'did:peer:abc',
+        publicKeyMultibase: 'z6Mkf5rGMoatrSj1f4CyvuHBeXJELe9RPdzo2PKGNCKVtZxP',
+      }],
+    });
+    const result = deserializeDIDDocument(JSON.stringify(doc));
+    expect(result).toEqual(doc);
+  });
+
+  test('accepts minimal valid DID document', () => {
+    const doc = validDIDDoc();
+    const result = deserializeDIDDocument(JSON.stringify(doc));
+    expect(result).toEqual(doc);
+  });
+});
+
+describe('deserializeCredential runtime validation', () => {
+  test('rejects JSON array', () => {
+    expect(() => deserializeCredential('[]')).toThrow('expected a JSON object');
+  });
+
+  test('rejects JSON string primitive', () => {
+    expect(() => deserializeCredential('"hello"')).toThrow('expected a JSON object');
+  });
+
+  test('rejects JSON number', () => {
+    expect(() => deserializeCredential('42')).toThrow('expected a JSON object');
+  });
+
+  test('rejects JSON null', () => {
+    expect(() => deserializeCredential('null')).toThrow('expected a JSON object');
+  });
+
+  test('rejects empty object (missing required fields)', () => {
+    expect(() => deserializeCredential('{}')).toThrow('Invalid Verifiable Credential');
+  });
+
+  test('rejects object missing @context', () => {
+    const vc = { type: ['VerifiableCredential'], issuer: 'did:peer:abc', issuanceDate: new Date().toISOString(), credentialSubject: {} };
+    expect(() => deserializeCredential(JSON.stringify(vc))).toThrow('@context must be a non-empty array');
+  });
+
+  test('rejects object with wrong @context (missing VC v1)', () => {
+    const vc = {
+      '@context': ['https://example.com/custom'],
+      type: ['VerifiableCredential'],
+      issuer: 'did:peer:abc',
+      issuanceDate: new Date().toISOString(),
+      credentialSubject: { id: 'did:peer:abc' },
+    };
+    expect(() => deserializeCredential(JSON.stringify(vc))).toThrow('@context must include W3C VC v1 context');
+  });
+
+  test('rejects object missing type', () => {
+    const vc = {
+      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      issuer: 'did:peer:abc',
+      issuanceDate: new Date().toISOString(),
+      credentialSubject: { id: 'did:peer:abc' },
+    };
+    expect(() => deserializeCredential(JSON.stringify(vc))).toThrow('type must be a non-empty array');
+  });
+
+  test('rejects object with type missing "VerifiableCredential"', () => {
+    const vc = {
+      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      type: ['SomeOtherType'],
+      issuer: 'did:peer:abc',
+      issuanceDate: new Date().toISOString(),
+      credentialSubject: { id: 'did:peer:abc' },
+    };
+    expect(() => deserializeCredential(JSON.stringify(vc))).toThrow('type must include "VerifiableCredential"');
+  });
+
+  test('rejects object missing issuer', () => {
+    const vc = {
+      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      type: ['VerifiableCredential'],
+      issuanceDate: new Date().toISOString(),
+      credentialSubject: { id: 'did:peer:abc' },
+    };
+    expect(() => deserializeCredential(JSON.stringify(vc))).toThrow('issuer is required');
+  });
+
+  test('rejects object with invalid issuer (not a DID)', () => {
+    const vc = validVC({ issuer: 'not-a-did' });
+    expect(() => deserializeCredential(JSON.stringify(vc))).toThrow('Invalid Verifiable Credential');
+  });
+
+  test('rejects object missing issuanceDate', () => {
+    const vc = {
+      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      type: ['VerifiableCredential'],
+      issuer: 'did:peer:abc',
+      credentialSubject: { id: 'did:peer:abc' },
+    };
+    expect(() => deserializeCredential(JSON.stringify(vc))).toThrow('issuanceDate is required');
+  });
+
+  test('rejects object with invalid issuanceDate', () => {
+    const vc = validVC({ issuanceDate: 'not-a-date' });
+    expect(() => deserializeCredential(JSON.stringify(vc))).toThrow('Invalid Verifiable Credential');
+  });
+
+  test('rejects object missing credentialSubject', () => {
+    const vc = {
+      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      type: ['VerifiableCredential'],
+      issuer: 'did:peer:abc',
+      issuanceDate: new Date().toISOString(),
+    };
+    expect(() => deserializeCredential(JSON.stringify(vc))).toThrow('credentialSubject must be a non-null object');
+  });
+
+  test('accepts valid VC with issuer as object', () => {
+    const vc = validVC({ issuer: { id: 'did:peer:abc', name: 'Test Issuer' } });
+    const result = deserializeCredential(JSON.stringify(vc));
+    expect(result).toEqual(vc);
+  });
+
+  test('accepts minimal valid VC', () => {
+    const vc = validVC();
+    const result = deserializeCredential(JSON.stringify(vc));
+    expect(result).toEqual(vc);
+  });
+});
+
+describe('fuzz tests: malformed-but-valid JSON objects', () => {
+  describe('DID Document fuzz', () => {
+    const fuzzCases: Array<{ name: string; input: unknown }> = [
+      { name: 'numeric @context', input: { '@context': 42, id: 'did:peer:abc' } },
+      { name: '@context as object', input: { '@context': { url: 'https://example.com' }, id: 'did:peer:abc' } },
+      { name: 'null id', input: { '@context': ['https://www.w3.org/ns/did/v1'], id: null } },
+      { name: 'numeric id', input: { '@context': ['https://www.w3.org/ns/did/v1'], id: 12345 } },
+      { name: 'array id', input: { '@context': ['https://www.w3.org/ns/did/v1'], id: ['did:peer:abc'] } },
+      { name: 'empty @context array', input: { '@context': [], id: 'did:peer:abc' } },
+      { name: '@context with non-string elements', input: { '@context': [123, null, true], id: 'did:peer:abc' } },
+      { name: 'verificationMethod as string', input: { '@context': ['https://www.w3.org/ns/did/v1'], id: 'did:peer:abc', verificationMethod: 'not-an-array' } },
+      { name: 'verificationMethod with empty objects', input: { '@context': ['https://www.w3.org/ns/did/v1'], id: 'did:peer:abc', verificationMethod: [{}] } },
+      { name: 'deeply nested garbage', input: { '@context': ['https://www.w3.org/ns/did/v1'], id: 'did:peer:abc', verificationMethod: [{ id: 'k1', type: 'T', controller: 'not-a-did', publicKeyMultibase: 'z123' }] } },
+      { name: 'extra properties only', input: { foo: 'bar', baz: 123 } },
+      { name: 'boolean @context', input: { '@context': true, id: 'did:peer:abc' } },
+      { name: 'id is empty string', input: { '@context': ['https://www.w3.org/ns/did/v1'], id: '' } },
+    ];
+
+    for (const { name, input } of fuzzCases) {
+      test(`rejects: ${name}`, () => {
+        expect(() => deserializeDIDDocument(JSON.stringify(input))).toThrow('Invalid DID Document');
+      });
+    }
+  });
+
+  describe('Verifiable Credential fuzz', () => {
+    const fuzzCases: Array<{ name: string; input: unknown }> = [
+      { name: 'numeric @context', input: { '@context': 42, type: ['VerifiableCredential'], issuer: 'did:peer:abc', issuanceDate: new Date().toISOString(), credentialSubject: {} } },
+      { name: '@context as object', input: { '@context': { url: 'https://example.com' }, type: ['VerifiableCredential'], issuer: 'did:peer:abc', issuanceDate: new Date().toISOString(), credentialSubject: {} } },
+      { name: 'null type', input: { '@context': ['https://www.w3.org/2018/credentials/v1'], type: null, issuer: 'did:peer:abc', issuanceDate: new Date().toISOString(), credentialSubject: {} } },
+      { name: 'type as string', input: { '@context': ['https://www.w3.org/2018/credentials/v1'], type: 'VerifiableCredential', issuer: 'did:peer:abc', issuanceDate: new Date().toISOString(), credentialSubject: {} } },
+      { name: 'issuer as number', input: { '@context': ['https://www.w3.org/2018/credentials/v1'], type: ['VerifiableCredential'], issuer: 42, issuanceDate: new Date().toISOString(), credentialSubject: {} } },
+      { name: 'issuer as array', input: { '@context': ['https://www.w3.org/2018/credentials/v1'], type: ['VerifiableCredential'], issuer: ['did:peer:abc'], issuanceDate: new Date().toISOString(), credentialSubject: {} } },
+      { name: 'issuanceDate as number', input: { '@context': ['https://www.w3.org/2018/credentials/v1'], type: ['VerifiableCredential'], issuer: 'did:peer:abc', issuanceDate: 1234567890, credentialSubject: {} } },
+      { name: 'credentialSubject as string', input: { '@context': ['https://www.w3.org/2018/credentials/v1'], type: ['VerifiableCredential'], issuer: 'did:peer:abc', issuanceDate: new Date().toISOString(), credentialSubject: 'not-an-object' } },
+      { name: 'credentialSubject as null', input: { '@context': ['https://www.w3.org/2018/credentials/v1'], type: ['VerifiableCredential'], issuer: 'did:peer:abc', issuanceDate: new Date().toISOString(), credentialSubject: null } },
+      { name: 'empty object', input: {} },
+      { name: 'all wrong types', input: { '@context': true, type: 123, issuer: null, issuanceDate: false, credentialSubject: [] } },
+      { name: 'empty arrays', input: { '@context': [], type: [], issuer: 'did:peer:abc', issuanceDate: new Date().toISOString(), credentialSubject: {} } },
+      { name: 'issuer object without id', input: { '@context': ['https://www.w3.org/2018/credentials/v1'], type: ['VerifiableCredential'], issuer: { name: 'No ID' }, issuanceDate: new Date().toISOString(), credentialSubject: { id: 'did:peer:abc' } } },
+    ];
+
+    for (const { name, input } of fuzzCases) {
+      test(`rejects: ${name}`, () => {
+        expect(() => deserializeCredential(JSON.stringify(input))).toThrow('Invalid Verifiable Credential');
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds runtime shape validation to `deserializeDIDDocument` and `deserializeCredential` in `packages/sdk/src/utils/serialization.ts`
- Previously these functions did `JSON.parse` then `as` cast with zero validation, allowing malformed objects into signing/verification/migration paths
- Now validates: object type, required fields (`@context`, `id`, `type`, `issuer`, `issuanceDate`, `credentialSubject`), field types, and delegates to existing `validateDIDDocument`/`validateCredential` for semantic checks
- Throws with field-level error messages for easier debugging

## Test plan

- [x] 55 new tests added covering:
  - Non-object JSON values (arrays, strings, numbers, null, booleans)
  - Missing required fields with specific error messages
  - Invalid field types (wrong @context format, non-DID id, etc.)
  - 13 DID Document fuzz cases (malformed-but-valid JSON)
  - 13 Verifiable Credential fuzz cases (malformed-but-valid JSON)
  - Valid document acceptance (roundtrip, with optional fields)
- [x] All 64 serialization tests pass
- [x] Full test suite shows no regressions (all failures are pre-existing)

Closes ORI-70

🤖 Generated with [Claude Code](https://claude.com/claude-code)