### PR TITLE
fix(bitcoin): throw on unknown network in getScureNetwork instead of defaulting to mainnet

### DIFF
--- a/packages/sdk/src/bitcoin/transactions/commit.ts
+++ b/packages/sdk/src/bitcoin/transactions/commit.ts
@@ -40,7 +40,7 @@ const REGTEST_NETWORK: typeof btc.NETWORK = {
 /**
  * Get @scure/btc-signer network configuration
  */
-function getScureNetwork(network: BitcoinNetwork): typeof btc.NETWORK {
+export function getScureNetwork(network: BitcoinNetwork): typeof btc.NETWORK {
   switch (network) {
     case 'mainnet':
       return btc.NETWORK;
@@ -49,8 +49,13 @@ function getScureNetwork(network: BitcoinNetwork): typeof btc.NETWORK {
     case 'testnet':
     case 'signet':
       return btc.TEST_NETWORK;
-    default:
-      return btc.NETWORK;
+    default: {
+      // Unknown network: fail loudly rather than silently assuming mainnet
+      // (real funds). The `never` assignment also makes any future addition to
+      // BitcoinNetwork a compile error until it is explicitly handled above.
+      const exhaustiveCheck: never = network;
+      throw new Error(`Unsupported Bitcoin network: ${String(exhaustiveCheck)}`);
+    }
   }
 }
 

--- a/packages/sdk/src/bitcoin/transfer.ts
+++ b/packages/sdk/src/bitcoin/transfer.ts
@@ -16,7 +16,7 @@ const REGTEST_NETWORK: typeof btc.NETWORK = {
 
 type TransferNetwork = 'mainnet' | 'regtest' | 'signet' | 'testnet';
 
-function getScureNetwork(network: TransferNetwork): typeof btc.NETWORK {
+export function getScureNetwork(network: TransferNetwork): typeof btc.NETWORK {
   switch (network) {
     case 'mainnet':
       return btc.NETWORK;
@@ -25,8 +25,13 @@ function getScureNetwork(network: TransferNetwork): typeof btc.NETWORK {
     case 'signet':
     case 'testnet':
       return btc.TEST_NETWORK;
-    default:
-      return btc.NETWORK;
+    default: {
+      // Unknown network: fail loudly rather than silently assuming mainnet
+      // (real funds). The `never` assignment also makes any future addition to
+      // TransferNetwork a compile error until it is explicitly handled above.
+      const exhaustiveCheck: never = network;
+      throw new Error(`Unsupported Bitcoin network: ${String(exhaustiveCheck)}`);
+    }
   }
 }
 

--- a/packages/sdk/tests/unit/bitcoin/getScureNetwork.test.ts
+++ b/packages/sdk/tests/unit/bitcoin/getScureNetwork.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Regression tests for getScureNetwork in transfer.ts and transactions/commit.ts.
+ *
+ * Both functions previously had a `default: return btc.NETWORK` (mainnet)
+ * fallback. Although the parameter is a union type, that branch is reachable at
+ * runtime via type coercion / external data, silently assuming mainnet (real
+ * funds). These tests assert that valid networks map correctly and that an
+ * unknown network value THROWS instead of silently returning mainnet.
+ */
+import { describe, test, expect } from 'bun:test';
+import * as btc from '@scure/btc-signer';
+import { getScureNetwork as getScureNetworkTransfer } from '../../../src/bitcoin/transfer';
+import { getScureNetwork as getScureNetworkCommit } from '../../../src/bitcoin/transactions/commit.js';
+
+const REGTEST_BECH32 = 'bcrt';
+
+describe('getScureNetwork (transfer.ts)', () => {
+  test('maps known networks to the correct @scure network objects', () => {
+    expect(getScureNetworkTransfer('mainnet')).toBe(btc.NETWORK);
+    expect(getScureNetworkTransfer('signet')).toBe(btc.TEST_NETWORK);
+    expect(getScureNetworkTransfer('testnet')).toBe(btc.TEST_NETWORK);
+    expect(getScureNetworkTransfer('regtest').bech32).toBe(REGTEST_BECH32);
+  });
+
+  test('throws on an unknown network instead of defaulting to mainnet', () => {
+    // Reaches the previously-silent default branch via type coercion.
+    expect(() => getScureNetworkTransfer('bogus' as any)).toThrow(/Unsupported Bitcoin network/);
+    expect(() => getScureNetworkTransfer(undefined as any)).toThrow(/Unsupported Bitcoin network/);
+    expect(() => getScureNetworkTransfer('Mainnet' as any)).toThrow(/Unsupported Bitcoin network/);
+  });
+});
+
+describe('getScureNetwork (transactions/commit.ts)', () => {
+  test('maps known networks to the correct @scure network objects', () => {
+    expect(getScureNetworkCommit('mainnet')).toBe(btc.NETWORK);
+    expect(getScureNetworkCommit('signet')).toBe(btc.TEST_NETWORK);
+    expect(getScureNetworkCommit('testnet')).toBe(btc.TEST_NETWORK);
+    expect(getScureNetworkCommit('regtest').bech32).toBe(REGTEST_BECH32);
+  });
+
+  test('throws on an unknown network instead of defaulting to mainnet', () => {
+    expect(() => getScureNetworkCommit('bogus' as any)).toThrow(/Unsupported Bitcoin network/);
+    expect(() => getScureNetworkCommit(undefined as any)).toThrow(/Unsupported Bitcoin network/);
+    expect(() => getScureNetworkCommit('Mainnet' as any)).toThrow(/Unsupported Bitcoin network/);
+  });
+});

--- a/plans/029-getscurenetwork-reject-unknown-network.md
+++ b/plans/029-getscurenetwork-reject-unknown-network.md
@@ -1,0 +1,82 @@
+# Plan 029: `getScureNetwork` must throw on unknown network instead of defaulting to mainnet
+
+## Status
+
+- **State**: DONE (branch `correctness/round1-3`)
+- **Priority**: P0 (critical)
+- **Effort**: S
+- **Risk**: LOW
+- **Category**: correctness / safety
+- **Planned at**: atop `origin/main`@`3b2f7df`, 2026-06-23
+
+## Why this matters
+
+Two copies of `getScureNetwork` map an SDK network name to a `@scure/btc-signer`
+network object:
+
+- `packages/sdk/src/bitcoin/transfer.ts` (lines 19-31)
+- `packages/sdk/src/bitcoin/transactions/commit.ts` (lines 43-55)
+
+Both end with:
+
+```ts
+default:
+  return btc.NETWORK; // mainnet
+```
+
+Although the parameter is a union type (`'mainnet' | 'regtest' | 'signet' |
+'testnet'`), the `default` branch is reachable at runtime. TypeScript's
+exhaustiveness narrowing does not delete the branch, and any value that reaches
+the function outside the type contract — from dynamic/external data, JSON
+deserialization, `as any` casts, or a future-added-but-unmapped network — will
+**silently fall through to mainnet**.
+
+This is dangerous: mainnet uses real funds. A value intended for testnet/regtest
+that is mistyped or corrupted would silently derive scripts and validate
+addresses against **mainnet** parameters, with no error and no warning. The
+correct behavior for an unrecognized network is to fail loudly.
+
+### Root cause
+
+The `default` branch returns a safe-looking fallback (`btc.NETWORK`) rather than
+throwing. The "safe-looking" value is the most dangerous possible default
+(mainnet / real funds).
+
+## The fix
+
+In **both** `getScureNetwork` implementations, replace the
+`default: return btc.NETWORK;` branch with a `default:` that throws an `Error`
+naming the offending value. Use an `exhaustiveCheck: never` assignment so the
+compiler also enforces that every member of the union is handled — turning any
+future addition to the union into a compile error rather than a silent mainnet
+fallback.
+
+```ts
+default: {
+  const exhaustiveCheck: never = network;
+  throw new Error(`Unsupported Bitcoin network: ${String(exhaustiveCheck)}`);
+}
+```
+
+The `mainnet`/`regtest`/`signet`/`testnet` cases are unchanged, so all existing
+valid call sites behave identically. Only the previously-silent fallback path
+changes — now it throws.
+
+## Regression test
+
+Both functions are module-private. To exercise the fallback branch (only
+reachable via type coercion), each module gains a minimal named export of its
+`getScureNetwork` and a unit test:
+
+- `tests/unit/bitcoin/getScureNetwork.test.ts`:
+  - For `transfer.ts`'s `getScureNetwork`: each valid network returns the
+    expected `@scure` network object; an unknown value (`'bogus' as any`,
+    `undefined as any`) **throws** with a message mentioning the value. This
+    test fails before the fix (returns `btc.NETWORK` silently) and passes after.
+  - Same assertions for `transactions/commit.ts`'s `getScureNetwork`.
+
+## Out of scope
+
+The duplication of `getScureNetwork`/`REGTEST_NETWORK` across the two modules is
+pre-existing tech debt; consolidating them into one shared helper is a separate
+refactor and is not required to close this safety defect.


### PR DESCRIPTION
## Summary
Both `getScureNetwork` implementations (`transfer.ts` and `transactions/commit.ts`) had a `default: return btc.NETWORK` (mainnet) fallback. Although the parameter is a union type, that branch is reachable at runtime via type coercion or external/dynamic data, silently assuming mainnet (real funds) for any unrecognized value.

This replaces the silent fallback with an exhaustive `never` check that throws an Error naming the offending network, making any future addition to the network union a compile error until explicitly handled.

## Changes
- `packages/sdk/src/bitcoin/transactions/commit.ts`: exhaustive never-check + named export for testability
- `packages/sdk/src/bitcoin/transfer.ts`: same
- `packages/sdk/tests/unit/bitcoin/getScureNetwork.test.ts`: regression tests (fail before, pass after)
- plan `029-getscurenetwork-reject-unknown-network.md`

## Verification (immediately before merge, on branch rebased onto latest origin/main)
- `bunx tsc --noEmit`: 0 errors
- `bun run build`: 2/2 successful
- `bun run test`: SDK 2487 pass / 0 fail, auth 167 pass / 0 fail (0 failures across all suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `getScureNetwork` to throw on unknown network instead of defaulting to mainnet
> - Both [`commit.ts`](https://github.com/onionoriginals/sdk/pull/195/files#diff-b6174e7b8349705e25b5d4b9b99b1ebc9986a41e30826d89895deda0fec46da0) and [`transfer.ts`](https://github.com/onionoriginals/sdk/pull/195/files#diff-2f59be995819bcc2bec77056ac3369779a45745e6ef113fbd3e119a287d84f90) previously returned `btc.NETWORK` (mainnet) for any unrecognized input; they now throw an `Error` with the unsupported value in the message.
> - The default switch branch uses a `never`-typed variable for exhaustiveness checking, ensuring TypeScript catches unhandled cases at compile time.
> - Unit tests in [`getScureNetwork.test.ts`](https://github.com/onionoriginals/sdk/pull/195/files#diff-db82a65f17e3940bb3fadd639d02c995fc7e9c89a11e84f8e5a216d12c8b0a99) cover known network mappings and assert that unknown values (e.g. `'bogus'`, `undefined`, wrong casing) throw with an 'Unsupported Bitcoin network' message.
> - Behavioral Change: callers passing an unrecognized network string will now receive a thrown `Error` instead of silently operating on mainnet.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86b9ca2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->