### PR TITLE
fix(sdk): make Data Integrity signatures cover all credential fields (#167)

### DIFF
--- a/packages/sdk/src/contexts/originals.json
+++ b/packages/sdk/src/contexts/originals.json
@@ -1,6 +1,7 @@
 {
   "@context": {
     "@version": 1.1,
+    "@vocab": "https://originals.build/vocab#",
     "type": "@type",
     "id": "@id",
     "Originals": "https://originals.build",

--- a/packages/sdk/src/utils/serialization.ts
+++ b/packages/sdk/src/utils/serialization.ts
@@ -17,7 +17,7 @@ import ordinalsContext from '../contexts/ordinals-plus.json';
 import originalsContext from '../contexts/originals.json';
 
 // Full context documents for proper canonicalization
-const PRELOADED_CONTEXTS: Record<string, unknown> = {
+export const PRELOADED_CONTEXTS: Record<string, unknown> = {
   // W3C and standard contexts
   'https://www.w3.org/2018/credentials/v1': credentialsV1Context,
   'https://www.w3.org/ns/credentials/v2': credentialsV2Context,
@@ -90,7 +90,9 @@ export async function canonicalizeDocument(
       documentLoader: options.documentLoader ?? defaultDocumentLoader,
       useNative: false,
       rdfDirection: 'i18n-datatype',
-      safe: false  // Disable safe mode to allow custom contexts
+      // Error on undefined terms instead of silently excluding them from the
+      // canonical dataset used for signing/hashing (issue #167).
+      safe: true
     });
     return result;
   } catch (error: unknown) {

--- a/packages/sdk/src/vc/CredentialManager.ts
+++ b/packages/sdk/src/vc/CredentialManager.ts
@@ -180,7 +180,11 @@ export class CredentialManager {
     issuer: string
   ): VerifiableCredential {
     return {
-      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      '@context': [
+        'https://www.w3.org/2018/credentials/v1',
+        'https://w3id.org/security/data-integrity/v2',
+        'https://originals.build/context'
+      ],
       type: ['VerifiableCredential', type],
       issuer,
       issuanceDate: new Date().toISOString(),
@@ -212,8 +216,9 @@ export class CredentialManager {
             type: docWithKey.type || 'Multikey'
           };
           const issuer = new Issuer(this.didManager, vm);
+          // Keep the credential's @context: replacing it would strip the term
+          // definitions its fields rely on, excluding them from the signature.
           const unsigned = { ...credential };
-          delete (unsigned as Partial<VerifiableCredential>)['@context'];
           delete (unsigned as Partial<VerifiableCredential>).proof;
           return issuer.issueCredential(unsigned, { proofPurpose: 'assertionMethod' });
         }
@@ -312,6 +317,9 @@ export class CredentialManager {
 
     const proofSansValue = { ...proof } as Record<string, unknown>;
     delete proofSansValue.proofValue;
+    // publicKeyMultibase is a key-discovery hint attached after signing; the
+    // sign-time digest never includes it, so exclude it here as well.
+    delete proofSansValue.publicKeyMultibase;
     const proofInput: Record<string, unknown> = { ...proofSansValue };
     const credentialContext = credential['@context'];
     if (credentialContext && !proofInput['@context']) {
@@ -762,7 +770,8 @@ export class CredentialManager {
     const credential: VerifiableCredential = {
       '@context': [
         'https://www.w3.org/2018/credentials/v1',
-        'https://w3id.org/security/data-integrity/v2'
+        'https://w3id.org/security/data-integrity/v2',
+        'https://originals.build/context'
       ],
       type: ['VerifiableCredential', type],
       id: this.generateCredentialId(),

--- a/packages/sdk/src/vc/Issuer.ts
+++ b/packages/sdk/src/vc/Issuer.ts
@@ -11,6 +11,33 @@ export interface IssueOptions {
   domain?: string;
 }
 
+// Default contexts for credentials issued without an explicit @context.
+// The Originals context supplies an @vocab so issuer-specific terms are
+// defined (and therefore signed) during safe-mode canonicalization.
+const DEFAULT_CONTEXTS = [
+  'https://www.w3.org/ns/credentials/v2',
+  'https://originals.build/context'
+];
+
+const DATA_INTEGRITY_CONTEXT = 'https://w3id.org/security/data-integrity/v2';
+// Contexts that already define the DataIntegrityProof terms used in proofs.
+const SECURING_CONTEXTS = ['https://www.w3.org/ns/credentials/v2', DATA_INTEGRITY_CONTEXT];
+
+/**
+ * Ensure the document's @context defines the Data Integrity proof terms,
+ * appending the data-integrity/v2 context when missing (mirrors the
+ * behaviour of jsonld-signatures). Without it, safe-mode canonicalization
+ * of the proof configuration fails for e.g. plain VCDM 1.1 credentials.
+ */
+function withSecuringContext(
+  context: VerifiableCredential['@context'] | undefined
+): VerifiableCredential['@context'] {
+  if (context === undefined) return [...DEFAULT_CONTEXTS];
+  const list = Array.isArray(context) ? context : [context];
+  const hasSecuring = list.some((c) => typeof c === 'string' && SECURING_CONTEXTS.includes(c));
+  return hasSecuring ? context : [...list, DATA_INTEGRITY_CONTEXT];
+}
+
 export type VerificationMethodLike = {
   id: string;
   controller: string;
@@ -31,7 +58,7 @@ export class Issuer {
   }
 
   async issueCredential(
-    unsigned: Omit<VerifiableCredential, '@context' | 'proof'>,
+    unsigned: Omit<VerifiableCredential, '@context' | 'proof'> & { '@context'?: VerifiableCredential['@context'] },
     options: IssueOptions
   ): Promise<VerifiableCredential> {
     const documentLoader = options.documentLoader || createDocumentLoader(this.didManager);
@@ -40,10 +67,12 @@ export class Issuer {
     const issuerId = typeof unsigned.issuer === 'string' ? unsigned.issuer : (unsigned.issuer as { id?: string })?.id;
     const credential: VerifiableCredential = {
       ...unsigned,
-      '@context': ['https://www.w3.org/ns/credentials/v2'],
-      issuer: issuerId || this.verificationMethod.controller,
-      proof: undefined
+      // Preserve the issuer-supplied @context so every stated term is part of
+      // the signed dataset; only default when none was provided (issue #167).
+      '@context': withSecuringContext(unsigned['@context']),
+      issuer: issuerId || this.verificationMethod.controller
     } as VerifiableCredential;
+    delete (credential as unknown as Record<string, unknown>).proof;
 
     if (!this.verificationMethod.secretKeyMultibase) {
       throw new Error('Missing secretKeyMultibase for issuance');
@@ -64,7 +93,7 @@ export class Issuer {
   }
 
   async issuePresentation(
-    presentation: Omit<VerifiablePresentation, '@context' | 'proof'>,
+    presentation: Omit<VerifiablePresentation, '@context' | 'proof'> & { '@context'?: VerifiablePresentation['@context'] },
     options: IssueOptions
   ): Promise<VerifiablePresentation> {
     const documentLoader = options.documentLoader || createDocumentLoader(this.didManager);
@@ -77,9 +106,10 @@ export class Issuer {
     if (keyType !== 'Ed25519') {
       throw new Error('Only Ed25519 supported for eddsa-rdfc-2022');
     }
+    const presentationContext = withSecuringContext(presentation['@context']);
     const presentationWithContext = {
       ...presentation,
-      '@context': ['https://www.w3.org/ns/credentials/v2']
+      '@context': presentationContext
     } as Record<string, unknown>;
 
     const proof = await DataIntegrityProofManager.createProof(
@@ -97,7 +127,7 @@ export class Issuer {
     );
     return {
       ...presentation,
-      '@context': ['https://www.w3.org/ns/credentials/v2'],
+      '@context': presentationContext,
       proof
     } as VerifiablePresentation;
   }

--- a/packages/sdk/src/vc/cryptosuites/eddsa.ts
+++ b/packages/sdk/src/vc/cryptosuites/eddsa.ts
@@ -16,7 +16,7 @@ export interface VerificationResult {
 export class EdDSACryptosuiteManager {
 
   static async createProof(document: any, options: any): Promise<DataIntegrityProof> {
-    const proofConfig = await this.createProofConfiguration(options);
+    const proofConfig = await this.createProofConfiguration(options, document?.['@context']);
     const transformedData = await this.transform(document, options);
     const hashData = await this.hash(transformedData, proofConfig, options);
     let privateKey: Uint8Array;
@@ -31,7 +31,8 @@ export class EdDSACryptosuiteManager {
     }
     const proofValueBytes = await this.sign({ data: hashData, privateKey });
     delete (proofConfig as any)['@context'];
-    return { ...proofConfig, proofValue: base58.encode(proofValueBytes) } as DataIntegrityProof;
+    // proofValue is multibase base58btc per the Data Integrity spec
+    return { ...proofConfig, proofValue: `z${base58.encode(proofValueBytes)}` } as DataIntegrityProof;
   }
 
   static async verifyProof(document: any, proof: DataIntegrityProof, options: any): Promise<VerificationResult> {
@@ -39,12 +40,19 @@ export class EdDSACryptosuiteManager {
       const documentToVerify = { ...document };
       delete (documentToVerify as any).proof;
       const transformedData = await this.transform(documentToVerify, options);
-      const hashData = await this.hash(transformedData, { '@context': document['@context'], ...proof }, options);
+      const hashData = await this.hash(
+        transformedData,
+        { '@context': document['@context'] ?? 'https://w3id.org/security/data-integrity/v2', ...proof },
+        options
+      );
       const vmDoc = await options.documentLoader(proof.verificationMethod);
       const pk = vmDoc.document.publicKeyMultibase as string;
       const dec = multikey.decodePublicKey(pk);
       if (dec.type !== 'Ed25519') throw new Error('Invalid key type for EdDSA');
-      const signature = base58.decode(proof.proofValue);
+      if (typeof proof.proofValue !== 'string' || !proof.proofValue.startsWith('z')) {
+        throw new Error('proofValue must be multibase base58btc (z-prefixed)');
+      }
+      const signature = base58.decode(proof.proofValue.slice(1));
       const verified = await this.verify({ data: hashData, signature, publicKey: dec.key });
       return verified ? { verified: true } : { verified: false, errors: ['Proof verification failed'] };
     } catch (e: any) {
@@ -52,9 +60,11 @@ export class EdDSACryptosuiteManager {
     }
   }
 
-  private static async createProofConfiguration(options: any): Promise<any> {
+  private static async createProofConfiguration(options: any, documentContext?: unknown): Promise<any> {
+    // Per eddsa-rdfc-2022, the proof configuration is canonicalized with the
+    // secured document's @context so create and verify hash identical data.
     return {
-      '@context': 'https://w3id.org/security/data-integrity/v2',
+      '@context': documentContext ?? 'https://w3id.org/security/data-integrity/v2',
       type: 'DataIntegrityProof',
       cryptosuite: 'eddsa-rdfc-2022',
       created: new Date().toISOString(),

--- a/packages/sdk/src/vc/documentLoader.ts
+++ b/packages/sdk/src/vc/documentLoader.ts
@@ -1,18 +1,12 @@
 import { DIDManager } from '../did/DIDManager';
+import { PRELOADED_CONTEXTS } from '../utils/serialization';
 
 type LoadedDocument = { document: unknown; documentUrl: string; contextUrl: string | null };
 
-interface ContextDocument {
-  '@context': {
-    '@version': number;
-  };
-}
-
-const CONTEXTS: Record<string, ContextDocument> = {
-  // Provide 1.1-compatible stubs for jsonld canonize
-  'https://www.w3.org/ns/credentials/v2': { '@context': { '@version': 1.1 } },
-  'https://w3id.org/security/data-integrity/v2': { '@context': { '@version': 1.1 } }
-};
+// Serve the full bundled context documents so canonicalization sees real term
+// definitions. Stub contexts here previously caused every credential field to
+// be dropped from the signed dataset (issue #167).
+const CONTEXTS: Record<string, unknown> = PRELOADED_CONTEXTS;
 
 export class DocumentLoader {
   constructor(private didManager: DIDManager) {}

--- a/packages/sdk/src/vc/utils/jsonld.ts
+++ b/packages/sdk/src/vc/utils/jsonld.ts
@@ -5,7 +5,9 @@ export async function canonize(input: any, { documentLoader }: any): Promise<str
     algorithm: 'URDNA2015',
     format: 'application/n-quads',
     documentLoader,
-    safe: false,
+    // Error on terms not defined in the supplied contexts instead of silently
+    // dropping them from the signed dataset (see issue #167).
+    safe: true,
     useNative: false,
     rdfDirection: 'i18n-datatype'
   } as any);

--- a/packages/sdk/tests/performance/credential-signing.perf.test.ts
+++ b/packages/sdk/tests/performance/credential-signing.perf.test.ts
@@ -28,7 +28,7 @@ function makeSubject(id: string): CredentialSubject {
 
 function makeBaseVC(id: string): VerifiableCredential {
   return {
-    '@context': ['https://www.w3.org/2018/credentials/v1'],
+    '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
     type: ['VerifiableCredential', 'ResourceCreated'],
     issuer: 'did:peer:issuer',
     issuanceDate: new Date().toISOString(),

--- a/packages/sdk/tests/security/credential-tampering.test.ts
+++ b/packages/sdk/tests/security/credential-tampering.test.ts
@@ -1,0 +1,148 @@
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { CredentialManager } from '../../src/vc/CredentialManager';
+import { DIDManager } from '../../src/did/DIDManager';
+import { registerVerificationMethod } from '../../src/vc/documentLoader';
+import { multikey } from '../../src/crypto/Multikey';
+import * as ed25519 from '@noble/ed25519';
+import type { VerifiableCredential } from '../../src/types';
+
+/**
+ * Regression tests for GitHub issue #167:
+ * Data Integrity signatures must cover ALL credential fields.
+ *
+ * Previously, stub JSON-LD contexts plus `safe: false` canonicalization
+ * meant undefined terms were silently dropped from the signed RDF dataset,
+ * so tampering with credentialSubject (and most other fields) did not
+ * invalidate the proof.
+ */
+
+const config = { network: 'regtest', defaultKeyType: 'Ed25519', enableLogging: false } as any;
+
+describe('credential tamper resistance (issue #167)', () => {
+  const didManager = new DIDManager(config);
+  const did = 'did:peer:issuer1';
+  const sk = new Uint8Array(32).map((_, i) => (i + 1) & 0xff);
+  const pk = ed25519.getPublicKey(sk);
+  const vm = {
+    id: `${did}#keys-1`,
+    controller: did,
+    type: 'Multikey',
+    publicKeyMultibase: multikey.encodePublicKey(pk, 'Ed25519'),
+    secretKeyMultibase: multikey.encodePrivateKey(sk, 'Ed25519')
+  };
+
+  beforeEach(() => {
+    registerVerificationMethod(vm);
+  });
+
+  const makeCredential = (): VerifiableCredential => ({
+    '@context': [
+      'https://www.w3.org/ns/credentials/v2',
+      'https://originals.build/context'
+    ],
+    type: ['VerifiableCredential', 'ResourceCreated'],
+    issuer: did,
+    validFrom: '2026-01-01T00:00:00Z',
+    credentialSubject: {
+      id: 'did:peer:subject1',
+      resourceId: 'resource-123',
+      contentHash: 'deadbeefcafe'
+    }
+  } as any);
+
+  test('untampered credential verifies', async () => {
+    const cm = new CredentialManager(config, didManager);
+    const signed = await cm.signCredential(makeCredential(), vm.secretKeyMultibase, vm.id);
+    expect(await cm.verifyCredential(signed)).toBe(true);
+  });
+
+  test('tampering credentialSubject invalidates the proof', async () => {
+    const cm = new CredentialManager(config, didManager);
+    const signed = await cm.signCredential(makeCredential(), vm.secretKeyMultibase, vm.id);
+    (signed.credentialSubject as any).contentHash = 'tampered';
+    expect(await cm.verifyCredential(signed)).toBe(false);
+  });
+
+  test('adding a field to credentialSubject invalidates the proof', async () => {
+    const cm = new CredentialManager(config, didManager);
+    const signed = await cm.signCredential(makeCredential(), vm.secretKeyMultibase, vm.id);
+    (signed.credentialSubject as any).resources = 'injected-claim';
+    expect(await cm.verifyCredential(signed)).toBe(false);
+  });
+
+  test('tampering validFrom invalidates the proof', async () => {
+    const cm = new CredentialManager(config, didManager);
+    const signed = await cm.signCredential(makeCredential(), vm.secretKeyMultibase, vm.id);
+    (signed as any).validFrom = '2030-01-01T00:00:00Z';
+    expect(await cm.verifyCredential(signed)).toBe(false);
+  });
+
+  test('issuer-supplied @context is preserved on the signed credential', async () => {
+    const cm = new CredentialManager(config, didManager);
+    const signed = await cm.signCredential(makeCredential(), vm.secretKeyMultibase, vm.id);
+    expect(signed['@context']).toContain('https://originals.build/context');
+    expect(signed['@context']).toContain('https://www.w3.org/ns/credentials/v2');
+  });
+
+  test('proofValue is multibase base58btc (z-prefixed)', async () => {
+    const cm = new CredentialManager(config, didManager);
+    const signed = await cm.signCredential(makeCredential(), vm.secretKeyMultibase, vm.id);
+    const proof = signed.proof as any;
+    expect(proof.proofValue.startsWith('z')).toBe(true);
+  });
+
+  test('signing a credential with terms undefined in its context throws', async () => {
+    const cm = new CredentialManager(config, didManager);
+    const cred = {
+      '@context': ['https://www.w3.org/ns/credentials/v2'],
+      type: ['VerifiableCredential'],
+      issuer: did,
+      validFrom: '2026-01-01T00:00:00Z',
+      credentialSubject: {
+        id: 'did:peer:subject1',
+        someUndefinedTerm: 'not in any context'
+      }
+    } as any;
+    await expect(
+      cm.signCredential(cred, vm.secretKeyMultibase, vm.id)
+    ).rejects.toThrow();
+  });
+
+  test('legacy signer path rejects undefined terms instead of silently dropping them', async () => {
+    // Without a DIDManager the fallback local signer is used; it must not
+    // sign a dataset from which unknown fields were silently excluded.
+    const cm = new CredentialManager(config);
+    const cred = {
+      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      type: ['VerifiableCredential'],
+      issuer: 'did:peer:issuer1',
+      issuanceDate: '2026-01-01T00:00:00Z',
+      credentialSubject: {
+        id: 'did:peer:subject1',
+        someUndefinedTerm: 'dropped silently before the fix'
+      }
+    } as any;
+    await expect(
+      cm.signCredential(cred, vm.secretKeyMultibase, vm.publicKeyMultibase)
+    ).rejects.toThrow();
+  });
+
+  test('factory-created credentials are signable and tamper-evident', async () => {
+    const cm = new CredentialManager(config, didManager);
+    const unsigned = cm.issueResourceCredential(
+      {
+        id: 'res-1',
+        type: 'text',
+        hash: 'abc123',
+        contentType: 'text/plain',
+        createdAt: '2026-01-01T00:00:00Z'
+      } as any,
+      'did:peer:asset1',
+      did
+    );
+    const signed = await cm.signCredential(unsigned, vm.secretKeyMultibase, vm.id);
+    expect(await cm.verifyCredential(signed)).toBe(true);
+    (signed.credentialSubject as any).contentHash = 'tampered';
+    expect(await cm.verifyCredential(signed)).toBe(false);
+  });
+});

--- a/packages/sdk/tests/unit/utils/serialization.test.ts
+++ b/packages/sdk/tests/unit/utils/serialization.test.ts
@@ -21,6 +21,7 @@ describe('serialization utils', () => {
       '@version': 1.1,
       id: '@id',
       type: '@type',
+      ExampleCredential: 'https://example.org/ExampleCredential',
       name: 'https://schema.org/name',
       details: {
         '@id': 'https://example.org/details',
@@ -112,7 +113,7 @@ describe('serialization utils', () => {
     const doc = {
       '@context': ['https://www.w3.org/2018/credentials/v1'],
       id: 'urn:test:1',
-      type: 'TestType'
+      type: 'VerifiableCredential'
     };
 
     // Normal case should work

--- a/packages/sdk/tests/unit/vc/CredentialManager.helpers.test.ts
+++ b/packages/sdk/tests/unit/vc/CredentialManager.helpers.test.ts
@@ -251,7 +251,7 @@ describe('CredentialManager - Credential Chaining', () => {
   describe('computeCredentialHash', () => {
     test('computes consistent hash for same credential', async () => {
       const credential: VerifiableCredential = {
-        '@context': ['https://www.w3.org/2018/credentials/v1'],
+        '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
         type: ['VerifiableCredential', 'TestCredential'],
         issuer: 'did:test:issuer',
         issuanceDate: '2024-01-15T10:00:00Z',
@@ -267,24 +267,24 @@ describe('CredentialManager - Credential Chaining', () => {
 
     test('computes different hash for different credentials', async () => {
       const credential1: VerifiableCredential = {
-        '@context': ['https://www.w3.org/2018/credentials/v1'],
+        '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
         type: ['VerifiableCredential', 'TypeOne'],
         issuer: 'did:test:issuer1',
         issuanceDate: '2024-01-15T10:00:00Z',
         credentialSubject: { 
-          id: 'subject1',
+          id: 'did:test:subject1',
           name: 'Alice',
           role: 'admin'
         }
       };
       
       const credential2: VerifiableCredential = {
-        '@context': ['https://www.w3.org/2018/credentials/v1'],
+        '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
         type: ['VerifiableCredential', 'TypeTwo'],
         issuer: 'did:test:issuer2',
         issuanceDate: '2024-01-16T10:00:00Z',
         credentialSubject: { 
-          id: 'subject2',
+          id: 'did:test:subject2',
           name: 'Bob',
           role: 'user'
         }
@@ -309,12 +309,12 @@ describe('CredentialManager - Credential Chaining', () => {
     test('validates chain with linked credentials', async () => {
       // Create first credential
       const cred1: VerifiableCredential = {
-        '@context': ['https://www.w3.org/2018/credentials/v1'],
+        '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
         type: ['VerifiableCredential'],
         id: 'urn:uuid:cred1',
         issuer: 'did:test:issuer',
         issuanceDate: '2024-01-01T00:00:00Z',
-        credentialSubject: { id: 'subject', value: 1 }
+        credentialSubject: { id: 'did:test:subject', value: 1 }
       };
       
       // Compute hash of first credential
@@ -322,13 +322,13 @@ describe('CredentialManager - Credential Chaining', () => {
       
       // Create second credential linked to first
       const cred2: VerifiableCredential = {
-        '@context': ['https://www.w3.org/2018/credentials/v1'],
+        '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
         type: ['VerifiableCredential'],
         id: 'urn:uuid:cred2',
         issuer: 'did:test:issuer',
         issuanceDate: '2024-01-02T00:00:00Z',
         credentialSubject: { 
-          id: 'subject', 
+          id: 'did:test:subject', 
           value: 2,
           previousCredential: { id: 'urn:uuid:cred1', hash: cred1Hash }
         }
@@ -352,7 +352,7 @@ describe('CredentialManager - Selective Disclosure', () => {
   describe('prepareSelectiveDisclosure', () => {
     test('prepares credential with mandatory pointers', async () => {
       const credential: VerifiableCredential = {
-        '@context': ['https://www.w3.org/2018/credentials/v1'],
+        '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
         type: ['VerifiableCredential'],
         issuer: 'did:test:issuer',
         issuanceDate: '2024-01-15T10:00:00Z',
@@ -377,11 +377,11 @@ describe('CredentialManager - Selective Disclosure', () => {
 
     test('throws error for empty mandatory pointers', async () => {
       const credential: VerifiableCredential = {
-        '@context': ['https://www.w3.org/2018/credentials/v1'],
+        '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
         type: ['VerifiableCredential'],
         issuer: 'did:test:issuer',
         issuanceDate: '2024-01-15T10:00:00Z',
-        credentialSubject: { id: 'subject' }
+        credentialSubject: { id: 'did:test:subject' }
       };
       
       await expect(
@@ -393,11 +393,11 @@ describe('CredentialManager - Selective Disclosure', () => {
 
     test('throws error for invalid JSON Pointer format', async () => {
       const credential: VerifiableCredential = {
-        '@context': ['https://www.w3.org/2018/credentials/v1'],
+        '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
         type: ['VerifiableCredential'],
         issuer: 'did:test:issuer',
         issuanceDate: '2024-01-15T10:00:00Z',
-        credentialSubject: { id: 'subject' }
+        credentialSubject: { id: 'did:test:subject' }
       };
       
       await expect(
@@ -411,7 +411,7 @@ describe('CredentialManager - Selective Disclosure', () => {
   describe('deriveSelectiveProof', () => {
     test('creates derived proof result with disclosed/hidden fields', async () => {
       const credential: VerifiableCredential = {
-        '@context': ['https://www.w3.org/2018/credentials/v1'],
+        '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
         type: ['VerifiableCredential'],
         issuer: 'did:test:issuer',
         issuanceDate: '2024-01-15T10:00:00Z',
@@ -435,11 +435,11 @@ describe('CredentialManager - Selective Disclosure', () => {
 
     test('throws error for invalid JSON Pointer in disclosure', async () => {
       const credential: VerifiableCredential = {
-        '@context': ['https://www.w3.org/2018/credentials/v1'],
+        '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
         type: ['VerifiableCredential'],
         issuer: 'did:test:issuer',
         issuanceDate: '2024-01-15T10:00:00Z',
-        credentialSubject: { id: 'subject' }
+        credentialSubject: { id: 'did:test:subject' }
       };
       
       await expect(
@@ -450,7 +450,7 @@ describe('CredentialManager - Selective Disclosure', () => {
 
   describe('getFieldByPointer', () => {
     const credential: VerifiableCredential = {
-      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
       type: ['VerifiableCredential'],
       issuer: 'did:test:issuer',
       issuanceDate: '2024-01-15T10:00:00Z',

--- a/packages/sdk/tests/unit/vc/CredentialManager.test.ts
+++ b/packages/sdk/tests/unit/vc/CredentialManager.test.ts
@@ -18,7 +18,7 @@ describe('CredentialManager', () => {
   } as any;
 
   const baseVC: VerifiableCredential = {
-    '@context': ['https://www.w3.org/2018/credentials/v1'],
+    '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
     type: ['VerifiableCredential', 'ResourceCreated'],
     issuer: 'did:peer:issuer',
     issuanceDate: new Date().toISOString(),
@@ -135,7 +135,7 @@ import { DIDManager } from '../../../src/did/DIDManager';
 describe('CredentialManager verification method resolution', () => {
   const baseConfig = { network: 'mainnet', defaultKeyType: 'ES256K' } as any;
   const credentialTemplate: VerifiableCredential = {
-    '@context': ['https://www.w3.org/2018/credentials/v1'],
+    '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
     type: ['VerifiableCredential', 'ResourceCreated'],
     issuer: 'did:example:issuer',
     issuanceDate: new Date().toISOString(),
@@ -197,7 +197,7 @@ describe('CredentialManager verify with didManager present but legacy path', () 
     const dm = new DIDManager({ network: 'mainnet', defaultKeyType: 'ES256K' } as any);
     const cm = new CredentialManager({ network: 'mainnet', defaultKeyType: 'ES256K' } as any, dm);
     const vc: any = {
-      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
       type: ['VerifiableCredential'],
       issuer: 'did:ex',
       issuanceDate: new Date().toISOString(),
@@ -229,7 +229,7 @@ describe('CredentialManager with didManager provided falls back to local signer 
     const skMb = multikey.encodePrivateKey(sk, 'Secp256k1');
 
     const vc: any = {
-      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
       type: ['VerifiableCredential'],
       issuer: 'did:ex',
       issuanceDate: new Date().toISOString(),
@@ -255,7 +255,7 @@ describe('CredentialManager DID path fallback when VM doc lacks type', () => {
     registerVerificationMethod({ id: 'did:ex:vm#x', controller: 'did:ex' } as any);
     const sk = new Uint8Array(32).fill(1);
     const pk = new Uint8Array(33).fill(2);
-    const vc: any = { '@context': ['https://www.w3.org/2018/credentials/v1'], type: ['VerifiableCredential'], issuer: 'did:ex', issuanceDate: new Date().toISOString(), credentialSubject: {} };
+    const vc: any = { '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'], type: ['VerifiableCredential'], issuer: 'did:ex', issuanceDate: new Date().toISOString(), credentialSubject: {} };
     const signed = await cm.signCredential(vc, multikey.encodePrivateKey(sk, 'Secp256k1'), 'did:ex:vm#x');
     expect(signed.proof).toBeDefined();
   });
@@ -270,7 +270,7 @@ describe('CredentialManager local verify path without didManager', () => {
   test('signs and verifies locally when didManager is undefined', async () => {
     const cm = new CredentialManager({ network: 'mainnet', defaultKeyType: 'ES256K' } as any);
     const baseVC: VerifiableCredential = {
-      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
       type: ['VerifiableCredential'],
       issuer: 'did:ex',
       issuanceDate: new Date().toISOString(),
@@ -294,7 +294,7 @@ describe('CredentialManager local verify path without didManager', () => {
     const issuanceDate = '2024-01-01T00:00:00Z';
 
     const credentialA: VerifiableCredential = {
-      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
       type: ['VerifiableCredential'],
       issuer: 'did:ex',
       issuanceDate,
@@ -312,7 +312,7 @@ describe('CredentialManager local verify path without didManager', () => {
     } as any;
 
     const credentialB: VerifiableCredential = {
-      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
       type: ['VerifiableCredential'],
       issuer: 'did:ex',
       issuanceDate,
@@ -330,12 +330,12 @@ describe('CredentialManager local verify path without didManager', () => {
     } as any;
 
     const signedA = await cm.signCredential(credentialA, skMb, pkMb);
-    const signedB = await cm.signCredential(credentialB, skMb, pkMb);
 
-    // Handle both single proof and proof array cases
-    const proofA = Array.isArray(signedA.proof) ? signedA.proof[0] : signedA.proof;
-    const proofB = Array.isArray(signedB.proof) ? signedB.proof[0] : signedB.proof;
-    expect(proofA?.proofValue).toEqual(proofB?.proofValue);
+    // Canonicalization is order-independent: the proof produced over A must
+    // verify against the same content with reordered properties. (proofValue
+    // can't be compared across two signing calls since the proof's `created`
+    // timestamp is part of the signed dataset.)
+    const signedB = { ...credentialB, proof: signedA.proof } as VerifiableCredential;
     await expect(cm.verifyCredential(signedA)).resolves.toBe(true);
     await expect(cm.verifyCredential(signedB)).resolves.toBe(true);
   });
@@ -348,7 +348,7 @@ describe('CredentialManager local verify path without didManager', () => {
     const pkMb = multikey.encodePublicKey(pk, 'Ed25519');
 
     const credential: VerifiableCredential = {
-      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
       type: ['VerifiableCredential'],
       issuer: 'did:ex',
       issuanceDate: '2024-01-01T00:00:00Z',
@@ -394,7 +394,7 @@ describe('CredentialManager DID path with VM missing type defaults to Multikey',
     const skMb = multikey.encodePrivateKey(sk, 'Ed25519');
     // Register VM without type so code path uses document.type || 'Multikey'
     registerVerificationMethod({ id: 'did:ex:vm#3', controller: 'did:ex', publicKeyMultibase: pkMb } as any);
-    const vc: any = { '@context': ['https://www.w3.org/2018/credentials/v1'], type: ['VerifiableCredential'], issuer: 'did:ex', issuanceDate: new Date().toISOString(), credentialSubject: {} };
+    const vc: any = { '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'], type: ['VerifiableCredential'], issuer: 'did:ex', issuanceDate: new Date().toISOString(), credentialSubject: {} };
     const signed = await cm.signCredential(vc, skMb, 'did:ex:vm#3');
     expect(signed.proof).toBeDefined();
   });
@@ -411,7 +411,7 @@ describe('CredentialManager additional branches', () => {
   });
   test('getSigner default case used for unknown key type', async () => {
     const cm = new CredentialManager({ network: 'mainnet', defaultKeyType: 'Unknown' as any });
-    const vc: any = { '@context': ['https://www.w3.org/2018/credentials/v1'], type: ['VerifiableCredential'], issuer: 'did:ex', issuanceDate: new Date().toISOString(), credentialSubject: {} };
+    const vc: any = { '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'], type: ['VerifiableCredential'], issuer: 'did:ex', issuanceDate: new Date().toISOString(), credentialSubject: {} };
     const sk = new Uint8Array(32).fill(1);
     const pk = new Uint8Array(33).fill(2);
     const signed = await cm.signCredential(vc, multikey.encodePrivateKey(sk, 'Secp256k1'), multikey.encodePublicKey(pk, 'Secp256k1'));
@@ -425,7 +425,7 @@ describe('CredentialManager additional branches', () => {
     const pk = new Uint8Array(32).fill(7);
     const vm = { id: 'did:ex:vm#1', controller: 'did:ex', publicKeyMultibase: (await import('../../../src/crypto/Multikey')).multikey.encodePublicKey(pk, 'Ed25519'), type: 'Multikey' } as any;
     registerVerificationMethod(vm as any);
-    const vc: any = { '@context': ['https://www.w3.org/2018/credentials/v1'], type: ['VerifiableCredential'], issuer: 'did:ex', issuanceDate: new Date().toISOString(), credentialSubject: {} };
+    const vc: any = { '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'], type: ['VerifiableCredential'], issuer: 'did:ex', issuanceDate: new Date().toISOString(), credentialSubject: {} };
     const skMb = (await import('../../../src/crypto/Multikey')).multikey.encodePrivateKey(sk, 'Ed25519');
     const signed = await cm.signCredential(vc, skMb, 'did:ex:vm#1');
     expect(signed.proof).toBeDefined();
@@ -439,7 +439,7 @@ describe('CredentialManager additional branches', () => {
     const { multikey } = await import('../../../src/crypto/Multikey');
     const vm = { id: 'did:ex:vm#2', controller: 'did:ex', publicKeyMultibase: multikey.encodePublicKey(pk, 'Ed25519'), type: 'Multikey' } as any;
     registerVerificationMethod(vm as any);
-    const vc: any = { '@context': ['https://www.w3.org/2018/credentials/v1'], type: ['VerifiableCredential'], issuer: { id: 'did:ex' }, issuanceDate: new Date().toISOString(), credentialSubject: {} };
+    const vc: any = { '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'], type: ['VerifiableCredential'], issuer: { id: 'did:ex' }, issuanceDate: new Date().toISOString(), credentialSubject: {} };
     const skMb = multikey.encodePrivateKey(sk, 'Ed25519');
     const signed = await cm.signCredential(vc, skMb, 'did:ex:vm#2');
     expect(signed.proof).toBeDefined();
@@ -455,7 +455,8 @@ describe('CredentialManager additional branches', () => {
     const pkMb = multikey.encodePublicKey(pk, 'Ed25519');
     const loader = async (iri: string) => {
       if (iri.includes('#')) return { document: { '@context': ['https://www.w3.org/ns/credentials/v2'], id: iri, publicKeyMultibase: pkMb }, documentUrl: iri, contextUrl: null };
-      return { document: { '@context': { '@version': 1.1 } }, documentUrl: iri, contextUrl: null } as any;
+      const { PRELOADED_CONTEXTS } = await import('../../../src/utils/serialization');
+      return { document: PRELOADED_CONTEXTS[iri] ?? { '@context': {} }, documentUrl: iri, contextUrl: null } as any;
     };
     const issuer = new (await import('../../../src/vc/Issuer')).Issuer(dm, { id: 'did:ex#k', controller: 'did:ex', publicKeyMultibase: pkMb, secretKeyMultibase: skMb } as any);
     // Register VM so verifier documentLoader can resolve the key by fragment
@@ -478,7 +479,7 @@ describe('CredentialManager additional branches', () => {
 describe('CredentialManager.getSigner default case when config keyType undefined', () => {
   test('defaults to ES256K', async () => {
     const cm = new CredentialManager({ network: 'mainnet' } as any);
-    const vc: any = { '@context': ['https://www.w3.org/2018/credentials/v1'], type: ['VerifiableCredential'], issuer: 'did:ex', issuanceDate: new Date().toISOString(), credentialSubject: {} };
+    const vc: any = { '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'], type: ['VerifiableCredential'], issuer: 'did:ex', issuanceDate: new Date().toISOString(), credentialSubject: {} };
     const sk = new Uint8Array(32).fill(3);
     const pk = new Uint8Array(33).fill(2);
     const signed = await cm.signCredential(vc, multikey.encodePrivateKey(sk, 'Secp256k1'), multikey.encodePublicKey(pk, 'Secp256k1'));

--- a/packages/sdk/tests/unit/vc/MultiSigManager.test.ts
+++ b/packages/sdk/tests/unit/vc/MultiSigManager.test.ts
@@ -39,7 +39,9 @@ describe('MultiSigManager', () => {
     manager = new MultiSigManager(config);
 
     baseVC = {
-      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      // The Originals context defines the custom subject terms so safe-mode
+      // canonicalization includes them in the signed dataset (issue #167).
+      '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
       type: ['VerifiableCredential', 'ResourceCreated'],
       issuer: 'did:peer:issuer',
       issuanceDate: new Date().toISOString(),

--- a/packages/sdk/tests/unit/vc/cryptosuites/eddsa.test.ts
+++ b/packages/sdk/tests/unit/vc/cryptosuites/eddsa.test.ts
@@ -4,18 +4,24 @@
 import { describe, test, expect } from 'bun:test';
 import { EdDSACryptosuiteManager } from '../../../../src/vc/cryptosuites/eddsa';
 import { multikey } from '../../../../src/crypto/Multikey';
+import { PRELOADED_CONTEXTS } from '../../../../src/utils/serialization';
+
+// Safe-mode canonicalization requires real context documents (issue #167);
+// stub contexts would silently drop every term from the signed dataset.
+const contextDocument = (iri: string) =>
+  ({ document: PRELOADED_CONTEXTS[iri] ?? { '@context': {} }, documentUrl: iri, contextUrl: null }) as any;
 
 describe('EdDSA additional branches', () => {
   test('createProof throws on invalid private key format', async () => {
-    await expect(EdDSACryptosuiteManager.createProof({ '@context': ['https://www.w3.org/ns/credentials/v2'], id: 'x' }, {
+    await expect(EdDSACryptosuiteManager.createProof({ '@context': ['https://www.w3.org/ns/credentials/v2'], id: 'urn:x', name: 'test' }, {
       verificationMethod: 'did:ex#k', proofPurpose: 'assertionMethod', cryptosuite: 'eddsa-rdfc-2022', privateKey: 123 as any,
-      documentLoader: async () => ({ document: { '@context': { '@version': 1.1 } }, documentUrl: '', contextUrl: null })
+      documentLoader: async (iri: string) => contextDocument(iri)
     } as any)).rejects.toThrow('Invalid private key format');
   });
 
   test('verifyProof returns error for non-Ed25519 VM', async () => {
     const pkMb = multikey.encodePublicKey(new Uint8Array(33).fill(1), 'Secp256k1');
-    const res = await EdDSACryptosuiteManager.verifyProof({ '@context': ['https://www.w3.org/ns/credentials/v2'], id: 'x' }, {
+    const res = await EdDSACryptosuiteManager.verifyProof({ '@context': ['https://www.w3.org/ns/credentials/v2'], id: 'urn:x', name: 'test' }, {
       type: 'DataIntegrityProof', cryptosuite: 'eddsa-rdfc-2022', verificationMethod: 'did:ex#k', proofPurpose: 'assertionMethod', proofValue: 'z1L'
     } as any, { documentLoader: async () => ({ document: { '@context': ['https://www.w3.org/ns/did/v1'], id: 'did:ex#k', publicKeyMultibase: pkMb }, documentUrl: '', contextUrl: null }) });
     expect(res.verified).toBe(false);
@@ -39,9 +45,9 @@ describe('EdDSA coverage extras', () => {
       if (iri.includes('#')) {
         return { document: { '@context': goodContext, id: iri, publicKeyMultibase: pkMb }, documentUrl: iri, contextUrl: null };
       }
-      return { document: { '@context': { '@version': 1.1 } }, documentUrl: iri, contextUrl: null } as any;
+      return contextDocument(iri);
     };
-    const doc: any = { '@context': goodContext, id: 'urn:doc-default-purpose' };
+    const doc: any = { '@context': goodContext, id: 'urn:doc-default-purpose', name: 'test' };
     const proof = await EdDSACryptosuiteManager.createProof(doc, { verificationMethod: vm, privateKey: sk, cryptosuite: 'eddsa-rdfc-2022', documentLoader: loader });
     // The method deletes @context before returning, so we assert the purpose value
     expect(proof.proofPurpose).toBe('assertionMethod');
@@ -55,9 +61,9 @@ describe('EdDSA coverage extras', () => {
       if (iri.includes('#')) {
         return { document: { '@context': goodContext, id: iri, publicKeyMultibase: pkMb }, documentUrl: iri, contextUrl: null };
       }
-      return { document: { '@context': { '@version': 1.1 } }, documentUrl: iri, contextUrl: null } as any;
+      return contextDocument(iri);
     };
-    const proof = await EdDSACryptosuiteManager.createProof({ '@context': goodContext, id: 'urn:chal' }, { verificationMethod: vm, privateKey: sk, cryptosuite: 'eddsa-rdfc-2022', challenge: '123', documentLoader: loader });
+    const proof = await EdDSACryptosuiteManager.createProof({ '@context': goodContext, id: 'urn:chal', name: 'test' }, { verificationMethod: vm, privateKey: sk, cryptosuite: 'eddsa-rdfc-2022', challenge: '123', documentLoader: loader });
     expect((proof as any).challenge).toBe('123');
     expect((proof as any).domain).toBeUndefined();
   });
@@ -70,9 +76,9 @@ describe('EdDSA coverage extras', () => {
       if (iri.includes('#')) {
         return { document: { '@context': goodContext, id: iri, publicKeyMultibase: pkMb }, documentUrl: iri, contextUrl: null };
       }
-      return { document: { '@context': { '@version': 1.1 } }, documentUrl: iri, contextUrl: null } as any;
+      return contextDocument(iri);
     };
-    const proof = await EdDSACryptosuiteManager.createProof({ '@context': goodContext, id: 'urn:domain' }, { verificationMethod: vm, privateKey: sk, cryptosuite: 'eddsa-rdfc-2022', domain: 'ex.org', documentLoader: loader });
+    const proof = await EdDSACryptosuiteManager.createProof({ '@context': goodContext, id: 'urn:domain', name: 'test' }, { verificationMethod: vm, privateKey: sk, cryptosuite: 'eddsa-rdfc-2022', domain: 'ex.org', documentLoader: loader });
     expect((proof as any).domain).toBe('ex.org');
     expect((proof as any).challenge).toBeUndefined();
   });
@@ -83,9 +89,9 @@ describe('EdDSA coverage extras', () => {
       if (iri.includes('#')) {
         return { document: { '@context': goodContext, id: iri, publicKeyMultibase: pkMb }, documentUrl: iri, contextUrl: null };
       }
-      return { document: { '@context': { '@version': 1.1 } }, documentUrl: iri, contextUrl: null } as any;
+      return contextDocument(iri);
     };
-    const doc: any = { '@context': goodContext, id: 'urn:doc' };
+    const doc: any = { '@context': goodContext, id: 'urn:doc', name: 'test' };
     const badProof: any = { type: 'DataIntegrityProof', cryptosuite: 'eddsa-rdfc-2022', verificationMethod: 'did:ex#k', proofPurpose: 'assertionMethod', proofValue: 'not-multibase' };
     const res = await EdDSACryptosuiteManager.verifyProof(doc, badProof, { documentLoader: loader });
     expect(res.verified).toBe(false);
@@ -95,14 +101,14 @@ describe('EdDSA coverage extras', () => {
 
   test('verifyProof uses Unknown verification error when thrown value lacks message', async () => {
     const pkMb = multikey.encodePublicKey(new Uint8Array(32).fill(4), 'Ed25519');
-    const doc: any = { '@context': goodContext, id: 'urn:doc-unknown' };
+    const doc: any = { '@context': goodContext, id: 'urn:doc-unknown', name: 'test' };
     const proof: any = { type: 'DataIntegrityProof', cryptosuite: 'eddsa-rdfc-2022', verificationMethod: 'did:ex#vm-unknown', proofPurpose: 'assertionMethod', proofValue: 'z1L' };
     const loader = async (iri: string) => {
       if (iri.includes('#')) {
         // Throw a primitive string (no message property) only on VM fetch, after transform/hash succeeded
         throw '';
       }
-      return { document: { '@context': { '@version': 1.1 } }, documentUrl: iri, contextUrl: null } as any;
+      return contextDocument(iri);
     };
     const res = await EdDSACryptosuiteManager.verifyProof(doc, proof, { documentLoader: loader });
     expect(res.verified).toBe(false);
@@ -126,11 +132,11 @@ describe('EdDSA cryptosuite edge cases', () => {
     if (iri.includes('#')) {
       return { document: { '@context': goodContext, id: iri, publicKeyMultibase: pkMb }, documentUrl: iri, contextUrl: null };
     }
-    return { document: { '@context': { '@version': 1.1 } }, documentUrl: iri, contextUrl: null } as any;
+    return contextDocument(iri);
   };
 
   test('createProof signs with raw Uint8Array 32-byte private key', async () => {
-    const proof = await EdDSACryptosuiteManager.createProof({ '@context': goodContext, id: 'urn:test:raw32' }, {
+    const proof = await EdDSACryptosuiteManager.createProof({ '@context': goodContext, id: 'urn:test:raw32', name: 'test' }, {
       verificationMethod: 'did:ex#key-raw', proofPurpose: 'assertionMethod', privateKey: pk32,
       cryptosuite: 'eddsa-rdfc-2022', documentLoader: okLoader
     });
@@ -139,7 +145,7 @@ describe('EdDSA cryptosuite edge cases', () => {
   });
 
   test('createProof includes challenge and domain options', async () => {
-    const proof = await EdDSACryptosuiteManager.createProof({ '@context': goodContext, id: 'urn:test:opts' }, {
+    const proof = await EdDSACryptosuiteManager.createProof({ '@context': goodContext, id: 'urn:test:opts', name: 'test' }, {
       verificationMethod: 'did:ex#key-opts', proofPurpose: 'assertionMethod', privateKey: pk32,
       cryptosuite: 'eddsa-rdfc-2022', challenge: 'abc', domain: 'example.org', documentLoader: okLoader
     });
@@ -149,7 +155,7 @@ describe('EdDSA cryptosuite edge cases', () => {
 
   test('createProof invalid private key length 33 throws', async () => {
     const bad33 = new Uint8Array(33);
-    await expect(EdDSACryptosuiteManager.createProof({ '@context': goodContext, id: 'urn:test:bad33' }, {
+    await expect(EdDSACryptosuiteManager.createProof({ '@context': goodContext, id: 'urn:test:bad33', name: 'test' }, {
       verificationMethod: 'did:ex#key-bad33', proofPurpose: 'assertionMethod', privateKey: bad33,
       cryptosuite: 'eddsa-rdfc-2022', documentLoader: okLoader
     })).rejects.toThrow('Invalid private key length');
@@ -157,7 +163,7 @@ describe('EdDSA cryptosuite edge cases', () => {
 
   test('createProof invalid private key length 63 throws', async () => {
     const bad63 = new Uint8Array(63);
-    await expect(EdDSACryptosuiteManager.createProof({ '@context': goodContext, id: 'urn:test:bad63' }, {
+    await expect(EdDSACryptosuiteManager.createProof({ '@context': goodContext, id: 'urn:test:bad63', name: 'test' }, {
       verificationMethod: 'did:ex#key-bad63', proofPurpose: 'assertionMethod', privateKey: bad63,
       cryptosuite: 'eddsa-rdfc-2022', documentLoader: okLoader
     })).rejects.toThrow('Invalid private key length');
@@ -166,7 +172,7 @@ describe('EdDSA cryptosuite edge cases', () => {
   test('createProof with non-Ed25519 multikey string errors', async () => {
     const secpSk = new Uint8Array(32).fill(5);
     const secpSkMb = multikey.encodePrivateKey(secpSk, 'Secp256k1');
-    await expect(EdDSACryptosuiteManager.createProof({ '@context': goodContext, id: 'urn:test:secpSk' }, {
+    await expect(EdDSACryptosuiteManager.createProof({ '@context': goodContext, id: 'urn:test:secpSk', name: 'test' }, {
       verificationMethod: 'did:ex#key-non-ed', proofPurpose: 'assertionMethod', privateKey: secpSkMb,
       cryptosuite: 'eddsa-rdfc-2022', documentLoader: okLoader
     })).rejects.toThrow('Invalid key type for EdDSA');
@@ -182,9 +188,9 @@ describe('EdDSA cryptosuite edge cases', () => {
       if (iri.includes('#')) {
         return { document: { '@context': goodContext, id: iri, publicKeyMultibase: signingPkMb }, documentUrl: iri, contextUrl: null };
       }
-      return { document: { '@context': { '@version': 1.1 } }, documentUrl: iri, contextUrl: null } as any;
+      return contextDocument(iri);
     };
-    const doc = { '@context': goodContext, id: 'urn:test:verify-wrong-pk' };
+    const doc = { '@context': goodContext, id: 'urn:test:verify-wrong-pk', name: 'test' };
     const proof = await EdDSACryptosuiteManager.createProof(doc, {
       verificationMethod: vmId, proofPurpose: 'assertionMethod', privateKey: signingSk,
       cryptosuite: 'eddsa-rdfc-2022', documentLoader: signingLoader
@@ -196,7 +202,7 @@ describe('EdDSA cryptosuite edge cases', () => {
       if (iri.includes('#')) {
         return { document: { '@context': goodContext, id: iri, publicKeyMultibase: wrongPkMb }, documentUrl: iri, contextUrl: null };
       }
-      return { document: { '@context': { '@version': 1.1 } }, documentUrl: iri, contextUrl: null } as any;
+      return contextDocument(iri);
     };
     const res = await EdDSACryptosuiteManager.verifyProof(doc, proof as any, { documentLoader: wrongLoader });
     expect(res.verified).toBe(false);
@@ -212,9 +218,9 @@ describe('EdDSA cryptosuite edge cases', () => {
       if (iri.includes('#')) {
         return { document: { '@context': goodContext, id: iri, publicKeyMultibase: pkMbLocal }, documentUrl: iri, contextUrl: null };
       }
-      return { document: { '@context': { '@version': 1.1 } }, documentUrl: iri, contextUrl: null } as any;
+      return contextDocument(iri);
     };
-    const doc = { '@context': goodContext, id: 'urn:test:verify-ok' };
+    const doc = { '@context': goodContext, id: 'urn:test:verify-ok', name: 'test' };
     const proof = await EdDSACryptosuiteManager.createProof(doc, {
       verificationMethod: vm, proofPurpose: 'assertionMethod', privateKey: sk, cryptosuite: 'eddsa-rdfc-2022', documentLoader: loader
     });
@@ -223,17 +229,21 @@ describe('EdDSA cryptosuite edge cases', () => {
   });
 
   test('createProof propagates canonizeProof/hash-stage exception via loader', async () => {
-    // Fail only during proof canonization stage (hash path), not during transform
+    // Fail only during proof canonization stage (hash path), not during transform.
+    // The proof config is canonicalized with the document's @context, so the
+    // context is loaded once for transform and again for the proof config.
+    let contextLoads = 0;
     const loader = async (iri: string) => {
-      if (iri.includes('w3id.org/security/data-integrity')) {
-        throw new Error('hash-stage canonize fail');
-      }
       if (iri.includes('#')) {
         return { document: { '@context': goodContext, id: iri, publicKeyMultibase: pkMb }, documentUrl: iri, contextUrl: null };
       }
-      return { document: { '@context': { '@version': 1.1 } }, documentUrl: iri, contextUrl: null } as any;
+      contextLoads++;
+      if (contextLoads > 1) {
+        throw new Error('hash-stage canonize fail');
+      }
+      return contextDocument(iri);
     };
-    await expect(EdDSACryptosuiteManager.createProof({ '@context': goodContext, id: 'urn:test:hash-fail' }, {
+    await expect(EdDSACryptosuiteManager.createProof({ '@context': goodContext, id: 'urn:test:hash-fail', name: 'test' }, {
       verificationMethod: 'did:ex#key-hash', proofPurpose: 'assertionMethod', privateKey: pk32,
       cryptosuite: 'eddsa-rdfc-2022', documentLoader: loader
     } as any)).rejects.toThrow();
@@ -251,9 +261,9 @@ describe('EdDSA error branches', () => {
     const skMbSecp = multikey.encodePrivateKey(sk, 'Secp256k1');
     const loader = async (iri: string) => {
       if (iri.includes('#')) return { document: { '@context': ['https://www.w3.org/ns/credentials/v2'], id: iri }, documentUrl: iri, contextUrl: null } as any;
-      return { document: { '@context': { '@version': 1.1 } }, documentUrl: iri, contextUrl: null } as any;
+      return contextDocument(iri);
     };
-    await expect(EdDSACryptosuiteManager.createProof({ '@context': ['https://www.w3.org/ns/credentials/v2'], id: 'urn:x' }, {
+    await expect(EdDSACryptosuiteManager.createProof({ '@context': ['https://www.w3.org/ns/credentials/v2'], id: 'urn:x', name: 'test' }, {
       verificationMethod: 'did:ex#key-1', proofPurpose: 'assertionMethod', privateKey: skMbSecp, cryptosuite: 'eddsa-rdfc-2022', documentLoader: loader
     })).rejects.toThrow('Invalid key type for EdDSA');
   });
@@ -263,7 +273,7 @@ describe('EdDSA error branches', () => {
     const pkMbSecp = multikey.encodePublicKey(pkSecp, 'Secp256k1');
     const loader = async (iri: string) => {
       if (iri.includes('#')) return { document: { '@context': ['https://www.w3.org/ns/credentials/v2'], id: iri, publicKeyMultibase: pkMbSecp }, documentUrl: iri, contextUrl: null } as any;
-      return { document: { '@context': { '@version': 1.1 } }, documentUrl: iri, contextUrl: null } as any;
+      return contextDocument(iri);
     };
     const proof = {
       type: 'DataIntegrityProof',
@@ -272,7 +282,7 @@ describe('EdDSA error branches', () => {
       proofPurpose: 'assertionMethod',
       proofValue: 'z1L'
     } as any;
-    const res = await EdDSACryptosuiteManager.verifyProof({ '@context': ['https://www.w3.org/ns/credentials/v2'], id: 'urn:x' }, proof, { documentLoader: loader });
+    const res = await EdDSACryptosuiteManager.verifyProof({ '@context': ['https://www.w3.org/ns/credentials/v2'], id: 'urn:x', name: 'test' }, proof, { documentLoader: loader });
     expect(res.verified).toBe(false);
     expect(res.errors?.[0]).toBe('Invalid key type for EdDSA');
   });
@@ -306,26 +316,26 @@ describe('EdDSACryptosuiteManager extra branches', () => {
     if (iri.includes('#')) {
       return { document: { '@context': ['https://www.w3.org/ns/credentials/v2'], id: iri, publicKeyMultibase: pubMb }, documentUrl: iri, contextUrl: null };
     }
-    return { document: { '@context': { '@version': 1.1 } }, documentUrl: iri, contextUrl: null } as any;
+    return contextDocument(iri);
   };
 
   test('sign with 64-byte private key slices to 32', async () => {
     const sixtyFour = new Uint8Array(64);
     sixtyFour.set(pkRaw);
-    const proof = await EdDSACryptosuiteManager.createProof({ '@context': ['https://www.w3.org/ns/credentials/v2'], id: 'x' }, {
+    const proof = await EdDSACryptosuiteManager.createProof({ '@context': ['https://www.w3.org/ns/credentials/v2'], id: 'urn:x', name: 'test' }, {
       verificationMethod: 'did:ex#k', proofPurpose: 'assertionMethod', privateKey: sixtyFour, cryptosuite: 'eddsa-rdfc-2022', documentLoader: loader
     });
     expect(proof.proofValue).toBeTruthy();
   });
 
   test('invalid private key length throws', async () => {
-    await expect(EdDSACryptosuiteManager.createProof({ '@context': ['https://www.w3.org/ns/credentials/v2'], id: 'x' }, {
+    await expect(EdDSACryptosuiteManager.createProof({ '@context': ['https://www.w3.org/ns/credentials/v2'], id: 'urn:x', name: 'test' }, {
       verificationMethod: 'did:ex#k', proofPurpose: 'assertionMethod', privateKey: new Uint8Array(31), cryptosuite: 'eddsa-rdfc-2022', documentLoader: loader
     })).rejects.toThrow('Invalid private key length');
   });
 
   test('verify returns false on signature mismatch', async () => {
-    const res = await EdDSACryptosuiteManager.verifyProof({ '@context': ['https://www.w3.org/ns/credentials/v2'], id: 'x' }, {
+    const res = await EdDSACryptosuiteManager.verifyProof({ '@context': ['https://www.w3.org/ns/credentials/v2'], id: 'urn:x', name: 'test' }, {
       type: 'DataIntegrityProof', cryptosuite: 'eddsa-rdfc-2022', verificationMethod: 'did:ex#k', proofPurpose: 'assertionMethod', proofValue: 'z1L' // invalid base58btc
     } as any, { documentLoader: loader });
     expect(res.verified).toBe(false);
@@ -336,7 +346,7 @@ describe('EdDSACryptosuiteManager extra branches', () => {
       if (iri.includes('#')) {
         return { document: { '@context': ['https://www.w3.org/ns/credentials/v2'], id: iri, publicKeyMultibase: pubMb }, documentUrl: iri, contextUrl: null };
       }
-      return { document: { '@context': { '@version': 1.1 } }, documentUrl: iri, contextUrl: null } as any;
+      return contextDocument(iri);
     };
     const proof: any = { type: 'DataIntegrityProof', cryptosuite: 'eddsa-rdfc-2022', verificationMethod: 'did:ex#k', proofPurpose: 'assertionMethod', proofValue: 'z1L' };
     const doc: any = { '@context': ['https://www.w3.org/ns/credentials/v2'] };
@@ -359,9 +369,9 @@ describe('EdDSA createProof with multikey string', () => {
     const pkMb = multikey.encodePublicKey(pk, 'Ed25519');
     const loader = async (iri: string) => {
       if (iri.includes('#')) return { document: { '@context': ['https://www.w3.org/ns/credentials/v2'], id: iri, publicKeyMultibase: pkMb }, documentUrl: iri, contextUrl: null };
-      return { document: { '@context': { '@version': 1.1 } }, documentUrl: iri, contextUrl: null } as any;
+      return contextDocument(iri);
     };
-    const proof = await EdDSACryptosuiteManager.createProof({ '@context': ['https://www.w3.org/ns/credentials/v2'], id: 'urn:x' }, {
+    const proof = await EdDSACryptosuiteManager.createProof({ '@context': ['https://www.w3.org/ns/credentials/v2'], id: 'urn:x', name: 'test' }, {
       verificationMethod: 'did:ex#key-1', proofPurpose: 'assertionMethod', privateKey: skMb, cryptosuite: 'eddsa-rdfc-2022', documentLoader: loader
     });
     expect(proof.type).toBe('DataIntegrityProof');
@@ -388,9 +398,9 @@ describe('EdDSA verifyProof success path', () => {
       if (iri.includes('#')) {
         return { document: { '@context': ['https://www.w3.org/ns/credentials/v2'], id: iri, publicKeyMultibase: pkMb }, documentUrl: iri, contextUrl: null };
       }
-      return { document: { '@context': { '@version': 1.1 } }, documentUrl: iri, contextUrl: null } as any;
+      return contextDocument(iri);
     };
-    const doc: any = { '@context': ['https://www.w3.org/ns/credentials/v2'], id: 'urn:doc' };
+    const doc: any = { '@context': ['https://www.w3.org/ns/credentials/v2'], id: 'urn:doc', name: 'test' };
     const proof = await EdDSACryptosuiteManager.createProof(doc, { verificationMethod: vmId, proofPurpose: 'assertionMethod', privateKey: skMb, cryptosuite: 'eddsa-rdfc-2022', documentLoader: loader });
     const res = await EdDSACryptosuiteManager.verifyProof({ ...doc, proof }, proof as any, { documentLoader: loader });
     expect(res.verified).toBe(true);


### PR DESCRIPTION
## Summary

Fixes #167 — credentials signed through the high-level path could be tampered without failing verification because undefined JSON-LD terms were silently excluded from the signed RDF dataset.

All five root causes from the issue are addressed:

1. **Context no longer stripped** — `Issuer.issueCredential` / `issuePresentation` and `CredentialManager.signCredential` preserve the issuer-supplied `@context` (defaulting to `[credentials/v2, originals.build/context]` only when none is provided). When the supplied context lacks Data Integrity terms (e.g. plain VCDM 1.1), `data-integrity/v2` is appended, mirroring jsonld-signatures.
2. **Real contexts instead of stubs** — the VC document loader now serves the full bundled context documents from `src/contexts/` (already vendored for `serialization.ts`) instead of `{'@version': 1.1}` stubs.
3. **`safe: true` canonicalization** — both `vc/utils/jsonld.ts` and `utils/serialization.ts` (legacy signer + MultiSig path) now error on undefined terms at issuance/verification instead of silently dropping them.
4. **Symmetric proof-config hashing** — `createProof` canonicalizes the proof configuration with the secured document's `@context` (per eddsa-rdfc-2022), exactly matching what `verifyProof` reconstructs.
5. **Multibase `proofValue`** — emitted as `z` + base58btc; the prefix is required at verification.

Additionally:
- The Originals context gains an `@vocab` (`https://originals.build/vocab#`) so SDK-specific credential terms (`resourceId`, `contentHash`, …) are defined and therefore signed; factory credentials now include this context.
- The legacy verification digest excludes the post-signing `publicKeyMultibase` key-discovery hint, matching the sign-time digest.

## Compatibility notes

- Credentials signed before this fix will no longer verify — their signatures covered a nearly-empty dataset, so this is intentional.
- Signing a credential whose fields are not defined by its `@context` now throws at issuance instead of producing a proof that silently omits those fields.

## Tests

New `tests/security/credential-tampering.test.ts` (9 tests): the issue's reproduction (tamper `credentialSubject` → verify must fail), field injection, `validFrom` tampering, context preservation, multibase encoding, undefined-term rejection on both the high-level and legacy paths, and factory-credential round-trips.

Full suite verified against `main`: no new failures introduced (the failures currently on `main` — key rotation/recovery, DIDCache, metrics, AuditLogger — are pre-existing and unrelated; build and lint output are byte-identical to baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)