### PR TITLE
fix(sdk): de-flake MetricsCollector timing (use performance.now in track)

### DIFF
--- a/packages/sdk/src/utils/MetricsCollector.ts
+++ b/packages/sdk/src/utils/MetricsCollector.ts
@@ -83,7 +83,7 @@ export class MetricsCollector {
    * Re-throws any error after recording the failure.
    */
   async track<T>(operation: string, fn: () => Promise<T>): Promise<T> {
-    const start = Date.now();
+    const start = performance.now();
     let success = true;
     try {
       return await fn();
@@ -91,7 +91,7 @@ export class MetricsCollector {
       success = false;
       throw e;
     } finally {
-      this.recordOperation(operation, Date.now() - start, success);
+      this.recordOperation(operation, performance.now() - start, success);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes the one flaky test in the suite: `Metrics Integration › DIDManager metrics tracking › should track createDIDPeer operation`.

**Root cause:** `MetricsCollector.track()` measured operation duration with `Date.now()` (1ms resolution). A sub-millisecond op (like `createDIDPeer`) recorded `duration = 0`, so `totalTime` stayed `0` and the test's `expect(totalTime).toBeGreaterThan(0)` failed intermittently.

**Fix:** use `performance.now()` (sub-millisecond) in `track()` — consistent with `startOperation()` in the same file, which already does. One method, two lines.

## Verification

- The previously-flaky test passed **30/30 consecutive runs**.
- Full SDK suite **0 fail on two consecutive runs** (2466 tests).
- `tsc` clean.

Base is `improve/audit-2026-06-11-run2` (PR #170) because that's where the DIDManager metrics wiring lives and where this test is exercised; it isn't wired on `main` yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix flaky timing in `MetricsCollector.track` by switching to `performance.now()`
> Replaces `Date.now()` with `performance.now()` in [MetricsCollector.ts](https://github.com/onionoriginals/sdk/pull/171/files#diff-3b39b6d9e858ad3648e61f9fb84fad619098aa7097cede6ac73c96060d0404da) for both start time capture and duration calculation. This provides sub-millisecond precision and avoids flakiness caused by the coarser, integer-millisecond resolution of `Date.now()`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 94ed0c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->