### PR TITLE
fix(cel): witness digest covers committed fields only, not proof array

### DIFF
--- a/packages/sdk/src/cel/algorithms/witnessEvent.ts
+++ b/packages/sdk/src/cel/algorithms/witnessEvent.ts
@@ -10,26 +10,7 @@
 import type { LogEntry, WitnessProof } from '../types';
 import type { WitnessService } from '../witnesses/WitnessService';
 import { computeDigestMultibase } from '../hash';
-
-/**
- * Serializes a log entry to bytes for hashing.
- * Uses deterministic JSON serialization with sorted keys.
- */
-function serializeEntry(entry: LogEntry): Uint8Array {
-  // Create a canonical representation with sorted keys
-  const canonical = JSON.stringify(entry, (key, value) => {
-    if (value && typeof value === 'object' && !Array.isArray(value)) {
-      return Object.keys(value)
-        .sort()
-        .reduce((sorted: Record<string, unknown>, k) => {
-          sorted[k] = value[k];
-          return sorted;
-        }, {});
-    }
-    return value;
-  });
-  return new TextEncoder().encode(canonical);
-}
+import { canonicalizeEntryForChain } from '../canonicalize';
 
 /**
  * Adds a witness proof to an event by calling a witness service.
@@ -64,8 +45,13 @@ export async function witnessEvent(
     throw new Error('Witness service is required');
   }
 
-  // Compute digest of the event
-  const eventBytes = serializeEntry(event);
+  // Compute digest over the *committed* fields only ({ type, data, previousEvent? }).
+  // The proof array is deliberately excluded: it carries unsigned, mutable metadata
+  // (created, verificationMethod, proofPurpose) and witness proofs that may be appended
+  // after the fact. A witness must attest to the immutable event content, not to proof
+  // metadata that could change later. This matches the hash-chain preimage used by
+  // updateEventLog / deactivateEventLog / verifyEventLog. See canonicalizeEntryForChain.
+  const eventBytes = canonicalizeEntryForChain(event);
   const digestMultibase = computeDigestMultibase(eventBytes);
 
   // Get witness proof

--- a/packages/sdk/tests/unit/cel/witnessEvent.test.ts
+++ b/packages/sdk/tests/unit/cel/witnessEvent.test.ts
@@ -3,6 +3,29 @@ import { witnessEvent } from '../../../src/cel/algorithms/witnessEvent';
 import { createEventLog } from '../../../src/cel/algorithms/createEventLog';
 import type { DataIntegrityProof, WitnessProof, LogEntry, CreateOptions } from '../../../src/cel/types';
 import type { WitnessService } from '../../../src/cel/witnesses/WitnessService';
+import { computeDigestMultibase } from '../../../src/cel/hash';
+import { canonicalizeEntryForChain } from '../../../src/cel/canonicalize';
+
+/**
+ * Witness service that records the digestMultibase it was asked to attest to.
+ */
+function createDigestCapturingWitnessService(): WitnessService & { lastDigest?: string } {
+  const service: WitnessService & { lastDigest?: string } = {
+    async witness(digestMultibase: string): Promise<WitnessProof> {
+      service.lastDigest = digestMultibase;
+      return {
+        type: 'DataIntegrityProof',
+        cryptosuite: 'eddsa-jcs-2022',
+        created: new Date().toISOString(),
+        verificationMethod: 'did:key:z6MkWitness#key-1',
+        proofPurpose: 'assertionMethod',
+        proofValue: 'z' + Buffer.from('witness-' + digestMultibase).toString('base64'),
+        witnessedAt: new Date().toISOString(),
+      };
+    },
+  };
+  return service;
+}
 
 /**
  * Mock signer that creates a valid DataIntegrityProof structure.
@@ -295,6 +318,61 @@ describe('witnessEvent', () => {
       };
 
       await expect(witnessEvent(event, failingWitness)).rejects.toThrow('Witness service unavailable');
+    });
+  });
+
+  describe('digest scope (committed fields only)', () => {
+    test('digest is computed over committed fields only, not the proof array', async () => {
+      const event = await createTestEvent();
+      const witness = createDigestCapturingWitnessService();
+
+      await witnessEvent(event, witness);
+
+      const expected = computeDigestMultibase(canonicalizeEntryForChain(event));
+      expect(witness.lastDigest).toBe(expected);
+    });
+
+    test('mutating the proof array does not change the witness digest', async () => {
+      const event = await createTestEvent();
+
+      // Same committed fields, but a different/mutated proof array.
+      const mutatedEvent: LogEntry = {
+        ...event,
+        proof: [
+          { ...event.proof[0], created: '1999-01-01T00:00:00Z', verificationMethod: 'did:key:zMutated#k' },
+          // An extra proof appended after the fact (e.g. a prior witness).
+          {
+            type: 'DataIntegrityProof',
+            cryptosuite: 'eddsa-jcs-2022',
+            created: new Date().toISOString(),
+            verificationMethod: 'did:key:z6MkOtherWitness#key-1',
+            proofPurpose: 'assertionMethod',
+            proofValue: 'zSomeOtherProofValue',
+            witnessedAt: new Date().toISOString(),
+          } as WitnessProof,
+        ],
+      };
+
+      const witnessA = createDigestCapturingWitnessService();
+      const witnessB = createDigestCapturingWitnessService();
+
+      await witnessEvent(event, witnessA);
+      await witnessEvent(mutatedEvent, witnessB);
+
+      expect(witnessB.lastDigest).toBe(witnessA.lastDigest);
+    });
+
+    test('changing committed data does change the witness digest', async () => {
+      const event = await createTestEvent();
+      const changedEvent: LogEntry = { ...event, data: { ...((event.data as object) ?? {}), name: 'Different' } };
+
+      const witnessA = createDigestCapturingWitnessService();
+      const witnessB = createDigestCapturingWitnessService();
+
+      await witnessEvent(event, witnessA);
+      await witnessEvent(changedEvent, witnessB);
+
+      expect(witnessB.lastDigest).not.toBe(witnessA.lastDigest);
     });
   });
 

--- a/plans/028-witness-digest-committed-fields-only.md
+++ b/plans/028-witness-digest-committed-fields-only.md
@@ -1,0 +1,72 @@
+# 028 — Witness digest must cover committed fields only, not the proof array
+
+## Finding (as reported)
+
+[critical] Witness digest calculated from full event including proofs instead of
+committed fields only (`packages/sdk/src/cel/algorithms/witnessEvent.ts`).
+
+> The `witnessEvent` function uses `serializeEntry(event)` which includes the entire
+> `LogEntry` including the `proof` array. According to the CEL specification and the
+> `canonicalize.ts` specification, the witness digest should only include the committed
+> fields (`type`, `data`, `previousEvent`), not the mutable `proof` array. This breaks
+> the security model where witnesses attest to immutable event data, not to proof
+> metadata that can be added/modified later.
+
+## Investigation result
+
+The defect is real and present on `origin/main` (base commit `334d0ec`).
+
+`witnessEvent` computed its digest like this:
+
+```ts
+const eventBytes = serializeEntry(event);          // serializes the WHOLE LogEntry
+const digestMultibase = computeDigestMultibase(eventBytes);
+```
+
+`serializeEntry` is a local, recursive (JCS-style) serializer — but it serializes the
+**entire** `LogEntry`, including the `proof` array. The `proof` array carries unsigned,
+mutable metadata (`created`, `verificationMethod`, `proofPurpose`) and any witness
+proofs appended later. So the witness ends up attesting to a digest over data no
+signature commits to.
+
+This contradicts the codebase's own canonicalization contract in
+`packages/sdk/src/cel/canonicalize.ts`: `canonicalizeEntryForChain(entry)` deliberately
+includes only `{ type, data, previousEvent? }` and excludes `proof` for exactly this
+reason. The chain-link computation (`updateEventLog`, `deactivateEventLog`,
+`verifyEventLog`) already uses `canonicalizeEntryForChain`. The witness digest must use
+the same committed-fields preimage so that:
+
+1. Appending a witness proof to an event does not retroactively change that event's
+   witness digest (idempotent, order-independent attestation).
+2. Witnesses attest to the immutable event content, not to mutable proof metadata.
+
+## Fix
+
+In `packages/sdk/src/cel/algorithms/witnessEvent.ts`:
+
+- Remove the local `serializeEntry` helper.
+- Import and use `canonicalizeEntryForChain` from `../canonicalize` to build the digest
+  preimage from committed fields only (`type`, `data`, `previousEvent`).
+
+This is the minimal change that aligns the witness digest with the documented
+committed-fields contract and the rest of the CEL hash-chain code.
+
+## Regression test (fails before / passes after)
+
+Added to `packages/sdk/tests/unit/cel/witnessEvent.test.ts` a `digest scope` block that
+captures the `digestMultibase` passed to the witness service and asserts:
+
+1. Witnessing an event yields the same digest as witnessing the same event with a
+   **different/mutated `proof` array** (e.g. an extra appended proof, or changed
+   `proof.created`/`verificationMethod`). The proof array must not affect the digest.
+2. The digest equals `computeDigestMultibase(canonicalizeEntryForChain(event))`
+   (committed fields only), confirming the exact preimage.
+
+Before the fix these assertions fail (the digest changes with the proof array and does
+not match the committed-fields preimage). After the fix they pass.
+
+## Verification
+
+- `bunx tsc --noEmit` — 0 errors
+- `bun run build` — succeeds
+- `bun run test` — SDK + auth suites 0-fail


### PR DESCRIPTION
## Summary
`witnessEvent` computed its digest via `serializeEntry()` over the entire `LogEntry`, including the mutable `proof` array. Appending a non-gating witness proof would change an event's digest and retroactively break the `previousEvent` hash chain for all later events.

This change uses `canonicalizeEntryForChain` (type, data, previousEvent) so witnesses attest to immutable committed fields, matching update/deactivate/verify.

## Tests
Adds regression tests in `witnessEvent.test.ts` asserting the witness digest equals `computeDigestMultibase(canonicalizeEntryForChain(event))` and is unchanged by proof-array mutation.

## Verification (run immediately before merge, on branch rebased onto latest origin/main)
- `bunx tsc --noEmit` — 0 errors
- `bun run build` — success (4/4 turbo tasks)
- `bun run test` — SDK + auth suites all 0 fail (auth 167 pass; sdk 2479 + 124 + 80 + 18 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix witness digest in `witnessEvent` to cover committed fields only, excluding proof array
> - The digest passed to `WitnessService.witness()` was computed over the full `LogEntry` including the proof array; it now uses `canonicalizeEntryForChain(event)`, which serializes only committed fields (`type`, `data`, `previousEvent`).
> - Tests assert that mutating the proof array does not change the digest, while changing committed data does.
> - Behavioral Change: any witness that previously received a digest including proof data will now receive a different digest for the same event.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5be01b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->