### PR TITLE
fix(vc): reject revoked/compromised verification methods in documentLoader

### DIFF
--- a/packages/sdk/src/vc/documentLoader.ts
+++ b/packages/sdk/src/vc/documentLoader.ts
@@ -31,10 +31,21 @@ export class DocumentLoader {
 
     interface DIDDocWithContext {
       '@context'?: unknown;
-      verificationMethod?: Array<{ id?: string }>;
+      verificationMethod?: Array<{ id?: string; revoked?: string; compromised?: string }>;
     }
 
     const didDocTyped = didDoc as DIDDocWithContext;
+
+    // Fail closed on retired keys: a verification method that has been revoked
+    // (rotated out) or marked compromised must never resolve as a usable
+    // verification key, otherwise an attacker holding the old private key could
+    // forge credential proofs that verifyProof would accept. The VM is left in
+    // the DID document precisely so verifiers can recognise it as retired.
+    const assertNotRetired = (vm: { revoked?: string; compromised?: string }): void => {
+      if (vm.revoked || vm.compromised) {
+        throw new Error(`Verification method is retired (revoked or compromised): ${didUrl}`);
+      }
+    };
 
     if (fragment) {
       // The resolved DID document is authoritative. A verification method
@@ -56,6 +67,7 @@ export class DocumentLoader {
       const requestedVmId = normalizeVmId(didUrl);
       const vm = vms?.find((m) => normalizeVmId(m.id) === requestedVmId);
       if (vm) {
+        assertNotRetired(vm);
         return {
           // Return the VM under the requested (absolute) id so the resolved
           // document is internally consistent with documentUrl, regardless of
@@ -69,6 +81,7 @@ export class DocumentLoader {
       // verification method. The registry can never override the DID document.
       const cached = verificationMethodRegistry.get(didUrl);
       if (cached) {
+        assertNotRetired(cached as { revoked?: string; compromised?: string });
         return {
           document: { '@context': didDocTyped['@context'], ...cached },
           documentUrl: didUrl,

--- a/packages/sdk/tests/unit/vc/documentLoader.test.ts
+++ b/packages/sdk/tests/unit/vc/documentLoader.test.ts
@@ -119,3 +119,68 @@ describe('documentLoader finds VM inside DID Document', () => {
     expect(res.document.publicKeyMultibase).toBe('zB');
   });
 });
+
+
+
+
+/** Plan 032: documentLoader must reject revoked / compromised verification methods */
+
+describe('documentLoader rejects retired verification methods', () => {
+  const activeVm = {
+    id: 'did:ex:rev#key-1',
+    type: 'Multikey',
+    controller: 'did:ex:rev',
+    publicKeyMultibase: 'zActive'
+  };
+
+  test('returns the key for an active VM (no over-rejection)', async () => {
+    const dm = new DIDManager({} as any);
+    spyOn(dm, 'resolveDID').mockResolvedValueOnce({
+      '@context': ['https://www.w3.org/ns/did/v1'],
+      id: 'did:ex:rev',
+      verificationMethod: [activeVm]
+    } as any);
+    const loader = createDocumentLoader(dm);
+    const res = await loader('did:ex:rev#key-1');
+    expect(res.document.publicKeyMultibase).toBe('zActive');
+  });
+
+  test('throws when the DID-document VM is revoked', async () => {
+    const dm = new DIDManager({} as any);
+    spyOn(dm, 'resolveDID').mockResolvedValueOnce({
+      '@context': ['https://www.w3.org/ns/did/v1'],
+      id: 'did:ex:rev',
+      verificationMethod: [{ ...activeVm, revoked: '2024-01-01T00:00:00Z' }]
+    } as any);
+    const loader = createDocumentLoader(dm);
+    await expect(loader('did:ex:rev#key-1')).rejects.toThrow('retired');
+  });
+
+  test('throws when the DID-document VM is compromised', async () => {
+    const dm = new DIDManager({} as any);
+    spyOn(dm, 'resolveDID').mockResolvedValueOnce({
+      '@context': ['https://www.w3.org/ns/did/v1'],
+      id: 'did:ex:rev',
+      verificationMethod: [{ ...activeVm, compromised: '2024-01-01T00:00:00Z' }]
+    } as any);
+    const loader = createDocumentLoader(dm);
+    await expect(loader('did:ex:rev#key-1')).rejects.toThrow('retired');
+  });
+
+  test('throws when the cached registry VM is revoked', async () => {
+    const dm = new DIDManager({} as any);
+    spyOn(dm, 'resolveDID').mockResolvedValueOnce({
+      '@context': ['https://www.w3.org/ns/did/v1'],
+      id: 'did:ex:revcache'
+    } as any);
+    const loader = createDocumentLoader(dm);
+    registerVerificationMethod({
+      id: 'did:ex:revcache#key-1',
+      type: 'Multikey',
+      controller: 'did:ex:revcache',
+      publicKeyMultibase: 'zCached',
+      revoked: '2024-01-01T00:00:00Z'
+    } as any);
+    await expect(loader('did:ex:revcache#key-1')).rejects.toThrow('retired');
+  });
+});

--- a/plans/032-documentloader-reject-revoked-vm.md
+++ b/plans/032-documentloader-reject-revoked-vm.md
@@ -1,0 +1,79 @@
+# Plan 032: documentLoader must reject revoked / compromised verification methods
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving on. Touch
+> only the files listed as in scope. If a STOP condition occurs, stop and
+> report. Commit on the worktree branch. SKIP updating `plans/README.md` — the
+> reviewer maintains the index.
+
+## Status
+
+- **Priority**: P0 (high)
+- **Effort**: S
+- **Risk**: LOW
+- **Category**: security / correctness
+- **Branch**: `correctness/round1-5` (from `origin/main`)
+- **Target file**: `packages/sdk/src/vc/documentLoader.ts`
+
+## Why this matters
+
+`DocumentLoader.resolveDID()` loads a verification method (VM) from a DID
+document (or the `verificationMethodRegistry` fallback) and returns it for VC
+Data Integrity proof verification. The consumer
+`EdDSACryptosuiteManager.verifyProof()` (`vc/cryptosuites/eddsa.ts`) reads
+`vmDoc.document.publicKeyMultibase` and uses it to verify the proof.
+
+The `VerificationMethod` type (`src/types/did.ts`) carries optional `revoked`
+and `compromised` ISO-8601 timestamps. `KeyManager` sets these when keys are
+rotated out (`revoked`) or recovered after compromise (`compromised`). A retired
+VM is deliberately left in the DID document so verifiers can recognise it as
+retired. However, the document loader spreads the matched VM verbatim into the
+returned document and never consults these fields, and `verifyProof` never
+checks them either. As a result a proof signed by a revoked/compromised key
+resolves to a valid public key and verifies successfully — an attacker holding
+the old private key could forge accepted credential signatures.
+
+This mirrors the previously fixed CEL key-resolver issue (plan 025) and the
+BBS/signWithKeyStore retired-VM issues (plans 026/030). The document loader is
+the single chokepoint for VC proof key resolution, so the fix belongs here.
+
+## The fix (minimal, correct)
+
+In `resolveDID()`, after locating the matching VM (and likewise for the cached
+registry VM fallback), fail closed by throwing when the VM carries a `revoked`
+or `compromised` timestamp. `EdDSACryptosuiteManager.verifyProof()` already
+wraps the loader call in try/catch and returns `{ verified: false }` on any
+thrown error, so a retired key cleanly fails verification rather than leaking a
+usable key.
+
+Throwing (rather than returning a key-less stub) is preferred because a stub
+would otherwise fall through to canonicalization with a missing key and could
+produce a confusing/ambiguous failure; an explicit error names the cause.
+
+## In scope
+
+- `packages/sdk/src/vc/documentLoader.ts` — reject DID-document VMs and cached
+  registry VMs that carry `revoked` or `compromised`; update JSDoc/comments.
+- `packages/sdk/tests/unit/vc/documentLoader.test.ts` — new regression test
+  (fails before, passes after): the loader returns the key for an active VM but
+  throws when the same VM is revoked or compromised.
+
+## Regression test
+
+A DID document publishes an Ed25519 VM. The loader returns its
+`publicKeyMultibase` when the VM is active (guards against over-rejection). When
+the same VM carries a `revoked` (or `compromised`) timestamp, the loader must
+reject (throw). Covers both the DID-document path and the registry-fallback
+path.
+
+## Verification (run at repo root unless noted)
+
+```
+bun install --frozen-lockfile || bun install
+bunx tsc --noEmit          # 0 errors
+bun run build              # succeeds
+bun run test               # SDK + auth suites 0-fail
+```
+
+STOP conditions: any tsc error, build failure, or a previously-passing test
+regressing.


### PR DESCRIPTION
## Summary
The documentLoader spread a matched verification method verbatim into the resolved document and never consulted its revoked/compromised timestamps. EdDSACryptosuiteManager.verifyProof consumed publicKeyMultibase without checking those fields, so a proof signed by a retired key verified successfully — an attacker holding an old private key could forge accepted credential signatures.

Fail closed in resolveDID(): throw when the matched DID-document VM or the cached registry VM carries a revoked or compromised timestamp. verifyProof already returns { verified: false } on a thrown loader error, mirroring the fail-closed design of the CEL key resolver.

## Verification (rebased onto latest origin/main)
- `tsc --noEmit` (sdk + auth): 0 errors
- `bun run build`: success
- SDK tests: 3018 pass, 0 fail
- Auth tests: 186 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject revoked or compromised verification methods in `DocumentLoader.resolveDID`
> Adds a guard in [documentLoader.ts](https://github.com/onionoriginals/sdk/pull/210/files#diff-226cf2a0a89becfefdc36ce8b49b4d979725522ed00db6e67a70ba26ebb2d80e) that throws when a resolved verification method has a `revoked` or `compromised` timestamp set. The check applies both to VMs found directly in the DID document and to those returned from the `verificationMethodRegistry` fallback. Behavioral Change: callers that previously received revoked or compromised VMs will now get a thrown `Error` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca1f172.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->