### PR TITLE
fix(sdk): BtcoDidResolver must use inscription content as DID document

### DIFF
--- a/packages/sdk/src/did/BtcoDidResolver.ts
+++ b/packages/sdk/src/did/BtcoDidResolver.ts
@@ -157,21 +157,35 @@ export class BtcoDidResolver {
           inscriptionData.metadata = null;
         }
 
-        inscriptionData.isValidDid = didPattern.test(inscriptionData.content);
+        // The DID document MUST come from the on-chain inscription CONTENT,
+        // never from the off-chain ord metadata endpoint. The metadata is
+        // surfaced for diagnostics only — trusting it would let an attacker who
+        // controls/spoofs the metadata API inject forged verification methods
+        // and forge signatures on this did:btco identity.
+        const documentFromContent = this.parseDidDocumentFromContent(inscriptionData.content);
 
-        if (inscriptionData.isValidDid && inscriptionData.metadata) {
-          const didDocument = inscriptionData.metadata as unknown as DIDDocument;
-          if (this.isValidDidDocument(didDocument) && didDocument.id === expectedDid) {
-            inscriptionData.didDocument = didDocument;
-          } else {
-            inscriptionData.error = 'Invalid DID document structure or mismatched ID';
-          }
-        }
+        // A content blob "is a DID" if it either matches the human-readable
+        // pattern or parses to a DID document carrying the expected id.
+        inscriptionData.isValidDid =
+          didPattern.test(inscriptionData.content) ||
+          (documentFromContent !== null && documentFromContent.id === expectedDid);
 
         if (inscriptionData.content.includes('🔥')) {
+          // Deactivation marker: the DID is tombstoned. Do not attempt to derive
+          // a document; just record the deactivation.
           inscriptionData.didDocument = null;
           if (!inscriptionData.error) {
             inscriptionData.error = 'DID has been deactivated';
+          }
+        } else if (inscriptionData.isValidDid) {
+          if (
+            documentFromContent &&
+            this.isValidDidDocument(documentFromContent) &&
+            documentFromContent.id === expectedDid
+          ) {
+            inscriptionData.didDocument = documentFromContent;
+          } else {
+            inscriptionData.error = 'Invalid DID document structure or mismatched ID';
           }
         }
       } catch (err: unknown) {
@@ -207,6 +221,33 @@ export class BtcoDidResolver {
         network
       }
     };
+  }
+
+  /**
+   * Parses the DID document out of the raw on-chain inscription content.
+   *
+   * The content is the authoritative artifact for a did:btco. It may be either
+   * the bare DID-document JSON, or that JSON preceded by a human-readable
+   * `BTCO DID: <did>` marker line. This strips any leading non-JSON marker text
+   * and parses the JSON object portion. Returns `null` if no valid JSON object
+   * can be recovered. The caller is responsible for structural / id validation.
+   */
+  private parseDidDocumentFromContent(content: string): DIDDocument | null {
+    if (typeof content !== 'string') return null;
+    // Strip an optional leading `BTCO DID: ` marker.
+    let text = content.replace(/^\s*BTCO DID:\s*/i, '');
+    // Locate the JSON object portion (the document may be preceded by a plain
+    // `did:btco:...` marker line before the JSON body).
+    const start = text.indexOf('{');
+    if (start === -1) return null;
+    text = text.slice(start);
+    try {
+      const parsed = JSON.parse(text);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+      return parsed as DIDDocument;
+    } catch {
+      return null;
+    }
   }
 
   private isValidDidDocument(doc: unknown): doc is DIDDocument {

--- a/packages/sdk/tests/unit/did/BtcoDidResolver.test.ts
+++ b/packages/sdk/tests/unit/did/BtcoDidResolver.test.ts
@@ -285,6 +285,175 @@ describe('BtcoDidResolver', () => {
   });
 });
 
+/**
+ * Regression (security, plans/032): the DID document MUST be parsed from the
+ * on-chain inscription CONTENT, never from the off-chain ord metadata endpoint.
+ *
+ * Previously the resolver only pattern-checked the content and then returned the
+ * `getMetadata()` object as the DID document. An attacker controlling the
+ * metadata endpoint could inject forged verification methods and forge
+ * signatures on a did:btco identity.
+ */
+describe('BtcoDidResolver uses inscription content (not ord metadata) as DID document', () => {
+  let provider: ResourceProviderLike;
+  let originalFetch: any;
+
+  const legitDoc: DIDDocument = {
+    '@context': ['https://www.w3.org/ns/did/v1'],
+    id: 'did:btco:500',
+    verificationMethod: [
+      {
+        id: 'did:btco:500#0',
+        type: 'Multikey',
+        controller: 'did:btco:500',
+        publicKeyMultibase: 'zLEGITIMATEKEY'
+      } as any
+    ],
+    authentication: ['did:btco:500#0']
+  };
+
+  beforeEach(() => {
+    provider = {
+      getSatInfo: mock(),
+      resolveInscription: mock(),
+      getMetadata: mock()
+    };
+    originalFetch = (global as any).fetch;
+  });
+
+  afterEach(() => {
+    (global as any).fetch = originalFetch;
+  });
+
+  test('forged metadata is ignored; resolved document comes from content', async () => {
+    const inscriptionId = 'insc-sec-1';
+    provider.getSatInfo.mockResolvedValue({ inscription_ids: [inscriptionId] });
+    provider.resolveInscription.mockResolvedValue({
+      id: inscriptionId,
+      sat: 500,
+      content_type: 'application/json',
+      content_url: 'http://local/content-sec-1'
+    });
+    // On-chain inscription content carries the legitimate DID document JSON.
+    (global as any).fetch = mock(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => JSON.stringify(legitDoc)
+    }));
+    // Malicious ord metadata endpoint returns a FORGED document with an
+    // attacker-controlled verification method.
+    const forgedDoc: DIDDocument = {
+      '@context': ['https://www.w3.org/ns/did/v1'],
+      id: 'did:btco:500',
+      verificationMethod: [
+        {
+          id: 'did:btco:500#attacker',
+          type: 'Multikey',
+          controller: 'did:btco:500',
+          publicKeyMultibase: 'zATTACKERKEY'
+        } as any
+      ],
+      authentication: ['did:btco:500#attacker']
+    };
+    provider.getMetadata.mockResolvedValue(forgedDoc);
+
+    const resolver = new BtcoDidResolver({ provider });
+    const res = await resolver.resolve('did:btco:500');
+
+    expect(res.didDocument).not.toBeNull();
+    const vmIds = (res.didDocument!.verificationMethod || []).map((vm: any) => vm.id);
+    // The attacker's metadata key MUST NOT appear in the resolved document.
+    expect(vmIds).toContain('did:btco:500#0');
+    expect(vmIds).not.toContain('did:btco:500#attacker');
+    const keys = (res.didDocument!.verificationMethod || []).map((vm: any) => vm.publicKeyMultibase);
+    expect(keys).toContain('zLEGITIMATEKEY');
+    expect(keys).not.toContain('zATTACKERKEY');
+  });
+
+  test('resolves from content even when metadata is null', async () => {
+    const inscriptionId = 'insc-sec-2';
+    provider.getSatInfo.mockResolvedValue({ inscription_ids: [inscriptionId] });
+    provider.resolveInscription.mockResolvedValue({
+      id: inscriptionId,
+      sat: 500,
+      content_type: 'application/json',
+      content_url: 'http://local/content-sec-2'
+    });
+    (global as any).fetch = mock(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      // Optional 'BTCO DID: ' marker prefix before the JSON document.
+      text: async () => 'BTCO DID: ' + JSON.stringify(legitDoc)
+    }));
+    provider.getMetadata.mockResolvedValue(null);
+
+    const resolver = new BtcoDidResolver({ provider });
+    const res = await resolver.resolve('did:btco:500');
+
+    expect(res.didDocument).not.toBeNull();
+    expect(res.didDocument!.id).toBe('did:btco:500');
+  });
+
+  test('content matches pattern but is not a valid DID-document JSON -> error', async () => {
+    const inscriptionId = 'insc-sec-3';
+    provider.getSatInfo.mockResolvedValue({ inscription_ids: [inscriptionId] });
+    provider.resolveInscription.mockResolvedValue({
+      id: inscriptionId,
+      sat: 500,
+      content_type: 'text/plain',
+      content_url: 'http://local/content-sec-3'
+    });
+    // Matches the DID pattern but is not parseable as a DID document.
+    (global as any).fetch = mock(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => 'BTCO DID: did:btco:500'
+    }));
+    // Even a perfectly valid metadata document must not rescue this.
+    provider.getMetadata.mockResolvedValue(legitDoc);
+
+    const resolver = new BtcoDidResolver({ provider });
+    const res = await resolver.resolve('did:btco:500');
+
+    const entry = (res.inscriptions as BtcoInscriptionData[])[0];
+    expect(entry.isValidDid).toBe(true);
+    expect(entry.error).toBe('Invalid DID document structure or mismatched ID');
+    expect(entry.didDocument).toBeUndefined();
+    expect(res.didDocument).toBeNull();
+  });
+
+  test('content document with mismatched id is rejected', async () => {
+    const inscriptionId = 'insc-sec-4';
+    provider.getSatInfo.mockResolvedValue({ inscription_ids: [inscriptionId] });
+    provider.resolveInscription.mockResolvedValue({
+      id: inscriptionId,
+      sat: 500,
+      content_type: 'application/json',
+      content_url: 'http://local/content-sec-4'
+    });
+    const mismatched: DIDDocument = {
+      '@context': ['https://www.w3.org/ns/did/v1'],
+      id: 'did:btco:999'
+    };
+    (global as any).fetch = mock(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => 'BTCO DID: did:btco:500\n' + JSON.stringify(mismatched)
+    }));
+    provider.getMetadata.mockResolvedValue(null);
+
+    const resolver = new BtcoDidResolver({ provider });
+    const res = await resolver.resolve('did:btco:500');
+    const entry = (res.inscriptions as BtcoInscriptionData[])[0];
+    expect(entry.error).toBe('Invalid DID document structure or mismatched ID');
+    expect(res.didDocument).toBeNull();
+  });
+});
+
 /** Inlined from BtcoDidResolver.branches.part.ts */
 // duplicate imports removed during inlining
 
@@ -355,10 +524,21 @@ describe('BtcoDidResolver branches', () => {
   });
 
   test('valid did doc selected as latest and network prefixes', async () => {
-    (global as any).fetch = mock(async () => ({ ok: true, status: 200, statusText: 'OK', text: async () => 'BTCO DID: did:btco:reg:2' }));
+    // The DID document is carried in the on-chain CONTENT; content_url is
+    // http://c/<inscriptionId> per makeProvider, so vary the document by id.
+    (global as any).fetch = mock(async (url: string) => {
+      const id = String(url).split('/').pop();
+      const docId = id === 'ins-b' ? 'did:btco:reg:2' : 'did:btco:reg:999';
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => JSON.stringify({ '@context': ['https://www.w3.org/ns/did/v1'], id: docId })
+      };
+    });
     const provider = makeProvider({
       getSatInfo: async () => ({ inscription_ids: ['ins-a', 'ins-b'] }),
-      getMetadata: async (id: string) => ({ '@context': ['https://www.w3.org/ns/did/v1'], id: id === 'ins-b' ? 'did:btco:reg:2' : 'did:btco:reg:999' })
+      getMetadata: async () => null
     });
     const r = new BtcoDidResolver({ provider });
     const res = await r.resolve('did:btco:reg:2');
@@ -405,13 +585,14 @@ describe('BtcoDidResolver deactivation preserves existing error', () => {
 
 /** Inlined from BtcoDidResolver.deactivation-preserve-existing-error.part.ts */
 
-describe('BtcoDidResolver deactivation preserves an existing error', () => {
-  test('error is not overwritten when content has flame and prior error set', async () => {
+describe('BtcoDidResolver deactivation takes precedence', () => {
+  test('flame content reports deactivation regardless of ord metadata', async () => {
     const provider: ResourceProviderLike = {
       async getSatInfo() { return { inscription_ids: ['a'] } as any; },
       async resolveInscription(id: string) { return { id, sat: 0, content_type: 'text/plain', content_url: 'http://c/' + id }; },
       async getMetadata() {
-        // Provide metadata so that isValidDid && metadata path is taken, but with invalid/mismatched DID
+        // Off-chain metadata is never consulted for the document; a tombstoned
+        // (flame) inscription must report deactivation, not a metadata-derived state.
         return { '@context': ['https://www.w3.org/ns/did/v1'], id: 'did:btco:999' } as any;
       }
     };
@@ -422,8 +603,7 @@ describe('BtcoDidResolver deactivation preserves an existing error', () => {
     (global as any).fetch = originalFetch;
     const entry = res.inscriptions![0];
     expect(entry.didDocument).toBeNull();
-    // Since an error was set due to invalid/mismatched DID, it should remain after deactivation branch
-    expect(entry.error).toBe('Invalid DID document structure or mismatched ID');
+    expect(entry.error).toBe('DID has been deactivated');
   });
 });
 
@@ -582,7 +762,13 @@ describe('BtcoDidResolver isValidDidDocument branches', () => {
 describe('BtcoDidResolver signet and error branches', () => {
   const originalFetch = global.fetch as any;
   beforeEach(() => {
-    (global as any).fetch = mock(async () => ({ ok: true, status: 200, statusText: 'OK', text: async () => 'BTCO DID: did:btco:sig:3' }));
+    // DID document (with the string-form w3id @context) carried in the content.
+    (global as any).fetch = mock(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => JSON.stringify({ '@context': 'https://w3id.org/did/v1', id: 'did:btco:sig:3' })
+    }));
   });
   afterAll(() => {
     (global as any).fetch = originalFetch;
@@ -591,7 +777,7 @@ describe('BtcoDidResolver signet and error branches', () => {
   const providerOk: ResourceProviderLike = {
     async getSatInfo() { return { inscription_ids: ['i1'] }; },
     async resolveInscription(id: string) { return { id, sat: 0, content_type: 'text/plain', content_url: 'http://c/' + id }; },
-    async getMetadata() { return { '@context': 'https://w3id.org/did/v1', id: 'did:btco:sig:3' }; }
+    async getMetadata() { return null as any; }
   };
 
   test('signet prefix resolution and w3id context accepted', async () => {
@@ -621,7 +807,12 @@ describe('BtcoDidResolver signet and error branches', () => {
 describe('BtcoDidResolver testnet prefix (did:btco:test)', () => {
   const originalFetch = global.fetch as any;
   beforeEach(() => {
-    (global as any).fetch = mock(async () => ({ ok: true, status: 200, statusText: 'OK', text: async () => 'BTCO DID: did:btco:test:3' }));
+    (global as any).fetch = mock(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => 'BTCO DID: ' + JSON.stringify({ '@context': ['https://www.w3.org/ns/did/v1'], id: 'did:btco:test:3' })
+    }));
   });
   afterAll(() => {
     (global as any).fetch = originalFetch;
@@ -630,7 +821,7 @@ describe('BtcoDidResolver testnet prefix (did:btco:test)', () => {
   const providerOk: ResourceProviderLike = {
     async getSatInfo() { return { inscription_ids: ['i1'] }; },
     async resolveInscription(id: string) { return { id, sat: 0, content_type: 'text/plain', content_url: 'http://c/' + id }; },
-    async getMetadata() { return { '@context': ['https://www.w3.org/ns/did/v1'], id: 'did:btco:test:3' }; }
+    async getMetadata() { return null as any; }
   };
 
   test('testnet DID is not rejected as invalidDid and resolves', async () => {

--- a/packages/sdk/tests/unit/did/did-layer-scenarios.test.ts
+++ b/packages/sdk/tests/unit/did/did-layer-scenarios.test.ts
@@ -722,12 +722,7 @@ describe('DID-015 — did:btco regtest prefix handling', () => {
    * document when queried with the correct regtest DID prefix.
    */
   function buildRegtestProvider(satNumber: string): ResourceProviderLike {
-    const did = `did:btco:reg:${satNumber}`;
     const inscriptionId = `regtest-inscription-${satNumber}i0`;
-    const mockDoc = {
-      '@context': ['https://www.w3.org/ns/did/v1'],
-      id: did,
-    };
     const mockContentUrl = `http://localhost:8080/content/${inscriptionId}`;
 
     return {
@@ -743,7 +738,8 @@ describe('DID-015 — did:btco regtest prefix handling', () => {
         };
       },
       async getMetadata(_id: string) {
-        return mockDoc as unknown as Record<string, unknown>;
+        // Off-chain metadata is non-authoritative; the document lives in content.
+        return null;
       },
     };
   }
@@ -752,14 +748,16 @@ describe('DID-015 — did:btco regtest prefix handling', () => {
     const satNumber = '4999999999';
     const did = `did:btco:reg:${satNumber}`;
     const provider = buildRegtestProvider(satNumber);
+    const mockDoc = { '@context': ['https://www.w3.org/ns/did/v1'], id: did };
 
-    // Mock fetch to return the expected DID content
+    // Mock fetch to return the authoritative DID document as the inscription
+    // content (the resolver must parse the document from content, not metadata).
     const originalFetch = (global as unknown as { fetch: unknown }).fetch;
     (global as unknown as { fetch: unknown }).fetch = async (_url: string) => ({
       ok: true,
       status: 200,
       statusText: 'OK',
-      text: async () => `BTCO DID: ${did}`,
+      text: async () => `BTCO DID: ${JSON.stringify(mockDoc)}`,
     });
 
     try {

--- a/plans/032-btco-resolver-use-inscription-content-as-did-document.md
+++ b/plans/032-btco-resolver-use-inscription-content-as-did-document.md
@@ -1,0 +1,106 @@
+# Plan 032: BtcoDidResolver must use inscription CONTENT (not ord metadata) as the DID document
+
+## Status
+
+- **State**: DONE (branch `correctness/round1-0`)
+- **Priority**: P0 (critical, security/correctness)
+- **Effort**: M
+- **Risk**: MEDIUM (changes the authoritative source of the resolved DID document)
+- **Category**: correctness / security
+- **Planned at**: atop `origin/main`@`8881c1d`, 2026-06-23
+
+## Why this matters
+
+`BtcoDidResolver.resolve` (src/did/BtcoDidResolver.ts) fetches the inscription
+content from `inscription.content_url` (the on-chain inscribed bytes) and the
+inscription "metadata" separately from the ord API server via
+`provider.getMetadata(inscriptionId)`.
+
+Before this fix (lines 160-169), the resolver:
+
+1. Fetched the inscription **content** and checked only that it *matched a
+   pattern* (`didPattern.test(inscriptionData.content)`), then
+2. **Discarded the content** and used the **metadata** object as the DID
+   document:
+
+```ts
+inscriptionData.isValidDid = didPattern.test(inscriptionData.content);
+if (inscriptionData.isValidDid && inscriptionData.metadata) {
+  const didDocument = inscriptionData.metadata as unknown as DIDDocument;
+  if (this.isValidDidDocument(didDocument) && didDocument.id === expectedDid) {
+    inscriptionData.didDocument = didDocument;
+  } ...
+}
+```
+
+The metadata comes from an off-chain API endpoint (the ord server), **not** from
+the immutable on-chain inscription. An attacker who controls (or can spoof / MITM)
+the ord metadata endpoint can return a DID document containing
+attacker-controlled `verificationMethod` / `authentication` entries. That forged
+document is then returned as the resolved DID document and used for signature
+verification — letting the attacker forge signatures that appear to be valid for
+a `did:btco` identity. This defeats the entire trust model of `did:btco`, where
+the Bitcoin inscription is supposed to be the single source of truth.
+
+This is consistent with the project THREAT_MODEL.md (F9) treating the on-chain
+inscription content as the authoritative artifact and the content_url fetch as
+security-relevant; the metadata endpoint is a non-authoritative convenience.
+
+## The fix
+
+Parse the **inscription content** as the DID document and stop trusting the ord
+metadata as the document source.
+
+In `BtcoDidResolver.resolve`, after fetching `inscriptionData.content`:
+
+1. Keep fetching metadata (it is still surfaced on `BtcoInscriptionData.metadata`
+   for diagnostics), but never treat it as the DID document.
+2. Determine `isValidDid` as before (content matches the expected
+   `did:btco[...]:<sat>` pattern, with optional `BTCO DID: ` prefix).
+3. When `isValidDid`, parse the DID document **from the content**:
+   - Strip an optional leading `BTCO DID: ` marker.
+   - `JSON.parse` the remaining text.
+   - Validate with the existing `isValidDidDocument` guard AND
+     `didDocument.id === expectedDid`.
+   - On success, set `inscriptionData.didDocument` to the parsed-from-content
+     document. On any parse/validation failure, set
+     `inscriptionData.error = 'Invalid DID document structure or mismatched ID'`
+     and leave `didDocument` unset.
+4. Deactivation (`🔥`) handling is unchanged and still clears `didDocument`.
+
+A new private helper `parseDidDocumentFromContent(content): DIDDocument | null`
+encapsulates the prefix-strip + JSON.parse (returns `null` on any error).
+
+### Why content can be JSON-parsed
+
+`createBtcoDidDocument` produces a standard W3C DID Document object. The
+canonical on-chain representation inscribed for a `did:btco` is that JSON
+document (optionally prefixed by the human-readable `BTCO DID: ` marker the
+resolver already special-cases in its pattern). Parsing the content as JSON is
+therefore the correct way to recover the authoritative document.
+
+## Tests
+
+- New regression test (security): a provider whose `getMetadata` returns a
+  **forged** document (extra attacker verificationMethod, or a different one)
+  while the inscription **content** carries the legitimate DID document JSON.
+  - BEFORE fix: resolver returns the forged metadata document (attacker keys).
+  - AFTER fix: resolver returns the document parsed from content; the attacker's
+    metadata keys never appear in the resolved document.
+- New test: content is valid DID-document JSON and metadata is `null` ⇒ resolves
+  successfully from content (previously impossible — required metadata).
+- New test: content matches the DID pattern but is NOT valid JSON / not a valid
+  document ⇒ `error = 'Invalid DID document structure or mismatched ID'`,
+  `didDocument` null.
+- Existing tests in `tests/unit/did/BtcoDidResolver.test.ts` that encoded the old
+  (insecure) "document comes from metadata, content is just a marker" behavior
+  are updated so the inscription **content** carries the DID-document JSON. This
+  reflects the corrected, secure contract.
+
+## Invariant
+
+```
+bunx tsc --noEmit   # 0 errors
+bun run build       # succeeds
+bun run test        # SDK + auth suites 0-fail
+```


### PR DESCRIPTION
## Summary
Security fix: `BtcoDidResolver` pattern-checked the on-chain inscription content but then returned the off-chain ord metadata (`provider.getMetadata`) as the DID document, discarding the authoritative content. An attacker controlling/spoofing the metadata endpoint could inject forged verification methods and forge signatures on a did:btco identity.

The resolver now parses the authoritative DID document from the inscription content (optionally prefixed by a `BTCO DID: ` marker), validates its structure and that `id === expectedDid`, and never trusts metadata as the document. Deactivation (flame) short-circuits document derivation.

## Verification (run immediately before merge on branch rebased onto latest origin/main)
- `bunx tsc --noEmit -p .` — 0 errors
- `bun run build` — success
- SDK `bun run test` — integration/unit/security/stress all 0 fail
- auth `bun run test` — 185 pass, 0 fail

Adds security regression tests and updates existing tests that encoded the old metadata-sourced contract. See plans/032.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `BtcoDidResolver` to use on-chain inscription content as the authoritative DID document
> - Replaces reliance on off-chain ord metadata with parsing the DID document directly from inscription content in [`BtcoDidResolver.resolve`](https://github.com/onionoriginals/sdk/pull/204/files#diff-2f94701335054c6bc05ad592c53776ff08e36415e95d7425b2dab80e2dd1aa93).
> - Adds a new private helper `parseDidDocumentFromContent` that strips an optional `BTCO DID: ` prefix, extracts the first JSON object, and returns a `DIDDocument` or null on failure.
> - Inscriptions whose content matches the DID pattern but contain invalid or mismatched JSON now resolve with an error and no `didDocument`; content containing the flame emoji sets `didDocument` to null with a `'DID has been deactivated'` error.
> - Metadata is still fetched but used only for diagnostics, never as the document source.
> - Behavioral Change: previously valid resolutions that relied solely on ord metadata will now fail or return errors if the inscription content does not contain a valid, id-matching DID document.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a070c29.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->