### PR TITLE
fix(auth): reject non-64-byte Ed25519 signatures in TurnkeyWebVHSigner

### DIFF
--- a/packages/auth/src/server/turnkey-signer.ts
+++ b/packages/auth/src/server/turnkey-signer.ts
@@ -91,12 +91,15 @@ export class TurnkeyWebVHSigner implements ExternalSigner, ExternalVerifier {
 
       // Convert signature to bytes
       const cleanSig = signature.startsWith('0x') ? signature.slice(2) : signature;
-      let signatureBytes = Buffer.from(cleanSig, 'hex');
+      const signatureBytes = Buffer.from(cleanSig, 'hex');
 
-      // Ed25519 signatures should be exactly 64 bytes
-      if (signatureBytes.length === 65) {
-        signatureBytes = signatureBytes.slice(0, 64);
-      } else if (signatureBytes.length !== 64) {
+      // Ed25519 signatures must be exactly 64 bytes (32-byte r + 32-byte s).
+      // Never truncate: a 65-byte value is not a valid Ed25519 signature with a
+      // spare byte, and silently slicing it would produce an invalid signature
+      // that is accepted/stored here but fails later verification (did:webvh
+      // resolution / credential validation). Reject anything that is not 64
+      // bytes, matching the client-side TurnkeyDIDSigner contract.
+      if (signatureBytes.length !== 64) {
         throw new Error(
           `Invalid Ed25519 signature length: ${signatureBytes.length} (expected 64 bytes)`
         );

--- a/packages/auth/tests/turnkey-signer.test.ts
+++ b/packages/auth/tests/turnkey-signer.test.ts
@@ -89,6 +89,76 @@ describe('turnkey-signer', () => {
       ).rejects.toThrow('Failed to sign with Turnkey');
     });
 
+    test('sign rejects a 65-byte signature instead of silently truncating it', async () => {
+      // 32-byte r + 33-byte s = 65 bytes total. A valid Ed25519 signature is
+      // exactly 64 bytes; the server signer must reject (not truncate) this,
+      // matching the client-side TurnkeyDIDSigner behaviour.
+      const r = '00'.repeat(32);
+      const s = '11'.repeat(33);
+      const mockClient = {
+        apiClient: () => ({
+          signRawPayload: mock(() =>
+            Promise.resolve({
+              activity: {
+                result: {
+                  signRawPayloadResult: { r, s },
+                },
+              },
+            })
+          ),
+        }),
+      } as unknown as import('@turnkey/sdk-server').Turnkey;
+
+      const signer = new TurnkeyWebVHSigner(
+        'sub_org_id',
+        'key_id',
+        'z6MkPubKey',
+        mockClient,
+        'did:key:z6Mk#z6Mk'
+      );
+
+      await expect(
+        signer.sign({
+          document: { id: 'did:example:123' },
+          proof: { type: 'DataIntegrityProof' },
+        })
+      ).rejects.toThrow(/65 \(expected 64 bytes\)/);
+    });
+
+    test('sign produces a proofValue for a valid 64-byte signature', async () => {
+      const r = 'aa'.repeat(32);
+      const s = 'bb'.repeat(32);
+      const mockClient = {
+        apiClient: () => ({
+          signRawPayload: mock(() =>
+            Promise.resolve({
+              activity: {
+                result: {
+                  signRawPayloadResult: { r, s },
+                },
+              },
+            })
+          ),
+        }),
+      } as unknown as import('@turnkey/sdk-server').Turnkey;
+
+      const signer = new TurnkeyWebVHSigner(
+        'sub_org_id',
+        'key_id',
+        'z6MkPubKey',
+        mockClient,
+        'did:key:z6Mk#z6Mk'
+      );
+
+      const result = await signer.sign({
+        document: { id: 'did:example:123' },
+        proof: { type: 'DataIntegrityProof' },
+      });
+
+      expect(typeof result.proofValue).toBe('string');
+      expect(result.proofValue.length).toBeGreaterThan(0);
+    });
+
     test('verify returns false for invalid public key length', async () => {
       const mockClient = {} as unknown as import('@turnkey/sdk-server').Turnkey;
       const signer = new TurnkeyWebVHSigner(

--- a/plans/031-turnkey-server-signer-reject-non64-signature.md
+++ b/plans/031-turnkey-server-signer-reject-non64-signature.md
@@ -1,0 +1,113 @@
+# Plan 031: Server-side `TurnkeyWebVHSigner` must reject non-64-byte Ed25519 signatures (no silent truncation)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. Make the minimal correct change plus a regression test that
+> fails before the fix and passes after.
+
+## Status
+
+- **Priority**: P0 (critical correctness / security)
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: bug
+- **Planned at**: origin/main commit `d2e51a4`, 2026-06-23
+
+## Why this matters
+
+`packages/auth/src/server/turnkey-signer.ts` (`TurnkeyWebVHSigner.sign`)
+silently truncates a 65-byte signature down to 64 bytes:
+
+```typescript
+// Ed25519 signatures should be exactly 64 bytes
+if (signatureBytes.length === 65) {
+  signatureBytes = signatureBytes.slice(0, 64);
+} else if (signatureBytes.length !== 64) {
+  throw new Error(
+    `Invalid Ed25519 signature length: ${signatureBytes.length} (expected 64 bytes)`
+  );
+}
+```
+
+An Ed25519 signature is exactly 64 bytes (32-byte `r` + 32-byte `s`). If
+Turnkey ever returns 65 bytes (e.g. a recovery id / encoding flag, or a
+different curve mis-routed to this signer), the value is **not** a valid
+Ed25519 signature with the last byte chopped off — truncating it produces an
+invalid signature that is nonetheless accepted, multibase-encoded, and stored
+in the did:webvh log / credential proof. Verification (during did:webvh
+resolution or credential validation) then fails on a proof that was already
+committed, destroying signature provenance: the user cannot prove ownership
+of their DID.
+
+This also breaks the `createTurnkeySigner` API contract by being
+**asymmetric** with the client-side signer. The client
+(`packages/auth/src/client/turnkey-did-signer.ts:83-87`) rejects anything that
+is not exactly 64 bytes:
+
+```typescript
+if (signatureBytes.length !== 64) {
+  throw new Error(
+    `Invalid Ed25519 signature length: ${signatureBytes.length} (expected 64 bytes)`
+  );
+}
+```
+
+Server and client paths produced by the same `createTurnkeySigner` factory
+must behave identically.
+
+## Current state
+
+- `packages/auth/src/server/turnkey-signer.ts:96-103` — truncates 65-byte
+  signatures (the bug).
+- `packages/auth/src/client/turnkey-did-signer.ts:83-87` — correctly rejects
+  any non-64-byte signature (reference behaviour).
+
+## The fix
+
+In `turnkey-signer.ts`, remove the `length === 65` truncation branch so the
+server signer rejects **any** signature that is not exactly 64 bytes, matching
+the client:
+
+```typescript
+// Ed25519 signatures must be exactly 64 bytes (32-byte r + 32-byte s).
+// Never truncate: a 65-byte value is not a valid Ed25519 signature with a
+// spare byte, and silently slicing it produces an invalid signature that
+// later fails verification.
+if (signatureBytes.length !== 64) {
+  throw new Error(
+    `Invalid Ed25519 signature length: ${signatureBytes.length} (expected 64 bytes)`
+  );
+}
+```
+
+`signatureBytes` can become `const`.
+
+## Regression test
+
+Add tests to `packages/auth/tests/turnkey-signer.test.ts` that drive `sign()`
+through a mocked Turnkey client:
+
+1. A 65-byte signature (32-byte `r` + 33-byte `s`) must cause `sign()` to
+   reject with an error mentioning the invalid length (65). This FAILS before
+   the fix (truncation makes it succeed) and PASSES after.
+2. A valid 64-byte signature (32-byte `r` + 32-byte `s`) must still produce a
+   `proofValue` — guards against over-rejection.
+
+## Verification
+
+```bash
+cd /Users/brian/Projects/onionoriginals/sdk
+bun install --frozen-lockfile || bun install
+bunx tsc --noEmit            # 0 errors
+bun run build                # succeeds
+bun run test                 # SDK + auth suites 0-fail
+```
+
+The new 65-byte regression test must fail before the fix and pass after.
+
+## STOP conditions
+
+- If the `signatureBytes.length === 65` truncation branch is already gone from
+  `turnkey-signer.ts` on the current base, the defect is already fixed — STOP
+  and report `alreadyResolved`.


### PR DESCRIPTION
## Summary
`TurnkeyWebVHSigner.sign` previously truncated a 65-byte signature value to 64 bytes via `slice(0, 64)`. A 65-byte value is not a valid Ed25519 signature with a spare byte; silently truncating it produces an invalid signature that is accepted/stored here but fails later verification (did:webvh resolution / credential validation).

This change rejects anything that is not exactly 64 bytes, matching the client-side `TurnkeyDIDSigner` contract.

## Verification (run immediately before merge on this branch)
- `bunx tsc --noEmit` — 0 errors
- `bun run build` — success
- `bun run test` — SDK + auth suites, 0 fail
- New tests: rejects 65-byte signature; still produces a proofValue for a valid 64-byte signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject non-64-byte Ed25519 signatures in `TurnkeyWebVHSigner.sign`
> Previously, `sign()` silently truncated 65-byte signatures to 64 bytes, which could produce invalid proofs. Now, any signature whose decoded length is not exactly 64 bytes causes `sign()` to throw an error instead.
>
> - Updates [turnkey-signer.ts](https://github.com/onionoriginals/sdk/pull/201/files#diff-0bc85aff7b742649b9aba1d2c34caeed85c94a77c9bb195720f1a397ce93d323) to use a `const` for `signatureBytes` and validate length strictly.
> - Adds regression tests in [turnkey-signer.test.ts](https://github.com/onionoriginals/sdk/pull/201/files#diff-ec7f9c8e34dcc2f344e5ae3deed38b1f0065984a49438c5efb2a0cb15a958b8b) for both the 65-byte rejection case and the valid 64-byte success case.
> - Risk: callers that previously relied on truncation (e.g. passing 65-byte signatures) will now receive an error instead of a silently corrupted proof.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a9232ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->