### PR TITLE
fix(auth): strip 0x from Turnkey r and s separately in server signer

### DIFF
--- a/packages/auth/src/server/turnkey-signer.ts
+++ b/packages/auth/src/server/turnkey-signer.ts
@@ -87,10 +87,17 @@ export class TurnkeyWebVHSigner implements ExternalSigner, ExternalVerifier {
         throw new Error('No signature returned from Turnkey');
       }
 
-      const signature = signRawResult.r + signRawResult.s;
-
-      // Convert signature to bytes
-      const cleanSig = signature.startsWith('0x') ? signature.slice(2) : signature;
+      // Turnkey may return r and s with or without a leading '0x' prefix.
+      // Strip the prefix from each component SEPARATELY before concatenating:
+      // concatenating first and stripping a single leading '0x' would leave an
+      // embedded '0x' in the middle (e.g. 'aaaa...0xbbbb...') when both values
+      // are prefixed, corrupting Buffer.from(..., 'hex') and breaking the
+      // signature. This mirrors the client-side TurnkeyDIDSigner behaviour.
+      const r = signRawResult.r;
+      const s = signRawResult.s;
+      const cleanR = r.startsWith('0x') ? r.slice(2) : r;
+      const cleanS = s.startsWith('0x') ? s.slice(2) : s;
+      const cleanSig = cleanR + cleanS;
       const signatureBytes = Buffer.from(cleanSig, 'hex');
 
       // Ed25519 signatures must be exactly 64 bytes (32-byte r + 32-byte s).

--- a/packages/auth/tests/turnkey-signer.test.ts
+++ b/packages/auth/tests/turnkey-signer.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, mock } from 'bun:test';
 import { TurnkeyWebVHSigner, createTurnkeySigner } from '../src/server/turnkey-signer';
+import { multikey } from '@originals/sdk';
 
 describe('turnkey-signer', () => {
   describe('createTurnkeySigner', () => {
@@ -157,6 +158,50 @@ describe('turnkey-signer', () => {
 
       expect(typeof result.proofValue).toBe('string');
       expect(result.proofValue.length).toBeGreaterThan(0);
+    });
+
+    test('sign handles r and s both 0x-prefixed without corrupting the signature', async () => {
+      // Regression: Turnkey may return r and s each carrying a '0x' prefix.
+      // The signer must strip the prefix from EACH component separately. The
+      // buggy implementation concatenated first and stripped only the single
+      // leading '0x', leaving an embedded '0x' in the middle of the hex string
+      // (e.g. 'aaaa...0xbbbb...') which corrupts the decoded signature bytes.
+      const rHex = 'aa'.repeat(32);
+      const sHex = 'bb'.repeat(32);
+      const mockClient = {
+        apiClient: () => ({
+          signRawPayload: mock(() =>
+            Promise.resolve({
+              activity: {
+                result: {
+                  signRawPayloadResult: { r: `0x${rHex}`, s: `0x${sHex}` },
+                },
+              },
+            })
+          ),
+        }),
+      } as unknown as import('@turnkey/sdk-server').Turnkey;
+
+      const signer = new TurnkeyWebVHSigner(
+        'sub_org_id',
+        'key_id',
+        'z6MkPubKey',
+        mockClient,
+        'did:key:z6Mk#z6Mk'
+      );
+
+      const result = await signer.sign({
+        document: { id: 'did:example:123' },
+        proof: { type: 'DataIntegrityProof' },
+      });
+
+      // Decode the multibase proofValue back to the raw 64-byte signature and
+      // confirm it is exactly the concatenation of the r and s bytes (with the
+      // 0x prefixes correctly stripped).
+      const decoded = multikey.decodeMultibase(result.proofValue);
+      const expected = Buffer.from(rHex + sHex, 'hex');
+      expect(decoded.length).toBe(64);
+      expect(Buffer.from(decoded).equals(expected)).toBe(true);
     });
 
     test('verify returns false for invalid public key length', async () => {

--- a/plans/031-fix-server-turnkey-signer-hex-concat.md
+++ b/plans/031-fix-server-turnkey-signer-hex-concat.md
@@ -1,0 +1,78 @@
+# Plan 031: Fix server `TurnkeyWebVHSigner` corrupting signature on r+s hex concat
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. Make the minimal correct change plus a regression test that
+> fails before the fix and passes after.
+
+## Status
+
+- **Priority**: P0 (critical correctness)
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: bug
+- **Planned at**: origin/main commit `8881c1d`, 2026-06-23
+
+## Why this matters
+
+`packages/auth/src/server/turnkey-signer.ts` (`TurnkeyWebVHSigner.sign`)
+builds the Ed25519 signature by concatenating the Turnkey `r` and `s` hex
+strings first, then strips a single leading `0x` from the concatenation:
+
+```typescript
+const signature = signRawResult.r + signRawResult.s;
+const cleanSig = signature.startsWith('0x') ? signature.slice(2) : signature;
+const signatureBytes = Buffer.from(cleanSig, 'hex');
+```
+
+Turnkey's `signRawPayload` API may return `r` and `s` with or without a `0x`
+prefix depending on the response format. When **both** `r` and `s` carry a
+`0x` prefix (e.g. `r = '0xaaaa...'`, `s = '0xbbbb...'`), the concatenation
+produces `'0xaaaa...0xbbbb...'`. Stripping only the single leading `0x`
+leaves an embedded `'0x'` in the middle of the string:
+`'aaaa...0xbbbb...'`.
+
+`Buffer.from(cleanSig, 'hex')` then stops/garbles at the non-hex `x`,
+producing wrong bytes. This corrupts the proofValue for every server-signed
+did:webvh update, breaking the hash chain and causing all such DID updates to
+fail later verification.
+
+The client signer (`packages/auth/src/client/turnkey-did-signer.ts`) already
+does this correctly: it strips `0x` from each of `r` and `s` **separately**
+before concatenating. The server signer must match that behaviour.
+
+## The fix
+
+In `packages/auth/src/server/turnkey-signer.ts`, strip the `0x` prefix from
+`r` and `s` independently before concatenating, mirroring the client signer:
+
+```typescript
+const r = signRawResult.r;
+const s = signRawResult.s;
+const cleanR = r.startsWith('0x') ? r.slice(2) : r;
+const cleanS = s.startsWith('0x') ? s.slice(2) : s;
+const cleanSig = cleanR + cleanS;
+const signatureBytes = Buffer.from(cleanSig, 'hex');
+```
+
+The existing 64-byte length guard remains unchanged and now also defends
+against any malformed concatenation.
+
+## Regression test
+
+Add a test to `packages/auth/tests/turnkey-signer.test.ts` that mocks Turnkey
+returning `r` and `s` **both prefixed with `0x`**, signs, decodes the
+resulting multibase proofValue, and asserts the 64 signature bytes equal the
+expected `r`/`s` bytes. This fails before the fix (embedded `0x` corrupts the
+bytes / produces wrong length) and passes after.
+
+## Verification
+
+```bash
+cd /Users/brian/Projects/onionoriginals/sdk
+bun install --frozen-lockfile || bun install
+bunx tsc --noEmit            # 0 errors
+bun run build                # succeeds
+bun run test                 # SDK + auth suites 0-fail
+```


### PR DESCRIPTION
## Summary
The server `TurnkeyWebVHSigner` concatenated the Turnkey `signRawPayload` `r` and `s` hex strings first, then stripped only a single leading `0x`. When both `r` and `s` carry a `0x` prefix the concatenation left an embedded `0x` in the middle (e.g. `aaaa...0xbbbb...`), corrupting `Buffer.from(..., 'hex')` and producing an invalid Ed25519 signature — breaking the did:webvh hash chain for every server-signed update.

This strips the `0x` prefix from `r` and `s` independently before concatenating, matching the client-side `TurnkeyDIDSigner`.

## Changes
- `packages/auth/src/server/turnkey-signer.ts`: strip `0x` from `r` and `s` separately.
- `packages/auth/tests/turnkey-signer.test.ts`: regression test decoding the multibase proofValue and asserting the 64 signature bytes equal `r||s` when both inputs are `0x`-prefixed (fails before, passes after).

## Verification (run immediately before merge on rebased branch)
- `bunx tsc --noEmit`: 0 errors
- `bun run build`: succeeded
- `bun run test`: SDK 2787 pass / 0 fail, auth 186 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `TurnkeyWebVHSigner.sign` to strip `0x` from r and s independently
> Turnkey's `signRawPayload` can return both `r` and `s` with individual `0x` prefixes. The previous code concatenated `r` and `s` first and stripped only one leading `0x`, leaving a stray `0x` in the middle of the hex string and producing malformed bytes that failed the 64-byte length check.
>
> - [turnkey-signer.ts](https://github.com/onionoriginals/sdk/pull/208/files#diff-0bc85aff7b742649b9aba1d2c34caeed85c94a77c9bb195720f1a397ce93d323) now strips `0x` from `r` and `s` separately before concatenating, matching the existing client-side behavior.
> - A regression test in [turnkey-signer.test.ts](https://github.com/onionoriginals/sdk/pull/208/files#diff-ec7f9c8e34dcc2f344e5ae3deed38b1f0065984a49438c5efb2a0cb15a958b8b) verifies the decoded `proofValue` equals the correct 64-byte concatenation when both fields carry `0x` prefixes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31296a0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->