### PR TITLE
fix(vc): verify BBS proofs against the DID-document key, not the proof-embedded key

### DIFF
--- a/packages/sdk/src/vc/cryptosuites/bbsCryptosuite.ts
+++ b/packages/sdk/src/vc/cryptosuites/bbsCryptosuite.ts
@@ -72,6 +72,14 @@ function credentialToMessages(credential: Record<string, unknown>, mandatoryPoin
   return { messages, fieldPaths, mandatoryIndexes, selectiveIndexes };
 }
 
+/** Constant-time-ish byte comparison for public key matching. */
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
+  return diff === 0;
+}
+
 export class BBSCryptosuiteManager {
 
   /**
@@ -176,24 +184,35 @@ export class BBSCryptosuiteManager {
         parsed.mandatoryPointers
       );
 
-      // Verify the BBS+ signature
+      // Resolve the public key from the DID document. The verification key MUST
+      // come from the resolved verification method, never from the proof itself
+      // (which is attacker-controlled). Mirrors EdDSACryptosuiteManager.
+      if (!options?.documentLoader) {
+        return { verified: false, errors: ['documentLoader is required to resolve the verification method public key'] };
+      }
+      const vmDoc = await options.documentLoader(proof.verificationMethod);
+      const publicKeyMultibase = vmDoc?.document?.publicKeyMultibase;
+      if (!publicKeyMultibase) {
+        return { verified: false, errors: ['Verification method does not contain a publicKeyMultibase'] };
+      }
+      const dec = multikey.decodePublicKey(publicKeyMultibase);
+      if (dec.type !== 'Bls12381G2') {
+        return { verified: false, errors: ['Verification method key is not Bls12381G2'] };
+      }
+
+      // The proof-embedded public key (if present) MUST match the DID-document
+      // key byte-for-byte. Reject key substitution before any signature check.
+      if (parsed.publicKey && !bytesEqual(parsed.publicKey, dec.key)) {
+        return { verified: false, errors: ['Proof public key does not match verification method'] };
+      }
+
+      // Verify the BBS+ signature against the DID-document public key.
       const valid = await BbsSimple.verify(
         messages,
         new Uint8Array([...parsed.bbsSignature, ...new Uint8Array(80 - parsed.bbsSignature.length)]).slice(0, 80),
-        parsed.publicKey,
+        dec.key,
         parsed.bbsHeader
       );
-
-      // Also verify the public key matches the verification method
-      if (options?.documentLoader) {
-        const vmDoc = await options.documentLoader(proof.verificationMethod);
-        if (vmDoc?.document?.publicKeyMultibase) {
-          const dec = multikey.decodePublicKey(vmDoc.document.publicKeyMultibase);
-          if (dec.type !== 'Bls12381G2') {
-            return { verified: false, errors: ['Verification method key is not Bls12381G2'] };
-          }
-        }
-      }
 
       return valid
         ? { verified: true }

--- a/packages/sdk/tests/unit/vc/cryptosuites/bbsCryptosuite.verifyProof.test.ts
+++ b/packages/sdk/tests/unit/vc/cryptosuites/bbsCryptosuite.verifyProof.test.ts
@@ -1,0 +1,118 @@
+import { describe, test, expect } from 'bun:test';
+import { BBSCryptosuiteManager, BBSCryptosuiteUtils, multikey } from '../../../../src';
+import type { DataIntegrityProof } from '../../../../src/vc/cryptosuites/eddsa';
+
+/**
+ * Regression test for the BBS key-substitution forgery hole:
+ * verifyProof must verify against the public key resolved from the DID
+ * document, not the attacker-controlled key embedded in the proof.
+ */
+
+function blsKey(fill: number): Uint8Array {
+  // BLS12381G2 public keys are 96 bytes.
+  return new Uint8Array(96).fill(fill);
+}
+
+function bytes(len: number, start = 0): Uint8Array {
+  const a = new Uint8Array(len);
+  for (let i = 0; i < len; i++) a[i] = (start + i) & 0xff;
+  return a;
+}
+
+function buildBaseProof(embeddedPublicKey: Uint8Array, verificationMethod: string): DataIntegrityProof {
+  const proofValue = BBSCryptosuiteUtils.serializeBaseProofValue(
+    bytes(80, 1), // bbsSignature
+    bytes(64, 2), // bbsHeader
+    embeddedPublicKey,
+    bytes(32, 4), // hmacKey
+    ['/issuer'],
+    'baseline'
+  );
+  return {
+    type: 'DataIntegrityProof',
+    cryptosuite: 'bbs-2023',
+    created: new Date().toISOString(),
+    verificationMethod,
+    proofPurpose: 'assertionMethod',
+    proofValue
+  };
+}
+
+const document = {
+  '@context': ['https://www.w3.org/ns/credentials/v2'],
+  issuer: 'did:example:victim',
+  credentialSubject: { id: 'did:example:subject' }
+};
+
+describe('BBSCryptosuiteManager.verifyProof key binding', () => {
+  const vm = 'did:example:victim#bls';
+
+  test('rejects a proof whose embedded public key differs from the DID document key', async () => {
+    const attackerKey = blsKey(0xaa);
+    const victimKey = blsKey(0xbb);
+    const proof = buildBaseProof(attackerKey, vm);
+
+    const documentLoader = async (url: string) => {
+      if (url === vm) {
+        return {
+          document: {
+            id: vm,
+            type: 'Multikey',
+            controller: 'did:example:victim',
+            publicKeyMultibase: multikey.encodePublicKey(victimKey, 'Bls12381G2')
+          }
+        };
+      }
+      throw new Error(`unexpected url ${url}`);
+    };
+
+    const result = await BBSCryptosuiteManager.verifyProof(document, proof, { documentLoader });
+
+    expect(result.verified).toBe(false);
+    expect(result.errors?.[0]).toContain('does not match');
+    // Must reject on the key mismatch, NOT reach BbsSimple.verify (not implemented).
+    expect(result.errors?.[0]).not.toMatch(/not implemented/i);
+  });
+
+  test('matching key proceeds to signature verification (reaches BbsSimple.verify)', async () => {
+    const key = blsKey(0xcc);
+    const proof = buildBaseProof(key, vm);
+
+    const documentLoader = async (url: string) => ({
+      document: {
+        id: vm,
+        type: 'Multikey',
+        controller: 'did:example:victim',
+        publicKeyMultibase: multikey.encodePublicKey(key, 'Bls12381G2')
+      }
+    });
+
+    const result = await BBSCryptosuiteManager.verifyProof(document, proof, { documentLoader });
+
+    // Keys match, so it progresses past the binding check to the signature
+    // check, which currently throws "not implemented".
+    expect(result.verified).toBe(false);
+    expect(result.errors?.[0]).toMatch(/not implemented/i);
+  });
+
+  test('fails closed when no documentLoader is supplied', async () => {
+    const proof = buildBaseProof(blsKey(0xaa), vm);
+    const result = await BBSCryptosuiteManager.verifyProof(document, proof, {});
+    expect(result.verified).toBe(false);
+    expect(result.errors?.[0]).toContain('documentLoader is required');
+  });
+
+  test('rejects when the DID document key is not Bls12381G2', async () => {
+    const proof = buildBaseProof(blsKey(0xaa), vm);
+    const ed25519Key = new Uint8Array(32).fill(7);
+    const documentLoader = async () => ({
+      document: {
+        id: vm,
+        publicKeyMultibase: multikey.encodePublicKey(ed25519Key, 'Ed25519')
+      }
+    });
+    const result = await BBSCryptosuiteManager.verifyProof(document, proof, { documentLoader });
+    expect(result.verified).toBe(false);
+    expect(result.errors?.[0]).toContain('not Bls12381G2');
+  });
+});

--- a/plans/026-bbs-verify-public-key-from-did-document.md
+++ b/plans/026-bbs-verify-public-key-from-did-document.md
@@ -1,0 +1,103 @@
+# Plan 026: BBS cryptosuite must verify against the DID-document public key, not the proof-embedded key
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving on. Touch
+> only the files listed as in scope. Commit on the worktree branch (conventional
+> commits). SKIP updating `plans/README.md` — the reviewer maintains the index.
+
+## Status
+
+- **Priority**: P0 (critical / key-substitution forgery)
+- **Effort**: S
+- **Risk**: LOW
+- **Category**: security / correctness
+- **Planned at**: `origin/main` @ `b03e50d`, 2026-06-22
+
+## Why this matters
+
+`BBSCryptosuiteManager.verifyProof`
+(`packages/sdk/src/vc/cryptosuites/bbsCryptosuite.ts`) extracts the public key
+from the **proof itself** (`parsed.publicKey`, derived from the base proof
+value) and passes it to `BbsSimple.verify(...)` as the verification key. The
+subsequent DID-document check only validates that *some* verification-method key
+on the resolved DID document is of type `Bls12381G2` — it never compares the
+actual key bytes.
+
+The proof is attacker-controlled data. A signature verifies against whatever
+public key it is checked against, so an attacker who embeds their own
+`Bls12381G2` public key in the base proof and signs with their own key produces
+a proof that "verifies" — as long as the victim issuer's DID document happens to
+contain any `Bls12381G2` verification method. This is a classic key-substitution
+forgery: credentials can be forged under any issuer with a BLS key, without
+possessing that issuer's signing key.
+
+Today this is latent only because `BbsSimple.verify` throws `not implemented`,
+so every BBS proof fails. The moment BBS+ verification is implemented this
+becomes a critical forgery hole.
+
+Contrast `EdDSACryptosuiteManager.verifyProof` (`eddsa.ts`, lines ~48-56) which
+resolves the public key from the DID document via `documentLoader` and verifies
+against *that* key. BBS must do the same.
+
+## The rule
+
+The public key used to verify a BBS proof MUST come from the resolved DID
+document's verification method, not from the proof. The proof-embedded key (when
+present) MUST equal the DID-document key, byte for byte; otherwise verification
+fails closed.
+
+## In scope (only these files)
+
+- `packages/sdk/src/vc/cryptosuites/bbsCryptosuite.ts` — fix `verifyProof`.
+- `packages/sdk/tests/unit/vc/cryptosuites/bbsCryptosuite.verifyProof.test.ts`
+  — new regression test.
+
+## Implementation
+
+In `BBSCryptosuiteManager.verifyProof`:
+
+1. Resolve the verification method via `options.documentLoader` (required for
+   verification — mirror EdDSA, which calls `options.documentLoader` directly).
+   If no `documentLoader` is provided, fail closed.
+2. Decode `publicKeyMultibase` from the resolved verification method. It MUST be
+   `Bls12381G2`; otherwise return `{ verified: false, errors: [...] }`.
+3. Compare the DID-document key bytes against `parsed.publicKey` (the
+   proof-embedded key). If they differ, return
+   `{ verified: false, errors: ['Proof public key does not match verification method'] }`.
+   This is the security fix: reject substitution before any signature check.
+4. Pass the **DID-document key** (not `parsed.publicKey`) to `BbsSimple.verify`.
+
+## Regression test
+
+`bbsCryptosuite.verifyProof.test.ts`:
+
+- Build a base proof value via `BBSCryptosuiteUtils.serializeBaseProofValue`
+  embedding an attacker `Bls12381G2` public key.
+- Provide a `documentLoader` that resolves the verification method to a
+  *different* (victim) `Bls12381G2` `publicKeyMultibase`.
+- Assert `verifyProof` returns `verified: false` with the
+  "does not match" error — i.e. it rejects on the key mismatch BEFORE reaching
+  `BbsSimple.verify` (which would otherwise throw `not implemented`). The error
+  must NOT be `not implemented`.
+- Add a second case where the embedded key DOES match the DID-document key:
+  verification then proceeds to `BbsSimple.verify` and surfaces the
+  `not implemented` error (proving the matched path reaches the signature check).
+
+Before the fix the mismatch case fails: the old code never compares key bytes,
+so it reaches `BbsSimple.verify` and returns the `not implemented` error instead
+of the "does not match" error. After the fix it returns the mismatch error.
+
+## Verification (run in the worktree)
+
+```bash
+cd /Users/brian/Projects/onionoriginals/sdk
+bun install --frozen-lockfile || bun install
+bunx tsc --noEmit            # 0 errors
+bun run build                # succeeds
+bun run test                 # SDK + auth suites 0-fail
+```
+
+## STOP conditions
+
+- If `bunx tsc --noEmit` reports new errors, stop and report.
+- If any previously-passing test regresses, stop and report.


### PR DESCRIPTION
## Summary
BBSCryptosuiteManager.verifyProof previously extracted the public key from the attacker-controlled base proof value (parsed.publicKey) and used it to verify the signature, while the DID-document check only validated the key TYPE (Bls12381G2), never the key bytes. Once BbsSimple.verify is implemented, this is a key-substitution forgery: an attacker could embed their own BLS key, sign with it, and have the proof "verify" under any issuer whose DID document contains any Bls12381G2 verification method.

Now verifyProof resolves the public key from the DID document via the documentLoader (mirroring EdDSACryptosuiteManager), fails closed when no loader is supplied, requires a Bls12381G2 verification-method key, rejects when the proof-embedded key does not match the DID-document key byte-for-byte, and verifies the signature against the DID-document key.

## Verification (run immediately before merge on rebased branch)
- `bunx tsc --noEmit` — 0 errors
- `bun run build` — success
- `bun run test` — SDK suites 0 fail (2467 + 124 + 192 across files), auth suite 167 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix BBS proof verification to use DID-document key instead of proof-embedded key
> - Verification previously trusted the public key embedded in the proof value; an attacker could substitute a key they control to bypass signature checks.
> - `BBSCryptosuiteManager.verifyProof` now resolves the verification method via `documentLoader`, decodes the public key, enforces it is `Bls12381G2`, and passes it to `BbsSimple.verify` instead of the proof-embedded key.
> - If a public key is present in the parsed proof, it is compared byte-for-byte against the DID-document key using a new `bytesEqual` helper; a mismatch causes verification to fail.
> - Risk: verification now fails closed when `options.documentLoader` is absent, which is a breaking behavioral change for callers that omit it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b4b702.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->