### PR TITLE
fix(sdk): DID document overrides VM registry to prevent signature forgery

### DIFF
--- a/packages/sdk/src/vc/documentLoader.ts
+++ b/packages/sdk/src/vc/documentLoader.ts
@@ -37,20 +37,26 @@ export class DocumentLoader {
     const didDocTyped = didDoc as DIDDocWithContext;
 
     if (fragment) {
-      // If a VM was registered explicitly, prefer it
-      const cached = verificationMethodRegistry.get(didUrl);
-      if (cached) {
-        return {
-          document: { '@context': didDocTyped['@context'], ...cached },
-          documentUrl: didUrl,
-          contextUrl: null
-        };
-      }
+      // The resolved DID document is authoritative. A verification method
+      // published by the DID document MUST take precedence over the global
+      // verificationMethodRegistry — otherwise any caller of
+      // `registerVerificationMethod` could shadow a DID's real key with an
+      // attacker-controlled key and forge credential signatures.
       const vms = didDocTyped.verificationMethod;
       const vm = vms?.find((m) => m.id === didUrl);
       if (vm) {
         return {
           document: { '@context': didDocTyped['@context'], ...vm },
+          documentUrl: didUrl,
+          contextUrl: null
+        };
+      }
+      // Fallback ONLY when the DID document does not itself publish this
+      // verification method. The registry can never override the DID document.
+      const cached = verificationMethodRegistry.get(didUrl);
+      if (cached) {
+        return {
+          document: { '@context': didDocTyped['@context'], ...cached },
           documentUrl: didUrl,
           contextUrl: null
         };

--- a/packages/sdk/tests/security/registry-no-override.test.ts
+++ b/packages/sdk/tests/security/registry-no-override.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import { DIDManager } from '../../src/did/DIDManager';
+import {
+  createDocumentLoader,
+  registerVerificationMethod,
+  verificationMethodRegistry
+} from '../../src/vc/documentLoader';
+import { multikey } from '../../src/crypto/Multikey';
+import * as ed25519 from '@noble/ed25519';
+
+/**
+ * Regression: the global verificationMethodRegistry must NEVER override a
+ * verification method that the resolved DID document actually publishes.
+ *
+ * Otherwise any caller of registerVerificationMethod could shadow a victim
+ * DID's real key with an attacker-controlled key and forge credential
+ * signatures.
+ */
+describe('verificationMethodRegistry must not override the DID document', () => {
+  beforeEach(() => verificationMethodRegistry.clear());
+  afterEach(() => verificationMethodRegistry.clear());
+
+  test('DID-document verification method wins over a registered forgery', async () => {
+    const did = 'did:peer:victim1';
+    const vmId = `${did}#keys-1`;
+
+    // The victim's REAL key, published in the DID document.
+    const realSk = new Uint8Array(32).map((_, i) => (i + 1) & 0xff);
+    const realPk = ed25519.getPublicKey(realSk);
+    const realPkMultibase = multikey.encodePublicKey(realPk, 'Ed25519');
+
+    // The attacker's FORGED key, registered under the same VM id.
+    const forgedSk = new Uint8Array(32).map((_, i) => (i + 100) & 0xff);
+    const forgedPk = ed25519.getPublicKey(forgedSk);
+    const forgedPkMultibase = multikey.encodePublicKey(forgedPk, 'Ed25519');
+
+    expect(forgedPkMultibase).not.toBe(realPkMultibase);
+
+    const didManager = new DIDManager({ network: 'mainnet', defaultKeyType: 'Ed25519' } as any);
+    const resolveSpy = spyOn(didManager, 'resolveDID').mockResolvedValue({
+      '@context': ['https://www.w3.org/ns/did/v1'],
+      id: did,
+      verificationMethod: [
+        { id: vmId, type: 'Multikey', controller: did, publicKeyMultibase: realPkMultibase }
+      ]
+    } as any);
+
+    // Attacker injects a forged key under the victim's VM id.
+    registerVerificationMethod({
+      id: vmId,
+      type: 'Multikey',
+      controller: did,
+      publicKeyMultibase: forgedPkMultibase
+    });
+
+    const loader = createDocumentLoader(didManager);
+    const res = await loader(vmId);
+
+    // The DID document's real key must be returned, NOT the forged one.
+    expect((res.document as any).publicKeyMultibase).toBe(realPkMultibase);
+    expect((res.document as any).publicKeyMultibase).not.toBe(forgedPkMultibase);
+
+    resolveSpy.mockRestore();
+  });
+
+  test('registry still serves as fallback when the DID document omits the VM', async () => {
+    const did = 'did:peer:stub1';
+    const vmId = `${did}#keys-1`;
+    const sk = new Uint8Array(32).map((_, i) => (i + 7) & 0xff);
+    const pk = ed25519.getPublicKey(sk);
+    const pkMultibase = multikey.encodePublicKey(pk, 'Ed25519');
+
+    const didManager = new DIDManager({ network: 'mainnet', defaultKeyType: 'Ed25519' } as any);
+    const resolveSpy = spyOn(didManager, 'resolveDID').mockResolvedValue({
+      '@context': ['https://www.w3.org/ns/did/v1'],
+      id: did
+      // no verificationMethod published
+    } as any);
+
+    registerVerificationMethod({ id: vmId, type: 'Multikey', controller: did, publicKeyMultibase: pkMultibase });
+
+    const loader = createDocumentLoader(didManager);
+    const res = await loader(vmId);
+
+    expect((res.document as any).publicKeyMultibase).toBe(pkMultibase);
+    resolveSpy.mockRestore();
+  });
+});

--- a/plans/024-vm-registry-must-not-override-did-document.md
+++ b/plans/024-vm-registry-must-not-override-did-document.md
@@ -1,0 +1,86 @@
+# Plan 024: Verification-method registry must never override the resolved DID document (signature-forgery fix)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving on. Touch
+> only the files listed as in scope. If a STOP condition occurs, stop and
+> report. Commit on the worktree branch. SKIP updating `plans/README.md` — the
+> reviewer maintains the index.
+
+## Status
+
+- **Priority**: P0
+- **Effort**: S
+- **Risk**: LOW
+- **Category**: security / correctness
+- **Branch**: `correctness/round1-4` (from `origin/main`)
+- **Target file**: `packages/sdk/src/vc/documentLoader.ts`
+
+## Why this matters
+
+`packages/sdk/src/vc/documentLoader.ts` exposes a module-level mutable
+`verificationMethodRegistry` and an exported `registerVerificationMethod`.
+During DID-fragment resolution (`resolveDID`), the loader consults this global
+registry **first** and returns the registered verification method **in
+preference to** the verification method published in the actual resolved DID
+document:
+
+```
+if (fragment) {
+  const cached = verificationMethodRegistry.get(didUrl);   // checked FIRST
+  if (cached) { return { ...cached } }                     // overrides the DID doc
+  const vm = didDocTyped.verificationMethod?.find(...);    // only reached if no override
+  ...
+}
+```
+
+This breaks the core security property of verifiable credentials: a credential
+must only verify against the **issuer's own published key**. Any caller of the
+exported `registerVerificationMethod` can register a fake key under a victim's
+DID identifier and have `EdDSACryptosuiteManager.verifyProof` retrieve that
+forged key, validating attacker-controlled signatures — even though the
+victim's real DID document publishes a different key.
+
+## The fix (minimal, correct)
+
+Make the **resolved DID document authoritative**. The registry may only act as
+a fallback for verification methods the DID document does not itself publish; it
+must never override a verification method that the DID document does publish.
+
+Concretely, in `resolveDID`, when a `fragment` is present:
+
+1. First look for the requested VM in the resolved DID document's
+   `verificationMethod` array. If found, return it (the DID document wins).
+2. Only if the DID document does **not** publish that VM, fall back to the
+   registry.
+3. Otherwise, fall back to the existing stub `{ '@context', id }`.
+
+This eliminates the override-forgery: a DID that publishes its key can no longer
+be shadowed by a registered key. The registry remains usable only for DIDs whose
+resolved document genuinely contains no matching verification method (the
+existing test/flow fixtures whose `did:peer:*` stubs carry no inline VM).
+
+## In scope
+
+- `packages/sdk/src/vc/documentLoader.ts` — reorder precedence so the DID
+  document is consulted before the registry; update the explanatory comment.
+- `packages/sdk/tests/security/registry-no-override.test.ts` — new regression
+  test (fails before, passes after).
+
+## Regression test
+
+A DID document publishes a real verification method (real public key). An
+attacker registers a *different* (forged) public key under the **same** VM id
+via `registerVerificationMethod`. After the fix, `loader('<did>#vm')` must
+return the **DID document's** public key, not the forged one.
+
+## Verification (run at repo root unless noted)
+
+```
+bun install --frozen-lockfile || bun install
+bunx tsc --noEmit          # 0 errors
+bun run build              # succeeds
+bun run test               # SDK + auth suites 0-fail
+```
+
+STOP conditions: any tsc error, build failure, or a previously-passing test
+regressing.


### PR DESCRIPTION
## Summary

Fixes a signature-forgery vulnerability in `packages/sdk/src/vc/documentLoader.ts`. During DID-fragment resolution, the module-level mutable `verificationMethodRegistry` (populated via the exported `registerVerificationMethod`) was consulted **before** the resolved DID document. A registered verification method therefore took precedence over the key actually published by the DID document, letting any caller register a forged key under a victim's DID identifier and have `EdDSACryptosuiteManager.verifyProof` validate attacker-controlled credential signatures.

This change makes the resolved DID document authoritative: the DID document's `verificationMethod` array is checked first, and the registry is consulted only as a fallback when the DID document does not itself publish the requested verification method.

## Changes
- `packages/sdk/src/vc/documentLoader.ts` — reorder precedence so the DID document wins over the registry.
- `packages/sdk/tests/security/registry-no-override.test.ts` — regression test (fails before, passes after), plus a fallback-still-works test.
- `plans/024-vm-registry-must-not-override-did-document.md` — plan doc.

## Verification (rebased onto latest main)
- `bunx tsc --noEmit` — 0 errors
- `bun run build` — succeeds
- `bun run test` — all suites 0-fail (SDK + auth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix signature forgery by making DID document authoritative over VM registry in `DocumentLoader.resolveDID`
> - Previously, `verificationMethodRegistry` could override the verification method published in a resolved DID document, allowing a forged key in the registry to be used for signature verification.
> - Reorders precedence in [`documentLoader.ts`](https://github.com/onionoriginals/sdk/pull/181/files#diff-226cf2a0a89becfefdc36ce8b49b4d979725522ed00db6e67a70ba26ebb2d80e): the DID document's `verificationMethod` array is checked first; the registry is used only as a fallback when the DID document does not publish that method.
> - Adds a [security test suite](https://github.com/onionoriginals/sdk/pull/181/files#diff-1a9fd5e7b5289962be2e8dc53e7813543c49e3d8196c3531ac24f280dd9cea91) covering both the override-prevention case and the legitimate fallback case.
> - Risk: any code that relied on registry entries silently overriding DID document keys will now resolve to the DID document's key instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a9020f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->