### PR TITLE
fix(cel): require data field in JSON/CBOR deserialization

### DIFF
--- a/packages/sdk/src/cel/serialization/cbor.ts
+++ b/packages/sdk/src/cel/serialization/cbor.ts
@@ -84,7 +84,14 @@ function parseEntry(entry: unknown): LogEntry {
   if (!Array.isArray(e.proof)) {
     throw new Error('Invalid entry: proof must be an array');
   }
-  
+
+  // `data` is a required field on LogEntry. Use a presence check (not a
+  // truthiness/undefined check) so an explicit falsy or null payload is
+  // preserved while a genuinely absent key is rejected.
+  if (!('data' in e)) {
+    throw new Error('Invalid entry: missing required data field');
+  }
+
   const parsedEntry: LogEntry = {
     type: e.type,
     data: e.data,

--- a/packages/sdk/src/cel/serialization/json.ts
+++ b/packages/sdk/src/cel/serialization/json.ts
@@ -133,7 +133,14 @@ function parseEntry(entry: unknown): LogEntry {
   if (!Array.isArray(e.proof)) {
     throw new Error('Invalid entry: proof must be an array');
   }
-  
+
+  // `data` is a required field on LogEntry. Use a presence check (not a
+  // truthiness/undefined check) so an explicit falsy or null payload is
+  // preserved while a genuinely absent key is rejected.
+  if (!('data' in e)) {
+    throw new Error('Invalid entry: missing required data field');
+  }
+
   const parsedEntry: LogEntry = {
     type: e.type,
     data: e.data,

--- a/packages/sdk/tests/unit/cel/cbor-serialization.test.ts
+++ b/packages/sdk/tests/unit/cel/cbor-serialization.test.ts
@@ -312,6 +312,44 @@ describe('CEL CBOR Serialization', () => {
       });
       expect(() => parseEventLogCbor(cbor)).toThrow('Invalid proof: missing or invalid cryptosuite');
     });
+
+    test('throws on entry missing required data field', () => {
+      const { encode } = require('../../../src/utils/cbor');
+      const cbor = encode({
+        events: [{
+          type: 'create',
+          // data field intentionally omitted
+          proof: [{
+            type: 'DataIntegrityProof',
+            cryptosuite: 'eddsa-jcs-2022',
+            verificationMethod: 'did:key:z6Mktest#key-1',
+            proofPurpose: 'assertionMethod',
+            proofValue: 'zMockProofValue123',
+          }],
+        }],
+      });
+      expect(() => parseEventLogCbor(cbor)).toThrow('Invalid entry: missing required data field');
+    });
+
+    test('accepts entry with falsy/null data (presence, not truthiness)', () => {
+      const { encode } = require('../../../src/utils/cbor');
+      const cbor = encode({
+        events: [{
+          type: 'create',
+          data: null,
+          proof: [{
+            type: 'DataIntegrityProof',
+            cryptosuite: 'eddsa-jcs-2022',
+            verificationMethod: 'did:key:z6Mktest#key-1',
+            proofPurpose: 'assertionMethod',
+            proofValue: 'zMockProofValue123',
+          }],
+        }],
+      });
+      const parsed = parseEventLogCbor(cbor);
+      expect(parsed.events.length).toBe(1);
+      expect(parsed.events[0].data).toBe(null);
+    });
   });
 
   describe('Round-trip serialization', () => {

--- a/packages/sdk/tests/unit/cel/json-serialization.test.ts
+++ b/packages/sdk/tests/unit/cel/json-serialization.test.ts
@@ -315,6 +315,44 @@ describe('CEL JSON Serialization', () => {
 
       expect(() => parseEventLogJson(json)).toThrow('Invalid proof: missing or invalid cryptosuite');
     });
+
+    test('throws on entry missing required data field', () => {
+      const json = JSON.stringify({
+        events: [{
+          type: 'create',
+          // data field intentionally omitted
+          proof: [{
+            type: 'DataIntegrityProof',
+            cryptosuite: 'eddsa-jcs-2022',
+            verificationMethod: 'did:key:z6Mktest#key-1',
+            proofPurpose: 'assertionMethod',
+            proofValue: 'zMockProofValue123',
+          }],
+        }],
+      });
+
+      expect(() => parseEventLogJson(json)).toThrow('Invalid entry: missing required data field');
+    });
+
+    test('accepts entry with falsy/null data (presence, not truthiness)', () => {
+      const json = JSON.stringify({
+        events: [{
+          type: 'create',
+          data: null,
+          proof: [{
+            type: 'DataIntegrityProof',
+            cryptosuite: 'eddsa-jcs-2022',
+            verificationMethod: 'did:key:z6Mktest#key-1',
+            proofPurpose: 'assertionMethod',
+            proofValue: 'zMockProofValue123',
+          }],
+        }],
+      });
+
+      const parsed = parseEventLogJson(json);
+      expect(parsed.events.length).toBe(1);
+      expect(parsed.events[0].data).toBe(null);
+    });
   });
 
   describe('Round-trip serialization', () => {

--- a/plans/031-cel-deserialize-require-data.md
+++ b/plans/031-cel-deserialize-require-data.md
@@ -1,0 +1,124 @@
+# Plan 031: Require the `data` field in CEL JSON/CBOR deserialization (match the LogEntry type)
+
+> **Executor instructions**: Follow step by step. Run every verification command
+> and confirm the expected result before moving on. Touch only in-scope files.
+> If a STOP condition occurs, stop and report. Commit on the worktree branch
+> (conventional commit; `--no-verify` if the commitlint hook lacks deps — note it).
+> SKIP updating `plans/README.md` — the reviewer maintains the index.
+
+## Worktree setup (REQUIRED FIRST)
+
+Worktree branches from `origin/main` (`correctness/round1-5`). At the worktree root:
+1. `bun install --frozen-lockfile || bun install`.
+2. Baseline: `bunx tsc --noEmit` → exit 0; `bun run test` → existing suites pass.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: S
+- **Risk**: LOW
+- **Category**: bug (type/serialization mismatch) / correctness
+- **Planned at**: `origin/main` @ `ff6cfb1`, 2026-06-23
+
+## Why this matters
+
+`LogEntry.data` is declared **required** (`data: unknown`, no `?`) in
+`packages/sdk/src/cel/types.ts:47`. The field carries the actual event payload
+and is part of the hash-chain commitment (`canonicalizeEntryForChain` includes
+it; `JSON.stringify` silently omits an `undefined` field, so a present-vs-absent
+`data` produces different committed bytes).
+
+But both deserialization parsers accept a `LogEntry` whose `data` key is
+**absent**, blindly copying `e.data` (which is `undefined`) into the
+reconstructed entry:
+- `src/cel/serialization/json.ts:137-141` — `data: e.data` with no presence check.
+- `src/cel/serialization/cbor.ts:88-92` — identical.
+
+Consequences:
+1. **Type-contract violation** — the parser returns a `LogEntry` with
+   `data === undefined`, which the interface forbids. Downstream code that
+   assumes a populated `data` fails with cryptic errors instead of a clear parse
+   error at the boundary.
+2. **Silent data loss** — a provider/API (or a corrupted file) can strip the
+   `data` field in transit and the SDK accepts the log without complaint.
+
+Every other required `LogEntry`/proof field (`type`, `proof`, proof `type`,
+`cryptosuite`, `verificationMethod`, `proofPurpose`, `proofValue`) is validated
+for presence; `data` is the lone gap. The existing tests in
+`packages/sdk/tests/unit/cel/{json,cbor}-serialization.test.ts` always include an
+explicit `data` field and never exercise the missing-`data` case.
+
+Decision: require `data` to be **present** (the key must exist) in both parsers,
+throwing a clear error when it is absent. Any value is allowed when present
+(including `null`, `{}`, `0`, `false`) because the type is `unknown` and existing
+tests round-trip empty objects and falsy payloads — only an entirely missing key
+is rejected.
+
+## Current state
+
+`parseEntry` in both `json.ts` and `cbor.ts` is identical:
+
+```typescript
+const parsedEntry: LogEntry = {
+  type: e.type,
+  data: e.data,        // no check that the key is present
+  proof: e.proof.map(parseProof),
+};
+```
+
+## Scope
+
+**In scope:**
+- `packages/sdk/src/cel/serialization/json.ts` (`parseEntry`: require `data` present)
+- `packages/sdk/src/cel/serialization/cbor.ts` (`parseEntry`: require `data` present)
+- `packages/sdk/tests/unit/cel/json-serialization.test.ts` (regression test)
+- `packages/sdk/tests/unit/cel/cbor-serialization.test.ts` (regression test)
+
+**Out of scope:**
+- Constraining the *value* of `data` beyond presence (it is `unknown`).
+- Any other field's validation.
+- `createEventLog`/signer validation.
+
+## Steps
+
+### Step 1: json.ts — require `data` present
+In `parseEntry`, after the `proof`-array check and before constructing
+`parsedEntry`, add a presence check:
+
+```typescript
+if (!('data' in e)) {
+  throw new Error('Invalid entry: missing required data field');
+}
+```
+
+Use `'data' in e` (not `e.data !== undefined`) so an explicit falsy/null payload
+is preserved while a genuinely absent key is rejected.
+
+### Step 2: cbor.ts — identical change
+Apply the same presence check to `cbor.ts`'s `parseEntry`. (CBOR maps decode to
+plain objects, so `'data' in e` works the same way.)
+
+### Step 3: Regression tests
+In both `json-serialization.test.ts` and `cbor-serialization.test.ts`, add:
+- A test that builds a serialized log/entry with the `data` key removed and
+  asserts the parser throws `Invalid entry: missing required data field`.
+  - For JSON: stringify an events object whose entry has no `data` key.
+  - For CBOR: encode (via the same `encode` util the parser's `decode` mirrors)
+    an events object whose entry has no `data` key, then parse.
+- A test confirming a present-but-falsy `data` (e.g. `null` or `{}`) still
+  round-trips successfully (guards against using a truthiness check).
+
+These tests FAIL before the fix (parse succeeds / returns `data: undefined`) and
+PASS after.
+
+## Done criteria (ALL must hold)
+- [ ] `bunx tsc --noEmit` exits 0
+- [ ] `bun run build` succeeds
+- [ ] An entry missing `data` is rejected by both JSON and CBOR parsers
+- [ ] An entry with falsy `data` (`null`/`{}`) still round-trips through both
+- [ ] `bun run test` — SDK + auth suites 0 fail
+- [ ] No out-of-scope files modified
+
+## STOP conditions
+- An existing valid path relies on `data` being omittable after parse (would
+  surface as a failing existing test) — report rather than weaken.


### PR DESCRIPTION
## Summary
`LogEntry.data` is a required field per the type, but `parseEntry` in both `json.ts` and `cbor.ts` copied `e.data` without checking presence, so a log entry missing `data` deserialized to `{ data: undefined }`, violating the interface contract and allowing silent data loss / hash-chain divergence.

This adds a presence check (`'data' in e`) to both parsers so an absent key is rejected with a clear error while explicit falsy/null payloads are preserved. Adds regression tests to the json/cbor serialization suites.

## Verification (run immediately before merge, rebased onto latest origin/main)
- `bunx tsc --noEmit`: 0 errors
- `bun run build`: success
- SDK `bun run test`: integration 124/0, unit 2501/0, security 83/0, stress 18/0 (all 0-fail)
- auth `bun test`: 169 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require `data` field presence in CEL JSON/CBOR deserialization
> Both `parseEntry` functions in [json.ts](https://github.com/onionoriginals/sdk/pull/202/files#diff-c8704f89611a80507c951ff18428c6351e72100637caa7e8a880856042afb18e) and [cbor.ts](https://github.com/onionoriginals/sdk/pull/202/files#diff-15a7fa6a80062e12157866de6136c30474d728b1eb1cd3cd7009fe5a95fe0d40) now throw `'Invalid entry: missing required data field'` when the `data` key is absent from the entry object. Present-but-falsy values (including `null`) are still accepted. Tests covering both the missing-key and null-value cases are added for each format.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2771707.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->