### PR TITLE
fix(sdk): remove unnecessary non-null assertion blocking lint gate on main

### DIFF
--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -773,7 +773,7 @@ export class LifecycleManager {
     // checking these fields would sign with a retired (possibly compromised)
     // key, breaking the integrity of the provenance chain.
     const didDoc = await this.didManager.resolveDID(issuer);
-    const docVms = Array.isArray(didDoc?.verificationMethod) ? didDoc!.verificationMethod : [];
+    const docVms = Array.isArray(didDoc?.verificationMethod) ? didDoc.verificationMethod : [];
 
     // Normalize a VM id to its absolute form so keyStore lookups and document
     // comparisons line up regardless of whether the document stored relative


### PR DESCRIPTION
## Context

PR #170 (Originals audit 2026-06-11) was already merged into main on 2026-06-22, and ~15 follow-up fixes (#183-#199) landed on top. However main CI is currently **red** on the **Lint** job.

## Root cause

`packages/sdk/src/lifecycle/LifecycleManager.ts:776` (introduced by #197, signWithKeyStore revoked/compromised VM skipping) contained a redundant non-null assertion:

```ts
const docVms = Array.isArray(didDoc?.verificationMethod) ? didDoc!.verificationMethod : [];
```

The `Array.isArray(didDoc?.verificationMethod)` guard already narrows `didDoc` to non-null in the truthy branch, so `didDoc!` triggers `@typescript-eslint/no-unnecessary-type-assertion` (1 error). The lint gate became required in #191, so this single error keeps main CI red.

## Fix

Drop the redundant `!`. **No behavioral change** — the optional-chaining guard already guarantees non-null.

## Verification (clean origin/main + this fix)

- `bun run lint` (sdk): 0 errors (was 1), warnings only
- `bunx tsc --noEmit` / `turbo typecheck`: pass
- `bun run build`: 2/2 packages succeed
- `bun run test`: SDK 2497 tests, 0 fail; all 4 turbo test tasks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unnecessary non-null assertion in `LifecycleManager` DID resolution
> Replaces `didDoc!.verificationMethod` with `didDoc.verificationMethod` in [LifecycleManager.ts](https://github.com/onionoriginals/sdk/pull/200/files#diff-f7ee48c88de9ace2f72662a51534f0bbb19607128b3c2178416d1b28c87fc9e8), relying on the existing `Array.isArray(didDoc?.verificationMethod)` guard instead. This fixes a lint error blocking the main branch gate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b21e6be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->