### PR TITLE
fix(sdk): CEL key resolver rejects revoked/compromised verification methods

### DIFF
--- a/packages/sdk/src/cel/keyResolver.ts
+++ b/packages/sdk/src/cel/keyResolver.ts
@@ -4,8 +4,8 @@ import { multikey } from '../crypto/Multikey';
 /**
  * Builds a CEL key resolver from a DIDManager. Resolves the proof's
  * verificationMethod DID to a DID document, finds the matching verification
- * method, and returns its Ed25519 public key bytes (or null if unresolvable
- * or not Ed25519 — caller then fails closed).
+ * method, and returns its Ed25519 public key bytes (or null if unresolvable,
+ * not Ed25519, or revoked/compromised — caller then fails closed).
  */
 export function createDidManagerKeyResolver(didManager: DIDManager) {
   return async (verificationMethod: string): Promise<Uint8Array | null> => {
@@ -18,6 +18,11 @@ export function createDidManagerKeyResolver(didManager: DIDManager) {
         vms.find(v => v.id === verificationMethod) ??
         vms.find(v => v.id.split('#')[1] === verificationMethod.split('#')[1]);
       if (!vm?.publicKeyMultibase) return null;
+      // Fail closed on retired keys: a verification method that has been
+      // revoked (rotated out) or marked compromised must never resolve as a
+      // valid signing key, otherwise an attacker holding the old private key
+      // could forge accepted CEL signatures.
+      if (vm.revoked || vm.compromised) return null;
       const decoded = multikey.decodePublicKey(vm.publicKeyMultibase);
       return decoded.type === 'Ed25519' ? decoded.key : null;
     } catch {

--- a/packages/sdk/tests/unit/cel/keyResolver.test.ts
+++ b/packages/sdk/tests/unit/cel/keyResolver.test.ts
@@ -1,0 +1,63 @@
+/**
+ * CEL key resolver tests
+ *
+ * The resolver maps a proof's verificationMethod DID URL to the Ed25519 public
+ * key used to verify CEL signatures. It must fail closed (return null) for
+ * verification methods that have been revoked or marked compromised, otherwise
+ * an attacker holding a retired private key could forge accepted signatures.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createDidManagerKeyResolver } from '../../../src/cel/keyResolver';
+import { multikey } from '../../../src/crypto/Multikey';
+import type { DIDManager } from '../../../src/did/DIDManager';
+import type { DIDDocument, VerificationMethod } from '../../../src/types/did';
+
+const DID = 'did:peer:zResolverTest';
+const VM_ID = `${DID}#key-1`;
+
+// A deterministic 32-byte Ed25519 public key encoded as multibase Multikey.
+const PUBLIC_KEY = new Uint8Array(32).map((_, i) => (i * 7 + 3) % 256);
+const PUBLIC_KEY_MULTIBASE = multikey.encodePublicKey(PUBLIC_KEY, 'Ed25519');
+
+function makeResolver(vm: VerificationMethod) {
+  const doc: DIDDocument = {
+    '@context': ['https://www.w3.org/ns/did/v1'],
+    id: DID,
+    verificationMethod: [vm]
+  };
+  const didManager = {
+    resolveDID: async (did: string) => (did === DID ? doc : null)
+  } as unknown as DIDManager;
+  return createDidManagerKeyResolver(didManager);
+}
+
+function baseVM(): VerificationMethod {
+  return {
+    id: VM_ID,
+    type: 'Multikey',
+    controller: DID,
+    publicKeyMultibase: PUBLIC_KEY_MULTIBASE
+  };
+}
+
+describe('createDidManagerKeyResolver', () => {
+  it('resolves the Ed25519 public key for an active verification method', async () => {
+    const resolve = makeResolver(baseVM());
+    const key = await resolve(VM_ID);
+    expect(key).not.toBeNull();
+    expect(Array.from(key!)).toEqual(Array.from(PUBLIC_KEY));
+  });
+
+  it('returns null for a revoked verification method', async () => {
+    const resolve = makeResolver({ ...baseVM(), revoked: '2024-01-01T00:00:00Z' });
+    const key = await resolve(VM_ID);
+    expect(key).toBeNull();
+  });
+
+  it('returns null for a compromised verification method', async () => {
+    const resolve = makeResolver({ ...baseVM(), compromised: '2024-01-01T00:00:00Z' });
+    const key = await resolve(VM_ID);
+    expect(key).toBeNull();
+  });
+});

--- a/plans/025-cel-key-resolver-reject-revoked-vm.md
+++ b/plans/025-cel-key-resolver-reject-revoked-vm.md
@@ -1,0 +1,67 @@
+# Plan 025: CEL key resolver must reject revoked / compromised verification methods
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving on. Touch
+> only the files listed as in scope. If a STOP condition occurs, stop and
+> report. Commit on the worktree branch. SKIP updating `plans/README.md` — the
+> reviewer maintains the index.
+
+## Status
+
+- **Priority**: P0 (high)
+- **Effort**: S
+- **Risk**: LOW
+- **Category**: security / correctness
+- **Branch**: `correctness/round1-3` (from `origin/main`)
+- **Target file**: `packages/sdk/src/cel/keyResolver.ts`
+
+## Why this matters
+
+`createDidManagerKeyResolver()` resolves a proof's `verificationMethod` DID URL
+to a DID document, finds the matching verification method, and returns its
+Ed25519 public key for CEL signature verification. CEL signatures gate
+commit-reveal proofs during Bitcoin inscriptions and event-log mutations.
+
+The `VerificationMethod` type (`src/types/did.ts`) carries optional `revoked`
+and `compromised` ISO-8601 timestamps. `KeyManager` sets these when keys are
+rotated (`revoked`) or recovered after compromise (`compromised`). However, the
+key resolver returns the matched VM's public key **without consulting these
+fields**. As a result a key that has been explicitly revoked or marked
+compromised — and is still present in the DID document precisely so verifiers
+can recognise it as retired — will resolve as a valid signing key. An attacker
+holding an old, revoked private key could forge CEL signatures that the resolver
+would accept, enabling unauthorized inscription transfers or event-log
+mutations.
+
+## The fix (minimal, correct)
+
+In the resolver, after locating the matching verification method, fail closed
+(return `null`) if the VM carries a `revoked` or `compromised` timestamp. This
+makes the resolver treat retired keys as non-resolvable, exactly like an unknown
+or non-Ed25519 key. The caller already fails closed on `null`.
+
+## In scope
+
+- `packages/sdk/src/cel/keyResolver.ts` — reject VMs with `revoked` or
+  `compromised` set; update the JSDoc.
+- `packages/sdk/tests/unit/cel/keyResolver.test.ts` — new regression test
+  (fails before, passes after).
+
+## Regression test
+
+A DID document publishes an Ed25519 verification method. The resolver returns
+its key when the VM is active. When the same VM carries a `revoked` (or
+`compromised`) timestamp, the resolver must return `null`. The active-key case
+also guards against over-rejection.
+
+## Verification (run at repo root unless noted)
+
+```
+bun install --frozen-lockfile || bun install
+bunx tsc --noEmit          # 0 errors
+bun run build              # succeeds
+bun run test               # SDK + auth suites 0-fail
+```
+
+STOP conditions: any tsc error, build failure, or a previously-passing test
+regressing.


### PR DESCRIPTION
## Summary
The CEL key resolver returned a verification method's Ed25519 public key without checking its revocation status. A VM that had been revoked (rotated out) or marked compromised is retained in the DID document so verifiers can recognise it as retired, but the resolver treated it as a valid signing key. An attacker holding the old private key could forge CEL signatures accepted during commit-reveal inscription proofs and event-log mutations.

The fix fails closed (returns null) when the matched VM carries a revoked or compromised timestamp. A regression test that fails before and passes after is included.

## Verification (run immediately before merge)
- `bunx tsc --noEmit` — 0 errors
- `bun run build` — success
- `bun run test` — SDK + auth suites 0-fail (SDK 104+2300+80+18 pass, auth 165 pass)

## Files
- packages/sdk/src/cel/keyResolver.ts
- packages/sdk/tests/unit/cel/keyResolver.test.ts
- plans/025-cel-key-resolver-reject-revoked-vm.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject revoked or compromised verification methods in CEL key resolver
> The `createDidManagerKeyResolver` function in [keyResolver.ts](https://github.com/onionoriginals/sdk/pull/182/files#diff-03df781c7845024add871ca355198c69cb54495aa819d812d8738c4e7cb929f9) previously returned a public key for any matched verification method, including revoked or compromised ones. It now returns `null` for verification methods where `vm.revoked` or `vm.compromised` is set, failing closed instead of open. Unit tests covering the active, revoked, and compromised cases are added in [keyResolver.test.ts](https://github.com/onionoriginals/sdk/pull/182/files#diff-faad5f6b12ffa1b026762bc07580f714502fb67f833b2adc9f25eb02e61ef5f1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ff2221.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->