### PR TITLE
fix(bitcoin): derive valid scriptPubKey in transferInscription fallback

### DIFF
--- a/packages/sdk/src/bitcoin/BitcoinManager.ts
+++ b/packages/sdk/src/bitcoin/BitcoinManager.ts
@@ -8,6 +8,7 @@ import type { FeeOracleAdapter, OrdinalsProvider } from '../adapters';
 import { emitTelemetry, StructuredError } from '../utils/telemetry';
 import { validateBitcoinAddress } from '../utils/bitcoin-address';
 import { validateSatoshiNumber } from '../utils/satoshi-validation';
+import { scriptPubKeyForAddress } from './transfer';
 
 export class BitcoinManager {
   private readonly feeOracle?: FeeOracleAdapter;
@@ -243,7 +244,14 @@ export class BitcoinManager {
       vout:
         response.vout?.length
           ? response.vout
-          : [{ value: DUST_LIMIT_SATS, scriptPubKey: 'script', address: toAddress }],
+          : [{
+              value: DUST_LIMIT_SATS,
+              // Derive a valid hex-encoded scriptPubKey from the (already
+              // validated) destination address so the fallback output can be
+              // correctly referenced by downstream transaction construction.
+              scriptPubKey: scriptPubKeyForAddress(toAddress, this.config.network),
+              address: toAddress
+            }],
       fee: response.fee,
       blockHeight: response.blockHeight,
       confirmations: response.confirmations

--- a/packages/sdk/src/bitcoin/transfer.ts
+++ b/packages/sdk/src/bitcoin/transfer.ts
@@ -34,10 +34,34 @@ function getScureNetwork(network: TransferNetwork): typeof btc.NETWORK {
  * Derives the scriptPubKey hex for a given address on the given network.
  * Throws if the address is invalid for that network.
  */
-function addressToScriptPubKey(address: string, network: typeof btc.NETWORK): string {
+export function addressToScriptPubKey(address: string, network: typeof btc.NETWORK): string {
   const decoded = btc.Address(network).decode(address);
   const script = btc.OutScript.encode(decoded);
   return Buffer.from(script).toString('hex');
+}
+
+/**
+ * Convenience wrapper that derives the hex-encoded scriptPubKey for an address
+ * using the SDK's configured Bitcoin network name (rather than the @scure
+ * network object). Throws if the address is invalid for that network.
+ *
+ * For `regtest` this mirrors `validateBitcoinAddress`'s leniency: regtest tooling
+ * commonly uses testnet-format (`tb1`/base58 testnet) addresses, so if decoding
+ * against the strict regtest (`bcrt`) parameters fails we fall back to the
+ * testnet parameters before giving up.
+ */
+export function scriptPubKeyForAddress(
+  address: string,
+  network: TransferNetwork = 'mainnet'
+): string {
+  try {
+    return addressToScriptPubKey(address, getScureNetwork(network));
+  } catch (error) {
+    if (network === 'regtest') {
+      return addressToScriptPubKey(address, btc.TEST_NETWORK);
+    }
+    throw error;
+  }
 }
 
 export interface BuildTransferOptions extends Omit<SelectionOptions, 'targetAmountSats' | 'feeRateSatsPerVb'> {

--- a/packages/sdk/tests/unit/bitcoin/transfer-inscription-scriptpubkey.test.ts
+++ b/packages/sdk/tests/unit/bitcoin/transfer-inscription-scriptpubkey.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect } from 'bun:test';
+import { OriginalsSDK } from '../../../src';
+import type { OrdinalsProvider } from '../../../src/adapters';
+import { scriptPubKeyForAddress } from '../../../src/bitcoin/transfer';
+
+// A valid regtest (bech32 'bcrt') P2WPKH destination address.
+const TO_ADDRESS = 'bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080';
+
+/**
+ * Provider whose transferInscription deliberately omits `vout`, forcing
+ * BitcoinManager.transferInscription onto its fallback-output code path.
+ */
+const createNoVoutProvider = (): OrdinalsProvider =>
+  ({
+    async createInscription({ data, contentType }: any) {
+      return {
+        inscriptionId: 'insc-test',
+        revealTxId: 'tx-reveal',
+        txid: 'tx-out',
+        vout: 0,
+        satoshi: '123456789',
+        content: data,
+        contentType
+      };
+    },
+    async getInscriptionById(id: string) {
+      return {
+        inscriptionId: id,
+        content: Buffer.from('x'),
+        contentType: 'text/plain',
+        txid: 'tx-out',
+        vout: 0,
+        satoshi: '123456789'
+      };
+    },
+    async transferInscription(_id: string, toAddress: string, options?: { feeRate?: number }) {
+      // Intentionally return NO vout -> exercises the fallback branch.
+      return {
+        txid: 'tx-transfer',
+        vin: [{ txid: 'tx-out', vout: 0 }],
+        vout: [] as Array<{ value: number; scriptPubKey: string; address?: string }>,
+        fee: options?.feeRate ? Math.round(options.feeRate) : 100,
+        satoshi: '123456789',
+        confirmations: 0
+      };
+    },
+    async getInscriptionsBySatoshi() {
+      return [];
+    },
+    async broadcastTransaction() {
+      return 'tx-broadcast';
+    },
+    async getTransactionStatus() {
+      return { confirmed: false };
+    },
+    async estimateFee(blocks = 1) {
+      return 5 * blocks;
+    }
+  } as unknown as OrdinalsProvider);
+
+describe('BitcoinManager.transferInscription fallback output scriptPubKey', () => {
+  test('derives a valid hex scriptPubKey from the destination address (not a placeholder)', async () => {
+    const sdk = OriginalsSDK.create({
+      network: 'regtest',
+      ordinalsProvider: createNoVoutProvider()
+    } as any);
+
+    const tx = await sdk.bitcoin.transferInscription(
+      {
+        inscriptionId: 'insc-test',
+        satoshi: '123456789',
+        txid: 'tx-out',
+        vout: 0
+      } as any,
+      TO_ADDRESS
+    );
+
+    expect(tx.vout.length).toBe(1);
+    const script = tx.vout[0].scriptPubKey;
+
+    // Must NOT be the old placeholder.
+    expect(script).not.toBe('script');
+
+    // Must be valid, non-empty, lowercase hex.
+    expect(script.length).toBeGreaterThan(0);
+    expect(/^[0-9a-f]+$/.test(script)).toBe(true);
+    // Hex strings have even length and round-trip through Buffer.
+    expect(script.length % 2).toBe(0);
+    expect(Buffer.from(script, 'hex').toString('hex')).toBe(script);
+
+    // Must equal the script genuinely derived from the destination address.
+    expect(script).toBe(scriptPubKeyForAddress(TO_ADDRESS, 'regtest'));
+  });
+});

--- a/plans/026-fix-transfer-inscription-placeholder-scriptpubkey.md
+++ b/plans/026-fix-transfer-inscription-placeholder-scriptpubkey.md
@@ -1,0 +1,69 @@
+# Plan 026: Fix placeholder scriptPubKey in BitcoinManager.transferInscription fallback
+
+## Status
+
+- **State**: DONE (branch `correctness/round1-5`)
+- **Priority**: P1
+- **Effort**: S
+- **Risk**: LOW
+- **Category**: correctness
+- **Planned at**: atop `origin/main`@`b03e50d`, 2026-06-22
+
+## Why this matters
+
+`BitcoinManager.transferInscription` returns a `BitcoinTransaction`. When the
+configured `OrdinalsProvider` does not return `vout` data, the method
+synthesizes a single fallback output:
+
+```ts
+[{ value: DUST_LIMIT_SATS, scriptPubKey: 'script', address: toAddress }]
+```
+
+`scriptPubKey` is typed as a hex-encoded Bitcoin output script (see
+`TransactionOutput`/`UTXO` in `src/types/bitcoin.ts`, and the consumers in
+`bitcoin/transactions/commit.ts` which do `Buffer.from(utxo.scriptPubKey,
+'hex')`). The literal string `'script'` is **not valid hex** — decoding it with
+`Buffer.from('script', 'hex')` silently produces garbage/truncated bytes, so any
+downstream code that references this output as an input (witness construction,
+re-spending the transferred inscription) builds a corrupt transaction.
+
+### Root cause
+
+The fallback was a placeholder that was never replaced with a real
+address-derived script. The destination address (`toAddress`) is already
+validated against `this.config.network` earlier in the method, so we have
+everything needed to derive a correct `scriptPubKey`.
+
+## The fix
+
+There is already a correct, tested helper in `src/bitcoin/transfer.ts`,
+`addressToScriptPubKey(address, network)`, which decodes an address and encodes
+its `OutScript` to hex via `@scure/btc-signer`. It was module-private.
+
+1. Export `addressToScriptPubKey` from `transfer.ts` and a small
+   `scriptPubKeyForAddress(address, network)` convenience that maps the SDK's
+   `'mainnet' | 'regtest' | 'signet'` config network to the scure network and
+   returns the hex script.
+2. In `BitcoinManager.transferInscription`, replace the placeholder
+   `scriptPubKey: 'script'` with `scriptPubKeyForAddress(toAddress,
+   this.config.network)`, producing a valid hex script for the fallback output.
+
+The address is already validated above, so derivation cannot fail on an invalid
+address. No public API shape changes (the `BitcoinTransaction` return type is
+unchanged; the output is now correct instead of a placeholder).
+
+## Regression test
+
+`tests/unit/bitcoin/transfer-inscription-scriptpubkey.test.ts`: configures a
+mock `OrdinalsProvider` whose `transferInscription` returns a response with NO
+`vout` (forcing the fallback path), then asserts the returned `vout[0]
+.scriptPubKey` is valid lowercase hex and decodes to the same script as the
+destination address. Fails before the fix (`'script'` is not hex), passes after.
+
+## Out of scope
+
+The same `scriptPubKey: 'script'` placeholder appears in the *mock* providers
+(`OrdMockProvider`, `OrdHttpProvider`). Those are test/dev doubles whose `vout`
+is consumed only as illustrative data; fixing the production fallback in
+`BitcoinManager` is the load-bearing correctness change. Mocks left untouched to
+keep the fix minimal.


### PR DESCRIPTION
## Summary
`BitcoinManager.transferInscription` returned a fallback output with the placeholder `scriptPubKey='script'` when the OrdinalsProvider omitted vout data. That literal is not valid hex; downstream code that decodes scriptPubKey via `Buffer.from(.., 'hex')` (e.g. witness/input construction in `transactions/commit.ts`) would silently build a corrupt transaction.

This change exports `addressToScriptPubKey` from `transfer.ts` and adds a `scriptPubKeyForAddress(address, network)` helper, then uses it to derive a real hex script from the (already validated) destination address. The helper mirrors `validateBitcoinAddress`'s regtest leniency so existing valid call sites keep working.

## Testing
- `bunx tsc --noEmit` — 0 errors
- `bun run build` — success
- `bun run test` — SDK + auth suites 0-fail
- Adds a regression test that forces the no-vout fallback path and asserts the output scriptPubKey is valid hex equal to the address-derived script (fails before, passes after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `transferInscription` fallback to derive valid `scriptPubKey` from destination address
> - The fallback output in `BitcoinManager.transferInscription` previously set `scriptPubKey` to the literal string `'script'`; it now calls `scriptPubKeyForAddress(toAddress, this.config.network)` to produce a valid hex-encoded value.
> - Adds `scriptPubKeyForAddress` as a new exported helper in [`transfer.ts`](https://github.com/onionoriginals/sdk/pull/187/files#diff-2f59be995819bcc2bec77056ac3369779a45745e6ef113fbd3e119a287d84f90) that maps the SDK network name to scure network params, with a regtest→testnet fallback for address decoding.
> - A unit test in [`transfer-inscription-scriptpubkey.test.ts`](https://github.com/onionoriginals/sdk/pull/187/files#diff-1c649176fb1ebe38705956805a23512f65999420ebdd5d1a03aa47ecae7e616d) covers the fallback path using a mock provider that returns no vout entries.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c83fe3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->