### PR TITLE
fix(vc): reject revoked/compromised verification methods in EdDSA verifyProof

### DIFF
--- a/packages/sdk/src/vc/cryptosuites/eddsa.ts
+++ b/packages/sdk/src/vc/cryptosuites/eddsa.ts
@@ -46,6 +46,15 @@ export class EdDSACryptosuiteManager {
         options
       );
       const vmDoc = await options.documentLoader(proof.verificationMethod);
+      // Fail closed on retired keys. A verification method that has been
+      // rotated out (`revoked`) or marked `compromised` is still published in
+      // the DID document so verifiers can recognise it as no longer valid;
+      // accepting a signature from it would let an attacker holding the old
+      // private key forge credentials, defeating key rotation / compromise
+      // recovery. Mirrors the CEL key resolver (src/cel/keyResolver.ts).
+      const vm = vmDoc.document as { revoked?: unknown; compromised?: unknown };
+      if (vm?.revoked) throw new Error('Verification method has been revoked');
+      if (vm?.compromised) throw new Error('Verification method has been marked as compromised');
       const pk = vmDoc.document.publicKeyMultibase as string;
       const dec = multikey.decodePublicKey(pk);
       if (dec.type !== 'Ed25519') throw new Error('Invalid key type for EdDSA');

--- a/packages/sdk/tests/unit/vc/cryptosuites/eddsa.test.ts
+++ b/packages/sdk/tests/unit/vc/cryptosuites/eddsa.test.ts
@@ -406,3 +406,69 @@ describe('EdDSA verifyProof success path', () => {
     expect(res.verified).toBe(true);
   });
 });
+
+
+
+
+/** Regression: revoked / compromised verification methods must fail closed. */
+
+describe('EdDSA verifyProof rejects retired verification methods', () => {
+  const goodContext = ['https://www.w3.org/ns/credentials/v2'];
+
+  // Build a credential with a genuinely valid Ed25519 signature, then verify it
+  // through a loader that returns the SAME public key with various retired-state
+  // flags. The signature itself is always valid, so the only thing that can make
+  // verification fail is the revoked/compromised check.
+  async function makeSignedCredential() {
+    const ed = await import('@noble/ed25519');
+    const sk = ed.utils.randomPrivateKey();
+    const pk = await ed.getPublicKeyAsync(sk);
+    const pkMb = multikey.encodePublicKey(new Uint8Array(pk), 'Ed25519');
+    const skMb = multikey.encodePrivateKey(new Uint8Array(sk), 'Ed25519');
+    const vmId = 'did:ex:retired#key-0';
+    const baseLoader = async (iri: string) => {
+      if (iri.includes('#')) {
+        return { document: { '@context': goodContext, id: iri, publicKeyMultibase: pkMb }, documentUrl: iri, contextUrl: null };
+      }
+      return contextDocument(iri);
+    };
+    const doc: any = { '@context': goodContext, id: 'urn:test:retired', name: 'test' };
+    const proof = await EdDSACryptosuiteManager.createProof(doc, {
+      verificationMethod: vmId, proofPurpose: 'assertionMethod', privateKey: skMb,
+      cryptosuite: 'eddsa-rdfc-2022', documentLoader: baseLoader
+    });
+    return { doc, proof, pkMb, vmId };
+  }
+
+  const loaderWith = (pkMb: string, extra: Record<string, unknown>) =>
+    async (iri: string) => {
+      if (iri.includes('#')) {
+        return { document: { '@context': goodContext, id: iri, publicKeyMultibase: pkMb, ...extra }, documentUrl: iri, contextUrl: null };
+      }
+      return contextDocument(iri);
+    };
+
+  test('control: active VM verifies successfully (no over-rejection)', async () => {
+    const { doc, proof, pkMb } = await makeSignedCredential();
+    const res = await EdDSACryptosuiteManager.verifyProof(doc, proof as any, { documentLoader: loaderWith(pkMb, {}) });
+    expect(res.verified).toBe(true);
+  });
+
+  test('rejects VM marked revoked even with an otherwise valid signature', async () => {
+    const { doc, proof, pkMb } = await makeSignedCredential();
+    const res = await EdDSACryptosuiteManager.verifyProof(doc, proof as any, {
+      documentLoader: loaderWith(pkMb, { revoked: '2024-01-01T00:00:00Z' })
+    });
+    expect(res.verified).toBe(false);
+    expect(res.errors?.[0]).toBe('Verification method has been revoked');
+  });
+
+  test('rejects VM marked compromised even with an otherwise valid signature', async () => {
+    const { doc, proof, pkMb } = await makeSignedCredential();
+    const res = await EdDSACryptosuiteManager.verifyProof(doc, proof as any, {
+      documentLoader: loaderWith(pkMb, { compromised: '2024-02-02T00:00:00Z' })
+    });
+    expect(res.verified).toBe(false);
+    expect(res.errors?.[0]).toBe('Verification method has been marked as compromised');
+  });
+});

--- a/plans/032-eddsa-verify-reject-revoked-vm.md
+++ b/plans/032-eddsa-verify-reject-revoked-vm.md
@@ -1,0 +1,74 @@
+# Plan 032: EdDSA verifyProof must reject revoked / compromised verification methods
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving on. Touch
+> only the files listed as in scope. If a STOP condition occurs, stop and
+> report. Commit on the worktree branch. SKIP updating `plans/README.md` — the
+> reviewer maintains the index.
+
+## Status
+
+- **Priority**: P0 (critical)
+- **Effort**: S
+- **Risk**: LOW
+- **Category**: security / correctness
+- **Branch**: `correctness/round1-1-eddsa-revoke` (from `origin/main`)
+- **Target file**: `packages/sdk/src/vc/cryptosuites/eddsa.ts`
+
+## Why this matters
+
+`EdDSACryptosuiteManager.verifyProof()` loads a verification method from the DID
+document via `documentLoader(proof.verificationMethod)` and uses its
+`publicKeyMultibase` to verify the signature. It never consults the VM's
+`revoked` or `compromised` status before accepting the signature.
+
+The `VerificationMethod` type (`src/types/did.ts`) carries optional `revoked`
+and `compromised` ISO-8601 timestamps. `KeyManager.rotateKeys()` sets `revoked`
+when a key is rotated out, and `KeyManager.recoverFromCompromise()` sets
+`compromised`. Retired VMs remain published in the DID document precisely so
+verifiers can recognise them as no longer valid signing keys. Because
+`verifyProof()` ignores these fields, an attacker holding an old, revoked or
+compromised private key can forge a credential signature that verifies
+successfully — defeating the entire purpose of key rotation / compromise
+recovery.
+
+The CEL key resolver (`src/cel/keyResolver.ts`, plan 025) already fails closed
+on `vm.revoked || vm.compromised`. The VC verification path must enforce the
+same invariant. The document loader (`src/vc/documentLoader.ts`) spreads the
+full matched VM (`...vm`) into the returned document, so the `revoked` /
+`compromised` fields are present on `vmDoc.document` and can be checked directly.
+
+## The fix (minimal, correct)
+
+In `verifyProof()`, after loading the verification method document, fail closed
+if the loaded VM carries a `revoked` or `compromised` timestamp — throw an error
+(which the existing try/catch converts into `{ verified: false, errors: [...] }`)
+before decoding the public key. This treats retired keys exactly like an invalid
+key type.
+
+## In scope
+
+- `packages/sdk/src/vc/cryptosuites/eddsa.ts` — reject loaded VMs with `revoked`
+  or `compromised` set, before public-key decode.
+- `packages/sdk/tests/unit/vc/cryptosuites/eddsa.test.ts` — new regression tests
+  (fail before, pass after).
+
+## Regression test
+
+Sign a credential with a valid Ed25519 key so the signature itself is valid.
+Then verify it with a document loader that returns the same VM but additionally
+marked `revoked` (and a second case `compromised`). `verifyProof()` must return
+`verified: false`. A control case (same VM, no revoked/compromised) must still
+return `verified: true`, guarding against over-rejection.
+
+## Verification (run at repo root unless noted)
+
+```
+bun install --frozen-lockfile || bun install
+bunx tsc --noEmit          # 0 errors
+bun run build              # succeeds
+bun run test               # SDK + auth suites 0-fail
+```
+
+STOP conditions: any tsc error, build failure, or a previously-passing test
+regressing.


### PR DESCRIPTION
## Summary
`EdDSACryptosuiteManager.verifyProof()` loaded a verification method via the document loader and verified the signature against its public key without checking the VM's revoked/compromised status. Keys rotated out (`KeyManager.rotateKeys` -> revoked) or marked compromised (`recoverFromCompromise` -> compromised) remain published in the DID document so verifiers can recognise them as retired, but the VC verification path accepted signatures from them.

An attacker holding an old private key could thus forge credentials that verify successfully, defeating key rotation and compromise recovery.

## Fix
Fail closed on revoked/compromised VMs before public-key decode, mirroring the CEL key resolver (`src/cel/keyResolver.ts`). Adds regression tests that fail before and pass after.

Plan: `plans/032-eddsa-verify-reject-revoked-vm.md`

## Verification
- `tsc --noEmit`: 0 errors (sdk + auth)
- `bun run build`: succeeds (sdk + auth)
- SDK tests: integration 124, unit 2787, security 83, stress 18 — all 0 fail
- Auth tests: 185 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject revoked or compromised verification methods in `EdDSACryptosuiteManager.verifyProof`
> Previously, `verifyProof` would attempt signature verification even when the verification method document indicated it had been revoked or compromised. Now, [eddsa.ts](https://github.com/onionoriginals/sdk/pull/205/files#diff-2fd80ff4a692f2e40e5ecc101becc2277c969c992ba2c28ee58474d580e26886) checks for `revoked` and `compromised` fields immediately after loading the verification method and returns `{ verified: false }` with a descriptive error before reaching signature verification. New regression tests in [eddsa.test.ts](https://github.com/onionoriginals/sdk/pull/205/files#diff-a8396217feed7866478ce96d5b99ea74303cb996b71d30d9a9ead6bca5b7e81a) cover the active, revoked, and compromised cases. Behavioral Change: any credential whose verification method carries a `revoked` or `compromised` field will now fail verification rather than succeed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1f7a84f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->