### PR TITLE
fix(cel): hash-chain link covers only committed fields, not mutable proof metadata

### DIFF
--- a/packages/sdk/src/cel/algorithms/deactivateEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/deactivateEventLog.ts
@@ -9,7 +9,7 @@
 
 import type { EventLog, LogEntry, DeactivateOptions, DataIntegrityProof } from '../types';
 import { computeDigestMultibase } from '../hash';
-import { canonicalizeEvent } from '../canonicalize';
+import { canonicalizeEntryForChain } from '../canonicalize';
 
 /**
  * Deactivates an event log by appending a final "deactivate" event.
@@ -55,7 +55,7 @@ export async function deactivateEventLog(
   }
 
   // Compute the digestMultibase of the last event
-  const previousEvent = computeDigestMultibase(canonicalizeEvent(lastEvent));
+  const previousEvent = computeDigestMultibase(canonicalizeEntryForChain(lastEvent));
 
   // Deactivation data includes the reason
   const deactivationData = {

--- a/packages/sdk/src/cel/algorithms/updateEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/updateEventLog.ts
@@ -9,7 +9,7 @@
 
 import type { EventLog, LogEntry, UpdateOptions, DataIntegrityProof } from '../types';
 import { computeDigestMultibase } from '../hash';
-import { canonicalizeEvent } from '../canonicalize';
+import { canonicalizeEntryForChain } from '../canonicalize';
 
 /**
  * Updates an event log by appending a new "update" event.
@@ -51,7 +51,7 @@ export async function updateEventLog(
   const lastEvent = log.events[log.events.length - 1];
   
   // Compute the digestMultibase of the last event
-  const previousEvent = computeDigestMultibase(canonicalizeEvent(lastEvent));
+  const previousEvent = computeDigestMultibase(canonicalizeEntryForChain(lastEvent));
 
   // Create the event structure without proof first
   const eventBase = {

--- a/packages/sdk/src/cel/algorithms/verifyEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/verifyEventLog.ts
@@ -17,7 +17,7 @@ import type {
   DataIntegrityProof
 } from '../types';
 import { computeDigestMultibase } from '../hash';
-import { canonicalizeEvent } from '../canonicalize';
+import { canonicalizeEvent, canonicalizeEntryForChain } from '../canonicalize';
 import { multikey } from '../../crypto/Multikey';
 
 /**
@@ -203,8 +203,13 @@ function verifyChain(
       return { chainValid: false, errors };
     }
     
-    // Compute the expected hash of the previous event
-    const expectedHash = computeDigestMultibase(canonicalizeEvent(previousEvent));
+    // Compute the expected hash of the previous event. The chain link covers
+    // ONLY the committed fields ({type, data, previousEvent}) — the same
+    // message the signer signed. The proof array (proofValue + unsigned
+    // metadata like created/verificationMethod, plus any witness proofs added
+    // later) is excluded, so the chain cannot depend on data no signature
+    // commits to. See canonicalizeEntryForChain.
+    const expectedHash = computeDigestMultibase(canonicalizeEntryForChain(previousEvent));
     
     if (event.previousEvent !== expectedHash) {
       errors.push(`Event ${index}: Hash chain broken - previousEvent does not match hash of prior event`);

--- a/packages/sdk/src/cel/canonicalize.ts
+++ b/packages/sdk/src/cel/canonicalize.ts
@@ -36,3 +36,38 @@ export function canonicalizeEvent(data: unknown): Uint8Array {
   });
   return new TextEncoder().encode(json);
 }
+
+/**
+ * Extracts the *committed* fields of a log entry — exactly the message the
+ * signer signs (`{ type, data, previousEvent? }`) — and canonicalizes them for
+ * use as the hash-chain preimage.
+ *
+ * The `proof` array is deliberately excluded. It carries both the signature
+ * (`proofValue`) and unsigned, mutable metadata (`created`, `type`,
+ * `cryptosuite`, `verificationMethod`, `proofPurpose`, and witness proofs that
+ * may be appended after the fact). None of those metadata fields are part of
+ * the signed message, so chaining over them would make the chain link depend
+ * on data that no signature commits to: a mutation of `proof.created` or
+ * `proof.verificationMethod` would "break" the chain even though it was never
+ * provable in the first place, and appending a (non-gating) witness proof to a
+ * prior event would retroactively break every later link. The chain must
+ * depend only on the committed fields.
+ *
+ * `previousEvent` is omitted when absent so the preimage of a first event is
+ * `{ type, data }`, matching what the verifier reconstructs.
+ *
+ * @param entry - A log entry (only `type`, `data`, `previousEvent` are read)
+ * @returns UTF-8 encoded bytes of the canonical committed payload
+ */
+export function canonicalizeEntryForChain(
+  entry: { type: unknown; data: unknown; previousEvent?: unknown }
+): Uint8Array {
+  const committed: { type: unknown; data: unknown; previousEvent?: unknown } = {
+    type: entry.type,
+    data: entry.data,
+  };
+  if (entry.previousEvent !== undefined) {
+    committed.previousEvent = entry.previousEvent;
+  }
+  return canonicalizeEvent(committed);
+}

--- a/packages/sdk/src/cel/cli/transfer.ts
+++ b/packages/sdk/src/cel/cli/transfer.ts
@@ -17,7 +17,7 @@ import { parseEventLogCbor } from '../serialization/cbor';
 import { serializeEventLogJson } from '../serialization/json';
 import { serializeEventLogCbor } from '../serialization/cbor';
 import { multikey } from '../../crypto/Multikey';
-import { canonicalizeEvent } from '../canonicalize';
+import { canonicalizeEvent, canonicalizeEntryForChain } from '../canonicalize';
 import { computeDigestMultibase } from '../hash';
 
 /**
@@ -229,7 +229,7 @@ export async function transferCommand(flags: TransferFlags): Promise<TransferRes
   // `transferData` would produce a signature that verification cannot reproduce,
   // yielding proofValid: false on every transferred log.
   const lastEvent = eventLog.events[eventLog.events.length - 1];
-  const previousEvent = computeDigestMultibase(canonicalizeEvent(lastEvent));
+  const previousEvent = computeDigestMultibase(canonicalizeEntryForChain(lastEvent));
 
   const eventBase = {
     type: 'update' as const,

--- a/packages/sdk/tests/unit/cel/deactivateEventLog.test.ts
+++ b/packages/sdk/tests/unit/cel/deactivateEventLog.test.ts
@@ -3,7 +3,7 @@ import { createEventLog } from '../../../src/cel/algorithms/createEventLog';
 import { updateEventLog } from '../../../src/cel/algorithms/updateEventLog';
 import { deactivateEventLog } from '../../../src/cel/algorithms/deactivateEventLog';
 import { computeDigestMultibase } from '../../../src/cel/hash';
-import { canonicalizeEvent } from '../../../src/cel/canonicalize';
+import { canonicalizeEntryForChain } from '../../../src/cel/canonicalize';
 import type { DataIntegrityProof, EventLog, CreateOptions, UpdateOptions, DeactivateOptions } from '../../../src/cel/types';
 
 /**
@@ -135,7 +135,7 @@ describe('deactivateEventLog', () => {
       
       const initialLog = await createEventLog({ name: 'Test' }, createOptions);
       const lastEvent = initialLog.events[0];
-      const expectedHash = computeDigestMultibase(canonicalizeEvent(lastEvent));
+      const expectedHash = computeDigestMultibase(canonicalizeEntryForChain(lastEvent));
 
       const deactivateOptions: DeactivateOptions = {
         signer: createMockSigner(verificationMethod),
@@ -177,7 +177,7 @@ describe('deactivateEventLog', () => {
       expect(deactivatedLog.events).toHaveLength(4);
       
       // Deactivate event links to last update
-      const expectedHash = computeDigestMultibase(canonicalizeEvent(log3.events[2]));
+      const expectedHash = computeDigestMultibase(canonicalizeEntryForChain(log3.events[2]));
       expect(deactivatedLog.events[3].previousEvent).toBe(expectedHash);
     });
   });

--- a/packages/sdk/tests/unit/cel/hash-chain-tamper.test.ts
+++ b/packages/sdk/tests/unit/cel/hash-chain-tamper.test.ts
@@ -130,25 +130,58 @@ describe('CEL hash chain tamper detection', () => {
     ).toBe(true);
   });
 
-  test('tampering proofValue inside event 0\'s proof breaks the chain at event 1', async () => {
+  test('tampering proofValue is caught by signature verification, NOT by the chain', async () => {
+    // proofValue is the signature itself: no enclosing signature commits to it,
+    // so it must NOT be part of the hash-chain preimage. Tampering it must
+    // therefore leave the chain intact but fail signature verification.
+    const realOptions: CreateOptions = {
+      signer: realSigner,
+      verificationMethod: `did:key:${realPublicKey}#${realPublicKey}`,
+    };
     const log0 = await createEventLog(
       { name: 'asset', resources: [{ id: 'r1', digestMultibase: 'uAbc' }] },
-      createOptions,
+      realOptions,
     );
-    const log1 = await updateEventLog(log0, { version: 2, note: 'first update' }, updateOptions);
-    const log2 = await updateEventLog(log1, { version: 3, note: 'second update' }, updateOptions);
+    const log1 = await updateEventLog(log0, { version: 2, note: 'first update' }, realOptions);
 
-    const tampered = JSON.parse(JSON.stringify(log2));
-
-    // Mutate the proofValue inside event 0's proof array — previously dropped
-    // by the broken array-allowlist serializer, so tampering went undetected.
+    const tampered = JSON.parse(JSON.stringify(log1));
     tampered.events[0].proof[0].proofValue = 'zTAMPEREDPROOF';
 
     const result = await verifyEventLog(tampered);
 
-    // Chain must be detected as broken at event 1
+    // Chain link covers only {type, data, previousEvent} — proof is excluded.
+    expect(result.events[1].chainValid).toBe(true);
+    // The signature no longer matches, so the proof fails verification.
+    expect(result.events[0].proofValid).toBe(false);
     expect(result.verified).toBe(false);
-    expect(result.events[1].chainValid).toBe(false);
+  });
+
+  test('tampering UNSIGNED proof metadata (created) does NOT break the chain or verification', async () => {
+    // proof.created / verificationMethod / proofPurpose are not part of the
+    // signed message, so they are excluded from the chain preimage. A mutation
+    // of `created` must change neither chainValid nor proofValid — the field
+    // was never committed to by any signature. (The OLD code hashed the whole
+    // prior entry including the proof array and broke the chain here on an
+    // unverifiable field; this is the exact regression being fixed.)
+    const realOptions: CreateOptions = {
+      signer: realSigner,
+      verificationMethod: `did:key:${realPublicKey}#${realPublicKey}`,
+    };
+    const log0 = await createEventLog(
+      { name: 'asset', resources: [{ id: 'r1', digestMultibase: 'uAbc' }] },
+      realOptions,
+    );
+    const log1 = await updateEventLog(log0, { version: 2, note: 'first update' }, realOptions);
+    const log2 = await updateEventLog(log1, { version: 3, note: 'second update' }, realOptions);
+
+    const tampered = JSON.parse(JSON.stringify(log2));
+    tampered.events[0].proof[0].created = '1999-01-01T00:00:00.000Z';
+
+    const result = await verifyEventLog(tampered);
+
+    // Chain stays intact for every event and all proofs still verify.
+    expect(result.events.every(e => e.chainValid)).toBe(true);
+    expect(result.verified).toBe(true);
   });
 
   test('tampering the top-level name field of event 0 also breaks the chain', async () => {

--- a/packages/sdk/tests/unit/cel/updateEventLog.test.ts
+++ b/packages/sdk/tests/unit/cel/updateEventLog.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from 'bun:test';
 import { createEventLog } from '../../../src/cel/algorithms/createEventLog';
 import { updateEventLog } from '../../../src/cel/algorithms/updateEventLog';
 import { computeDigestMultibase } from '../../../src/cel/hash';
-import { canonicalizeEvent } from '../../../src/cel/canonicalize';
+import { canonicalizeEntryForChain } from '../../../src/cel/canonicalize';
 import type { DataIntegrityProof, EventLog, CreateOptions, UpdateOptions } from '../../../src/cel/types';
 
 /**
@@ -111,7 +111,7 @@ describe('updateEventLog', () => {
       
       const initialLog = await createEventLog({ name: 'Test' }, createOptions);
       const lastEvent = initialLog.events[0];
-      const expectedHash = computeDigestMultibase(canonicalizeEvent(lastEvent));
+      const expectedHash = computeDigestMultibase(canonicalizeEntryForChain(lastEvent));
       
       const updateOptions: UpdateOptions = {
         signer: createMockSigner(verificationMethod),
@@ -150,11 +150,11 @@ describe('updateEventLog', () => {
       expect(log3.events[0].previousEvent).toBeUndefined();
       
       // Second event links to first
-      const expectedHash1 = computeDigestMultibase(canonicalizeEvent(log3.events[0]));
+      const expectedHash1 = computeDigestMultibase(canonicalizeEntryForChain(log3.events[0]));
       expect(log3.events[1].previousEvent).toBe(expectedHash1);
 
       // Third event links to second
-      const expectedHash2 = computeDigestMultibase(canonicalizeEvent(log3.events[1]));
+      const expectedHash2 = computeDigestMultibase(canonicalizeEntryForChain(log3.events[1]));
       expect(log3.events[2].previousEvent).toBe(expectedHash2);
     });
   });

--- a/plans/022-fix-proof-canonicalization-chain.md
+++ b/plans/022-fix-proof-canonicalization-chain.md
@@ -1,0 +1,209 @@
+# Plan 022: Hash-chain link must cover only committed fields, not mutable proof metadata
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report.
+
+## Status
+
+- **Priority**: P1 (high)
+- **Effort**: S
+- **Risk**: MED (changes the chain-hash preimage; pre-existing logs re-hash differently)
+- **Depends on**: plan 014 (shared `canonicalizeEvent`), plan 015 (real crypto verification)
+- **Category**: correctness / security
+- **Planned at**: origin/main `0b8cd11`, 2026-06-22
+
+## Why this matters
+
+The CEL hash chain links event N to event N-1 by storing
+`previousEvent = computeDigestMultibase(canonicalizeEvent(priorEvent))`.
+Today every site computes that digest over the **entire prior `LogEntry`**,
+including its `proof` array. But the `proof` array contains two kinds of
+fields:
+
+- `proof.proofValue` — the actual signature, which the signer committed to.
+- `proof.created`, `proof.type`, `proof.cryptosuite`,
+  `proof.verificationMethod`, `proof.proofPurpose` (and witness proofs added
+  later) — metadata that the signer never signed.
+
+The signed message (reconstructed in `verifyEventLog.ts` as
+`{ type, data, ...(previousEvent ? { previousEvent } : {}) }`, and produced by
+`createSigner`/`updateEventLog`/`deactivateEventLog` as `eventBase`) contains
+**no proof fields at all**. So the chain link currently depends on
+unverifiable, mutable metadata:
+
+- An attacker who flips `proof.created` or `proof.verificationMethod` on a
+  prior event changes the recomputed digest and "breaks" the chain — yet those
+  fields were never committed to by any signature, so there is nothing to
+  prove they were authentic in the first place. The chain reports a break that
+  is not cryptographically meaningful.
+- Conversely, the security property the chain *should* provide — binding the
+  committed content `{type, data, previousEvent}` of every prior event — is
+  diluted by mixing in fields no signature covers.
+- Adding a witness proof to a prior event (an intentionally non-gating,
+  append-after-the-fact operation per plan 021) mutates that event's `proof`
+  array and therefore changes its chain digest, retroactively breaking every
+  later link. The chain must not depend on witness proofs.
+
+The correct preimage for the chain link is exactly the committed fields —
+the same `{type, data, previousEvent}` shape the signer signs — and nothing
+from `proof`.
+
+## Current state
+
+The digest of the prior event is computed over the whole `LogEntry` at four
+sites (all under `packages/sdk/`):
+
+- `src/cel/algorithms/updateEventLog.ts:54`
+  `const previousEvent = computeDigestMultibase(canonicalizeEvent(lastEvent));`
+- `src/cel/algorithms/deactivateEventLog.ts:58` — identical line.
+- `src/cel/cli/transfer.ts:238` — identical line.
+- `src/cel/algorithms/verifyEventLog.ts:207` (in `verifyChain`)
+  `const expectedHash = computeDigestMultibase(canonicalizeEvent(previousEvent));`
+
+`canonicalizeEvent` (`src/cel/canonicalize.ts`) is the correct recursive JCS
+serializer from plan 014. `computeDigestMultibase` (`src/cel/hash.ts`) is the
+correct digest function. Both stay as-is.
+
+The signed payload shape (the committed fields) is built two ways that must
+stay byte-for-byte identical to the new chain preimage:
+- producers: `eventBase = { type, data, previousEvent }` (key insertion order
+  is irrelevant — `canonicalizeEvent` sorts keys).
+- verifier: `verifyEventLog.ts:276-280`
+  `{ type, data, ...(previousEvent ? { previousEvent } : {}) }`.
+
+The first event has no `previousEvent`; the committed shape for it is
+`{ type, data }`. Producers build their `previousEvent` from the *prior*
+event whose committed shape may or may not include `previousEvent` — the
+helper must omit the field when it is `undefined` so the digest matches what
+the verifier reconstructs for that same prior event.
+
+### A test currently encodes the bug
+
+`packages/sdk/tests/unit/cel/hash-chain-tamper.test.ts` has a case
+(`"tampering proofValue inside event 0's proof breaks the chain at event 1"`,
+~lines 133-152) that asserts mutating `proof[0].proofValue` sets
+`events[1].chainValid === false`. That is the buggy behavior: proof fields
+must NOT be in the chain preimage. After the fix, tampering `proofValue` is
+caught by **signature verification** (`proofValid: false`), not by the chain.
+This test must be updated to reflect the correct contract.
+
+## Scope
+
+**In scope** (the only files to modify/create):
+- `packages/sdk/src/cel/canonicalize.ts` — add `canonicalizeEntryForChain`.
+- `packages/sdk/src/cel/index.ts` — export it (if `canonicalizeEvent` is exported there).
+- `packages/sdk/src/cel/algorithms/updateEventLog.ts`
+- `packages/sdk/src/cel/algorithms/deactivateEventLog.ts`
+- `packages/sdk/src/cel/cli/transfer.ts`
+- `packages/sdk/src/cel/algorithms/verifyEventLog.ts`
+- `packages/sdk/tests/unit/cel/hash-chain-tamper.test.ts` — update the
+  `proofValue` case + add a `proof.created` metadata-mutation regression case.
+- `plans/README.md` (status row only)
+
+**Out of scope**: `hash.ts`, `canonicalizeEvent` itself, the VC subsystem,
+file-I/O serialization (`serialization/*.ts`), witness signing.
+
+## Steps
+
+### Step 1: Add the chain-preimage helper
+
+In `src/cel/canonicalize.ts`, add and export:
+
+```typescript
+import type { LogEntry } from './types';
+
+/**
+ * Extracts the *committed* fields of a log entry — exactly the message the
+ * signer signs (`{ type, data, previousEvent? }`) — for use as the hash-chain
+ * preimage. The `proof` array is deliberately excluded: it carries both the
+ * signature (`proofValue`) and unsigned, mutable metadata (`created`,
+ * `verificationMethod`, witness proofs added later). Chaining over those
+ * fields would make the chain link depend on data no signature commits to.
+ */
+export function canonicalizeEntryForChain(entry: LogEntry): Uint8Array {
+  const committed: { type: unknown; data: unknown; previousEvent?: unknown } = {
+    type: entry.type,
+    data: entry.data,
+  };
+  if (entry.previousEvent !== undefined) {
+    committed.previousEvent = entry.previousEvent;
+  }
+  return canonicalizeEvent(committed);
+}
+```
+
+(If `canonicalize.ts` cannot import `LogEntry` without a cycle, type the param
+as `{ type: unknown; data: unknown; previousEvent?: unknown }` instead.)
+
+Export from `src/cel/index.ts` next to `canonicalizeEvent` if present.
+
+**Verify**: `cd packages/sdk && bunx tsc --noEmit` → exit 0.
+
+### Step 2: Switch all four hash sites to the helper
+
+Replace `canonicalizeEvent(lastEvent)` / `canonicalizeEvent(previousEvent)`
+with `canonicalizeEntryForChain(...)` at:
+- `updateEventLog.ts:54`
+- `deactivateEventLog.ts:58`
+- `cli/transfer.ts:238`
+- `verifyEventLog.ts:207`
+
+Add the import `canonicalizeEntryForChain` from `../canonicalize` to each
+(verifyEventLog/updateEventLog/deactivateEventLog) and `../canonicalize` for
+the CLI file. Keep the existing `canonicalizeEvent` import where it is still
+used (e.g. verifyEventLog still uses it for the signed-message check).
+
+**Verify**: `grep -rn "canonicalizeEvent(lastEvent)\|canonicalizeEvent(previousEvent)" packages/sdk/src/cel/`
+→ no matches.
+
+### Step 3: Fix the tamper test contract + add metadata regression
+
+In `tests/unit/cel/hash-chain-tamper.test.ts`:
+
+- Replace the `proofValue` case so it asserts the corrected contract: mutating
+  `events[0].proof[0].proofValue` does NOT break the chain
+  (`events[1].chainValid === true`) but IS caught by signature verification —
+  use the **real** Ed25519 signer for this case and assert
+  `events[0].proofValid === false` and overall `verified === false`.
+- Add a new case: mutating `events[0].proof[0].created` (pure unsigned
+  metadata) does NOT change `events[1].chainValid` (stays `true`). With the
+  real signer the proof itself still verifies because `created` is not in the
+  signed message either, so `verified` stays `true`. This is the regression
+  that fails before the fix (old code breaks the chain on a `created` change)
+  and passes after.
+- Keep the nested-data and top-level-name cases unchanged (they must still
+  break the chain — `data` IS committed).
+
+**Verify**: `cd packages/sdk && bun test tests/unit/cel/hash-chain-tamper.test.ts`
+→ all pass. Confirm the `created` case fails when Step 2 is reverted.
+
+### Step 4: Full CEL + suite check
+
+**Verify**:
+- `cd packages/sdk && bunx tsc --noEmit` → 0 errors
+- `bun run build` → succeeds
+- `bun test` (SDK + auth) → 0 failures
+
+## Done criteria
+
+- [ ] Chain preimage excludes the `proof` array at all four sites.
+- [ ] `created` / `verificationMethod` mutations on a prior event no longer
+      affect `chainValid`.
+- [ ] `proofValue` tampering is caught by `proofValid`, not by the chain.
+- [ ] Nested `data` tampering still breaks the chain.
+- [ ] tsc 0, build ok, full test suite 0-fail.
+
+## STOP conditions
+
+- Any committed fixture embeds precomputed `previousEvent` hashes from the old
+  (proof-inclusive) preimage and cannot be regenerated.
+- A verification fails twice after a reasonable fix attempt.
+
+## Maintenance notes
+
+- This changes the chain-link preimage, so logs hashed by the old code will
+  re-hash differently. Same caveat as plan 014: re-create/re-hash logs at
+  ≥ this version. Combined with plan 021 (non-gating witness proofs), the chain
+  now correctly ignores witness proofs appended to prior events.

--- a/plans/README.md
+++ b/plans/README.md
@@ -33,6 +33,7 @@ Two audit runs so far:
 | 019 | Inscription-safe commit funding + real scriptPubKeys in transfer builder | P2 | M | MED | — | DONE (reviewed+approved; commit `b534961` on worktree branch `worktree-agent-a5cf45cb611463d6e`; 198/0 bitcoin tests, placeholder greps clean, regtest supported; merges clean with `2b86eaa`) |
 | 020 | CEL verification checks EVERY signature (resolve did:webvh/did:btco keys; fail closed) | P1 | L | MED | 014, 015 | DONE-with-followup (controller-proof verification reviewed+approved, commit `08087b2`, full suite 0 fail; review found it over-gates witness proofs → plan 021. NOT pushed alone) |
 | 021 | Witness proofs non-gating (controller gates `verified`; witnesses checked + reported separately) | P1 | M | MED | 020 | IN PROGRESS (executor dispatched on 020 state `08087b2`) |
+| 022 | Hash-chain link covers only committed fields, not mutable proof metadata | P1 | S | MED | 014, 015 | DONE (worktree branch `correctness/round1-5` atop `0b8cd11`; chain preimage now `canonicalizeEntryForChain` = `{type,data,previousEvent?}`, proof array excluded; tsc 0, build ok, full suite 0 fail; tamper test updated: proofValue→proofValid (not chain), created→no-op; NOT pushed) |
 
 > **Post-merge review findings (review #1 + #2) → fixed/in-progress.** After the
 > six plans landed, two review passes of the run-2 code surfaced edge cases the


### PR DESCRIPTION
## Summary

The CEL hash chain previously hashed the **entire** prior log entry — including the `proof` array — via `canonicalizeEvent`. The proof array carries the signature (`proofValue`) plus unsigned, mutable metadata (`created`, `verificationMethod`, witness proofs that may be appended later). None of that metadata is part of the signed message, so chaining over it meant:

- a mutation of `proof.created` or `proof.verificationMethod` would "break" the chain even though no signature ever committed to those values, and
- appending a (non-gating) witness proof to an earlier event would **retroactively break every later link**.

## Fix

Introduce `canonicalizeEntryForChain`, which canonicalizes **only** the committed fields the signer signs (`{ type, data, previousEvent? }`), and use it for the chain preimage in:

- `cel/algorithms/updateEventLog.ts`
- `cel/algorithms/deactivateEventLog.ts`
- `cel/algorithms/verifyEventLog.ts`
- `cel/cli/transfer.ts`

Tamper tests updated: mutating `proofValue` now surfaces as `proofValid: false` (not a chain break), and mutating `proof.created` is a no-op for the chain.

## Verification (run immediately before merge, on this branch rebased onto latest origin/main)

- `tsc --noEmit` (TypeScript 5.9.3, project-pinned): **0 errors**
- `bun run build`: **success** (@originals/sdk + @originals/auth)
- `bun run test`: **0 fail** (SDK + auth suites); CEL suite 621 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CEL hash-chain links to cover only committed fields, excluding proof metadata
> - Changes the hash-chain preimage from the full event (including `proof` array) to only the committed fields `{type, data, previousEvent?}` via a new `canonicalizeEntryForChain` utility in [`canonicalize.ts`](https://github.com/onionoriginals/sdk/pull/177/files#diff-251d4b30880037c03d4f3e8f496788bbeef44a6d9cc51ff47b33189655ddb0ba).
> - Updates `deactivateEventLog`, `updateEventLog`, and the transfer CLI to use `canonicalizeEntryForChain` when computing the `previousEvent` digest.
> - Updates `verifyChain` in [`verifyEventLog.ts`](https://github.com/onionoriginals/sdk/pull/177/files#diff-aba8e823ef267585b4b8a9603e5b6afe67fce86d0fee4f9ce67bd95b013efedf) to recompute prior-event hashes the same way, so proof mutations (e.g. witness additions, metadata changes) no longer cause chain breaks.
> - Behavioral Change: existing chains where `previousEvent` was computed over the full event will fail chain verification under the new scheme.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9cc089.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->