### PR TITLE
fix(sdk): #207 hardening — deactivation auto-detect, publishToWeb domain validation, + integration tests

### DIFF
--- a/packages/auth/tests/turnkey-did-creation.integration.test.ts
+++ b/packages/auth/tests/turnkey-did-creation.integration.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Integration test: Turnkey DID creation happy path with a real Ed25519 keypair.
+ *
+ * Background
+ * ----------
+ * The skipped tests in uncovered-scenarios.test.ts (AUTH-029) couldn't use a mock
+ * Turnkey signRawPayload returning random bytes because didwebvh-ts calls
+ * documentStateIsValid() immediately after signing, which performs real Ed25519
+ * proof verification via verifier.verify().
+ *
+ * This file resolves that by constructing a *real* Ed25519 keypair and wrapping it
+ * in a Turnkey-shaped signRawPayload mock that produces a genuine signature over
+ * the exact payload bytes the SDK sends. The proof therefore verifies successfully
+ * and createDIDWithTurnkey() can complete end-to-end without any source changes.
+ *
+ * Turnkey signRawPayload shape (what TurnkeyDIDSigner reads):
+ *   { activity: { result: { signRawPayloadResult: { r: hexString, s: hexString } } } }
+ * where r = first 32 bytes of the Ed25519 signature (hex),
+ *       s = last 32 bytes of the Ed25519 signature (hex).
+ */
+
+import { describe, test, expect } from 'bun:test';
+// Import the SDK first — its noble-init module configures @noble/ed25519's sha512Sync
+// before any crypto operations run, so we don't need to configure it ourselves.
+import { encoding } from '@originals/sdk';
+import * as ed25519Module from '@noble/ed25519';
+import { TurnkeyDIDSigner, createDIDWithTurnkey } from '../src/client/turnkey-did-signer';
+import { TurnkeySessionExpiredError } from '../src/client/turnkey-client';
+import type { Turnkey } from '@turnkey/sdk-server';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// @noble/ed25519 v2 exports at the module level: getPublicKeyAsync, signAsync, utils.
+const ed = ed25519Module as unknown as {
+  utils: { randomPrivateKey: () => Uint8Array };
+  getPublicKeyAsync: (priv: Uint8Array) => Promise<Uint8Array>;
+  signAsync: (msg: Uint8Array, priv: Uint8Array) => Promise<Uint8Array>;
+};
+
+// Multicodec prefix for Ed25519 public keys (0xed 0x01).
+const ED25519_PUB_PREFIX = new Uint8Array([0xed, 0x01]);
+
+/**
+ * Encodes a 32-byte Ed25519 public key as a Multikey publicKeyMultibase string.
+ * Format: "z" + base58btc( 0xed 0x01 || publicKeyBytes )
+ * This is the format TurnkeyDIDSigner.getVerificationMethodId() and didwebvh-ts expect.
+ */
+function toPublicKeyMultibase(publicKeyBytes: Uint8Array): string {
+  const prefixed = new Uint8Array(ED25519_PUB_PREFIX.length + publicKeyBytes.length);
+  prefixed.set(ED25519_PUB_PREFIX);
+  prefixed.set(publicKeyBytes, ED25519_PUB_PREFIX.length);
+  // encoding.multibase.encode with 'base58btc' prepends the 'z' multibase prefix
+  return encoding.multibase.encode(prefixed, 'base58btc');
+}
+
+/**
+ * Generate a fresh Ed25519 keypair + the publicKeyMultibase string that
+ * TurnkeyDIDSigner and didwebvh-ts expect.
+ */
+async function generateKeypair(): Promise<{
+  privateKeyBytes: Uint8Array;
+  publicKeyMultibase: string;
+}> {
+  const privateKeyBytes = ed.utils.randomPrivateKey();
+  const publicKeyBytes = await ed.getPublicKeyAsync(privateKeyBytes);
+  const publicKeyMultibase = toPublicKeyMultibase(publicKeyBytes);
+  return { privateKeyBytes, publicKeyMultibase };
+}
+
+/**
+ * Build a Turnkey-shaped mock client whose signRawPayload:
+ * 1. Receives the payload as a hex string (what TurnkeyDIDSigner sends).
+ * 2. Signs it with the real Ed25519 private key.
+ * 3. Returns the Turnkey-nested response shape the SDK expects.
+ *
+ * This allows TurnkeyDIDSigner to produce a signature that passes didwebvh-ts's
+ * immediate post-creation Ed25519 proof verification.
+ */
+function makeRealSigningClient(
+  privateKeyBytes: Uint8Array,
+  callSpy?: { count: number }
+): Turnkey {
+  return {
+    apiClient: () => ({
+      signRawPayload: async (request: { payload: string; [k: string]: unknown }) => {
+        if (callSpy) callSpy.count++;
+
+        const payloadBytes = Buffer.from(request.payload, 'hex');
+        const sigBytes = await ed.signAsync(payloadBytes, privateKeyBytes);
+
+        // Ed25519 signature is always 64 bytes: first 32 = r, last 32 = s
+        const r = Buffer.from(sigBytes.slice(0, 32)).toString('hex');
+        const s = Buffer.from(sigBytes.slice(32, 64)).toString('hex');
+
+        return {
+          activity: { result: { signRawPayloadResult: { r, s } } },
+        };
+      },
+    }),
+  } as unknown as Turnkey;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('[AUTH-029-INTEGRATION] createDIDWithTurnkey — real Ed25519 keypair', () => {
+  test(
+    'happy path: returns { did, didDocument, didLog } with a valid did: identifier',
+    async () => {
+      const update = await generateKeypair();
+      const auth = await generateKeypair();
+      const assertion = await generateKeypair();
+
+      const turnkeyClient = makeRealSigningClient(update.privateKeyBytes);
+
+      const result = await createDIDWithTurnkey({
+        turnkeyClient,
+        updateKeyAccount: {
+          address: 'key_addr_update',
+          curve: 'CURVE_ED25519',
+          path: "m/44'/501'/1'/0'",
+          addressFormat: 'ADDRESS_FORMAT_SOLANA',
+        },
+        subOrgId: 'sub_org_integration_test',
+        authKeyPublic: auth.publicKeyMultibase,
+        assertionKeyPublic: assertion.publicKeyMultibase,
+        updateKeyPublic: update.publicKeyMultibase,
+        domain: 'magby.originals.build',
+        slug: 'integration-test-user',
+      });
+
+      // Shape assertions
+      expect(result).toHaveProperty('did');
+      expect(result).toHaveProperty('didDocument');
+      expect(result).toHaveProperty('didLog');
+
+      // DID must be a string starting with "did:"
+      expect(typeof result.did).toBe('string');
+      expect(result.did).toMatch(/^did:/);
+
+      // DID document must be a non-null object
+      expect(result.didDocument).toBeTruthy();
+      expect(typeof result.didDocument).toBe('object');
+
+      // Log must be present
+      expect(result.didLog).toBeTruthy();
+    },
+    15_000
+  );
+
+  test(
+    'signRawPayload is called at least once during DID creation',
+    async () => {
+      const update = await generateKeypair();
+      const auth = await generateKeypair();
+      const assertion = await generateKeypair();
+
+      const spy = { count: 0 };
+      const turnkeyClient = makeRealSigningClient(update.privateKeyBytes, spy);
+
+      await createDIDWithTurnkey({
+        turnkeyClient,
+        updateKeyAccount: {
+          address: 'key_addr_update',
+          curve: 'CURVE_ED25519',
+          path: "m/44'/501'/1'/0'",
+          addressFormat: 'ADDRESS_FORMAT_SOLANA',
+        },
+        subOrgId: 'sub_org_spy_test',
+        authKeyPublic: auth.publicKeyMultibase,
+        assertionKeyPublic: assertion.publicKeyMultibase,
+        updateKeyPublic: update.publicKeyMultibase,
+        domain: 'magby.originals.build',
+        slug: 'spy-test-user',
+      });
+
+      expect(spy.count).toBeGreaterThan(0);
+    },
+    15_000
+  );
+
+  test(
+    'TurnkeyDIDSigner.sign() with real keypair produces a z-prefixed base58btc proofValue',
+    async () => {
+      const { privateKeyBytes, publicKeyMultibase } = await generateKeypair();
+      const turnkeyClient = makeRealSigningClient(privateKeyBytes);
+
+      const signer = new TurnkeyDIDSigner(
+        turnkeyClient,
+        'key_addr_update',
+        'sub_org_test',
+        publicKeyMultibase
+      );
+
+      const result = await signer.sign({
+        document: { id: 'did:webvh:magby.originals.build:test-signer' },
+        proof: {
+          type: 'DataIntegrityProof',
+          cryptosuite: 'eddsa-jcs-2022',
+          verificationMethod: `did:key:${publicKeyMultibase}`,
+          created: new Date().toISOString(),
+          proofPurpose: 'assertionMethod',
+        },
+      });
+
+      expect(result).toHaveProperty('proofValue');
+      expect(typeof result.proofValue).toBe('string');
+      // base58btc multibase prefix
+      expect(result.proofValue.startsWith('z')).toBe(true);
+      // Ed25519 signature is 64 bytes; base58btc encoding of 64 bytes is ~88 chars
+      expect(result.proofValue.length).toBeGreaterThan(80);
+    },
+    10_000
+  );
+
+  test(
+    'expired session during DID creation fires onExpired and throws TurnkeySessionExpiredError',
+    async () => {
+      // Does not need a real key — throws before signing succeeds
+      const expiredError = { code: 'api_key_expired', message: 'api_key_expired' };
+
+      const turnkeyClient: Turnkey = {
+        apiClient: () => ({
+          signRawPayload: async () => { throw expiredError; },
+        }),
+      } as unknown as Turnkey;
+
+      let onExpiredCalled = false;
+
+      await expect(
+        createDIDWithTurnkey({
+          turnkeyClient,
+          updateKeyAccount: {
+            address: 'key_addr',
+            curve: 'CURVE_ED25519',
+            path: "m/44'/501'/1'/0'",
+            addressFormat: 'ADDRESS_FORMAT_SOLANA',
+          },
+          subOrgId: 'sub_org_test',
+          // Reuse the well-known fixture keys from uncovered-scenarios.test.ts
+          authKeyPublic: 'z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp',
+          assertionKeyPublic: 'z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK',
+          updateKeyPublic: 'z6MknGc3omQfErKtumfzKgaEsXYP4amJiosdMXaGK9PFqaHh',
+          domain: 'magby.originals.build',
+          slug: 'expired-session-test',
+          onExpired: () => { onExpiredCalled = true; },
+        })
+      ).rejects.toBeInstanceOf(TurnkeySessionExpiredError);
+
+      expect(onExpiredCalled).toBe(true);
+    },
+    10_000
+  );
+});

--- a/packages/sdk/src/lifecycle/BatchLifecycleOperations.ts
+++ b/packages/sdk/src/lifecycle/BatchLifecycleOperations.ts
@@ -8,6 +8,7 @@ import { OriginalsAsset } from './OriginalsAsset';
 import { validateBitcoinAddress } from '../utils/bitcoin-address';
 import { EventEmitter } from '../events/EventEmitter';
 import { StructuredError } from '../utils/telemetry';
+import { validateAndNormalizeDomain } from './domainUtils';
 import {
   BatchOperationExecutor,
   BatchValidator,
@@ -126,33 +127,8 @@ export class BatchLifecycleOperations {
   ): Promise<BatchResult<OriginalsAsset>> {
     const batchId = this.batchExecutor.generateBatchId();
 
-    // Validate domain once
-    if (!domain || typeof domain !== 'string') {
-      throw new StructuredError('INVALID_DOMAIN', 'Invalid domain: must be a non-empty string');
-    }
-
-    const normalized = domain.trim().toLowerCase();
-
-    // Split domain and port if present
-    const [domainPart, portPart] = normalized.split(':');
-
-    // Validate port if present
-    if (portPart && (!/^\d+$/.test(portPart) || parseInt(portPart) < 1 || parseInt(portPart) > 65535)) {
-      throw new StructuredError('INVALID_DOMAIN', `Invalid domain format: ${domain} - invalid port`);
-    }
-
-    // Allow localhost and IP addresses for development
-    const isLocalhost = domainPart === 'localhost';
-    const isIP = /^(\d{1,3}\.){3}\d{1,3}$/.test(domainPart);
-
-    if (!isLocalhost && !isIP) {
-      // For non-localhost domains, require proper domain format
-      const label = '[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?';
-      const domainRegex = new RegExp(`^(?=.{1,253}$)(?:${label})(?:\\.(?:${label}))+?$`, 'i');
-      if (!domainRegex.test(domainPart)) {
-        throw new StructuredError('INVALID_DOMAIN', `Invalid domain format: ${domain}. Must be a valid hostname (e.g., example.com) or localhost.`);
-      }
-    }
+    // Validate domain once (shared with the single-asset path in LifecycleManager).
+    validateAndNormalizeDomain(domain);
 
     // Emit batch:started event
     await this.eventEmitter.emit({

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -598,6 +598,34 @@ export class LifecycleManager {
     }
   }
 
+  /**
+   * Validate that a domain string has a proper hostname format.
+   * Mirrors the validation used in batchPublishToWeb.
+   */
+  private validateDomain(domain: string): void {
+    if (!domain || typeof domain !== 'string') {
+      throw new StructuredError('INVALID_DOMAIN', 'Invalid domain: must be a non-empty string');
+    }
+
+    const normalized = domain.trim().toLowerCase();
+    const [domainPart, portPart] = normalized.split(':');
+
+    if (portPart && (!/^\d+$/.test(portPart) || parseInt(portPart) < 1 || parseInt(portPart) > 65535)) {
+      throw new StructuredError('INVALID_DOMAIN', `Invalid domain format: ${domain} - invalid port`);
+    }
+
+    const isLocalhost = domainPart === 'localhost';
+    const isIP = /^(\d{1,3}\.){3}\d{1,3}$/.test(domainPart);
+
+    if (!isLocalhost && !isIP) {
+      const label = '[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?';
+      const domainRegex = new RegExp(`^(?=.{1,253}$)(?:${label})(?:\\.(?:${label}))+?$`, 'i');
+      if (!domainRegex.test(domainPart)) {
+        throw new StructuredError('INVALID_DOMAIN', `Invalid domain format: ${domain}. Must be a valid hostname (e.g., example.com) or localhost.`);
+      }
+    }
+  }
+
   private extractPublisherInfo(publisherDidOrSigner: string | ExternalSigner): {
     publisherDid: string;
     signer?: ExternalSigner;
@@ -608,10 +636,11 @@ export class LifecycleManager {
         return { publisherDid: publisherDidOrSigner };
       }
 
-      // Otherwise, treat it as a domain and construct a did:webvh DID
-      // Format: did:webvh:domain:user (use 'user' as default user path)
-      // Encode the domain to handle ports (e.g., localhost:5000 -> localhost%3A5000)
+      // Otherwise, treat it as a domain and construct a did:webvh DID.
+      // Validate domain format before encoding.
       const domain = publisherDidOrSigner;
+      this.validateDomain(domain);
+      // Encode the domain to handle ports (e.g., localhost:5000 -> localhost%3A5000)
       const encodedDomain = encodeURIComponent(domain);
       const publisherDid = `did:webvh:${encodedDomain}:user`;
       return { publisherDid };

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -26,6 +26,7 @@ import {
   type BatchInscriptionOptions,
 } from './BatchOperations';
 import { BatchLifecycleOperations } from './BatchLifecycleOperations';
+import { validateAndNormalizeDomain } from './domainUtils';
 import { 
   type OriginalKind, 
   type OriginalManifest, 
@@ -598,34 +599,6 @@ export class LifecycleManager {
     }
   }
 
-  /**
-   * Validate that a domain string has a proper hostname format.
-   * Mirrors the validation used in batchPublishToWeb.
-   */
-  private validateDomain(domain: string): void {
-    if (!domain || typeof domain !== 'string') {
-      throw new StructuredError('INVALID_DOMAIN', 'Invalid domain: must be a non-empty string');
-    }
-
-    const normalized = domain.trim().toLowerCase();
-    const [domainPart, portPart] = normalized.split(':');
-
-    if (portPart && (!/^\d+$/.test(portPart) || parseInt(portPart) < 1 || parseInt(portPart) > 65535)) {
-      throw new StructuredError('INVALID_DOMAIN', `Invalid domain format: ${domain} - invalid port`);
-    }
-
-    const isLocalhost = domainPart === 'localhost';
-    const isIP = /^(\d{1,3}\.){3}\d{1,3}$/.test(domainPart);
-
-    if (!isLocalhost && !isIP) {
-      const label = '[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?';
-      const domainRegex = new RegExp(`^(?=.{1,253}$)(?:${label})(?:\\.(?:${label}))+?$`, 'i');
-      if (!domainRegex.test(domainPart)) {
-        throw new StructuredError('INVALID_DOMAIN', `Invalid domain format: ${domain}. Must be a valid hostname (e.g., example.com) or localhost.`);
-      }
-    }
-  }
-
   private extractPublisherInfo(publisherDidOrSigner: string | ExternalSigner): {
     publisherDid: string;
     signer?: ExternalSigner;
@@ -637,11 +610,12 @@ export class LifecycleManager {
       }
 
       // Otherwise, treat it as a domain and construct a did:webvh DID.
-      // Validate domain format before encoding.
-      const domain = publisherDidOrSigner;
-      this.validateDomain(domain);
+      // Validate AND normalize before encoding so the DID is built from the
+      // same normalized form that validation checked (avoids whitespace/case
+      // drift between validation and the value actually encoded).
+      const normalizedDomain = validateAndNormalizeDomain(publisherDidOrSigner);
       // Encode the domain to handle ports (e.g., localhost:5000 -> localhost%3A5000)
-      const encodedDomain = encodeURIComponent(domain);
+      const encodedDomain = encodeURIComponent(normalizedDomain);
       const publisherDid = `did:webvh:${encodedDomain}:user`;
       return { publisherDid };
     }

--- a/packages/sdk/src/lifecycle/domainUtils.ts
+++ b/packages/sdk/src/lifecycle/domainUtils.ts
@@ -1,0 +1,60 @@
+import { StructuredError } from '../utils/telemetry';
+
+/**
+ * Validate a domain string and return its normalized (trimmed, lowercased) form.
+ *
+ * Accepts hostnames (e.g. `example.com`), `localhost`, and IPv4 addresses, each
+ * optionally followed by a single `:port`. Rejects empty/non-string input,
+ * strings containing more than one colon, out-of-range ports, and malformed
+ * hostnames.
+ *
+ * The normalized return value MUST be used for any subsequent encoding/DID
+ * construction so that validation and the value actually used cannot diverge
+ * (a domain with surrounding whitespace or mixed case otherwise passes
+ * validation but produces a DID built from the un-normalized string).
+ *
+ * @param domain Raw domain string supplied by the caller.
+ * @returns The normalized domain (trimmed + lowercased).
+ * @throws StructuredError('INVALID_DOMAIN') when the domain is malformed.
+ */
+export function validateAndNormalizeDomain(domain: string): string {
+  if (!domain || typeof domain !== 'string') {
+    throw new StructuredError('INVALID_DOMAIN', 'Invalid domain: must be a non-empty string');
+  }
+
+  const normalized = domain.trim().toLowerCase();
+
+  // Reject more than one colon up front: `split(':')` would otherwise silently
+  // discard everything after the second segment, letting `example.com:8080:path`
+  // pass validation while being handed to encodeURIComponent verbatim.
+  const colonParts = normalized.split(':');
+  if (colonParts.length > 2) {
+    throw new StructuredError(
+      'INVALID_DOMAIN',
+      `Invalid domain format: ${domain}. Must be a valid hostname with at most one port (e.g., example.com or example.com:8080).`
+    );
+  }
+
+  const [domainPart, portPart] = colonParts;
+
+  if (portPart && (!/^\d+$/.test(portPart) || parseInt(portPart) < 1 || parseInt(portPart) > 65535)) {
+    throw new StructuredError('INVALID_DOMAIN', `Invalid domain format: ${domain} - invalid port`);
+  }
+
+  // Allow localhost and IP addresses for development.
+  const isLocalhost = domainPart === 'localhost';
+  const isIP = /^(\d{1,3}\.){3}\d{1,3}$/.test(domainPart);
+
+  if (!isLocalhost && !isIP) {
+    const label = '[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?';
+    const domainRegex = new RegExp(`^(?=.{1,253}$)(?:${label})(?:\\.(?:${label}))+?$`, 'i');
+    if (!domainRegex.test(domainPart)) {
+      throw new StructuredError(
+        'INVALID_DOMAIN',
+        `Invalid domain format: ${domain}. Must be a valid hostname (e.g., example.com) or localhost.`
+      );
+    }
+  }
+
+  return normalized;
+}

--- a/packages/sdk/src/lifecycle/domainUtils.ts
+++ b/packages/sdk/src/lifecycle/domainUtils.ts
@@ -37,7 +37,11 @@ export function validateAndNormalizeDomain(domain: string): string {
 
   const [domainPart, portPart] = colonParts;
 
-  if (portPart && (!/^\d+$/.test(portPart) || parseInt(portPart) < 1 || parseInt(portPart) > 65535)) {
+  // `portPart !== undefined` means a colon was present, so a port is required.
+  // An empty string (trailing colon, e.g. `example.com:`) must be rejected, not
+  // skipped as falsy — otherwise it would encode to a DID like
+  // `did:webvh:example.com%3A:user`.
+  if (portPart !== undefined && (portPart === '' || !/^\d+$/.test(portPart) || parseInt(portPart) < 1 || parseInt(portPart) > 65535)) {
     throw new StructuredError('INVALID_DOMAIN', `Invalid domain format: ${domain} - invalid port`);
   }
 

--- a/packages/sdk/src/migration/validation/LifecycleValidator.ts
+++ b/packages/sdk/src/migration/validation/LifecycleValidator.ts
@@ -10,11 +10,14 @@ import {
   IValidator
 } from '../types';
 import { OriginalsConfig } from '../../types';
+import type { DIDManager } from '../../did/DIDManager';
 
 export class LifecycleValidator implements IValidator {
-  constructor(private config: OriginalsConfig) {}
+  constructor(
+    private config: OriginalsConfig,
+    private didManager?: DIDManager
+  ) {}
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   async validate(options: MigrationOptions): Promise<MigrationValidationResult> {
     const errors: ValidationError[] = [];
     const warnings: ValidationWarning[] = [];
@@ -22,11 +25,11 @@ export class LifecycleValidator implements IValidator {
     try {
       // DEF-019: Reject migration of deactivated assets.
       //
-      // Deactivation state is not encoded in the DIDDocument itself (DIDDocument
-      // has no `deactivated` field in this SDK's type system).  The caller
-      // signals deactivation through MigrationOptions.metadata.deactivated.
-      // Sources that set this include the CEL layer state machines
-      // (PeerCelManager / BtcoCelManager) and the OriginalsSDK verify path.
+      // Belt-and-braces: two complementary detection paths.
+      //
+      // Path 1 (caller-supplied flag): The caller may signal deactivation via
+      // MigrationOptions.metadata.deactivated (used by CEL layer state machines
+      // and the OriginalsSDK verify path).
       const deactivated = options.metadata?.['deactivated'];
       if (deactivated === true) {
         errors.push({
@@ -35,6 +38,39 @@ export class LifecycleValidator implements IValidator {
           field: 'metadata.deactivated',
           details: { sourceDid: options.sourceDid }
         });
+      }
+
+      // Path 2 (auto-detect via DID resolution): If a DIDManager is available
+      // and the caller has NOT already flagged deactivation, resolve the source
+      // DID and treat a null result as a deactivation signal.
+      //
+      // Rationale: BtcoDidResolver sets didDocument to null when the inscription
+      // contains a deactivation marker (🔥), so DIDManager.resolveDID() returns
+      // null for a deactivated did:btco. For did:peer / did:webvh the resolver
+      // always returns a (possibly stub) document, so a null result specifically
+      // indicates a resolution failure that is treated conservatively as
+      // deactivation to prevent migration of an unresolvable asset.
+      //
+      // We skip this check when the metadata flag already fired (to avoid
+      // duplicating the error) and skip it when no DIDManager is wired in
+      // (preserves backward-compatibility for callers that construct the
+      // validator without a resolver).
+      if (deactivated !== true && this.didManager && options.sourceDid) {
+        let resolvedDoc: Awaited<ReturnType<DIDManager['resolveDID']>> | undefined;
+        try {
+          resolvedDoc = await this.didManager.resolveDID(options.sourceDid);
+        } catch {
+          // Resolution errors are non-fatal for the validator; the DID
+          // compatibility validator will surface connectivity issues separately.
+        }
+        if (resolvedDoc === null) {
+          errors.push({
+            code: 'ASSET_DEACTIVATED',
+            message: 'Cannot migrate a deactivated asset',
+            field: 'sourceDid',
+            details: { sourceDid: options.sourceDid, detectedBy: 'did-resolution' }
+          });
+        }
       }
 
       return {

--- a/packages/sdk/src/migration/validation/ValidationPipeline.ts
+++ b/packages/sdk/src/migration/validation/ValidationPipeline.ts
@@ -37,7 +37,7 @@ export class ValidationPipeline {
     this.validators.set('did', new DIDCompatibilityValidator(this.config, this.didManager));
     this.validators.set('credential', new CredentialValidator(this.config));
     this.validators.set('storage', new StorageValidator(this.config));
-    this.validators.set('lifecycle', new LifecycleValidator(this.config));
+    this.validators.set('lifecycle', new LifecycleValidator(this.config, this.didManager));
     if (this.bitcoinManager) {
       this.validators.set('bitcoin', new BitcoinValidator(this.config, this.bitcoinManager));
     }

--- a/packages/sdk/tests/integration/cel-cli.integration.test.ts
+++ b/packages/sdk/tests/integration/cel-cli.integration.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Integration tests for the CEL CLI command routing via the real entry point.
+ *
+ * These tests MUST run as subprocesses. The CLI entry point (src/cel/cli/index.ts)
+ * calls process.exit() on errors, which would kill the test runner if invoked
+ * in-process. Subprocess execution also captures real stdout/stderr and real
+ * OS exit codes, making it the only way to verify the actual routing behaviour.
+ *
+ * CLI entry: packages/sdk/dist/cel/cli/index.js  (referenced in package.json bin)
+ * Invoked as: `bun <path> <args>`
+ *
+ * Verified behaviors:
+ *  1. --version prints "originals-cel v<version>" and exits 0
+ *  2. --help prints usage and exits 0
+ *  3. Unknown command exits 1 with "Unknown command:" error message
+ *  4. Missing required argument exits 1 with descriptive error message
+ *  5. Valid `create` command with a real file exits 0 and writes JSON to output
+ *  6. `verify` on the created log exits 0 with "VERIFICATION PASSED"
+ *  7. `inspect` on the created log exits 0 with event timeline
+ *  8. `verify --log <nonexistent>` exits 1 with "Failed to load event log"
+ */
+
+import { describe, test, expect, afterAll } from 'bun:test';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Absolute path to the compiled CLI entry point. */
+const CLI_ENTRY = path.resolve(
+  __dirname,
+  '../../dist/cel/cli/index.js'
+);
+
+/** Temporary files created by the tests. Cleaned up in afterAll. */
+const tmpFiles: string[] = [];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the CLI as a subprocess via `bun <CLI_ENTRY> ...args`.
+ * Returns { stdout, stderr, exitCode }.
+ */
+function runCli(args: string[], options: { timeout?: number } = {}): {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+} {
+  const result = spawnSync('bun', [CLI_ENTRY, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, NODE_OPTIONS: '' },
+    timeout: options.timeout ?? 30_000,
+  });
+
+  return {
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    exitCode: result.status ?? 1,
+  };
+}
+
+/**
+ * Create a temporary file with the given content.
+ * The path is registered for cleanup in afterAll.
+ */
+function makeTmpFile(suffix: string, content: string | Buffer = ''): string {
+  const filePath = path.join(os.tmpdir(), `cel-cli-test-${Date.now()}-${Math.random().toString(36).slice(2)}${suffix}`);
+  if (typeof content === 'string') {
+    fs.writeFileSync(filePath, content, 'utf-8');
+  } else {
+    fs.writeFileSync(filePath, content);
+  }
+  tmpFiles.push(filePath);
+  return filePath;
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+afterAll(() => {
+  for (const f of tmpFiles) {
+    try { fs.unlinkSync(f); } catch { /* ignore */ }
+  }
+  // Also clean up any .key files the CLI may have generated alongside output files
+  for (const f of tmpFiles) {
+    try { fs.unlinkSync(f + '.key'); } catch { /* ignore */ }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('[CEL-CLI] Command routing via real subprocess entry point', () => {
+  // ── Global options ────────────────────────────────────────────────────────
+
+  test('--version prints version string and exits 0', () => {
+    const { stdout, exitCode } = runCli(['--version']);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/originals-cel v\d+\.\d+\.\d+/);
+  });
+
+  test('-v prints version string and exits 0', () => {
+    const { stdout, exitCode } = runCli(['-v']);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/originals-cel v\d+\.\d+\.\d+/);
+  });
+
+  test('--help prints usage text and exits 0', () => {
+    const { stdout, exitCode } = runCli(['--help']);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('originals-cel');
+    expect(stdout).toContain('COMMANDS');
+    expect(stdout).toContain('create');
+    expect(stdout).toContain('verify');
+  });
+
+  test('no arguments prints help and exits 0', () => {
+    const { stdout, exitCode } = runCli([]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('originals-cel');
+  });
+
+  // ── Unknown command ────────────────────────────────────────────────────────
+
+  test('unknown command exits 1 with error message', () => {
+    const { stderr, exitCode } = runCli(['unknowncmd']);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('Unknown command:');
+    expect(stderr).toContain('unknowncmd');
+  });
+
+  test('unknown command error message suggests --help', () => {
+    const { stderr } = runCli(['totally-unknown-xyz']);
+
+    expect(stderr).toMatch(/--help|usage/i);
+  });
+
+  // ── Missing required arguments ────────────────────────────────────────────
+
+  test('create without --name exits 1 with descriptive error', () => {
+    const tmpFile = makeTmpFile('.txt', 'test content');
+    const { stderr, exitCode } = runCli(['create', '--file', tmpFile]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toMatch(/--name.*required|required.*--name/i);
+  });
+
+  test('create without --file exits 1 with descriptive error', () => {
+    const { stderr, exitCode } = runCli(['create', '--name', 'TestAsset']);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toMatch(/--file.*required|required.*--file/i);
+  });
+
+  test('verify without --log exits 1 with descriptive error', () => {
+    const { stderr, exitCode } = runCli(['verify']);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toMatch(/--log.*required|required.*--log/i);
+  });
+
+  test('inspect without --log exits 1 with descriptive error', () => {
+    const { stderr, exitCode } = runCli(['inspect']);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toMatch(/--log.*required|required.*--log/i);
+  });
+
+  // ── verify with nonexistent file ──────────────────────────────────────────
+
+  test('verify --log <nonexistent> exits 1 with "Failed to load event log"', () => {
+    const { stderr, exitCode } = runCli(['verify', '--log', '/nonexistent-cel-file.cel.json']);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('Failed to load event log');
+  });
+
+  // ── Happy path: create → verify → inspect ────────────────────────────────
+
+  test(
+    'create with valid file exits 0 and writes valid JSON to output',
+    async () => {
+      const contentFile = makeTmpFile('.txt', 'Hello, CEL integration test!\n');
+      const outputLog = makeTmpFile('.cel.json');
+      // Remove the empty output file so the CLI creates it fresh
+      fs.unlinkSync(outputLog);
+
+      const { exitCode, stderr } = runCli([
+        'create',
+        '--name', 'IntegrationTestAsset',
+        '--file', contentFile,
+        '--output', outputLog,
+      ]);
+
+      // Must exit 0
+      expect(exitCode).toBe(0);
+
+      // Output file must exist and be valid JSON
+      expect(fs.existsSync(outputLog)).toBe(true);
+      const raw = fs.readFileSync(outputLog, 'utf-8');
+      const parsed = JSON.parse(raw) as unknown;
+      expect(parsed).toBeTruthy();
+      expect(typeof parsed).toBe('object');
+
+      // JSON must have an events array
+      expect((parsed as { events: unknown }).events).toBeTruthy();
+      const events = (parsed as { events: unknown[] }).events;
+      expect(Array.isArray(events)).toBe(true);
+      expect(events.length).toBeGreaterThan(0);
+
+      // First event must be a "create" type
+      const firstEvent = events[0] as { type: string };
+      expect(firstEvent.type).toBe('create');
+
+      // stderr should mention key generation (since no --key was given)
+      expect(stderr).toContain('key pair generated');
+    },
+    30_000
+  );
+
+  test(
+    'verify on a freshly created log exits 0 with VERIFICATION PASSED',
+    async () => {
+      const contentFile = makeTmpFile('.txt', 'Hello, CEL verify test!\n');
+      const outputLog = makeTmpFile('.cel.json');
+      fs.unlinkSync(outputLog);
+
+      // Step 1: create
+      const createResult = runCli([
+        'create',
+        '--name', 'VerifyTestAsset',
+        '--file', contentFile,
+        '--output', outputLog,
+      ]);
+      expect(createResult.exitCode).toBe(0);
+      expect(fs.existsSync(outputLog)).toBe(true);
+
+      // Step 2: verify
+      const verifyResult = runCli(['verify', '--log', outputLog]);
+
+      expect(verifyResult.exitCode).toBe(0);
+      expect(verifyResult.stdout).toContain('VERIFICATION PASSED');
+    },
+    30_000
+  );
+
+  test(
+    'inspect on a freshly created log exits 0 with event timeline',
+    async () => {
+      const contentFile = makeTmpFile('.txt', 'Hello, CEL inspect test!\n');
+      const outputLog = makeTmpFile('.cel.json');
+      fs.unlinkSync(outputLog);
+
+      // Step 1: create
+      const createResult = runCli([
+        'create',
+        '--name', 'InspectTestAsset',
+        '--file', contentFile,
+        '--output', outputLog,
+      ]);
+      expect(createResult.exitCode).toBe(0);
+
+      // Step 2: inspect
+      const inspectResult = runCli(['inspect', '--log', outputLog]);
+
+      expect(inspectResult.exitCode).toBe(0);
+      expect(inspectResult.stdout).toContain('InspectTestAsset');
+      // Should show event timeline
+      expect(inspectResult.stdout).toMatch(/create|CREATE/i);
+    },
+    30_000
+  );
+
+  // ── Command help flags ────────────────────────────────────────────────────
+
+  test('create --help prints create-specific help and exits 0', () => {
+    const { stdout, exitCode } = runCli(['create', '--help']);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('--name');
+    expect(stdout).toContain('--file');
+  });
+
+  test('verify --help prints verify-specific help and exits 0', () => {
+    const { stdout, exitCode } = runCli(['verify', '--help']);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('--log');
+  });
+});

--- a/packages/sdk/tests/unit/lifecycle/publish-domain-validation.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/publish-domain-validation.test.ts
@@ -44,6 +44,25 @@ describe('LifecycleManager.publishToWeb — domain format validation', () => {
     await expect(sdk.lifecycle.publishToWeb(asset, 'example.com:abc')).rejects.toThrow('Invalid domain format');
   });
 
+  it('rejects a domain with more than one colon (extra segments not silently dropped)', async () => {
+    const { sdk, asset } = await createDraftAsset();
+    // Greptile #211: split(':') previously discarded everything after the port,
+    // so example.com:8080:path passed validation then got encoded verbatim.
+    await expect(sdk.lifecycle.publishToWeb(asset, 'example.com:8080:path')).rejects.toThrow('Invalid domain format');
+  });
+
+  it('normalizes domain (trim + lowercase) before building the DID', async () => {
+    const { sdk, asset } = await createDraftAsset();
+    // Macroscope #211: validation normalized but the original string was encoded,
+    // so whitespace/mixed-case produced a DID that didn't match the normalized form.
+    const published = await sdk.lifecycle.publishToWeb(asset, '  Example.COM  ');
+    expect(published.currentLayer).toBe('did:webvh');
+    const webvh = published.bindings?.['did:webvh'] ?? '';
+    expect(webvh).toContain('example.com');
+    expect(webvh).not.toContain('Example.COM');
+    expect(webvh).not.toContain('%20'); // no encoded leading/trailing whitespace
+  });
+
   it('accepts a valid domain (example.com)', async () => {
     const { sdk, asset } = await createDraftAsset();
     // Should not throw on domain validation (may fail later in resource publish, which is OK)

--- a/packages/sdk/tests/unit/lifecycle/publish-domain-validation.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/publish-domain-validation.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests: publishToWeb validates domain format (issue #207)
+ *
+ * Verifies that LifecycleManager.publishToWeb rejects malformed domain strings
+ * before any resource publishing occurs, matching the validation already
+ * present in batchPublishToWeb.
+ */
+import { describe, it, expect } from 'bun:test';
+import { OriginalsSDK } from '../../../src';
+
+const resources = [
+  {
+    id: 'res1',
+    type: 'text',
+    content: 'hello world',
+    contentType: 'text/plain',
+    hash: 'deadbeef',
+  },
+];
+
+async function createDraftAsset() {
+  const sdk = OriginalsSDK.create({ network: 'regtest', enableLogging: false });
+  return { sdk, asset: await sdk.lifecycle.createAsset(resources) };
+}
+
+describe('LifecycleManager.publishToWeb — domain format validation', () => {
+  it('rejects a clearly malformed domain (bare label, no TLD)', async () => {
+    const { sdk, asset } = await createDraftAsset();
+    await expect(sdk.lifecycle.publishToWeb(asset, 'notadomain')).rejects.toThrow('Invalid domain format');
+  });
+
+  it('rejects a domain with spaces', async () => {
+    const { sdk, asset } = await createDraftAsset();
+    await expect(sdk.lifecycle.publishToWeb(asset, 'invalid domain.com')).rejects.toThrow('Invalid domain format');
+  });
+
+  it('rejects a domain with an invalid port', async () => {
+    const { sdk, asset } = await createDraftAsset();
+    await expect(sdk.lifecycle.publishToWeb(asset, 'example.com:99999')).rejects.toThrow('Invalid domain format');
+  });
+
+  it('rejects a domain with a non-numeric port', async () => {
+    const { sdk, asset } = await createDraftAsset();
+    await expect(sdk.lifecycle.publishToWeb(asset, 'example.com:abc')).rejects.toThrow('Invalid domain format');
+  });
+
+  it('accepts a valid domain (example.com)', async () => {
+    const { sdk, asset } = await createDraftAsset();
+    // Should not throw on domain validation (may fail later in resource publish, which is OK)
+    const published = await sdk.lifecycle.publishToWeb(asset, 'example.com');
+    expect(published.currentLayer).toBe('did:webvh');
+    expect(published.bindings?.['did:webvh']).toContain('example.com');
+  });
+
+  it('accepts localhost (development domain)', async () => {
+    const { sdk, asset } = await createDraftAsset();
+    const published = await sdk.lifecycle.publishToWeb(asset, 'localhost');
+    expect(published.currentLayer).toBe('did:webvh');
+  });
+
+  it('accepts localhost with a valid port', async () => {
+    const { sdk, asset } = await createDraftAsset();
+    const published = await sdk.lifecycle.publishToWeb(asset, 'localhost:5000');
+    expect(published.currentLayer).toBe('did:webvh');
+  });
+
+  it('bypasses domain validation when a full did:webvh DID is supplied', async () => {
+    const { sdk, asset } = await createDraftAsset();
+    // Supplying a full did:webvh DID bypasses domain extraction/validation entirely
+    const published = await sdk.lifecycle.publishToWeb(asset, 'did:webvh:example.com:user');
+    expect(published.currentLayer).toBe('did:webvh');
+  });
+});

--- a/packages/sdk/tests/unit/lifecycle/publish-domain-validation.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/publish-domain-validation.test.ts
@@ -44,6 +44,13 @@ describe('LifecycleManager.publishToWeb — domain format validation', () => {
     await expect(sdk.lifecycle.publishToWeb(asset, 'example.com:abc')).rejects.toThrow('Invalid domain format');
   });
 
+  it('rejects a domain with a trailing colon (empty port)', async () => {
+    const { sdk, asset } = await createDraftAsset();
+    // Macroscope #211: 'example.com:' splits to portPart='' which is falsy;
+    // an empty port must be rejected, not skipped.
+    await expect(sdk.lifecycle.publishToWeb(asset, 'example.com:')).rejects.toThrow('Invalid domain format');
+  });
+
   it('rejects a domain with more than one colon (extra segments not silently dropped)', async () => {
     const { sdk, asset } = await createDraftAsset();
     // Greptile #211: split(':') previously discarded everything after the port,

--- a/packages/sdk/tests/unit/migration/lifecycle-validator-deactivation.test.ts
+++ b/packages/sdk/tests/unit/migration/lifecycle-validator-deactivation.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests: LifecycleValidator auto-detects deactivation via DID resolution (issue #207)
+ *
+ * Verifies that the validator rejects a migration when the source DID resolves
+ * to null (the signal for a deactivated did:btco) WITHOUT the caller having to
+ * pass metadata.deactivated = true.
+ */
+import { describe, it, expect } from 'bun:test';
+import { LifecycleValidator } from '../../../src/migration/validation/LifecycleValidator';
+import type { DIDManager } from '../../../src/did/DIDManager';
+import type { MigrationOptions } from '../../../src/migration/types';
+import type { OriginalsConfig } from '../../../src/types';
+
+const testConfig: OriginalsConfig = {
+  network: 'regtest',
+  webvhNetwork: 'magby',
+  defaultKeyType: 'Ed25519',
+  enableLogging: false,
+};
+
+/** Minimal MigrationOptions pointing to a did:btco source */
+const btcoOptions: MigrationOptions = {
+  sourceDid: 'did:btco:reg:123456',
+  targetLayer: 'webvh',
+};
+
+describe('LifecycleValidator — deactivation auto-detect', () => {
+  it('rejects migration when DIDManager.resolveDID returns null (deactivated DID), without metadata flag', async () => {
+    // Arrange: mock DIDManager whose resolveDID returns null (simulates 🔥 deactivation)
+    const mockDIDManager = {
+      resolveDID: async (_did: string) => null,
+    } as unknown as DIDManager;
+
+    const validator = new LifecycleValidator(testConfig, mockDIDManager);
+
+    // Act: validate without setting metadata.deactivated
+    const result = await validator.validate(btcoOptions);
+
+    // Assert: should be invalid with ASSET_DEACTIVATED error detected via resolution
+    expect(result.valid).toBe(false);
+    const deactivatedError = result.errors.find(e => e.code === 'ASSET_DEACTIVATED');
+    expect(deactivatedError).toBeDefined();
+    expect(deactivatedError!.details).toMatchObject({ detectedBy: 'did-resolution' });
+  });
+
+  it('rejects migration when metadata.deactivated is true (existing path still works)', async () => {
+    const validator = new LifecycleValidator(testConfig);
+
+    const result = await validator.validate({
+      ...btcoOptions,
+      metadata: { deactivated: true },
+    });
+
+    expect(result.valid).toBe(false);
+    const deactivatedError = result.errors.find(e => e.code === 'ASSET_DEACTIVATED');
+    expect(deactivatedError).toBeDefined();
+    expect(deactivatedError!.field).toBe('metadata.deactivated');
+  });
+
+  it('does not add duplicate error when both metadata flag and null resolution are present', async () => {
+    // When metadata.deactivated is true, Path 2 is skipped entirely to avoid duplicates
+    const mockDIDManager = {
+      resolveDID: async (_did: string) => null,
+    } as unknown as DIDManager;
+
+    const validator = new LifecycleValidator(testConfig, mockDIDManager);
+
+    const result = await validator.validate({
+      ...btcoOptions,
+      metadata: { deactivated: true },
+    });
+
+    expect(result.valid).toBe(false);
+    const deactivatedErrors = result.errors.filter(e => e.code === 'ASSET_DEACTIVATED');
+    // Only one error should be emitted (from Path 1; Path 2 is skipped)
+    expect(deactivatedErrors.length).toBe(1);
+  });
+
+  it('allows migration when DIDManager.resolveDID returns a valid document', async () => {
+    const mockDIDManager = {
+      resolveDID: async (_did: string) => ({
+        '@context': ['https://www.w3.org/ns/did/v1'],
+        id: 'did:btco:reg:123456',
+      }),
+    } as unknown as DIDManager;
+
+    const validator = new LifecycleValidator(testConfig, mockDIDManager);
+
+    const result = await validator.validate(btcoOptions);
+
+    // Should pass (no ASSET_DEACTIVATED error)
+    const deactivatedError = result.errors.find(e => e.code === 'ASSET_DEACTIVATED');
+    expect(deactivatedError).toBeUndefined();
+  });
+
+  it('allows migration when no DIDManager is wired in (backward-compat: resolver-less path)', async () => {
+    // Without a DIDManager, Path 2 is skipped entirely
+    const validator = new LifecycleValidator(testConfig);
+
+    const result = await validator.validate(btcoOptions);
+
+    // No deactivation error from resolution
+    const deactivatedError = result.errors.find(e => e.code === 'ASSET_DEACTIVATED');
+    expect(deactivatedError).toBeUndefined();
+  });
+
+  it('is non-fatal when DIDManager.resolveDID throws (resolution error does not block migration)', async () => {
+    const mockDIDManager = {
+      resolveDID: async (_did: string) => {
+        throw new Error('network unreachable');
+      },
+    } as unknown as DIDManager;
+
+    const validator = new LifecycleValidator(testConfig, mockDIDManager);
+
+    // Should not throw and should not emit ASSET_DEACTIVATED (can't confirm deactivation)
+    const result = await validator.validate(btcoOptions);
+
+    const deactivatedError = result.errors.find(e => e.code === 'ASSET_DEACTIVATED');
+    expect(deactivatedError).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Addresses items 1, 2, 3, 5 of #207.

- **(3) `LifecycleValidator` auto-detects deactivation** — resolves the source DID and rejects deactivated/unresolvable assets (`ASSET_DEACTIVATED`), in addition to the existing caller-supplied metadata flag. Pre-flight migration safety.
- **(5) `publishToWeb` validates domain format** — the single-asset path now applies the same domain validation as `batchPublishToWeb` (`INVALID_DOMAIN`).
- **(1) Turnkey DID-creation integration test** — uses a *real* Ed25519 key wrapped in the Turnkey response shape so the proof actually verifies (replaces the previously-`.skip`'d mock-limited test).
- **(2) CEL-CLI subprocess integration test** — runs the real CLI via subprocess to cover routing / `--version` / unknown-command / exit-code paths that unit tests can't (async `process.exit`).

Verification: `tsc` 0, SDK suite **3099/0**, auth suite **193/0**. New tests: 6 (deactivation) + 8 (domain) + 4 (Turnkey real-key) + 16 (CLI subprocess).

Item 4 (pre-rotation) is a separate PR stacked on the didwebvh-ts 2.7.5 upgrade (#190). Item 6 (lint-warning burn-down) remains open — an automated pass broke `tsc` by over-stripping load-bearing \`any\`s, so it needs careful hand-work; left tracked in #207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden DID lifecycle validation with deactivation auto-detect and domain validation
> - Adds [`validateAndNormalizeDomain`](https://github.com/onionoriginals/sdk/pull/211/files#diff-cd981a4799c6a09ce9e319dcd761c9bf059e9bc8bc5009b99d5a963dfc0a0e70) utility that trims, lowercases, and validates domain strings, throwing `StructuredError('INVALID_DOMAIN')` for malformed inputs (empty ports, multiple colons, out-of-range ports).
> - [`LifecycleManager`](https://github.com/onionoriginals/sdk/pull/211/files#diff-f7ee48c88de9ace2f72662a51534f0bbb19607128b3c2178416d1b28c87fc9e8) and [`BatchLifecycleOperations`](https://github.com/onionoriginals/sdk/pull/211/files#diff-2b57cef7483248cebe9888d1d5c0311c1a65154ea558ef6d58c785324176a2ae) now use this shared utility instead of inline validation for `publishToWeb` and `batchPublishToWeb`.
> - [`LifecycleValidator`](https://github.com/onionoriginals/sdk/pull/211/files#diff-2cf9a9afedb96c610803218e2780c7f23a0bd5b5d4d1f4064a8fbe0bcb410f32) now accepts an optional `DIDManager` and auto-detects deactivated source DIDs by resolving them — a `null` result appends an `ASSET_DEACTIVATED` error even without an explicit metadata flag.
> - Adds integration tests for the Turnkey DID signer and CLI flows, plus unit tests for domain validation and deactivation detection.
> - Behavioral Change: `publishToWeb` and `batchPublishToWeb` will now reject domain strings that previously passed inline validation (e.g. empty ports, multiple colons).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f29c167.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->