### PR TITLE
fix(auth): client TurnkeyDIDSigner reads nested signRawPayload response shape

### DIFF
--- a/packages/auth/src/client/turnkey-did-signer.ts
+++ b/packages/auth/src/client/turnkey-did-signer.ts
@@ -61,8 +61,13 @@ export class TurnkeyDIDSigner {
           hashFunction: 'HASH_FUNCTION_NO_OP',
         });
 
-        const r = result.r;
-        const s = result.s;
+        // Turnkey's signRawPayload nests the signature under
+        // activity.result.signRawPayloadResult.{r, s} (same shape the
+        // server-side signer reads). Reading result.r/result.s directly is
+        // always undefined and breaks every real Turnkey response.
+        const signRawResult = result.activity?.result?.signRawPayloadResult;
+        const r = signRawResult?.r;
+        const s = signRawResult?.s;
 
         if (!r || !s) {
           throw new Error('Invalid signature response from Turnkey');

--- a/packages/auth/tests/uncovered-scenarios.test.ts
+++ b/packages/auth/tests/uncovered-scenarios.test.ts
@@ -602,10 +602,15 @@ describe('[AUTH-028] TurnkeyDIDSigner', () => {
       apiClient: () => ({
         signRawPayload:
           overrides?.signRawPayload ??
+          // Real Turnkey signRawPayload nests r/s under
+          // activity.result.signRawPayloadResult (matches server-signer tests).
           mock(() =>
             Promise.resolve({
-              r: VALID_R,
-              s: VALID_S,
+              activity: {
+                result: {
+                  signRawPayloadResult: { r: VALID_R, s: VALID_S },
+                },
+              },
             })
           ),
       }),
@@ -634,6 +639,59 @@ describe('[AUTH-028] TurnkeyDIDSigner', () => {
     expect(typeof result.proofValue).toBe('string');
     // Base58btc multibase starts with 'z'
     expect(result.proofValue.startsWith('z')).toBe(true);
+  });
+
+  // REGRESSION (plan 026): the real Turnkey signRawPayload response nests r/s
+  // under activity.result.signRawPayloadResult. The client signer previously
+  // read result.r / result.s at the top level, so every real response threw
+  // 'Invalid signature response from Turnkey'. These two tests pin the correct
+  // response path: the nested shape must succeed, and the legacy flat shape
+  // (which the buggy code accepted) must now be rejected.
+  test('sign reads r/s from activity.result.signRawPayloadResult (nested shape)', async () => {
+    const signRawPayload = mock(() =>
+      Promise.resolve({
+        activity: {
+          result: {
+            signRawPayloadResult: { r: VALID_R, s: VALID_S },
+          },
+        },
+      })
+    );
+    const client = makeDIDSignerClient({ signRawPayload });
+    const signer = new TurnkeyDIDSigner(
+      client,
+      'key_id_abc',
+      'sub_org_123',
+      FIXTURE_PUBKEY_MULTIBASE
+    );
+
+    const result = await signer.sign({
+      document: { id: 'did:webvh:example.com:user' },
+      proof: { type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022' },
+    });
+
+    expect(result.proofValue.startsWith('z')).toBe(true);
+    expect(signRawPayload).toHaveBeenCalled();
+  });
+
+  test('sign rejects legacy flat { r, s } response (no nested result)', async () => {
+    const signRawPayload = mock(() =>
+      Promise.resolve({ r: VALID_R, s: VALID_S })
+    );
+    const client = makeDIDSignerClient({ signRawPayload });
+    const signer = new TurnkeyDIDSigner(
+      client,
+      'key_id_abc',
+      'sub_org_123',
+      FIXTURE_PUBKEY_MULTIBASE
+    );
+
+    await expect(
+      signer.sign({
+        document: { id: 'did:webvh:example.com:user' },
+        proof: { type: 'DataIntegrityProof' },
+      })
+    ).rejects.toThrow('Invalid signature response from Turnkey');
   });
 
   test('verify → returns boolean', async () => {
@@ -728,7 +786,15 @@ describe('[AUTH-029] createDIDWithTurnkey', () => {
       apiClient: () => ({
         signRawPayload:
           signRawPayloadFn ??
-          mock(() => Promise.resolve({ r: VALID_R, s: VALID_S })),
+          mock(() =>
+            Promise.resolve({
+              activity: {
+                result: {
+                  signRawPayloadResult: { r: VALID_R, s: VALID_S },
+                },
+              },
+            })
+          ),
       }),
     } as unknown as import('@turnkey/sdk-server').Turnkey;
   }
@@ -766,7 +832,11 @@ describe('[AUTH-029] createDIDWithTurnkey', () => {
     // SKIP REASON: Same as above — didwebvh-ts verifies the proof synchronously during
     // createDIDOriginal(); a mock signature fails real Ed25519 verification before
     // this test can assert that signRawPayload was called.
-    const signRawPayload = mock(() => Promise.resolve({ r: VALID_R, s: VALID_S }));
+    const signRawPayload = mock(() =>
+      Promise.resolve({
+        activity: { result: { signRawPayloadResult: { r: VALID_R, s: VALID_S } } },
+      })
+    );
     const client = makeCreateDIDClient(signRawPayload);
 
     await createDIDWithTurnkey({

--- a/plans/026-fix-client-turnkey-did-signer-response-shape.md
+++ b/plans/026-fix-client-turnkey-did-signer-response-shape.md
@@ -1,0 +1,92 @@
+# Plan 026: Fix client `TurnkeyDIDSigner` reading wrong Turnkey `signRawPayload` response shape
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. Make the minimal correct change plus a regression test that
+> fails before the fix and passes after.
+
+## Status
+
+- **Priority**: P1 (critical correctness)
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: bug
+- **Planned at**: origin/main commit `b03e50d`, 2026-06-22
+
+## Why this matters
+
+`packages/auth/src/client/turnkey-did-signer.ts` (`TurnkeyDIDSigner.sign`)
+reads the Turnkey signature directly off the top level of the
+`signRawPayload` response:
+
+```typescript
+const r = result.r;
+const s = result.s;
+if (!r || !s) {
+  throw new Error('Invalid signature response from Turnkey');
+}
+```
+
+But the real `@turnkey/sdk-server` `apiClient().signRawPayload` response wraps
+`r`/`s` under `result.activity.result.signRawPayloadResult.{r, s}`. The
+server-side signer (`packages/auth/src/server/turnkey-signer.ts:81`) reads
+this nested shape correctly:
+
+```typescript
+const signRawResult = result.activity?.result?.signRawPayloadResult;
+if (!signRawResult?.r || !signRawResult?.s) { ... }
+```
+
+Because `result.r`/`result.s` are `undefined` for every real Turnkey
+response, the client signer always throws `'Invalid signature response from
+Turnkey'`. This breaks **all** client-side DID creation via
+`createDIDWithTurnkey`, violating the documented API contract.
+
+### Why the existing tests didn't catch it
+
+The `[AUTH-028]` / `[AUTH-029]` tests in
+`packages/auth/tests/uncovered-scenarios.test.ts` mock `signRawPayload`
+returning the **flat** shape `{ r, s }`, which matches the buggy code rather
+than the real API. The authoritative shape is confirmed by the server-side
+test in `packages/auth/tests/turnkey-signer.test.ts`, which mocks
+`{ activity: { result: { signRawPayloadResult: { r, s } } } }`.
+
+## Current state
+
+- `packages/auth/src/client/turnkey-did-signer.ts:64-69` — flat access (bug).
+- `packages/auth/src/server/turnkey-signer.ts:80-83` — correct nested access (reference).
+- `packages/auth/tests/uncovered-scenarios.test.ts:603-611, 730-731` — mocks
+  use the flat (wrong) shape and so mask the defect.
+
+## The fix
+
+1. In `turnkey-did-signer.ts`, read `r`/`s` from
+   `result.activity?.result?.signRawPayloadResult`, mirroring the server
+   signer. Keep the existing `if (!r || !s)` guard and the rest of the logic
+   (0x-strip, 64-byte combine, multibase encode) unchanged.
+2. Update the masking test mocks in `uncovered-scenarios.test.ts` (AUTH-028
+   and AUTH-029) to return the real nested shape.
+3. Add a regression test that:
+   - asserts the realistic **nested** response produces a `proofValue`, and
+   - asserts that a legacy **flat** `{ r, s }` response (the shape the old
+     buggy code expected) now throws `'Invalid signature response from
+     Turnkey'` — proving the signer reads the correct path.
+
+## Verification
+
+```bash
+cd /Users/brian/Projects/onionoriginals/sdk
+bun install --frozen-lockfile || bun install
+bunx tsc --noEmit            # 0 errors
+bun run build                # succeeds
+bun run test                 # SDK + auth suites 0-fail
+```
+
+The new regression test must fail before step 1 and pass after.
+
+## STOP conditions
+
+- If `result.r`/`result.s` flat access is already gone from
+  `turnkey-did-signer.ts` on the current base, the defect is already fixed —
+  STOP and report `alreadyResolved`.


### PR DESCRIPTION
## Summary
`TurnkeyDIDSigner.sign()` read `result.r` / `result.s` at the top level of the Turnkey `signRawPayload` response, but the real `@turnkey/sdk-server` response nests the signature under `activity.result.signRawPayloadResult.{r, s}`. Because `result.r`/`result.s` were undefined for every real response, the `if (!r || !s)` guard always threw 'Invalid signature response from Turnkey', breaking all client-side DID creation via `createDIDWithTurnkey`.

This fix reads `r`/`s` from `result.activity?.result?.signRawPayloadResult`, mirroring `server/turnkey-signer.ts`. Updates the AUTH-028/AUTH-029 test mocks (which returned the flat shape and masked the bug) to the real nested shape, and adds regression tests pinning the correct response path.

## Verification (run immediately before merge on this branch, rebased onto latest origin/main)
- `bunx tsc --noEmit` — 0 errors
- `bun run build` — success
- `bun run test` — SDK + auth suites 0 failures (Tasks: 4 successful)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `TurnkeyDIDSigner.sign` to read r/s from nested Turnkey response shape
> - `TurnkeyDIDSigner.sign` was reading `r` and `s` from the top-level `signRawPayload` result, but the Turnkey API returns them nested under `activity.result.signRawPayloadResult`.
> - The fix updates [turnkey-did-signer.ts](https://github.com/onionoriginals/sdk/pull/185/files#diff-733521f2c747d425cf13428332a1c8f7d4e891d3a787d6a6b546332954ae32c3) to read from the correct nested path and throws `'Invalid signature response from Turnkey'` if values are missing.
> - Tests in [uncovered-scenarios.test.ts](https://github.com/onionoriginals/sdk/pull/185/files#diff-a55385c479e755393066c6452793a37f543c7a64d97a74bfce217d75a36fa578) are updated to use the nested mock shape, with regression tests confirming both acceptance of the correct shape and rejection of the legacy flat `{r, s}` shape.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 529d293.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->