### PR TITLE
fix(cel/cli): sign full transfer event base so transferred logs verify

### DIFF
--- a/packages/sdk/src/cel/cli/transfer.ts
+++ b/packages/sdk/src/cel/cli/transfer.ts
@@ -223,19 +223,29 @@ export async function transferCommand(flags: TransferFlags): Promise<TransferRes
     transferredAt: new Date().toISOString(),
   };
 
+  // Compute previous event hash first (same canonicalization as updateEventLog),
+  // then sign over the full event base so the signed payload matches what
+  // verifyEventLog reconstructs: { type, data, previousEvent }. Signing only
+  // `transferData` would produce a signature that verification cannot reproduce,
+  // yielding proofValid: false on every transferred log.
+  const lastEvent = eventLog.events[eventLog.events.length - 1];
+  const previousEvent = computeDigestMultibase(canonicalizeEvent(lastEvent));
+
+  const eventBase = {
+    type: 'update' as const,
+    data: transferData,
+    previousEvent,
+  };
+
   let proof: DataIntegrityProof;
   try {
-    proof = await signer(transferData);
+    proof = await signer(eventBase);
   } catch (e) {
     return {
       success: false,
       message: `Error: Failed to sign transfer: ${(e as Error).message}`,
     };
   }
-
-  // Compute previous event hash using the same canonicalization as updateEventLog
-  const lastEvent = eventLog.events[eventLog.events.length - 1];
-  const previousEvent = computeDigestMultibase(canonicalizeEvent(lastEvent));
 
   // Append transfer event to log
   eventLog.events.push({

--- a/packages/sdk/tests/unit/cel/cli-transfer.test.ts
+++ b/packages/sdk/tests/unit/cel/cli-transfer.test.ts
@@ -14,6 +14,8 @@ import { updateEventLog } from '../../../src/cel/algorithms/updateEventLog';
 import { serializeEventLogJson } from '../../../src/cel/serialization/json';
 import { serializeEventLogCbor } from '../../../src/cel/serialization/cbor';
 import { parseEventLogJson } from '../../../src/cel/serialization/json';
+import { verifyEventLog } from '../../../src/cel/algorithms/verifyEventLog';
+import { canonicalizeEvent } from '../../../src/cel/canonicalize';
 import type { DataIntegrityProof, EventLog } from '../../../src/cel/types';
 import { multikey } from '../../../src/crypto/Multikey';
 
@@ -427,6 +429,96 @@ describe('CLI Transfer Command', () => {
 
       expect(result.success).toBe(false);
       expect(result.message).toContain('Failed to load event log');
+    });
+  });
+
+  describe('cryptographic verification of transferred logs (plan 014)', () => {
+    // The CLI derives the public key from the wallet's private key and signs
+    // with verificationMethod did:key:<pub>#<pub>. To make the *create* event
+    // also verify under the built-in did:key resolver, we sign it with the SAME
+    // key and matching verificationMethod, then write that key as the wallet so
+    // the transfer is signed by the same key. The resulting log must verify
+    // end-to-end: every event proofValid AND chainValid.
+    async function createRealKeyPeerLogAndWallet(dir: string): Promise<{
+      logPath: string;
+      walletPath: string;
+      did: string;
+    }> {
+      const ed25519 = await import('@noble/ed25519');
+      const privateKeyBytes = ed25519.utils.randomPrivateKey();
+      const publicKeyBytes = new Uint8Array(
+        await (ed25519 as any).getPublicKeyAsync(privateKeyBytes),
+      );
+      const publicKeyMultikey = multikey.encodePublicKey(publicKeyBytes, 'Ed25519');
+      const privateKeyMultikey = multikey.encodePrivateKey(privateKeyBytes as Uint8Array, 'Ed25519');
+      const verificationMethod = `did:key:${publicKeyMultikey}#${publicKeyMultikey}`;
+
+      const signer = async (data: unknown): Promise<DataIntegrityProof> => {
+        const dataBytes = canonicalizeEvent(data);
+        const signature = await (ed25519 as any).signAsync(dataBytes, privateKeyBytes);
+        const proofValue = multikey.encodeMultibase(new Uint8Array(signature));
+        return {
+          type: 'DataIntegrityProof',
+          cryptosuite: 'eddsa-jcs-2022',
+          created: new Date().toISOString(),
+          verificationMethod,
+          proofPurpose: 'assertionMethod',
+          proofValue,
+        };
+      };
+
+      const did = 'did:peer:4z6MkRealKeyTransferTest';
+      const log = await createEventLog({
+        name: 'Real Key Asset',
+        did,
+        layer: 'peer',
+        createdAt: new Date().toISOString(),
+        resources: [],
+        creator: did,
+      }, {
+        signer,
+        verificationMethod,
+        proofPurpose: 'assertionMethod',
+      });
+
+      const logPath = path.join(dir, 'real-key-asset.cel.json');
+      fs.writeFileSync(logPath, serializeEventLogJson(log));
+
+      // Wallet holds the same private key the create event was signed with.
+      const walletPath = path.join(dir, 'real-key-wallet.key');
+      fs.writeFileSync(walletPath, privateKeyMultikey);
+
+      return { logPath, walletPath, did };
+    }
+
+    it('produces a transferred log that verifies cryptographically (proofValid + chainValid)', async () => {
+      const { logPath, walletPath, did } = await createRealKeyPeerLogAndWallet(tempDir);
+      const outputPath = path.join(tempDir, 'real-key-transferred.cel.json');
+
+      const result = await transferCommand({
+        log: logPath,
+        to: 'did:btco:987654',
+        wallet: walletPath,
+        output: outputPath,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.previousOwner).toBe(did);
+
+      const transferredLog = parseEventLogJson(fs.readFileSync(outputPath, 'utf-8'));
+      expect(transferredLog.events.length).toBe(2);
+
+      const verifyResult = await verifyEventLog(transferredLog);
+
+      // The whole log must verify: this is the regression guard. Before the fix,
+      // the transfer event was signed over only `transferData` while
+      // verifyEventLog reconstructs { type, data, previousEvent }, so the
+      // transfer event reported proofValid: false and verified was false.
+      expect(verifyResult.verified).toBe(true);
+
+      const transferEvent = verifyResult.events[1];
+      expect(transferEvent.proofValid).toBe(true);
+      expect(transferEvent.chainValid).toBe(true);
     });
   });
 

--- a/plans/022-cel-canonicalization-hash-chain.md
+++ b/plans/022-cel-canonicalization-hash-chain.md
@@ -1,0 +1,67 @@
+# 022 — CEL canonicalization for the hash chain (verification of prior fix)
+
+## Finding (as reported)
+
+[critical] Broken JSON serialization in `updateEventLog` hash chain computation.
+
+> The `serializeEntry()` function uses `JSON.stringify(entry, Object.keys(entry).sort())`.
+> When the second argument to `JSON.stringify` is an array it acts as a property
+> *allowlist* applied at **every** nesting level — any key not present in the
+> top-level key list is silently dropped from nested objects. As a result nested
+> `data` fields, resource metadata, and even `proofValue` inside the `proof` array
+> are omitted from the hash input. An attacker can mutate those nested fields after
+> the `previousEvent` hash was computed and verification still passes, defeating the
+> immutability guarantee of the provenance chain.
+
+## Investigation result
+
+This defect has **already been remediated on `origin/main`** (the base of this
+worktree, at commit `0b8cd11`, audit PR #170). The broken
+`JSON.stringify(entry, Object.keys(entry).sort())` array-replacer pattern no longer
+exists in any CEL algorithm.
+
+Specifically:
+
+- A single canonicalization helper was introduced at
+  `packages/sdk/src/cel/canonicalize.ts` exporting `canonicalizeEvent(data)`. It uses
+  the **replacer-function** form of `JSON.stringify`, which recurses into every nested
+  object and sorts keys at every depth without dropping any field (JCS-style). Its
+  doc comment explicitly documents the array-replacer footgun and warns against it.
+- All event algorithms compute the chain link via `canonicalizeEvent`:
+  - `algorithms/updateEventLog.ts` → `computeDigestMultibase(canonicalizeEvent(lastEvent))`
+  - `algorithms/deactivateEventLog.ts` → same
+  - `algorithms/verifyEventLog.ts` → uses `canonicalizeEvent` both for the expected
+    previous-event hash and for proof message bytes
+  - CLI paths (`cli/create.ts`, `cli/transfer.ts`, `cli/migrate.ts`) likewise use it
+- `algorithms/witnessEvent.ts` uses the equivalent correct recursive replacer-function
+  form inline, so it was never vulnerable.
+
+## Regression coverage (already present)
+
+`packages/sdk/tests/unit/cel/hash-chain-tamper.test.ts` already covers exactly the
+finding's scenarios:
+
+1. tampering a **nested** field of event 0's `data` breaks the chain at event 1
+2. tampering `proofValue` inside event 0's `proof` array breaks the chain
+3. tampering the top-level `name` field breaks the chain
+4. a valid log verifies as a baseline
+
+Plus `packages/sdk/tests/unit/cel/canonicalize.test.ts` directly tests the serializer.
+
+## Verification performed (fails-before / passes-after)
+
+To prove the regression suite actually guards the fix, the body of `canonicalizeEvent`
+was temporarily reverted to the broken `JSON.stringify(x, Object.keys(x).sort())`
+array-replacer form and the tamper suite was run:
+
+- broken serializer → 3 of 4 tamper tests FAIL (nested, proofValue, and top-level
+  mutations all go undetected — the exact defect)
+- correct serializer (restored) → 4 of 4 PASS
+
+The temporary edit was reverted; the worktree is byte-identical to `origin/main`.
+
+## Conclusion
+
+No source change is required: the critical defect is already fixed and protected by
+regression tests on `origin/main`. This plan records the verification so the finding
+can be closed.

--- a/plans/023-fix-cli-transfer-signed-payload.md
+++ b/plans/023-fix-cli-transfer-signed-payload.md
@@ -1,0 +1,61 @@
+# Plan 023: Fix CLI transfer signed-payload mismatch (transferred logs fail verification)
+
+## Status
+
+- **State**: DONE (branch `correctness/round1-1`)
+- **Priority**: P1
+- **Effort**: S
+- **Risk**: LOW
+- **Category**: correctness
+- **Planned at**: commit `29bda1e` (branch `correctness/round1-1`, atop `origin/main`@`0b8cd11`), 2026-06-22
+
+## Why this matters
+
+PR #170 fixed the hash-chain digest part of the CLI transfer command, so
+`chainValid` is `true` on transferred logs. But a second, independent
+correctness defect remained: the *signed payload* the CLI transfer command
+produced did not match the payload `verifyEventLog` reconstructs and verifies
+against, so every CLI-transferred log failed cryptographic proof verification
+(`proofValid: false`), breaking the provenance chain via the proof.
+
+### Root cause
+
+`updateEventLog` (the SDK path) signs over the full event base
+`{ type: 'update', data, previousEvent }` (updateEventLog.ts lines 57-64), and
+`verifyEventLog` reconstructs the same payload to verify
+`{ type, data, ...(previousEvent ? { previousEvent } : {}) }`
+(verifyEventLog.ts lines 276-280).
+
+The CLI transfer command instead signed over only the inner `transferData`
+object (`transfer.ts` previously: `proof = await signer(transferData)`), so the
+signed bytes differed from the verified bytes and `verifyAsync` returned false.
+
+## The fix
+
+In `packages/sdk/src/cel/cli/transfer.ts`, compute `previousEvent` *before*
+signing (reorder), build the event base
+`{ type: 'update', data: transferData, previousEvent }`, and sign that base so
+the signed payload matches what `verifyEventLog` reconstructs. `createSigner`
+already canonicalizes whatever object it is handed via `canonicalizeEvent`, so
+signing the base object is sufficient. No other files change; the pushed event
+shape (`data` / `proof` / `previousEvent`) is unchanged.
+
+## Regression test
+
+Added to `packages/sdk/tests/unit/cel/cli-transfer.test.ts` (describe block
+"cryptographic verification of transferred logs (plan 014/023)"):
+
+1. Generate one real Ed25519 key; sign a `create` event with the matching
+   `did:key` verificationMethod so the create event itself verifies offline.
+2. Write that same key as the wallet, transfer via `transferCommand`.
+3. Parse the transferred log and call `verifyEventLog(transferredLog)`.
+4. Assert `verified === true`, and the transfer event reports `proofValid: true`
+   and `chainValid: true`.
+
+Confirmed: this test fails before the fix (`verified: false`) and passes after.
+
+## Verification (this branch)
+
+- `bun run typecheck` (tsc 5.9.3): 0 errors
+- `bun run build`: succeeds
+- `bun run test`: SDK 2217/0 + 104/0 (68 skip), auth 140/0 — 0 failures


### PR DESCRIPTION
## Summary
Fixes the CEL CLI transfer flow so that transferred event logs verify correctly. The CLI now signs the full transfer event base rather than a partial payload, ensuring hash-chain verification succeeds for transferred assets.

## Changes
- `packages/sdk/src/cel/cli/transfer.ts`: sign the complete transfer event base
- `packages/sdk/tests/unit/cel/cli-transfer.test.ts`: regression coverage for signed transfer payloads
- Plans 022 (CEL canonicalization hash-chain) and 023 (CLI transfer signed payload)

## Verification (run on latest origin/main)
- `bunx tsc` per-package typecheck: 0 errors
- `bun run build`: 2/2 packages succeed
- `bun run test`: SDK 2217 + 104 + 18 pass, auth 140 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `transferCommand` to sign the full event base so transferred logs verify
> - The CLI transfer command was signing only `transferData` instead of the full event base `{ type, data, previousEvent }`, causing proof verification to fail on transferred logs.
> - [transfer.ts](https://github.com/onionoriginals/sdk/pull/175/files#diff-318fe1d9054a9086a9d2148efa44fad95c9762d8fedc7f687cb9c2941639eed7) now computes `previousEvent` via `canonicalizeEvent` before signing and passes the full `eventBase` to `signer()`.
> - A new cryptographic regression test in [cli-transfer.test.ts](https://github.com/onionoriginals/sdk/pull/175/files#diff-9e9363c3e6c8ee882fec1291995ed8d9b66bf58b774954cc298bc769a9b02589) generates a real Ed25519 keypair, runs `transferCommand`, and asserts `verifyEventLog` returns `verified === true` with `proofValid` and `chainValid` on the transfer event.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 838154a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->