### PR TITLE
fix: update moduleResolution from node to bundler for TypeScript 6

### DIFF
--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -12,7 +12,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "types": ["node", "bun-types"],
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "module": "ESNext",
     "lib": ["ES2020"],
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary

- `bunx tsc --noEmit` (green invariant check) was failing with error TS5107 because TypeScript 6.0.2 hard-errors on `moduleResolution=node10` (the internal alias for the `"node"` value).
- Both `tsconfig.json` (root) and `packages/sdk/tsconfig.json` used `"moduleResolution": "node"`.
- Fixed by changing both to `"moduleResolution": "bundler"`, which is the correct value for this ESNext/Bun project.

## What was red

**Real failure** (not flaky): `bunx tsc --noEmit` exited with code 2:
```
tsconfig.json(6,25): error TS5107: Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0.
packages/sdk/tsconfig.json(15,25): error TS5107: Option 'moduleResolution=node10' is deprecated ...
```

**Root cause**: The installed global `bunx tsc` resolves to TypeScript 6.0.2, which upgraded the `moduleResolution=node` deprecation from warning to hard error. The package-local build (`bun run build`) uses TypeScript 5.9.3 and succeeded, which is why the build appeared healthy.

## Fix

Changed `"moduleResolution": "node"` → `"moduleResolution": "bundler"` in:
- `tsconfig.json` (root composite config)
- `packages/sdk/tsconfig.json`

`"bundler"` is the appropriate value for an ESNext/Bun project — it supports modern import resolution semantics without requiring file extensions in imports, matching what Bun expects.

No test was skipped, deleted, weakened, or masked. No cryptographic or provenance guarantee was changed.

## Green invariant output (post-fix)

```
$ bunx tsc --noEmit          → exit 0 (0 errors)
$ bun run build              → Tasks: 2 successful, 2 total
$ bun run test               → Tasks: 4 successful, 4 total (0 failures)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARrmXSAk2etATwKegmBfu2

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARrmXSAk2etATwKegmBfu2)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update `moduleResolution` from `node` to `bundler` in TypeScript configs
> Updates the `moduleResolution` compiler option in [tsconfig.json](https://github.com/onionoriginals/sdk/pull/173/files#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0) and [packages/sdk/tsconfig.json](https://github.com/onionoriginals/sdk/pull/173/files#diff-62ec9179a1fd352f07b1db2aae889fa66e81cf7f72ceffe25ae527ff7ad6c492) to `bundler` for TypeScript 6 compatibility.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2df562e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->