### PR TITLE
fix(build): silence TypeScript 6.0 moduleResolution deprecation in root tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "lib": ["ES2020"],
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## What was red

`bunx tsc --noEmit` (part of the green invariant) exited with code 2:

```
tsconfig.json(6,25): error TS5107: Option 'moduleResolution=node10' is deprecated
and will stop functioning in TypeScript 7.0. Specify compilerOption
'"ignoreDeprecations": "6.0"' to silence this error.
```

**Classification: REAL** — fails deterministically every run.

## Root cause

`bunx tsc` resolves to TypeScript **6.0.2** (the latest available to bun). TypeScript 6.0 promotes the `moduleResolution: "node"` (internally `node10`) deprecation from a warning to a hard error (TS5107). The root `tsconfig.json` uses this value, so the invariant check fails.

The packages/sdk build is unaffected because it uses its own local TypeScript **5.9.3** (`packages/sdk/node_modules/.bin/tsc`), which does not yet emit TS5107.

## Fix

Added `"ignoreDeprecations": "6.0"` to the root `tsconfig.json` — exactly what the TypeScript error message instructs. This one-line change silences the TS6 deprecation without altering any compiler semantics. The packages/sdk tsconfig was not changed (TypeScript 5.9.3 rejects the `"6.0"` value for that option).

## Green invariant output (post-fix)

```
$ bunx tsc --noEmit    → exit 0, no output
$ bun run build        → Tasks: 2 successful, 2 total
$ bun run test         → Tasks: 4 successful, 4 total
                          @originals/auth:  140 pass, 0 fail
                          @originals/sdk:   104 pass, 0 fail
                          @originals/sdk:  2220 pass, 0 fail
                          @originals/sdk:    18 pass, 0 fail (stress)
```

No tests were skipped, deleted, weakened, or masked. No cryptographic or provenance guarantees were changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQxswCWAQcEcpXT34gnFVU)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Silence TypeScript 6.0 `moduleResolution` deprecation warning in root tsconfig
> Adds `"ignoreDeprecations": "6.0"` to [tsconfig.json](https://github.com/onionoriginals/sdk/pull/178/files#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0) to suppress the TypeScript 6.0 deprecation warning for the current `moduleResolution` setting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9cb3e14.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->