### PR TITLE
fix(sdk): BtcoDidResolver recognizes did:btco:test (testnet) prefix

### DIFF
--- a/packages/sdk/src/did/BtcoDidResolver.ts
+++ b/packages/sdk/src/did/BtcoDidResolver.ts
@@ -52,7 +52,7 @@ export class BtcoDidResolver {
   }
 
   private parseBtcoDid(did: string): { satNumber: string; path?: string; network: string } | null {
-    const regex = /^did:btco(?::(reg|sig))?:([0-9]+)(?:\/(.+))?$/;
+    const regex = /^did:btco(?::(reg|sig|test))?:([0-9]+)(?:\/(.+))?$/;
     const match = did.match(regex);
     if (!match) return null;
     const [, networkSuffix, satNumber, path] = match;
@@ -68,6 +68,9 @@ export class BtcoDidResolver {
       case 'sig':
       case 'signet':
         return 'did:btco:sig';
+      case 'test':
+      case 'testnet':
+        return 'did:btco:test';
       default:
         return 'did:btco';
     }

--- a/packages/sdk/tests/unit/did/BtcoDidResolver.test.ts
+++ b/packages/sdk/tests/unit/did/BtcoDidResolver.test.ts
@@ -276,9 +276,11 @@ describe('BtcoDidResolver', () => {
     const resolver = new BtcoDidResolver({ provider });
     const prefixRegtest = (resolver as any).getDidPrefix('regtest');
     const prefixSignet = (resolver as any).getDidPrefix('signet');
+    const prefixTestnet = (resolver as any).getDidPrefix('test');
     const prefixMain = (resolver as any).getDidPrefix('mainnet');
     expect(prefixRegtest).toBe('did:btco:reg');
     expect(prefixSignet).toBe('did:btco:sig');
+    expect(prefixTestnet).toBe('did:btco:test');
     expect(prefixMain).toBe('did:btco');
   });
 });
@@ -607,5 +609,35 @@ describe('BtcoDidResolver signet and error branches', () => {
     const r = new BtcoDidResolver({ provider: providerErr });
     const res = await r.resolve('did:btco:sig:3');
     expect(res.inscriptions?.[0].error).toContain('Failed to process inscription');
+  });
+});
+
+/**
+ * Regression: BtcoDidResolver must recognize the testnet prefix `did:btco:test:`.
+ * satoshi-validation, BitcoinManager, and DIDManager.resolveDID all accept/route
+ * `did:btco:test:<sat>`, but the resolver previously rejected it with
+ * `invalidDid`, making testnet DIDs unresolvable. See plans/027.
+ */
+describe('BtcoDidResolver testnet prefix (did:btco:test)', () => {
+  const originalFetch = global.fetch as any;
+  beforeEach(() => {
+    (global as any).fetch = mock(async () => ({ ok: true, status: 200, statusText: 'OK', text: async () => 'BTCO DID: did:btco:test:3' }));
+  });
+  afterAll(() => {
+    (global as any).fetch = originalFetch;
+  });
+
+  const providerOk: ResourceProviderLike = {
+    async getSatInfo() { return { inscription_ids: ['i1'] }; },
+    async resolveInscription(id: string) { return { id, sat: 0, content_type: 'text/plain', content_url: 'http://c/' + id }; },
+    async getMetadata() { return { '@context': ['https://www.w3.org/ns/did/v1'], id: 'did:btco:test:3' }; }
+  };
+
+  test('testnet DID is not rejected as invalidDid and resolves', async () => {
+    const r = new BtcoDidResolver({ provider: providerOk });
+    const res = await r.resolve('did:btco:test:3');
+    expect(res.resolutionMetadata.error).not.toBe('invalidDid');
+    expect(res.resolutionMetadata.network).toBe('test');
+    expect(res.didDocument?.id).toBe('did:btco:test:3');
   });
 });

--- a/plans/027-btco-resolver-accept-testnet-prefix.md
+++ b/plans/027-btco-resolver-accept-testnet-prefix.md
@@ -1,0 +1,82 @@
+# Plan 027: BtcoDidResolver must recognize the `did:btco:test:` (testnet) prefix
+
+## Status
+
+- **State**: DONE (branch `correctness/round1-1-btco`)
+- **Priority**: P0
+- **Effort**: S
+- **Risk**: LOW
+- **Category**: correctness
+- **Planned at**: atop `origin/main`@`334d0ec`, 2026-06-22
+
+## Why this matters
+
+`BtcoDidResolver.parseBtcoDid` (src/did/BtcoDidResolver.ts) parses incoming
+DIDs with:
+
+```ts
+const regex = /^did:btco(?::(reg|sig))?:([0-9]+)(?:\/(.+))?$/;
+```
+
+Only the network suffixes `reg` (regtest) and `sig` (signet) are accepted, plus
+the bare mainnet form. Any `did:btco:test:<SATOSHI>` DID fails the match and the
+resolver returns an `invalidDid` error.
+
+This is inconsistent with the rest of the SDK, which explicitly documents and
+accepts the `test` (testnet) prefix:
+
+- `src/utils/satoshi-validation.ts` (lines 134-160) parses
+  `did:btco:test:123456` as a valid testnet identifier; only `test` and `sig`
+  are accepted as 4-part network prefixes.
+- `src/bitcoin/BitcoinManager.ts` `extractSatoshiFromBTCODID` (lines 304-334)
+  accepts only `test` and `sig`.
+- `src/did/DIDManager.ts` `resolveDID` (line 245) explicitly routes
+  `did.startsWith('did:btco:test:')` DIDs into `BtcoDidResolver.resolve()`.
+
+So `DIDManager.resolveDID('did:btco:test:123')` dispatches the DID to the
+resolver, which then rejects it as `invalidDid`. Any asset/credential created or
+identified on testnet via the satoshi-validation utilities produces a DID that
+cannot be resolved — breaking transfer and verification workflows. This is a
+provenance/correctness bug.
+
+### Root cause
+
+The resolver's `parseBtcoDid` regex and its `getDidPrefix` switch predate the
+testnet support added to `satoshi-validation` / `BitcoinManager` and were never
+updated. The two halves of the codebase disagree on the testnet prefix.
+
+## The fix
+
+Make the resolver accept `test` as a recognized network prefix, alongside the
+existing `reg` and `sig`, with a correct round-trip:
+
+1. `parseBtcoDid`: extend the alternation to
+   `/^did:btco(?::(reg|sig|test))?:([0-9]+)(?:\/(.+))?$/`.
+2. `getDidPrefix`: add a `case 'test'` (and `'testnet'`) returning
+   `did:btco:test`, so the `expectedDid` used to match the inscription content
+   and the DID document `id` round-trips correctly for testnet DIDs
+   (`did:btco:test:123` ⇒ expected document id `did:btco:test:123`).
+
+Existing `reg`/`sig`/mainnet behavior is unchanged; this is purely additive.
+No public API shape changes.
+
+## Regression test
+
+`tests/unit/did/BtcoDidResolver.test.ts` gains:
+
+- A test that `resolve('did:btco:test:3')` does NOT return `invalidDid` and that
+  a matching testnet DID document is selected as the resolved document with
+  `resolutionMetadata.network === 'test'`. This fails before the fix (regex
+  rejects `test`, yielding `invalidDid`) and passes after.
+- A unit assertion that the private `getDidPrefix('test')` maps to
+  `did:btco:test` (mirrors the existing `reg`/`sig` prefix-mapping test).
+
+## Out of scope
+
+The naming asymmetry between `did:btco:reg` (used by `createBtcoDidDocument` /
+`DIDManager` migration for regtest) and `did:btco:test` (used by
+`satoshi-validation` / `BitcoinManager` for testnet) reflects two distinct
+Bitcoin networks (regtest vs testnet) and is a broader design question. This fix
+only ensures the resolver recognizes every prefix the rest of the SDK already
+emits and routes, closing the resolution gap for `test`. Reconciling the network
+taxonomy is left to a separate change.


### PR DESCRIPTION
## Summary
The resolver's `parseBtcoDid` regex only accepted reg/sig/mainnet network prefixes, so any `did:btco:test:<sat>` DID was rejected as `invalidDid`. This contradicted `satoshi-validation.ts`, `BitcoinManager.extractSatoshiFromBTCODID`, and `DIDManager.resolveDID` (which explicitly routes `did:btco:test:` DIDs to this resolver), making testnet DIDs unresolvable and breaking transfer/verification workflows.

Adds `test`/`testnet` to the accepted network suffixes in the regex and to `getDidPrefix` so `expectedDid` round-trips correctly. Existing reg/sig/mainnet behavior unchanged.

## Verification
- `bunx tsc --noEmit`: 0 errors
- `bun run build`: success
- `bun run test`: SDK + auth suites 0 fail

Adds regression tests in `BtcoDidResolver.test.ts`. See plans/027.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `BtcoDidResolver` to recognize `did:btco:test` (testnet) DID prefix
> - Extends the regex in `parseBtcoDid` to accept `test` as a valid network suffix alongside `reg` and `sig`, so `did:btco:test:<sat>` resolves instead of returning `invalidDid`.
> - Adds a `test`/`testnet` case in `getDidPrefix` that returns the `did:btco:test` prefix, matching the new parsing support.
> - Adds regression tests in [BtcoDidResolver.test.ts](https://github.com/onionoriginals/sdk/pull/188/files#diff-f228b87cc4e33d3e05de6d7eb6d5b840855db16f86a17a73df9525de79366db0) covering prefix mapping and full resolution of `did:btco:test:3`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56b9b43.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->