### PR TITLE
fix(lifecycle): signWithKeyStore must skip revoked/compromised verification methods

### DIFF
--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -764,59 +764,92 @@ export class LifecycleManager {
     if (!this.keyStore) {
       throw new StructuredError('KEYSTORE_REQUIRED', 'KeyStore required for signing. Provide keyStore to LifecycleManager constructor or use an external signer.');
     }
-    
-    // Try to find a key in the keyStore for this DID
+
+    // Resolve the issuer DID document up front so we can consult the retirement
+    // status of each candidate verification method. After a key rotation or
+    // compromise recovery, KeyManager stamps the OLD verification methods with
+    // a `revoked`/`compromised` timestamp and appends the new active key LAST
+    // (document = [...retiredVMs, newActiveVM]). Selecting a VM without
+    // checking these fields would sign with a retired (possibly compromised)
+    // key, breaking the integrity of the provenance chain.
+    const didDoc = await this.didManager.resolveDID(issuer);
+    const docVms = Array.isArray(didDoc?.verificationMethod) ? didDoc!.verificationMethod : [];
+
+    // Normalize a VM id to its absolute form so keyStore lookups and document
+    // comparisons line up regardless of whether the document stored relative
+    // (`#frag`) ids.
+    const absoluteVmId = (id: string): string => (id.startsWith('#') ? `${issuer}${id}` : id);
+
+    // A candidate VM is usable unless the DID document explicitly marks it as
+    // retired. VM ids absent from the document (e.g. legacy keys only present
+    // in the keyStore) are not disqualified — only an explicit
+    // `revoked`/`compromised` timestamp retires a key.
+    const isRetiredVmId = (id: string): boolean => {
+      const abs = absoluteVmId(id);
+      const entry = docVms.find(vm => absoluteVmId(vm.id) === abs);
+      return !!entry && (!!entry.revoked || !!entry.compromised);
+    };
+
+    let privateKey: string | null = null;
+    let vmId: string | null = null;
+
+    const tryCandidate = async (candidateVmId: string): Promise<boolean> => {
+      if (isRetiredVmId(candidateVmId)) {
+        return false;
+      }
+      const key = await this.keyStore!.getPrivateKey(candidateVmId);
+      if (key) {
+        privateKey = key;
+        vmId = candidateVmId;
+        return true;
+      }
+      return false;
+    };
+
     // First try common verification method patterns: #key-0, #keys-1, etc.
     const commonVmIds = [
       `${issuer}#key-0`,
       `${issuer}#keys-1`,
       `${issuer}#authentication`,
     ];
-    
-    let privateKey: string | null = null;
-    let vmId: string | null = null;
-    
+
     for (const testVmId of commonVmIds) {
-      const key = await this.keyStore.getPrivateKey(testVmId);
-      if (key) {
-        privateKey = key;
-        vmId = testVmId;
+      if (await tryCandidate(testVmId)) {
         break;
       }
     }
-    
-    // If not found, try to find ANY key that starts with the issuer DID
+
+    // If not found, try to find ANY active key that starts with the issuer DID
     const keyStoreWithGetAll = this.keyStore as { getAllVerificationMethodIds?: () => string[] };
     if (!privateKey && typeof keyStoreWithGetAll.getAllVerificationMethodIds === 'function') {
       const allVmIds = keyStoreWithGetAll.getAllVerificationMethodIds();
       for (const testVmId of allVmIds) {
-        if (testVmId.startsWith(issuer)) {
-          const key = await this.keyStore.getPrivateKey(testVmId);
-          if (key) {
-            privateKey = key;
-            vmId = testVmId;
-            break;
-          }
+        if (testVmId.startsWith(issuer) && (await tryCandidate(testVmId))) {
+          break;
         }
       }
     }
-    
-    // If no key found in common patterns, try resolving the DID
+
+    // If no key found in common patterns / keyStore scan, fall back to the DID
+    // document. Select the first ACTIVE verification method (skipping retired
+    // ones), never blindly verificationMethod[0].
     if (!privateKey) {
-      const didDoc = await this.didManager.resolveDID(issuer);
-      if (!didDoc?.verificationMethod?.[0]) {
+      if (docVms.length === 0) {
         throw new StructuredError('INVALID_DID_DOCUMENT', 'No verification method found in publisher DID document. Ensure the DID document includes at least one verificationMethod.');
       }
-      
-      vmId = didDoc.verificationMethod[0].id;
-      if (vmId.startsWith('#')) {
-        vmId = `${issuer}${vmId}`;
+
+      const activeVm = docVms.find(vm => !vm.revoked && !vm.compromised);
+      if (!activeVm) {
+        throw new StructuredError('INVALID_DID_DOCUMENT', 'No active verification method found in publisher DID document. All verification methods have been revoked or marked compromised; rotate to a new key before signing.');
       }
-      
-      privateKey = await this.keyStore.getPrivateKey(vmId);
-      if (!privateKey) {
+
+      const candidateVmId = absoluteVmId(activeVm.id);
+      const key = await this.keyStore.getPrivateKey(candidateVmId);
+      if (!key) {
         throw new StructuredError('KEYSTORE_REQUIRED', 'Private key not found in keyStore. Register the key with lifecycle.registerKey() before signing.');
       }
+      privateKey = key;
+      vmId = candidateVmId;
     }
 
     if (!vmId) {

--- a/packages/sdk/tests/unit/lifecycle/LifecycleManager.keymanagement.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/LifecycleManager.keymanagement.test.ts
@@ -242,6 +242,106 @@ describe('LifecycleManager Key Management', () => {
     });
   });
 
+  describe('Revoked / compromised verification method selection (regression for plan 030)', () => {
+    // After a key rotation/recovery, KeyManager places retired keys FIRST and
+    // the new active key LAST in the DID document. signWithKeyStore must select
+    // the active key, never blindly verificationMethod[0].
+    async function buildRotatedDoc(retireField: 'revoked' | 'compromised') {
+      const keyManager = new KeyManager();
+      const oldKeyPair = await keyManager.generateKeyPair('Ed25519');
+      const newKeyPair = await keyManager.generateKeyPair('Ed25519');
+
+      const oldVmId = `${publisherDid}#key-0`;
+      const newVmId = `${publisherDid}#key-1`;
+
+      const didDoc = {
+        '@context': ['https://www.w3.org/ns/did/v1'],
+        id: publisherDid,
+        verificationMethod: [
+          {
+            id: oldVmId,
+            type: 'Multikey',
+            controller: publisherDid,
+            publicKeyMultibase: oldKeyPair.publicKey,
+            [retireField]: '2024-01-01T00:00:00Z'
+          },
+          {
+            id: newVmId,
+            type: 'Multikey',
+            controller: publisherDid,
+            publicKeyMultibase: newKeyPair.publicKey
+          }
+        ]
+      };
+
+      // Fresh keyStore that holds BOTH keys: the retired key is still present
+      // (it was registered before rotation) alongside the new active key. The
+      // old key is inserted FIRST so a naive "first match" scan would pick it.
+      const rotatedKeyStore = new MockKeyStore();
+      await rotatedKeyStore.setPrivateKey(oldVmId, oldKeyPair.privateKey);
+      await rotatedKeyStore.setPrivateKey(newVmId, newKeyPair.privateKey);
+
+      const lm = new LifecycleManager(config, didManager, credentialManager, undefined, rotatedKeyStore);
+      // Stub resolution to return the rotated document.
+      (didManager as any).resolveDID = async () => didDoc;
+
+      return { lm, oldVmId, newVmId };
+    }
+
+    test('should NOT sign with a revoked verificationMethod[0]', async () => {
+      const { lm, oldVmId, newVmId } = await buildRotatedDoc('revoked');
+      const asset = await lm.createAsset(resources);
+      const published = await lm.publishToWeb(asset, publisherDid);
+
+      expect(published.credentials.length).toBe(1);
+      const proof = published.credentials[0].proof as any;
+      expect(proof.verificationMethod).toBe(newVmId);
+      expect(proof.verificationMethod).not.toBe(oldVmId);
+    });
+
+    test('should NOT sign with a compromised verificationMethod[0]', async () => {
+      const { lm, oldVmId, newVmId } = await buildRotatedDoc('compromised');
+      const asset = await lm.createAsset(resources);
+      const published = await lm.publishToWeb(asset, publisherDid);
+
+      expect(published.credentials.length).toBe(1);
+      const proof = published.credentials[0].proof as any;
+      expect(proof.verificationMethod).toBe(newVmId);
+      expect(proof.verificationMethod).not.toBe(oldVmId);
+    });
+
+    test('should still sign when the only verification method is active (no over-rejection)', async () => {
+      const keyManager = new KeyManager();
+      const activeKeyPair = await keyManager.generateKeyPair('Ed25519');
+      const activeVmId = `${publisherDid}#key-0`;
+
+      const didDoc = {
+        '@context': ['https://www.w3.org/ns/did/v1'],
+        id: publisherDid,
+        verificationMethod: [
+          {
+            id: activeVmId,
+            type: 'Multikey',
+            controller: publisherDid,
+            publicKeyMultibase: activeKeyPair.publicKey
+          }
+        ]
+      };
+
+      const activeKeyStore = new MockKeyStore();
+      await activeKeyStore.setPrivateKey(activeVmId, activeKeyPair.privateKey);
+      const lm = new LifecycleManager(config, didManager, credentialManager, undefined, activeKeyStore);
+      (didManager as any).resolveDID = async () => didDoc;
+
+      const asset = await lm.createAsset(resources);
+      const published = await lm.publishToWeb(asset, publisherDid);
+
+      expect(published.credentials.length).toBe(1);
+      const proof = published.credentials[0].proof as any;
+      expect(proof.verificationMethod).toBe(activeVmId);
+    });
+  });
+
   describe('Key rotation scenario', () => {
     test('should allow registering multiple keys for different verification methods', async () => {
       const keyManager = new KeyManager();

--- a/plans/030-signwithkeystore-skip-retired-vm.md
+++ b/plans/030-signwithkeystore-skip-retired-vm.md
@@ -1,0 +1,88 @@
+# Plan 030: signWithKeyStore must not select a revoked / compromised verification method
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving on. Touch
+> only the files listed as in scope. If a STOP condition occurs, stop and
+> report. Commit on the worktree branch. SKIP updating `plans/README.md` — the
+> reviewer maintains the index.
+
+## Status
+
+- **Priority**: P0 (high)
+- **Effort**: S
+- **Risk**: LOW
+- **Category**: security / correctness
+- **Branch**: `correctness/round1-0-vmselect` (from `origin/main`)
+- **Target file**: `packages/sdk/src/lifecycle/LifecycleManager.ts`
+
+## Why this matters
+
+`LifecycleManager.signWithKeyStore()` (issuing migration / provenance
+credentials) selects the verification method to sign with. When no key matches
+the common patterns (`#key-0`, `#keys-1`, `#authentication`) and no keyStore VM
+id prefixed by the issuer is found, it falls back to resolving the issuer's DID
+document and **blindly picks `verificationMethod[0]`** (lines ~805-820).
+
+The `VerificationMethod` type (`src/types/did.ts`) carries optional `revoked`
+and `compromised` ISO-8601 timestamps. `KeyManager.rotateKeys()` /
+`recoverFromCompromise()` stamp the OLD keys with those fields and build the
+document as `[...retiredVerificationMethods, newActiveVerificationMethod]` —
+i.e. after any rotation or compromise recovery, the **retired key sits at index
+0 and the current active key is last**.
+
+So after a single rotation, `verificationMethod[0]` is exactly the revoked /
+compromised key. Signing a credential with it means the provenance chain is
+anchored to a retired (possibly attacker-held) key, breaking integrity and
+permitting forgery with a key that was deliberately retired. The same blind
+"first match" defect exists in the keyStore prefix-scan fallback (it returns the
+first stored id that starts with the issuer DID, with no revocation check).
+
+This mirrors the fix already shipped for the CEL key resolver in plan 025
+(`src/cel/keyResolver.ts` fails closed on `revoked || compromised`).
+
+## The fix (minimal, correct)
+
+Make verification-method selection in `signWithKeyStore` revocation-aware:
+
+1. Resolve the issuer DID document up front so the retirement status of each
+   candidate VM is known.
+2. Treat a verification method as usable only if its DID-document entry is
+   **active** (no `revoked` and no `compromised` timestamp). VM ids not present
+   in the document (e.g. legacy keys only in the keyStore) remain usable —
+   only an explicit retirement disqualifies a key.
+3. When falling back to the DID document, select the **first active**
+   verification method instead of `verificationMethod[0]`. If every VM is
+   retired, fail closed with a clear `INVALID_DID_DOCUMENT` error rather than
+   signing with a retired key.
+
+Keep the common-pattern and prefix-scan fast paths, but gate each candidate
+through the active-VM check before accepting it.
+
+## In scope
+
+- `packages/sdk/src/lifecycle/LifecycleManager.ts` — revocation-aware VM
+  selection in `signWithKeyStore`.
+- `packages/sdk/tests/unit/lifecycle/LifecycleManager.keymanagement.test.ts` —
+  new regression test (fails before, passes after).
+
+## Regression test
+
+Construct a DID document with two Ed25519 verification methods where index 0 is
+`revoked` (and a second variant where index 0 is `compromised`) and index 1 is
+active. Store ONLY the active key in the keyStore under its full VM id, and stub
+`didManager.resolveDID` to return that document. Sign via the publish path and
+assert the resulting proof's `verificationMethod` is the active (index-1) VM,
+never the retired index-0 one. Add a guard asserting the single-active-VM case
+still signs correctly (no over-rejection).
+
+## Verification (run at repo root unless noted)
+
+```
+bun install --frozen-lockfile || bun install
+bunx tsc --noEmit          # 0 errors
+bun run build              # succeeds
+bun run test               # SDK + auth suites 0-fail
+```
+
+STOP conditions: any tsc error, build failure, or a previously-passing test
+regressing.


### PR DESCRIPTION
## Summary

`signWithKeyStore` selected the verification method used to sign provenance credentials, but the DID-document fallback blindly used `verificationMethod[0]` and the keyStore prefix scan returned the first matching id, neither consulting the VM's revoked/compromised status.

After a key rotation or compromise recovery, `KeyManager` retires the old VMs (stamping revoked/compromised) and appends the new active key LAST (`document = [...retiredVMs, newActiveVM]`). So `verificationMethod[0]` is exactly the retired key, and signing with it anchored the provenance chain to a possibly-compromised key, enabling forgery with a retired key.

## Fix

Make VM selection revocation-aware: gate every candidate (common patterns, keyStore prefix scan, and DID-document fallback) through an active-VM check, select the first ACTIVE verification method, and fail closed with `INVALID_DID_DOCUMENT` when all VMs are retired. VM ids not present in the resolved document remain usable; only an explicit revoked/compromised timestamp disqualifies a key. Mirrors plan 025's fail-closed fix in the CEL key resolver.

## Verification

Rebased onto latest origin/main, then ran the full green invariant:
- `bunx tsc --noEmit` / `bun run typecheck`: 0 errors
- `bun run build`: succeeds
- `bun run test`: SDK 2493 pass / 0 fail, auth 167 pass / 0 fail

Plan: `plans/030-signwithkeystore-skip-retired-vm.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `signWithKeyStore` to skip revoked and compromised verification methods
> - `LifecycleManager.signWithKeyStore` now resolves the issuer DID document and classifies any VM with a `revoked` or `compromised` timestamp as retired before selecting a signing key.
> - Adds `isRetiredVmId` and `tryCandidate` helpers in [LifecycleManager.ts](https://github.com/onionoriginals/sdk/pull/197/files#diff-f7ee48c88de9ace2f72662a51534f0bbb19607128b3c2178416d1b28c87fc9e8) to filter retired VMs from both the common probe loop and the keyStore prefix-scan fallback.
> - The DID-document fallback now selects the first active VM and throws explicitly if all VMs are retired or if the active VM's key is missing from the keyStore.
> - Regression tests covering revoked, compromised, and single-active-VM scenarios are added in [LifecycleManager.keymanagement.test.ts](https://github.com/onionoriginals/sdk/pull/197/files#diff-8f939bea5d1e0bf92b6401d1c06294e11222de347eba1a656da403e4f582a2ee).
> - Behavioral Change: previously, signing could silently use a revoked or compromised VM; it now errors if no active VM is available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b85948.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->