### PR TITLE
fix(sdk): validate changeAddress against network in createCommitTransaction

### DIFF
--- a/packages/sdk/src/bitcoin/transactions/commit.ts
+++ b/packages/sdk/src/bitcoin/transactions/commit.ts
@@ -13,6 +13,7 @@ import { schnorr } from '@noble/curves/secp256k1';
 import { Utxo, ResourceUtxo } from '../../types/bitcoin.js';
 import { calculateFee } from '../fee-calculation.js';
 import { selectUtxos, SimpleUtxoSelectionOptions } from '../utxo-selection.js';
+import { validateBitcoinAddress } from '../../utils/bitcoin-address.js';
 
 // Define minimum dust limit (satoshis)
 const MIN_DUST_LIMIT = 546;
@@ -187,6 +188,16 @@ export async function createCommitTransaction(
   if (!changeAddress) {
     throw new Error('Change address is required.');
   }
+
+  // Fail fast: validate the change address against the target network BEFORE any
+  // expensive UTXO selection / fee calculation runs. Without this, a wrong-network
+  // address (e.g. a testnet address on mainnet) is only rejected late inside
+  // tx.addOutputAddress() with a cryptic @scure error, after work has been wasted.
+  // Mirrors buildTransferTransaction in ../transfer.ts. validateBitcoinAddress
+  // accepts 'mainnet' | 'regtest' | 'signet'; testnet shares signet's prefix.
+  const validateNetwork: 'mainnet' | 'regtest' | 'signet' =
+    network === 'testnet' ? 'signet' : network;
+  validateBitcoinAddress(changeAddress, validateNetwork);
 
   if (feeRate <= 0) {
     throw new Error(`Invalid fee rate: ${feeRate}`);

--- a/packages/sdk/tests/unit/bitcoin/transactions/commit.test.ts
+++ b/packages/sdk/tests/unit/bitcoin/transactions/commit.test.ts
@@ -372,6 +372,37 @@ describe('createCommitTransaction', () => {
       await expect(createCommitTransaction(params)).rejects.toThrow(/Change address is required/);
     });
 
+    test('rejects a wrong-network changeAddress with a clear error', async () => {
+      // mainnet network but a testnet/signet (tb1...) change address.
+      const params = createCommitParams({
+        network: 'mainnet',
+        changeAddress: 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx'
+      });
+      await expect(createCommitTransaction(params)).rejects.toThrow(/Invalid .*address|address/i);
+    });
+
+    test('rejects a mainnet changeAddress on signet with a clear error', async () => {
+      const params = createCommitParams({
+        network: 'signet',
+        changeAddress: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4'
+      });
+      await expect(createCommitTransaction(params)).rejects.toThrow(/Invalid .*address|address/i);
+    });
+
+    test('fail-fast: wrong-network changeAddress rejected before UTXO selection', async () => {
+      // Provide structurally invalid UTXOs alongside a wrong-network address.
+      // If validation is fail-fast (at entry), the address error is thrown
+      // BEFORE the UTXO-selection error — proving no expensive work ran first.
+      const params = createCommitParams({
+        network: 'mainnet',
+        changeAddress: 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx',
+        utxos: [createUtxo(10000, 0)]
+      });
+      // Must throw an address error, not an insufficient-funds / UTXO error.
+      await expect(createCommitTransaction(params)).rejects.toThrow(/address/i);
+      await expect(createCommitTransaction(params)).rejects.not.toThrow(/Insufficient funds|No valid spendable/);
+    });
+
     test('throws when feeRate is invalid', async () => {
       const params = createCommitParams({ feeRate: 0 });
       await expect(createCommitTransaction(params)).rejects.toThrow(/Invalid fee rate/);

--- a/plans/030-commit-validate-changeaddress-network.md
+++ b/plans/030-commit-validate-changeaddress-network.md
@@ -1,0 +1,98 @@
+# Plan 030: Validate changeAddress against network in createCommitTransaction
+
+> **Executor instructions**: Follow step by step. Run every verification command
+> and confirm the expected result before moving on. Touch only in-scope files.
+> If a STOP condition occurs, stop and report. Commit on the worktree branch
+> (conventional commit; `--no-verify` if the commitlint hook lacks deps — note it).
+> SKIP updating `plans/README.md` — the reviewer maintains the index.
+
+## Worktree setup (REQUIRED FIRST)
+
+Worktree branches from `origin/main` (`correctness/round1-2-commit-changeaddr`).
+At the worktree root:
+1. `bun install --frozen-lockfile || bun install`.
+2. Baseline: `bunx tsc --noEmit` → exit 0; `bun run test` → existing suites pass.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: S
+- **Risk**: LOW
+- **Category**: correctness / fail-fast validation
+- **Planned at**: `origin/main` @ `bb8a1f3`, 2026-06-23
+
+## Why this matters
+
+`createCommitTransaction` in
+`packages/sdk/src/bitcoin/transactions/commit.ts` accepts a `changeAddress`
+parameter but only checks that it is non-empty (line ~187, `if (!changeAddress)`).
+It does NOT validate the address against the configured `network`. The address
+is only implicitly validated late at `tx.addOutputAddress(changeAddress, ...)`
+(line ~480), which decodes it via `@scure/btc-signer`.
+
+Consequences of the missing fail-fast validation:
+
+1. A wrong-network address (e.g. a mainnet `bc1...` address passed on a
+   `testnet`/`signet`/`regtest` flow, or vice versa) is not rejected until after
+   the expensive work — UTXO filtering, iterative UTXO selection, and repeated
+   fee calculation — has already run. This is wasted computation and a
+   resource-exhaustion lever for an attacker who can supply addresses.
+2. The eventual error from `@scure/btc-signer`'s address decoder is cryptic and
+   does not clearly state that the address is wrong for the network.
+3. It is inconsistent with `buildTransferTransaction` in
+   `packages/sdk/src/bitcoin/transfer.ts` (lines 97-98), which validates the
+   `changeAddress` at function entry using `validateBitcoinAddress()`. This
+   inconsistency is a maintenance hazard.
+
+## Scope (files to change)
+
+- `packages/sdk/src/bitcoin/transactions/commit.ts` — import
+  `validateBitcoinAddress` and call it at function entry, mapping the
+  `BitcoinNetwork` (`mainnet | testnet | regtest | signet`) to the
+  `validateBitcoinAddress` network type (`mainnet | regtest | signet`) exactly
+  as `transfer.ts` does (`testnet` → `signet`).
+- `packages/sdk/tests/unit/bitcoin/transactions/commit.test.ts` — add a
+  regression test asserting a wrong-network `changeAddress` is rejected early
+  with a clear error, plus a test confirming a correctly-networked address still
+  succeeds (already covered by existing tests, but add an explicit assertion).
+
+## Implementation
+
+1. Add the import at the top of `commit.ts`:
+   ```ts
+   import { validateBitcoinAddress } from '../../utils/bitcoin-address.js';
+   ```
+2. Immediately after the existing `if (!changeAddress) { ... }` presence check,
+   validate against the network (mirroring `transfer.ts`):
+   ```ts
+   // Fail fast: validate the change address for the target network BEFORE any
+   // expensive UTXO selection / fee calculation. validateBitcoinAddress accepts
+   // 'mainnet' | 'regtest' | 'signet'; testnet shares signet's prefix.
+   const validateNetwork: 'mainnet' | 'regtest' | 'signet' =
+     network === 'testnet' ? 'signet' : network;
+   validateBitcoinAddress(changeAddress, validateNetwork);
+   ```
+   Place it after the `feeRate` check (keep all input validation together,
+   before UTXO filtering).
+
+## Verification (must all pass)
+
+From the worktree checkout root:
+
+```
+bun install --frozen-lockfile || bun install
+bunx tsc --noEmit            # 0 errors
+bun run build                # succeeds
+bun run test                 # SDK + auth suites 0-fail
+```
+
+Regression-specific: the new "rejects a wrong-network changeAddress before UTXO
+selection" test fails on pre-fix code (the wrong-network address slips past the
+presence check and only fails later, or with a cryptic `@scure` error) and
+passes after (clear `Invalid ... address` error thrown at entry).
+
+## STOP conditions
+
+- If `createCommitTransaction` already calls `validateBitcoinAddress` (or
+  otherwise validates `changeAddress` against the network) at function entry on
+  `origin/main`, STOP — already resolved.


### PR DESCRIPTION
## Summary
`createCommitTransaction` only checked the change address for presence, deferring network validation to `tx.addOutputAddress()` deep in transaction construction. A wrong-network address (e.g. a testnet address on mainnet) was therefore only rejected after expensive UTXO selection and fee calculation, surfacing a cryptic `@scure` error -- a resource-exhaustion lever and an operator footgun.

This adds a fail-fast `validateBitcoinAddress()` call at function entry, mirroring `buildTransferTransaction` in `transfer.ts` (testnet maps to signet for validation).

## Tests
Adds regression tests asserting wrong-network change addresses are rejected early with a clear error, before UTXO selection runs.

## Verification (green invariant, run immediately before merge)
- `bunx tsc --noEmit`: 0 errors
- `bun run build`: success (@originals/sdk + @originals/auth)
- `bun run test`: 0 fail (SDK 2496 + 192, auth 167)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate `changeAddress` against network in `createCommitTransaction`
> Adds an early network validation check for `changeAddress` in [`createCommitTransaction`](https://github.com/onionoriginals/sdk/pull/198/files#diff-b6174e7b8349705e25b5d4b9b99b1ebc9986a41e30826d89895deda0fec46da0) using `validateBitcoinAddress`. The function now throws immediately on wrong-network or malformed addresses before UTXO selection and fee calculation. `testnet` is mapped to `signet` for the validator's accepted network set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b06e78.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->