### PR TITLE
fix(sdk): regtest network mapping + optional proof.created in CEL deserialization

### DIFF
--- a/packages/sdk/src/bitcoin/transactions/commit.ts
+++ b/packages/sdk/src/bitcoin/transactions/commit.ts
@@ -25,6 +25,18 @@ const MAX_SELECTION_ITERATIONS = 5;
  */
 type BitcoinNetwork = 'mainnet' | 'testnet' | 'regtest' | 'signet';
 
+// Regtest uses the bech32 prefix 'bcrt', which is not covered by
+// @scure/btc-signer's built-in TEST_NETWORK (which uses 'tb'). We define a
+// minimal network object so that address <-> script derivation works for
+// regtest addresses (matching packages/sdk/src/bitcoin/transfer.ts).
+// BTC_NETWORK shape is { bech32, pubKeyHash, scriptHash, wif }.
+const REGTEST_NETWORK: typeof btc.NETWORK = {
+  bech32: 'bcrt',
+  pubKeyHash: 0x6f,
+  scriptHash: 0xc4,
+  wif: 0xef,
+};
+
 /**
  * Get @scure/btc-signer network configuration
  */
@@ -32,9 +44,10 @@ function getScureNetwork(network: BitcoinNetwork): typeof btc.NETWORK {
   switch (network) {
     case 'mainnet':
       return btc.NETWORK;
+    case 'regtest':
+      return REGTEST_NETWORK;
     case 'testnet':
     case 'signet':
-    case 'regtest':
       return btc.TEST_NETWORK;
     default:
       return btc.NETWORK;

--- a/packages/sdk/src/cel/serialization/cbor.ts
+++ b/packages/sdk/src/cel/serialization/cbor.ts
@@ -32,8 +32,10 @@ function parseProof(proof: unknown): DataIntegrityProof | WitnessProof {
   if (typeof p.cryptosuite !== 'string') {
     throw new Error('Invalid proof: missing or invalid cryptosuite');
   }
-  if (typeof p.created !== 'string') {
-    throw new Error('Invalid proof: missing or invalid created');
+  // `created` is optional per the DataIntegrityProof type and the creation path
+  // (createEventLog does not require it). Only validate it when present.
+  if (p.created !== undefined && typeof p.created !== 'string') {
+    throw new Error('Invalid proof: created must be a string');
   }
   if (typeof p.verificationMethod !== 'string') {
     throw new Error('Invalid proof: missing or invalid verificationMethod');
@@ -48,12 +50,14 @@ function parseProof(proof: unknown): DataIntegrityProof | WitnessProof {
   const baseProof: DataIntegrityProof = {
     type: p.type,
     cryptosuite: p.cryptosuite,
-    created: p.created,
     verificationMethod: p.verificationMethod,
     proofPurpose: p.proofPurpose,
     proofValue: p.proofValue,
   };
-  
+  if (typeof p.created === 'string') {
+    baseProof.created = p.created;
+  }
+
   // Check for WitnessProof
   if ('witnessedAt' in p) {
     if (typeof p.witnessedAt !== 'string') {

--- a/packages/sdk/src/cel/serialization/json.ts
+++ b/packages/sdk/src/cel/serialization/json.ts
@@ -81,8 +81,10 @@ function parseProof(proof: unknown): DataIntegrityProof | WitnessProof {
   if (typeof p.cryptosuite !== 'string') {
     throw new Error('Invalid proof: missing or invalid cryptosuite');
   }
-  if (typeof p.created !== 'string') {
-    throw new Error('Invalid proof: missing or invalid created');
+  // `created` is optional per the DataIntegrityProof type and the creation path
+  // (createEventLog does not require it). Only validate it when present.
+  if (p.created !== undefined && typeof p.created !== 'string') {
+    throw new Error('Invalid proof: created must be a string');
   }
   if (typeof p.verificationMethod !== 'string') {
     throw new Error('Invalid proof: missing or invalid verificationMethod');
@@ -97,12 +99,14 @@ function parseProof(proof: unknown): DataIntegrityProof | WitnessProof {
   const baseProof: DataIntegrityProof = {
     type: p.type,
     cryptosuite: p.cryptosuite,
-    created: p.created,
     verificationMethod: p.verificationMethod,
     proofPurpose: p.proofPurpose,
     proofValue: p.proofValue,
   };
-  
+  if (typeof p.created === 'string') {
+    baseProof.created = p.created;
+  }
+
   // Check for WitnessProof
   if ('witnessedAt' in p) {
     if (typeof p.witnessedAt !== 'string') {

--- a/packages/sdk/tests/unit/bitcoin/transactions/commit.test.ts
+++ b/packages/sdk/tests/unit/bitcoin/transactions/commit.test.ts
@@ -15,7 +15,7 @@ const createUtxo = (value: number, index: number = 0, network: 'mainnet' | 'test
     mainnet: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
     testnet: 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx',
     signet: 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx',
-    regtest: 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx' // Use testnet format for regtest compatibility with @scure/btc-signer
+    regtest: 'bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080' // Native regtest bech32 (bcrt) address
   };
 
   return {
@@ -34,7 +34,7 @@ const createCommitParams = (overrides: Partial<CommitTransactionParams> = {}): C
     mainnet: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
     testnet: 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx',
     signet: 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx',
-    regtest: 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx' // Use testnet format for regtest compatibility with @scure/btc-signer
+    regtest: 'bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080' // Native regtest bech32 (bcrt) address
   };
 
   return {
@@ -332,8 +332,22 @@ describe('createCommitTransaction', () => {
       const params = createCommitParams({ network: 'regtest' });
       const result = await createCommitTransaction(params);
 
-      // Regtest uses TEST_NETWORK which generates tb1p addresses
-      expect(result.commitAddress).toMatch(/^tb1p/);
+      // Regtest must use the 'bcrt' bech32 prefix (bcrt1p...), NOT testnet 'tb1p'.
+      // This is the regression guard for the regtest network-mapping fix.
+      expect(result.commitAddress).toMatch(/^bcrt1p[a-z0-9]{58}$/);
+    });
+
+    test('regtest commit accepts a native bcrt change address', async () => {
+      // A real regtest change address (bcrt1...) must decode against the
+      // regtest network; with the buggy TEST_NETWORK mapping this threw.
+      const params = createCommitParams({
+        network: 'regtest',
+        changeAddress: 'bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080'
+      });
+      const result = await createCommitTransaction(params);
+
+      expect(result.commitAddress).toMatch(/^bcrt1p/);
+      expect(result.commitPsbtBase64).toBeDefined();
     });
   });
 

--- a/packages/sdk/tests/unit/cel/cbor-serialization.test.ts
+++ b/packages/sdk/tests/unit/cel/cbor-serialization.test.ts
@@ -631,4 +631,58 @@ describe('CEL CBOR Serialization', () => {
       expect((parsed.events[1].data as { reason: string }).reason).toBe('No longer needed');
     });
   });
+
+  describe('optional created field (type/serialization parity)', () => {
+    // The DataIntegrityProof type marks `created` as optional, and
+    // createEventLog accepts proofs without it. A proof omitting `created`
+    // must therefore survive a CBOR round-trip rather than failing to parse.
+    test('round-trips a proof that omits created', () => {
+      const original: EventLog = {
+        events: [{
+          type: 'create',
+          data: { name: 'No Created Asset' },
+          proof: [{
+            type: 'DataIntegrityProof',
+            cryptosuite: 'eddsa-jcs-2022',
+            // created intentionally omitted
+            verificationMethod: 'did:key:z6Mktest#key-1',
+            proofPurpose: 'assertionMethod',
+            proofValue: 'zMockProofValue123',
+          }],
+        }],
+      };
+
+      const cbor = serializeEventLogCbor(original);
+      const parsed = parseEventLogCbor(cbor);
+
+      expect(parsed.events.length).toBe(1);
+      const proof = parsed.events[0].proof[0] as DataIntegrityProof;
+      expect(proof.type).toBe('DataIntegrityProof');
+      expect(proof.proofValue).toBe('zMockProofValue123');
+      expect('created' in proof).toBe(false);
+      expect(proof.created).toBeUndefined();
+    });
+
+    test('still rejects a non-string created', () => {
+      // Build a malformed log and encode it directly (serializeEventLogCbor
+      // does not validate), then ensure the parser rejects it.
+      const bad = {
+        events: [{
+          type: 'create',
+          data: { name: 'Bad Created' },
+          proof: [{
+            type: 'DataIntegrityProof',
+            cryptosuite: 'eddsa-jcs-2022',
+            created: 12345,
+            verificationMethod: 'did:key:z6Mktest#key-1',
+            proofPurpose: 'assertionMethod',
+            proofValue: 'zMockProofValue123',
+          }],
+        }],
+      } as unknown as EventLog;
+
+      const cbor = serializeEventLogCbor(bad);
+      expect(() => parseEventLogCbor(cbor)).toThrow('Invalid proof: created must be a string');
+    });
+  });
 });

--- a/packages/sdk/tests/unit/cel/json-serialization.test.ts
+++ b/packages/sdk/tests/unit/cel/json-serialization.test.ts
@@ -559,4 +559,55 @@ describe('CEL JSON Serialization', () => {
       expect((parsed.events[1].data as { reason: string }).reason).toBe('No longer needed');
     });
   });
+
+  describe('optional created field (type/serialization parity)', () => {
+    // The DataIntegrityProof type marks `created` as optional, and
+    // createEventLog accepts proofs without it. A proof omitting `created`
+    // must therefore survive a JSON round-trip rather than failing to parse.
+    test('round-trips a proof that omits created', () => {
+      const original: EventLog = {
+        events: [{
+          type: 'create',
+          data: { name: 'No Created Asset' },
+          proof: [{
+            type: 'DataIntegrityProof',
+            cryptosuite: 'eddsa-jcs-2022',
+            // created intentionally omitted
+            verificationMethod: 'did:key:z6Mktest#key-1',
+            proofPurpose: 'assertionMethod',
+            proofValue: 'zMockProofValue123',
+          }],
+        }],
+      };
+
+      const json = serializeEventLogJson(original);
+      const parsed = parseEventLogJson(json);
+
+      expect(parsed.events.length).toBe(1);
+      const proof = parsed.events[0].proof[0] as DataIntegrityProof;
+      expect(proof.type).toBe('DataIntegrityProof');
+      expect(proof.proofValue).toBe('zMockProofValue123');
+      expect('created' in proof).toBe(false);
+      expect(proof.created).toBeUndefined();
+    });
+
+    test('still rejects a non-string created', () => {
+      const bad = JSON.stringify({
+        events: [{
+          type: 'create',
+          data: { name: 'Bad Created' },
+          proof: [{
+            type: 'DataIntegrityProof',
+            cryptosuite: 'eddsa-jcs-2022',
+            created: 12345,
+            verificationMethod: 'did:key:z6Mktest#key-1',
+            proofPurpose: 'assertionMethod',
+            proofValue: 'zMockProofValue123',
+          }],
+        }],
+      });
+
+      expect(() => parseEventLogJson(bad)).toThrow('Invalid proof: created must be a string');
+    });
+  });
 });

--- a/plans/025-cel-serialization-optional-created.md
+++ b/plans/025-cel-serialization-optional-created.md
@@ -1,0 +1,115 @@
+# Plan 025: Make CEL proof `created` optional in JSON/CBOR deserialization (match the type + creation path)
+
+> **Executor instructions**: Follow step by step. Run every verification command
+> and confirm the expected result before moving on. Touch only in-scope files.
+> If a STOP condition occurs, stop and report. Commit on the worktree branch
+> (conventional commit; `--no-verify` if the commitlint hook lacks deps — note it).
+> SKIP updating `plans/README.md` — the reviewer maintains the index.
+
+## Worktree setup (REQUIRED FIRST)
+
+Worktree branches from `origin/main` (`correctness/round1-2`). At the worktree root:
+1. `bun install --frozen-lockfile || bun install`.
+2. Baseline: `bunx tsc --noEmit` → exit 0; `bun run test` → existing suites pass.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW
+- **Category**: bug (type/serialization mismatch) / correctness
+- **Planned at**: `origin/main` @ `5dd0d44`, 2026-06-22
+
+## Why this matters
+
+`DataIntegrityProof.created` is declared **optional** (`created?: string`) in
+`packages/sdk/src/types/proof.ts:21`. The creation path agrees: `createEventLog`
+(`src/cel/algorithms/createEventLog.ts:51`) validates only `type`, `cryptosuite`,
+`proofValue` — never `created`. A `CelSigner` is therefore permitted to return a
+valid proof with `created` omitted, and `createEventLog`/`updateEventLog` will
+accept it into an `EventLog`.
+
+But both deserialization parsers **require** `created` to be a present string:
+- `src/cel/serialization/json.ts:84-85` throws `Invalid proof: missing or invalid created`.
+- `src/cel/serialization/cbor.ts:35-36` throws the same.
+
+Consequence: a valid in-memory log can be **un-serializable round-trip** — it
+serializes fine (serialization just key-sorts/encodes the object), but
+re-parsing the JSON/CBOR throws. This breaks the provenance layer's lossless
+cross-tool (SDK ↔ CLI) transport/storage requirement. The CLI already treats
+`created` as optional for display (`src/cel/cli/verify.ts:87` prints `N/A` when
+absent), confirming the intended contract is "optional".
+
+Decision: make the parsers treat `created` as **optional**, consistent with the
+type and the creation path. When present it must still be a string (reject a
+non-string `created`); when absent, omit it from the reconstructed proof.
+
+## Current state
+
+`parseProof` in both `json.ts` and `cbor.ts` is identical for the `created`
+handling:
+
+```typescript
+if (typeof p.created !== 'string') {
+  throw new Error('Invalid proof: missing or invalid created');
+}
+...
+const baseProof: DataIntegrityProof = {
+  type: p.type,
+  cryptosuite: p.cryptosuite,
+  created: p.created,      // unconditionally set
+  verificationMethod: p.verificationMethod,
+  proofPurpose: p.proofPurpose,
+  proofValue: p.proofValue,
+};
+```
+
+`type`, `cryptosuite`, `verificationMethod`, `proofPurpose`, `proofValue` remain
+genuinely required (all non-optional in the type) — do NOT relax those.
+
+## Scope
+
+**In scope:**
+- `packages/sdk/src/cel/serialization/json.ts` (`parseProof`: optional `created`)
+- `packages/sdk/src/cel/serialization/cbor.ts` (`parseProof`: optional `created`)
+- `packages/sdk/tests/unit/cel/json-serialization.test.ts` (regression test)
+- `packages/sdk/tests/unit/cel/cbor-serialization.test.ts` (regression test)
+
+**Out of scope:**
+- Relaxing any other required field.
+- Changing `createEventLog`/signer validation.
+- Witness proof `witnessedAt` handling.
+
+## Steps
+
+### Step 1: json.ts — make `created` optional
+Replace the hard `created` check with: only validate when present, and only set
+it on the reconstructed proof when it is a string.
+
+- Remove the `if (typeof p.created !== 'string') throw ...` block.
+- Add, after the required-field checks: `if (p.created !== undefined && typeof p.created !== 'string') throw new Error('Invalid proof: created must be a string');`
+- Build `baseProof` without `created`, then conditionally add it:
+  `if (typeof p.created === 'string') baseProof.created = p.created;`
+
+### Step 2: cbor.ts — identical change
+Apply the same edit to `cbor.ts`'s `parseProof`.
+
+### Step 3: Regression tests
+In both `json-serialization.test.ts` and `cbor-serialization.test.ts`, add a test
+that builds an `EventLog` whose proof omits `created`, serializes it, re-parses it,
+and asserts the round-trip succeeds and `created` is absent on the parsed proof.
+Also add a test asserting a non-string `created` is still rejected.
+
+These tests FAIL before the fix (parse throws) and PASS after.
+
+## Done criteria (ALL must hold)
+- [ ] `bunx tsc --noEmit` exits 0
+- [ ] `bun run build` succeeds
+- [ ] A proof without `created` round-trips through JSON and CBOR
+- [ ] A proof with a non-string `created` is still rejected by both parsers
+- [ ] `bun run test` — SDK + auth suites 0 fail
+- [ ] No out-of-scope files modified
+
+## STOP conditions
+- Some other code path actually depends on `created` always being present after
+  parse (would surface as a failing existing test) — report rather than weaken.

--- a/plans/026-fix-commit-regtest-network-mapping.md
+++ b/plans/026-fix-commit-regtest-network-mapping.md
@@ -1,0 +1,90 @@
+# Plan 026: Fix regtest network mapping in commit transaction creation
+
+> **Executor instructions**: Follow step by step. Run every verification command
+> and confirm the expected result before moving on. Touch only in-scope files.
+> If a STOP condition occurs, stop and report. Commit on the worktree branch
+> (conventional commit; `--no-verify` if the commitlint hook lacks deps — note it).
+> SKIP updating `plans/README.md` — the reviewer maintains the index.
+
+## Worktree setup (REQUIRED FIRST)
+
+Worktree branches from `origin/main` (`correctness/round1-2`). At the worktree root:
+1. `bun install --frozen-lockfile || bun install`.
+2. Baseline: `bunx tsc --noEmit` → exit 0; `bun run test` → existing suites pass.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: S
+- **Risk**: LOW
+- **Category**: bug (network mapping) / correctness
+- **Planned at**: `origin/main` @ `b865f3f`, 2026-06-22
+
+## Why this matters
+
+`getScureNetwork()` in `packages/sdk/src/bitcoin/transactions/commit.ts`
+(lines 31-42) maps the `regtest` network to `btc.TEST_NETWORK`, which uses the
+testnet bech32 prefix `tb`. Regtest uses the bech32 prefix `bcrt`. As a result,
+`createCommitTransaction` on `regtest`:
+
+1. Generates a P2TR **commit address** with the wrong prefix (`tb1p...` instead
+   of `bcrt1p...`), which is invalid on a real regtest network.
+2. Cannot decode a real regtest `changeAddress` (which starts with `bcrt1`)
+   because `tx.addOutputAddress(changeAddress, ..., scureNetwork)` decodes the
+   address against `TEST_NETWORK` and throws on a `bcrt` prefix.
+
+This breaks the entire commit-reveal inscription flow on regtest. The correct
+pattern already exists in `packages/sdk/src/bitcoin/transfer.ts:10-15`, which
+defines a `REGTEST_NETWORK` constant with `bech32: 'bcrt'` (and the matching
+`pubKeyHash`/`scriptHash`/`wif` values) and selects it for `regtest`.
+
+## Scope (files to change)
+
+- `packages/sdk/src/bitcoin/transactions/commit.ts` — add a `REGTEST_NETWORK`
+  constant (mirroring `transfer.ts`) and return it from `getScureNetwork` for
+  the `regtest` case.
+- `packages/sdk/tests/unit/bitcoin/transactions/commit.test.ts` — add/adjust a
+  regression test that asserts a `bcrt1p...` commit address on regtest and that
+  a real `bcrt1` change address is accepted. Fix the existing regtest test
+  helpers/assertions that encode the buggy behavior.
+
+## Implementation
+
+1. In `commit.ts`, above `getScureNetwork`, add:
+
+   ```ts
+   // Regtest uses the bech32 prefix 'bcrt', which is not covered by
+   // @scure/btc-signer's built-in TEST_NETWORK (which uses 'tb').
+   const REGTEST_NETWORK: typeof btc.NETWORK = {
+     bech32: 'bcrt',
+     pubKeyHash: 0x6f,
+     scriptHash: 0xc4,
+     wif: 0xef,
+   };
+   ```
+
+2. Change the `regtest` case to `return REGTEST_NETWORK;` (separate it from the
+   `testnet`/`signet` cases which keep `btc.TEST_NETWORK`).
+
+3. Update the test: regtest fixtures use a real `bcrt1q...` address; the
+   `creates regtest commit address` test asserts `/^bcrt1p/`.
+
+## Verification (must all pass)
+
+From the worktree root `/Users/brian/Projects/onionoriginals/sdk`-equivalent
+(i.e. the worktree checkout):
+
+```
+bun install --frozen-lockfile || bun install
+bunx tsc --noEmit            # 0 errors
+bun run build                # succeeds
+bun run test                 # SDK + auth suites 0-fail
+```
+
+Regression-specific: the new/updated `creates regtest commit address` test
+fails on the pre-fix code (asserts `bcrt1p` but gets `tb1p`) and passes after.
+
+## STOP conditions
+
+- If `getScureNetwork` already returns a `bcrt`-prefixed network for regtest on
+  `origin/main`, STOP — already resolved.


### PR DESCRIPTION
## Summary
Verified correctness fixes (round1-2), rebased onto latest origin/main.

- **commit.ts**: Map `regtest` to a dedicated `bcrt` bech32 network object instead of reusing `TEST_NETWORK` (`tb`), so regtest address <-> script derivation works in commit transaction creation (matches `transfer.ts`).
- **cel/serialization/{json,cbor}.ts**: Treat `proof.created` as optional in JSON/CBOR deserialization, matching the `DataIntegrityProof` type and the `createEventLog` creation path. Only validate `created` when present.

## Verification (run immediately before merge, on rebased branch)
- `bunx tsc --noEmit`: 0 errors
- `bun run build`: 2/2 packages succeed
- `bun run test`: SDK 124 pass / 0 fail, auth 167 pass / 0 fail, stress 2474 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix regtest network mapping to use `bcrt` bech32 prefix and make CEL proof `created` field optional
> - Adds a `REGTEST_NETWORK` constant with the correct `bcrt` bech32 HRP and updates `getScureNetwork` in [`commit.ts`](https://github.com/onionoriginals/sdk/pull/189/files#diff-b6174e7b8349705e25b5d4b9b99b1ebc9986a41e30826d89895deda0fec46da0) to return it for the `'regtest'` case, so regtest addresses are now `bcrt1…` instead of `tb1…`.
> - Relaxes `parseProof` in both [`cbor.ts`](https://github.com/onionoriginals/sdk/pull/189/files#diff-15a7fa6a80062e12157866de6136c30474d728b1eb1cd3cd7009fe5a95fe0d40) and [`json.ts`](https://github.com/onionoriginals/sdk/pull/189/files#diff-c8704f89611a80507c951ff18428c6351e72100637caa7e8a880856042afb18e) to accept `DataIntegrityProof` objects where `created` is absent, while still rejecting non-string values.
> - Behavioral Change: regtest commit addresses and change addresses now use the `bcrt1p…` prefix; any code expecting `tb1…` addresses on regtest will need to be updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56ddfae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->