### PR TITLE
fix(events): align MigrationFailedEvent.error with emitted MigrationError

### DIFF
--- a/packages/sdk/src/events/types.ts
+++ b/packages/sdk/src/events/types.ts
@@ -8,6 +8,7 @@
  */
 
 import { LayerType } from '../types';
+import type { MigrationError } from '../migration/types';
 
 /**
  * Base event interface that all events extend
@@ -240,7 +241,16 @@ export interface MigrationCompletedEvent extends BaseEvent {
 export interface MigrationFailedEvent extends BaseEvent {
   type: 'migration:failed';
   migrationId: string;
-  error: Error | { message: string; code?: string };
+  /**
+   * The structured migration error emitted by MigrationManager.
+   *
+   * This is the exact `MigrationError` payload constructed in
+   * `MigrationManager.handleMigrationError` and passed to
+   * `emitEvent('migration:failed', ...)`. Subscribers receive this full
+   * structured shape (type/code/message/timestamp + optional details),
+   * not a bare `Error` instance.
+   */
+  error: MigrationError;
 }
 
 /**
@@ -330,3 +340,27 @@ export interface EventTypeMap {
   'migration:rolledback': MigrationRolledbackEvent;
   'migration:quarantine': MigrationQuarantineEvent;
 }
+
+/**
+ * Compile-time contract guard against event payload drift.
+ *
+ * `MigrationFailedEvent.error` MUST stay structurally identical to the
+ * `MigrationError` object that `MigrationManager.handleMigrationError`
+ * actually emits. If the two ever diverge, one of the `AssertEqual`
+ * checks below resolves to `never` and `tsc --noEmit` fails — surfacing
+ * the drift at build time instead of at runtime for subscribers.
+ *
+ * Regression for: plans/030-migration-failed-event-error-type-contract.md
+ */
+type AssertExtends<A, B> = A extends B ? true : never;
+type _MigrationFailedErrorIsMigrationError =
+  AssertExtends<MigrationFailedEvent['error'], MigrationError>;
+type _MigrationErrorIsMigrationFailedError =
+  AssertExtends<MigrationError, MigrationFailedEvent['error']>;
+
+// These constants force evaluation of the conditional types above.
+const _assertMigrationFailedErrorContract: [
+  _MigrationFailedErrorIsMigrationError,
+  _MigrationErrorIsMigrationFailedError
+] = [true, true];
+void _assertMigrationFailedErrorContract;

--- a/packages/sdk/tests/unit/events/EventContracts.test.ts
+++ b/packages/sdk/tests/unit/events/EventContracts.test.ts
@@ -22,6 +22,8 @@ import type {
   MigrationQuarantineEvent,
   OriginalsEvent,
 } from '../../../src/events/types';
+import type { MigrationError } from '../../../src/migration/types';
+import { MigrationErrorType } from '../../../src/migration/types';
 
 /**
  * Golden contract tests for event payload shapes.
@@ -348,10 +350,46 @@ describe('Event contract tests — exact payload shapes', () => {
       type: 'migration:failed' as const,
       timestamp,
       migrationId: 'mig-1',
-      error: { message: 'DID resolution failed', code: 'DID_RESOLVE_ERROR' },
+      // The emitter (MigrationManager.handleMigrationError) emits a
+      // MigrationError, so the contract must accept that exact shape.
+      error: {
+        type: MigrationErrorType.UNKNOWN_ERROR,
+        code: 'DID_RESOLVE_ERROR',
+        message: 'DID resolution failed',
+        timestamp: Date.now(),
+      } satisfies MigrationError,
     } satisfies MigrationFailedEvent;
 
     expect(sortedKeys(event)).toEqual(['error', 'migrationId', 'timestamp', 'type']);
+  });
+
+  test('MigrationFailedEvent.error accepts the full MigrationError payload emitted by MigrationManager', () => {
+    // This mirrors the object constructed at MigrationManager.ts (handleMigrationError),
+    // which is what is actually passed to emitEvent('migration:failed', ...).
+    const migrationError: MigrationError = {
+      type: MigrationErrorType.UNKNOWN_ERROR,
+      code: 'MIGRATION_FAILED',
+      message: 'boom',
+      technicalDetails: 'stack trace here',
+      suggestedRecovery: 'retry',
+      migrationId: 'mig-1',
+      sourceDid: 'did:peer:abc',
+      targetDid: 'did:webvh:example.com:abc',
+      timestamp: Date.now(),
+      stack: 'Error: boom\n  at ...',
+    };
+
+    const event = {
+      type: 'migration:failed' as const,
+      timestamp,
+      migrationId: 'mig-1',
+      error: migrationError,
+    } satisfies MigrationFailedEvent;
+
+    // The contract field must surface MigrationError-specific properties.
+    expect(event.error.type).toBe(MigrationErrorType.UNKNOWN_ERROR);
+    expect(event.error.code).toBe('MIGRATION_FAILED');
+    expect(typeof event.error.timestamp).toBe('number');
   });
 
   test('MigrationRolledbackEvent has exactly the declared fields', () => {

--- a/plans/030-migration-failed-event-error-type-contract.md
+++ b/plans/030-migration-failed-event-error-type-contract.md
@@ -1,0 +1,65 @@
+# 030 - Fix MigrationFailedEvent.error type contract drift
+
+## Finding
+
+[high] Event payload contract drift: `MigrationFailedEvent.error` type mismatch.
+
+`MigrationFailedEvent` (in `packages/sdk/src/events/types.ts`) declares:
+
+```ts
+error: Error | { message: string; code?: string };
+```
+
+But the actual emitter at `MigrationManager.ts:400` emits a `MigrationError`
+object (see `packages/sdk/src/migration/types.ts:166`) with fields:
+`type`, `code`, `message`, `technicalDetails?`, `suggestedRecovery?`,
+`migrationId?`, `sourceDid?`, `targetDid?`, `timestamp`, `stack?`.
+
+This is a contract drift: subscribers typed against the interface receive an
+object with unexpected fields, and key shape differences (e.g. `code` is
+declared optional but is always present as a required `string` on
+`MigrationError`; `type`/`timestamp` are required on `MigrationError` but absent
+from the declared union). A subscriber relying on an `error instanceof Error`
+check would also be misled — the runtime value is a plain object, never an
+`Error` instance.
+
+## Root cause
+
+The event interface was authored independently of the emitter and was never
+aligned with the real `MigrationError` payload that `MigrationManager`
+constructs and emits.
+
+## Fix (minimal, correct)
+
+Change `MigrationFailedEvent.error` to be typed as the actual emitted payload,
+`MigrationError`, imported from `../migration/types`. This makes the declared
+event contract match the implementation exactly, restoring type safety for
+event handlers.
+
+```ts
+import type { MigrationError } from '../migration/types';
+
+export interface MigrationFailedEvent extends BaseEvent {
+  type: 'migration:failed';
+  migrationId: string;
+  error: MigrationError;
+}
+```
+
+## Regression test
+
+Add a test in `packages/sdk/tests/unit/events/EventContracts.test.ts` (the
+existing golden-contract suite) that constructs the *actual* `MigrationError`
+payload shape that `MigrationManager` emits and asserts (via `satisfies
+MigrationFailedEvent`) that it is assignable to the event interface. Before the
+fix this fails to type-check (`tsc --noEmit` errors); after the fix it passes.
+The existing "exactly the declared fields" test for `MigrationFailedEvent` is
+updated to use the real `MigrationError` shape.
+
+## Green invariant
+
+```
+bunx tsc --noEmit   # 0 errors
+bun run build       # succeeds
+bun run test        # 0 failures
+```


### PR DESCRIPTION
## Summary
`MigrationFailedEvent.error` declared `Error | { message; code? }` but `MigrationManager.handleMigrationError` emits a full `MigrationError` (type/code/message/timestamp + optional details). Subscribers typed against the interface could not access the real fields and could be misled into an `error instanceof Error` check that never holds.

This types `error` as `MigrationError` to match the actual emitted payload, adds a compile-time contract guard (enforced by tsc/build), and updates the golden contract tests so future drift fails the build.

Plan: `plans/030-migration-failed-event-error-type-contract.md`

## Verification
- `bunx tsc --noEmit`: 0 errors
- `bun run build`: success
- `bun run test`: SDK + auth suites 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `MigrationFailedEvent.error` type to match the `MigrationError` emitted by `MigrationManager`
> - Changes the `error` field in `MigrationFailedEvent` from `Error | { message: string; code?: string }` to `MigrationError` in [types.ts](https://github.com/onionoriginals/sdk/pull/199/files#diff-b126ee623b4feaec59bbba1e48980fb8568938b1116a5a3c76f786a965f9cca9) to reflect what `MigrationManager.handleMigrationError` actually emits.
> - Adds compile-time contract guards using conditional types to make any future type drift a build error.
> - Adds unit tests in [EventContracts.test.ts](https://github.com/onionoriginals/sdk/pull/199/files#diff-1718bcecb5e3f96284e29f09ea772af7b72a6581ceb49cdce47b38bf754f6352) that construct a full `MigrationError` payload (including optional fields) and assert it satisfies `MigrationFailedEvent`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ce5bdc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->