### PR TITLE
fix: update root tsconfig moduleResolution from deprecated node to bundler

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "module": "ESNext",
     "lib": ["ES2020"],
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary

- `bunx tsc --noEmit` was failing with exit code 2 (TS5107) because TypeScript 6.0 marks `moduleResolution: "node"` (alias `node10`) as deprecated and will stop supporting it in TypeScript 7.0
- The root `tsconfig.json` is a project-references coordinator with `"files": []` — it compiles no source files, so `moduleResolution` has no effect on actual type checking or output
- Changed `"moduleResolution": "node"` → `"moduleResolution": "bundler"`, matching `packages/auth/tsconfig.json`

## What was red

**REAL failure** — `bunx tsc --noEmit` (exit code 2):
```
tsconfig.json(6,25): error TS5107: Option 'moduleResolution=node10' is deprecated
and will stop functioning in TypeScript 7.0. Specify compilerOption
'"ignoreDeprecations": "6.0"' to silence this error.
```

No flaky failures detected. Build and all tests were already passing.

## Root cause

TypeScript upgraded to 6.0.2 in this environment. TS6 promotes the long-standing `moduleResolution=node` deprecation to a hard error (TS5107). The root `tsconfig.json` still used the old value.

## Fix

One-line change in `tsconfig.json`:
```diff
- "moduleResolution": "node",
+ "moduleResolution": "bundler",
```

## Green invariant evidence

```
bunx tsc --noEmit  → exit: 0  (was exit: 2)
bun run build      → Tasks: 2 successful, 2 total
bun run test       → 2216 pass, 0 fail (sdk) + 140 pass, 0 fail (auth)
                     Ran 2356 tests total, 0 failures
```

No tests skipped, deleted, weakened, or masked. No cryptographic or provenance guarantees altered.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFtVHByE7aF5K8YQMfa1we)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update root `tsconfig.json` moduleResolution from deprecated `node` to `bundler`
> The `moduleResolution` compiler option in [tsconfig.json](https://github.com/onionoriginals/sdk/pull/172/files#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0) is changed from `"node"` to `"bundler"`, which better reflects how a bundler-based toolchain resolves imports. Behavioral Change: TypeScript will now apply bundler-style module resolution rules during type checking, which may surface new resolution errors for imports that previously resolved under the `node` strategy.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 32caab4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->