### PR TITLE
fix(sdk): two-stage VM matching in CredentialManager fallback

### DIFF
--- a/packages/sdk/src/vc/CredentialManager.ts
+++ b/packages/sdk/src/vc/CredentialManager.ts
@@ -499,7 +499,22 @@ export class CredentialManager {
       const docWithVMs = didDoc as DIDDocWithVMs;
       const vms = docWithVMs?.verificationMethod;
       if (Array.isArray(vms)) {
-        const vm = vms.find((m) => m?.id === verificationMethod);
+        // Two-stage matching, mirroring the CEL key resolver
+        // (cel/keyResolver.ts): match the verification method by exact id
+        // first, then fall back to matching the fragment. DID documents may
+        // publish a verification method under a relative id (e.g. "#keys-1")
+        // while the proof references the absolute form
+        // ("did:...#keys-1") — or vice versa. Both refer to the same key, so
+        // both code paths must agree on which key authorized the signature.
+        // The issuer-binding check above already constrained `verificationMethod`
+        // to the resolved issuer DID, so the fragment fallback does not widen
+        // trust beyond this DID document.
+        const fragment = verificationMethod.split('#')[1];
+        const vm =
+          vms.find((m) => m?.id === verificationMethod) ??
+          (fragment !== undefined
+            ? vms.find((m) => typeof m?.id === 'string' && m.id.split('#')[1] === fragment)
+            : undefined);
         if (vm && typeof vm.publicKeyMultibase === 'string') {
           return vm.publicKeyMultibase;
         }

--- a/packages/sdk/tests/unit/vc/CredentialManager.vmFragment.test.ts
+++ b/packages/sdk/tests/unit/vc/CredentialManager.vmFragment.test.ts
@@ -1,0 +1,89 @@
+import { describe, test, expect } from 'bun:test';
+import { CredentialManager } from '../../../src';
+import { DIDManager } from '../../../src/did/DIDManager';
+
+const config: any = {
+  network: 'regtest',
+  defaultKeyType: 'Ed25519',
+  enableLogging: false
+};
+
+// Regression test for plan 028: CredentialManager.resolveVerificationMethodMultibase
+// fallback must use two-stage matching (exact id, then fragment), mirroring the CEL
+// keyResolver. Previously the fallback used an exact string match only, so a DID
+// document that publishes a verification method under a *relative* id
+// (e.g. "#keys-1") would not be found when the proof references the *absolute*
+// form ("did:webvh:example.com:asset#keys-1"), causing legitimate credentials
+// signed with a published key to fail verification.
+describe('CredentialManager - VM fragment fallback resolution', () => {
+  const issuerDid = 'did:webvh:example.com:asset';
+  const absoluteVm = `${issuerDid}#keys-1`;
+  const publicKeyMultibase = 'z6MkfakeKeyForResolutionTestOnlyNotUsedToVerify';
+
+  function makeDidManager(vmId: string): DIDManager {
+    const didManager = new DIDManager(config);
+    // Force the documentLoader path to miss its publicKeyMultibase (the loader
+    // also matches by absolute id, so a relative-id VM is not surfaced there
+    // either) and exercise the fallback resolveDID branch directly.
+    (didManager as any).resolveDID = async (did: string) => {
+      if (did !== issuerDid) return null;
+      return {
+        '@context': ['https://www.w3.org/ns/did/v1'],
+        id: issuerDid,
+        verificationMethod: [
+          { id: vmId, type: 'Multikey', controller: issuerDid, publicKeyMultibase }
+        ]
+      };
+    };
+    return didManager;
+  }
+
+  test('resolves a published VM when proof uses absolute id and document uses relative id', async () => {
+    const didManager = makeDidManager('#keys-1');
+    const credentialManager = new CredentialManager(config, didManager);
+
+    const resolved = await (credentialManager as any).resolveVerificationMethodMultibase(
+      absoluteVm,
+      issuerDid
+    );
+
+    expect(resolved).toBe(publicKeyMultibase);
+  });
+
+  test('still resolves when both proof and document use the absolute id (exact match)', async () => {
+    const didManager = makeDidManager(absoluteVm);
+    const credentialManager = new CredentialManager(config, didManager);
+
+    const resolved = await (credentialManager as any).resolveVerificationMethodMultibase(
+      absoluteVm,
+      issuerDid
+    );
+
+    expect(resolved).toBe(publicKeyMultibase);
+  });
+
+  test('does not resolve a VM whose fragment differs', async () => {
+    const didManager = makeDidManager('#keys-2');
+    const credentialManager = new CredentialManager(config, didManager);
+
+    const resolved = await (credentialManager as any).resolveVerificationMethodMultibase(
+      absoluteVm,
+      issuerDid
+    );
+
+    expect(resolved).toBeNull();
+  });
+
+  test('does not resolve when the VM belongs to a different DID than the issuer', async () => {
+    const didManager = makeDidManager('#keys-1');
+    const credentialManager = new CredentialManager(config, didManager);
+
+    // issuer-binding check should reject before any document lookup
+    const resolved = await (credentialManager as any).resolveVerificationMethodMultibase(
+      absoluteVm,
+      'did:webvh:example.com:other'
+    );
+
+    expect(resolved).toBeNull();
+  });
+});

--- a/plans/028-credentialmanager-vm-fragment-fallback.md
+++ b/plans/028-credentialmanager-vm-fragment-fallback.md
@@ -1,0 +1,77 @@
+# Plan 028: CredentialManager VM fallback must use two-stage (exact + fragment) matching
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving on. Touch
+> only the files listed as in scope. Commit on the worktree branch (conventional
+> commits). SKIP updating `plans/README.md` — the reviewer maintains the index.
+
+## Status
+
+- **Priority**: P0 (critical / legitimate credentials fail verification)
+- **Effort**: S
+- **Risk**: LOW
+- **Category**: correctness
+- **Planned at**: `origin/main` @ `f1f45ec`, 2026-06-23
+
+## Why this matters
+
+`CredentialManager.resolveVerificationMethodMultibase`
+(`packages/sdk/src/vc/CredentialManager.ts`) has a fallback path used when the
+`documentLoader` does not resolve the proof's `verificationMethod`. That
+fallback resolves the issuer DID document and searches its `verificationMethod`
+array for the key:
+
+```ts
+const vm = vms.find((m) => m?.id === verificationMethod);
+```
+
+This is an **exact string match**. When a DID document publishes a verification
+method with a *relative* id (e.g. `#keys-1`) while the proof references the
+*absolute* form (`did:webvh:...#keys-1`) — or vice versa — the lookup fails and
+a legitimate credential signed with a *published* key is rejected.
+
+The CEL verification path already solves exactly this with **two-stage
+matching** in `packages/sdk/src/cel/keyResolver.ts`:
+
+```ts
+const vm =
+  vms.find(v => v.id === verificationMethod) ??
+  vms.find(v => v.id.split('#')[1] === verificationMethod.split('#')[1]);
+```
+
+The two code paths (CEL event logs vs VC credentials) disagree on which key
+authorizes a signature. A credential that verifies through the CEL path can fail
+through the VC path. This inconsistency breaks the invariant that all code paths
+agree on key authorization, and rejects valid credentials.
+
+## The fix
+
+In `resolveVerificationMethodMultibase`, replace the exact-only fallback match
+with the same two-stage match used by the CEL key resolver: try exact id match
+first, then fall back to fragment match. The fragment fallback is only reached
+after the issuer-binding check (`verificationMethod.split('#')[0] !== issuerDid`
+returns null earlier), so the key still must belong to the issuer's resolved DID
+document — no trust is widened.
+
+### In scope
+
+- `packages/sdk/src/vc/CredentialManager.ts` — fallback VM lookup only.
+- `packages/sdk/tests/unit/vc/CredentialManager.helpers.test.ts` — regression
+  test (or a new focused test file).
+
+## Regression test
+
+Add a test that drives `verifyCredential` (or the resolver directly) with a DID
+document whose published verification method uses a relative id while the proof
+references the absolute id, and assert the credential verifies. The test must
+fail before the fix (exact match misses) and pass after.
+
+## Verification commands
+
+```
+cd /Users/brian/Projects/onionoriginals/sdk
+bun install --frozen-lockfile || bun install
+bunx tsc --noEmit            # 0 errors
+bun run build                # succeeds
+bun run test                 # SDK + auth suites 0-fail
+```


### PR DESCRIPTION
## Summary
Fixes a credential verification false-negative in `CredentialManager`'s fallback verification-method resolution.

`resolveVerificationMethodMultibase`'s fallback (resolveDID branch) used an exact-string match on the verification method id. When a DID document publishes a VM under a relative id (e.g. `#keys-1`) while the proof references the absolute form (`did:webvh:...#keys-1`) -- or vice versa -- the lookup missed and a legitimate credential signed with a published key failed verification. This diverged from the CEL key resolver (`cel/keyResolver.ts`), which already does two-stage matching (exact id, then fragment).

This change applies the same two-stage match in the fallback. The issuer-binding check that runs earlier already constrains the VM to the resolved issuer DID, so the fragment fallback does not widen trust.

## Tests
Adds a regression test (`CredentialManager.vmFragment.test.ts`) that fails before and passes after.

## Verification (run immediately before merge)
- `bunx tsc --noEmit` / `bun run typecheck`: 0 errors (both packages)
- `bun run build`: success
- `bun run test`: SDK 2483+124 pass, auth 167 pass, 0 fail

Plan: `plans/028-credentialmanager-vm-fragment-fallback.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix two-stage VM fragment matching in `CredentialManager.resolveVerificationMethodMultibase`
> The fallback lookup in `resolveVerificationMethodMultibase` previously used exact `id` equality only, causing resolution to fail when a DID document uses a relative id (e.g. `#keys-1`) but the proof references an absolute id (e.g. `did:...#keys-1`), or vice versa.
>
> - Adds a second matching stage in [CredentialManager.ts](https://github.com/onionoriginals/sdk/pull/194/files#diff-ad932dc812104d04b2de4ae763553b969386db2e377ab25fe9ecbc7d64dabb92): if exact match fails and a fragment exists, compare only the fragment portion of each VM's `id`
> - New unit tests in [CredentialManager.vmFragment.test.ts](https://github.com/onionoriginals/sdk/pull/194/files#diff-1d7518c186cc773ab0a1a977a9446a5ba4d553c7135302d89b0d2e31249d5f8d) cover relative-vs-absolute, both-absolute, mismatched-fragment, and issuer-binding-mismatch cases
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c700af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->