### PR TITLE
fix(sdk): bind issuer DID to signing key controller in Issuer.issueCredential

### DIFF
--- a/packages/sdk/src/vc/Issuer.ts
+++ b/packages/sdk/src/vc/Issuer.ts
@@ -65,12 +65,22 @@ export class Issuer {
     await documentLoader(this.verificationMethod.id);
 
     const issuerId = typeof unsigned.issuer === 'string' ? unsigned.issuer : (unsigned.issuer as { id?: string })?.id;
+    // The credential's issuer must be the DID that controls the signing key.
+    // Otherwise the issuer claim is decoupled from the key that signed it,
+    // letting a holder of issuer A's key mint a credential claiming issuer B.
+    // Fail closed: refuse to sign when the stated issuer doesn't own the key.
+    const keyController = this.verificationMethod.controller || this.verificationMethod.id.split('#')[0];
+    if (issuerId && issuerId !== keyController) {
+      throw new Error(
+        `Issuer DID (${issuerId}) does not match the verification method controller (${keyController})`
+      );
+    }
     const credential: VerifiableCredential = {
       ...unsigned,
       // Preserve the issuer-supplied @context so every stated term is part of
       // the signed dataset; only default when none was provided (issue #167).
       '@context': withSecuringContext(unsigned['@context']),
-      issuer: issuerId || this.verificationMethod.controller
+      issuer: issuerId || keyController
     } as VerifiableCredential;
     delete (credential as unknown as Record<string, unknown>).proof;
 

--- a/packages/sdk/tests/unit/vc/Issuer.test.ts
+++ b/packages/sdk/tests/unit/vc/Issuer.test.ts
@@ -49,6 +49,33 @@ describe('diwings Issuer', () => {
     expect(vc['@context'][0]).toContain('/ns/credentials/v2');
     expect(vc.proof).toBeDefined();
   });
+
+  test('rejects credential whose issuer DID does not match the signing key controller', async () => {
+    // The verification method (and its private key) is controlled by `did`
+    // (issuer A). Attempting to mint a credential claiming a different issuer
+    // (issuer B) must fail closed instead of producing a credential whose
+    // issuer claim is decoupled from the key that signed it.
+    const issuer = new Issuer(didManager, vm);
+    const forged = { ...baseCredential, issuer: 'did:peer:attacker' } as any;
+    await expect(
+      issuer.issueCredential(forged, { proofPurpose: 'assertionMethod' })
+    ).rejects.toThrow(/issuer/i);
+  });
+
+  test('rejects credential whose issuer object id does not match the signing key controller', async () => {
+    const issuer = new Issuer(didManager, vm);
+    const forged = { ...baseCredential, issuer: { id: 'did:peer:attacker' } } as any;
+    await expect(
+      issuer.issueCredential(forged, { proofPurpose: 'assertionMethod' })
+    ).rejects.toThrow(/issuer/i);
+  });
+
+  test('allows credential whose issuer object id matches the controller', async () => {
+    const issuer = new Issuer(didManager, vm);
+    const matching = { ...baseCredential, issuer: { id: did } } as any;
+    const vc = await issuer.issueCredential(matching, { proofPurpose: 'assertionMethod' });
+    expect(vc.proof).toBeDefined();
+  });
 });
 
 /** Inlined from Issuer.more.part.ts */

--- a/plans/024-issuer-vm-controller-binding.md
+++ b/plans/024-issuer-vm-controller-binding.md
@@ -1,0 +1,99 @@
+# Plan 024: Issuer.issueCredential must bind the issuer DID to the signing verification method (fail closed)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving on. Touch
+> only the files listed as in scope. Commit on the worktree branch (conventional
+> commits). SKIP updating `plans/README.md` — the reviewer maintains the index.
+
+## Status
+
+- **Priority**: P0 (critical)
+- **Effort**: S
+- **Risk**: LOW
+- **Category**: security / correctness
+- **Planned at**: `origin/main` @ `eccee62`, 2026-06-22
+
+## Why this matters
+
+`Issuer.issueCredential` (`packages/sdk/src/vc/Issuer.ts`, lines ~60-92)
+extracts `issuerId` from the caller-supplied unsigned credential and uses it
+directly as the credential's `issuer` value, falling back to
+`this.verificationMethod.controller` only when no issuer is present:
+
+```ts
+const issuerId = typeof unsigned.issuer === 'string'
+  ? unsigned.issuer
+  : (unsigned.issuer as { id?: string })?.id;
+const credential = {
+  ...unsigned,
+  '@context': withSecuringContext(unsigned['@context']),
+  issuer: issuerId || this.verificationMethod.controller
+};
+```
+
+There is **no validation** that `issuerId` matches the DID that actually owns
+the signing key (`this.verificationMethod.controller`, which equals the DID
+prefix of `this.verificationMethod.id`). This decouples the issuer claim from
+the key that signs the credential: an attacker holding issuer A's private key
+can call `issueCredential` with `issuer: B` and obtain a credential that claims
+to be issued by B while being signed by A's key.
+
+`CredentialManager.verifyCredential` already rejects this binding mismatch at
+verification time (`resolveVerificationMethodMultibase` returns `null` when the
+verification method's DID differs from the issuer DID). But issuance is the
+fail-closed boundary: any code that serializes/stores the unsigned-then-signed
+credential before verifying it would persist a malformed credential. Issuance
+must refuse to mint a credential whose issuer does not own the signing key.
+
+## The binding rule
+
+A credential's `issuer` DID must equal the DID that controls the verification
+method used to sign it. The controlling DID is:
+
+- `this.verificationMethod.controller`, and
+- the substring of `this.verificationMethod.id` before the `#` fragment.
+
+When the caller supplies an `issuer` (string or `{ id }`), its DID must match
+that controlling DID. When the caller omits the issuer, we default to the
+controller (existing safe behavior).
+
+## In scope (only these files)
+
+- `packages/sdk/src/vc/Issuer.ts` — add the binding check in `issueCredential`.
+- `packages/sdk/tests/unit/vc/Issuer.test.ts` — add a regression test.
+
+## Implementation
+
+1. In `issueCredential`, after computing `issuerId`, derive the controlling DID
+   for the verification method. Prefer `this.verificationMethod.controller`;
+   also compute the DID prefix of `this.verificationMethod.id` (the part before
+   `#`) as the authoritative owner of the key.
+2. If `issuerId` is present and does not equal the controlling DID, throw a
+   clear error (e.g. `Issuer DID does not match verification method controller`).
+   This is fail-closed: do not silently rewrite the issuer.
+3. If `issuerId` is absent, keep defaulting to the controller (unchanged).
+
+## Regression test
+
+Add a test to `Issuer.test.ts` that constructs an Issuer whose verification
+method is controlled by issuer A, then calls `issueCredential` with an unsigned
+credential claiming `issuer: B`, and asserts it rejects. Also assert the
+matching-issuer case still succeeds (covered by existing tests).
+
+This test FAILS before the fix (the mismatched credential is happily signed and
+returned) and PASSES after.
+
+## Verification (run in the worktree)
+
+```bash
+cd /Users/brian/Projects/onionoriginals/sdk
+bun install --frozen-lockfile || bun install
+bunx tsc --noEmit            # 0 errors
+bun run build                # succeeds
+bun run test                 # SDK + auth suites 0-fail
+```
+
+## STOP conditions
+
+- If `bunx tsc --noEmit` reports new errors, stop and report.
+- If any previously-passing test regresses, stop and report.


### PR DESCRIPTION
## Summary

Security fix: the credential's `issuer` must be the DID that controls the signing key. Previously the stated `issuer` was decoupled from the key that signed it, letting a holder of issuer A's key mint a credential claiming issuer B. `Issuer.issueCredential` now fails closed when the stated issuer DID does not match the verification method controller.

## Changes
- `packages/sdk/src/vc/Issuer.ts`: derive `keyController` from the verification method controller (or DID portion of its id) and throw if the supplied `issuer` doesn't match.
- `packages/sdk/tests/unit/vc/Issuer.test.ts`: coverage for the new fail-closed behavior.
- `plans/024-issuer-vm-controller-binding.md`: design notes.

## Verification (immediately pre-merge, rebased on latest origin/main)
- `bunx tsc --noEmit` / `bun run typecheck`: 0 errors
- `bun run build`: success
- `bun run test`: SDK + auth suites 0 fail (2297 + 104 + 165 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind issuer DID to signing key controller in `Issuer.issueCredential`
> - Derives `keyController` from `verificationMethod.controller`, falling back to the DID prefix of `verificationMethod.id` (before the `#` fragment).
> - Throws an error if a caller-supplied issuer DID does not match `keyController`, preventing credentials from being signed by a key the issuer does not control.
> - Defaults the credential `issuer` field to `keyController` when no issuer is supplied.
> - Adds three regression tests covering mismatch rejection (string and object forms) and successful matching in [Issuer.test.ts](https://github.com/onionoriginals/sdk/pull/180/files#diff-320031b55c5c958e8a3aff2cca8f04862406e304087882ae9ff560aac7e5f046).
> - Risk: callers that pass an issuer DID not matching the signing key's controller will now receive a thrown error instead of silently issuing the credential.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4de5c90.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->