### PR TITLE
fix(sdk): validate documents during deserialization

### DIFF
--- a/packages/sdk/src/utils/serialization.ts
+++ b/packages/sdk/src/utils/serialization.ts
@@ -1,5 +1,6 @@
 import jsonld from 'jsonld';
 import { DIDDocument, VerifiableCredential } from '../types';
+import { validateDIDDocument, validateCredential } from './validation';
 
 type DocumentLoader = (url: string) => Promise<{
   documentUrl: string;
@@ -51,12 +52,22 @@ export function serializeDIDDocument(didDoc: DIDDocument): string {
 
 export function deserializeDIDDocument(data: string): DIDDocument {
   // Parse from JSON-LD
+  let parsed: unknown;
   try {
-    const parsed: unknown = JSON.parse(data);
-    return parsed as DIDDocument;
+    parsed = JSON.parse(data);
   } catch (error) {
     throw new Error('Invalid DID Document JSON');
   }
+  // Runtime structure validation: never trust a cast over untrusted
+  // network/storage data. Reject anything that isn't a well-formed DID Document.
+  if (
+    parsed === null ||
+    typeof parsed !== 'object' ||
+    !validateDIDDocument(parsed as DIDDocument)
+  ) {
+    throw new Error('Invalid DID Document JSON');
+  }
+  return parsed as DIDDocument;
 }
 
 export function serializeCredential(vc: VerifiableCredential): string {
@@ -66,12 +77,22 @@ export function serializeCredential(vc: VerifiableCredential): string {
 
 export function deserializeCredential(data: string): VerifiableCredential {
   // Parse VC from JSON-LD
+  let parsed: unknown;
   try {
-    const parsed: unknown = JSON.parse(data);
-    return parsed as VerifiableCredential;
+    parsed = JSON.parse(data);
   } catch (error) {
     throw new Error('Invalid Verifiable Credential JSON');
   }
+  // Runtime structure validation: never trust a cast over untrusted
+  // network/storage data. Reject anything that isn't a well-formed credential.
+  if (
+    parsed === null ||
+    typeof parsed !== 'object' ||
+    !validateCredential(parsed as VerifiableCredential)
+  ) {
+    throw new Error('Invalid Verifiable Credential JSON');
+  }
+  return parsed as VerifiableCredential;
 }
 
 export async function canonicalizeDocument(

--- a/packages/sdk/tests/unit/utils/serialization.test.ts
+++ b/packages/sdk/tests/unit/utils/serialization.test.ts
@@ -71,6 +71,35 @@ describe('serialization utils', () => {
     expect(() => deserializeCredential('{invalid')).toThrow('Invalid Verifiable Credential JSON');
   });
 
+  test('deserializeDIDDocument rejects structurally-invalid (but JSON-valid) input', () => {
+    // Missing @context and id
+    expect(() => deserializeDIDDocument('{}')).toThrow('Invalid DID Document JSON');
+    // Invalid DID format for id
+    expect(() => deserializeDIDDocument('{"@context":["https://www.w3.org/ns/did/v1"],"id":"not-a-did"}')).toThrow('Invalid DID Document JSON');
+    // @context not an array
+    expect(() => deserializeDIDDocument('{"@context":"https://www.w3.org/ns/did/v1","id":"did:peer:abc"}')).toThrow('Invalid DID Document JSON');
+    // Malformed verification method (missing publicKeyMultibase)
+    expect(() => deserializeDIDDocument('{"@context":["https://www.w3.org/ns/did/v1"],"id":"did:peer:abc","verificationMethod":[{"id":"did:peer:abc#k","type":"Multikey","controller":"did:peer:abc"}]}')).toThrow('Invalid DID Document JSON');
+    // Non-object parse results
+    expect(() => deserializeDIDDocument('5')).toThrow('Invalid DID Document JSON');
+    expect(() => deserializeDIDDocument('null')).toThrow('Invalid DID Document JSON');
+    expect(() => deserializeDIDDocument('"a string"')).toThrow('Invalid DID Document JSON');
+  });
+
+  test('deserializeCredential rejects structurally-invalid (but JSON-valid) input', () => {
+    // Empty object: no @context/type/issuer
+    expect(() => deserializeCredential('{}')).toThrow('Invalid Verifiable Credential JSON');
+    // Invalid issuer DID
+    expect(() => deserializeCredential('{"@context":["https://www.w3.org/2018/credentials/v1"],"type":["VerifiableCredential"],"issuer":"not-a-did","issuanceDate":"2020-01-01T00:00:00Z","credentialSubject":{}}')).toThrow('Invalid Verifiable Credential JSON');
+    // Missing credentialSubject
+    expect(() => deserializeCredential('{"@context":["https://www.w3.org/2018/credentials/v1"],"type":["VerifiableCredential"],"issuer":"did:peer:abc","issuanceDate":"2020-01-01T00:00:00Z"}')).toThrow('Invalid Verifiable Credential JSON');
+    // Missing VC v1 context
+    expect(() => deserializeCredential('{"@context":["https://example.com/other"],"type":["VerifiableCredential"],"issuer":"did:peer:abc","issuanceDate":"2020-01-01T00:00:00Z","credentialSubject":{}}')).toThrow('Invalid Verifiable Credential JSON');
+    // Non-object parse results
+    expect(() => deserializeCredential('5')).toThrow('Invalid Verifiable Credential JSON');
+    expect(() => deserializeCredential('null')).toThrow('Invalid Verifiable Credential JSON');
+  });
+
   test('canonicalizeDocument with custom documentLoader', async () => {
     const customLoader = async (url: string) => {
       return {

--- a/plans/022-validate-deserialized-documents.md
+++ b/plans/022-validate-deserialized-documents.md
@@ -1,0 +1,126 @@
+# Plan 022: Validate deserialized DID Documents and Verifiable Credentials
+
+> **Executor instructions**: Follow step by step. Run every verification command
+> and confirm the expected result before moving on. Touch only in-scope files.
+> Commit on the worktree branch (conventional commit). SKIP updating
+> `plans/README.md` — the reviewer maintains the index.
+
+## Status
+
+- **Priority**: P0
+- **Effort**: S
+- **Risk**: LOW
+- **Category**: security / correctness
+- **Branch**: `correctness/round1-3`
+
+## Why this matters
+
+`deserializeDIDDocument()` and `deserializeCredential()` in
+`packages/sdk/src/utils/serialization.ts` parse JSON and then **cast** the result
+directly to `DIDDocument` / `VerifiableCredential` with no runtime validation:
+
+```typescript
+const parsed: unknown = JSON.parse(data);
+return parsed as DIDDocument;  // No validation!
+```
+
+Any malformed or malicious JSON that happens to be syntactically valid is
+silently accepted as a typed object. Deserialized documents are reconstructed
+from network/storage sources, so an attacker controlling that source
+(compromised storage, MITM) can inject documents missing required fields, with
+invalid DID formats, non-string values, or absent verification methods — all of
+which downstream code trusts because the TypeScript type says it is valid.
+
+The repo already has `validateDIDDocument()` and `validateCredential()` in
+`packages/sdk/src/utils/validation.ts`, but they are never called in the
+deserialization path. The fix is to wire them in.
+
+## Current state
+
+- `packages/sdk/src/utils/serialization.ts`
+  - `deserializeDIDDocument(data)` (lines 52–60): `JSON.parse` then `as DIDDocument`.
+  - `deserializeCredential(data)` (lines 67–75): `JSON.parse` then `as VerifiableCredential`.
+  - Both wrap parse in try/catch throwing `Invalid DID Document JSON` /
+    `Invalid Verifiable Credential JSON`.
+- `packages/sdk/src/utils/validation.ts`
+  - `validateDIDDocument(didDoc): boolean` — checks `@context` array, `id` is a
+    valid DID, verification methods well-formed, controller entries valid DIDs.
+  - `validateCredential(vc): boolean` — checks `@context` (with VC v1), `type`
+    includes `VerifiableCredential`, valid DID issuer, ISO `issuanceDate`,
+    `credentialSubject` present.
+- `packages/sdk/tests/unit/utils/serialization.test.ts` — existing roundtrip +
+  invalid-JSON tests. The roundtrip fixtures are already valid per the validators
+  (DID doc has `@context` array + `did:peer:` id; VC has VC v1 context, type,
+  DID issuer, issuanceDate, credentialSubject), so they keep passing.
+
+## Scope
+
+**In scope:**
+- `packages/sdk/src/utils/serialization.ts` — call the validators after parsing;
+  throw on validation failure.
+- `packages/sdk/tests/unit/utils/serialization.test.ts` — add regression tests
+  for structurally-invalid (but JSON-valid) input being rejected.
+
+**Out of scope:**
+- Changing the validator semantics in `validation.ts`.
+- Changing error message strings for the existing invalid-JSON cases.
+
+## Design decision
+
+The validators expect typed inputs but only do structural/`typeof` checks, so
+passing parsed `unknown` is safe. After a successful `JSON.parse`, run the
+matching validator; if it returns `false`, throw the SAME error message already
+used for the parse failure (`Invalid DID Document JSON` /
+`Invalid Verifiable Credential JSON`). Reusing the message keeps the public
+contract stable (callers/tests only assert that message) while closing the hole:
+"invalid" now covers structurally invalid, not just syntactically invalid.
+
+A non-object parse result (e.g. `JSON.parse('5')` → number, `'null'` → null)
+must also be rejected; the validators already return `false` for these because
+the `@context` check fails on a non-object, but guard explicitly for clarity.
+
+## Steps
+
+### Step 1: Add a failing regression test
+In `serialization.test.ts`, add tests asserting structurally-invalid JSON is
+rejected with the existing error messages:
+- `deserializeDIDDocument('{}')` → throws `Invalid DID Document JSON` (no
+  `@context`, no `id`).
+- `deserializeDIDDocument('{"@context":["https://www.w3.org/ns/did/v1"],"id":"not-a-did"}')`
+  → throws (invalid DID format).
+- `deserializeCredential('{}')` → throws `Invalid Verifiable Credential JSON`.
+- `deserializeCredential('{"@context":["https://www.w3.org/2018/credentials/v1"],"type":["VerifiableCredential"],"issuer":"not-a-did","issuanceDate":"2020-01-01T00:00:00Z","credentialSubject":{}}')`
+  → throws (invalid issuer DID).
+- `deserializeDIDDocument('5')` and `deserializeCredential('null')` → throw.
+
+**Verify (must FAIL before the fix):**
+`cd packages/sdk && NODE_OPTIONS= bun test tests/unit/utils/serialization.test.ts`
+
+### Step 2: Wire validators into deserialization
+In `serialization.ts`, import `validateDIDDocument` and `validateCredential`
+from `./validation`. In each deserialize function, after parsing, run the
+validator and throw the existing error message if it returns false. Keep the
+try/catch for `JSON.parse`; do the validation outside the parse catch (or
+re-throw) so a validation failure isn't masked into a generic message — but it
+should produce the SAME message string. Implementation: parse inside try/catch
+(throws on syntax error), then validate after and throw the same message.
+
+**Verify:**
+- `cd packages/sdk && NODE_OPTIONS= bunx tsc --noEmit -p .` → exit 0
+- `cd packages/sdk && NODE_OPTIONS= bun test tests/unit/utils/serialization.test.ts` → all pass
+
+### Step 3: Full invariant
+- `bunx tsc --noEmit` → 0 errors
+- `bun run build` → succeeds
+- `bun run test` → SDK + auth suites 0-fail
+
+## Done criteria (ALL must hold)
+- [ ] Structurally invalid (but JSON-valid) DID docs / VCs are rejected.
+- [ ] Existing roundtrip + invalid-JSON tests still pass (same error messages).
+- [ ] `tsc --noEmit` 0 errors; `build` succeeds; full test suite 0-fail.
+- [ ] Only in-scope files modified.
+
+## STOP conditions
+- An existing roundtrip fixture turns out to be invalid per the validators
+  (would mean a real consumer relies on lax deserialization) — report instead of
+  weakening a validator.


### PR DESCRIPTION
## Summary
`deserializeDIDDocument()` and `deserializeCredential()` parsed JSON and cast the result straight to `DIDDocument` / `VerifiableCredential` with no runtime validation, so any syntactically valid but structurally invalid or malicious JSON from network/storage was silently accepted as a typed object. This wires the existing `validateDIDDocument()` / `validateCredential()` checks into the deserialization path and rejects non-object parse results, throwing the same existing error messages.

## Verification (green invariant, run immediately before merge)
- `bun install --frozen-lockfile`: clean (no changes)
- typecheck: 0 type errors (`bun run typecheck`; `bunx tsc --noEmit` clean aside from a pre-existing repo-wide `moduleResolution: node10` deprecation also present on `main`)
- `bun run build`: success
- `bun run test`: SDK + auth suites 0 fail (2219 + 104 + 18 + 140 pass; 68 intentional skips)

Rebased onto latest `origin/main` (`13ffa39`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate DID Documents and Verifiable Credentials during deserialization
> - `deserializeDIDDocument` and `deserializeCredential` in [serialization.ts](https://github.com/onionoriginals/sdk/pull/176/files#diff-652409e120c15c37fda5579b1f060c9ed6125eec261cebdcfc244fc6a60d7fb2) now call `validateDIDDocument` and `validateCredential` respectively after JSON parsing.
> - Inputs that are JSON-valid but structurally invalid (e.g. missing required fields, invalid DID formats, wrong `@context`) now throw `Error('Invalid DID Document JSON')` or `Error('Invalid Verifiable Credential JSON')` instead of returning a bad value.
> - New unit tests in [serialization.test.ts](https://github.com/onionoriginals/sdk/pull/176/files#diff-d75e717b3ca1e5e85fac8b064bab33cfde83a51f16e1899b98ca1cd9a87ddf12) cover these invalid-structure cases alongside existing roundtrip tests.
> - Behavioral Change: callers that previously received malformed objects from these functions will now receive a thrown error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7735f18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->