### PR TITLE
feat(sdk): opt-in did:webvh pre-rotation key support (#207 item 4)

### DIFF
--- a/packages/sdk/src/did/WebVHManager.ts
+++ b/packages/sdk/src/did/WebVHManager.ts
@@ -309,6 +309,15 @@ export class WebVHManager {
     let verificationMethods: VerificationMethod[];
     let updateKeys: string[];
 
+    // Pre-rotation is incompatible with externalSigner (which manages its own
+    // key material externally). Check this up front, before the externalSigner
+    // requirement validation below, so the clearer "not supported" error isn't
+    // masked by a "verificationMethods are required" error the caller would hit
+    // first only to then discover the combination is unsupported anyway.
+    if (prerotation && externalSigner) {
+      throw new Error('prerotation is not supported with externalSigner; manage nextKeyHashes externally');
+    }
+
     // Use external signer if provided (e.g., Turnkey integration)
     if (externalSigner) {
       if (!providedVerificationMethods || providedVerificationMethods.length === 0) {
@@ -354,9 +363,7 @@ export class WebVHManager {
     let nextKeyPairForPrerotation: KeyPair | undefined;
     let nextKeyHashes: string[] | undefined;
     if (prerotation) {
-      if (externalSigner) {
-        throw new Error('prerotation is not supported with externalSigner; manage nextKeyHashes externally');
-      }
+      // (externalSigner + prerotation already rejected up front.)
       nextKeyPairForPrerotation = await this.keyManager.generateKeyPair('Ed25519');
       const nextKeyId = `did:key:${nextKeyPairForPrerotation.publicKey}`;
       nextKeyHashes = [computeNextKeyHash(nextKeyId)];
@@ -808,6 +815,9 @@ export class WebVHManager {
     // Enforce the pre-rotation invariant at SDK level:
     // The activeKeyPair's hash must appear in the previous entry's nextKeyHashes.
     // (didwebvh-ts only checks this during log resolution, not at updateDID time.)
+    if (currentLog.length === 0) {
+      throw new Error('Cannot perform pre-rotation on an empty DID log');
+    }
     const lastEntry = currentLog[currentLog.length - 1];
     const prevNextKeyHashes = (lastEntry.parameters as { nextKeyHashes?: string[] }).nextKeyHashes ?? [];
     if (prevNextKeyHashes.length === 0) {

--- a/packages/sdk/src/did/WebVHManager.ts
+++ b/packages/sdk/src/did/WebVHManager.ts
@@ -554,6 +554,18 @@ export class WebVHManager {
   }): Promise<{ didDocument: DIDDocument; log: DIDLog; logPath?: string }> {
     const { did, currentLog, updates, signer: providedSigner, verifier: providedVerifier, outputDir } = options;
 
+    // updateDIDWebVH appends an ordinary (non-pre-rotation) entry. On a
+    // pre-rotation chain that would set an un-committed updateKey and break
+    // resolution, so refuse rather than silently corrupt the log. Document
+    // updates on pre-rotation DIDs must go through the pre-rotation rotation path.
+    if (this.logHasPendingPrerotation(currentLog)) {
+      throw new Error(
+        'updateDIDWebVH does not support DIDs on a pre-rotation chain (the latest log entry ' +
+        'commits nextKeyHashes). Such DIDs require rotating to the pre-committed key for every ' +
+        'new entry; use rotateDIDWebVHKeys with prerotation:true instead.'
+      );
+    }
+
     // Dynamically import didwebvh-ts
     const mod = await import('didwebvh-ts') as unknown as {
       updateDID: (options: Record<string, unknown>) => Promise<{
@@ -658,6 +670,19 @@ export class WebVHManager {
       nextKeyPairOut = freshNextKeyPair;
       rotationResult = await this.appendKeyChangePrerotation(did, currentLog, currentKeyPair, freshNextKeyPair);
     } else {
+      // Guard against silently corrupting a pre-rotation chain: if the latest
+      // entry committed nextKeyHashes, a non-pre-rotation rotation would set an
+      // un-committed updateKey and fail resolution. Require explicit opt-in
+      // rather than auto-switching, because `currentKeyPair` has different
+      // semantics in pre-rotation mode (it must be the pre-committed next key).
+      if (this.logHasPendingPrerotation(currentLog)) {
+        throw new Error(
+          'This DID is on a pre-rotation chain (the latest log entry commits nextKeyHashes). ' +
+          'Call rotateDIDWebVHKeys with prerotation:true and pass the pre-committed nextKeyPair ' +
+          '(returned by the previous create/rotate) as currentKeyPair. A non-pre-rotation ' +
+          'rotation would break verification and corrupt the DID history.'
+        );
+      }
       newKeyPair = providedNewKeyPair || await this.keyManager.generateKeyPair('Ed25519');
       rotationResult = await this.appendKeyChange(did, currentLog, currentKeyPair, newKeyPair);
     }
@@ -683,6 +708,16 @@ export class WebVHManager {
    */
   async recoverDIDWebVH(options: RecoverWebVHOptions): Promise<RecoverWebVHResult> {
     const { did, currentLog, signingKeyPair, recoveryKeyPair: providedRecoveryKeyPair, outputDir } = options;
+
+    // recoverDIDWebVH appends an ordinary key-change entry; on a pre-rotation
+    // chain that breaks the committed-key invariant and fails resolution.
+    if (this.logHasPendingPrerotation(currentLog)) {
+      throw new Error(
+        'recoverDIDWebVH does not support DIDs on a pre-rotation chain (the latest log entry ' +
+        'commits nextKeyHashes); a recovery entry would violate the pre-rotation invariant. ' +
+        'Rotate to the pre-committed key via rotateDIDWebVHKeys with prerotation:true.'
+      );
+    }
 
     const newKeyPair = providedRecoveryKeyPair || await this.keyManager.generateKeyPair('Ed25519');
 
@@ -715,6 +750,22 @@ export class WebVHManager {
     }
 
     return { log: result.log, didDocument: result.didDocument, newKeyPair, recoveryCredential, logPath };
+  }
+
+  /**
+   * True when the latest log entry commits a non-empty `nextKeyHashes`, i.e. the
+   * DID is on a pre-rotation chain. The next entry MUST be produced via the
+   * pre-rotation path (signed by, and authorizing, the pre-committed key);
+   * appending an ordinary key-change/update entry would set an un-committed
+   * updateKey, fail `newKeysAreInNextKeys` during resolution, and silently
+   * corrupt the log. Callers that would append a non-pre-rotation entry use this
+   * to fail fast with a clear error instead.
+   */
+  private logHasPendingPrerotation(currentLog: DIDLog): boolean {
+    if (currentLog.length === 0) return false;
+    const last = currentLog[currentLog.length - 1];
+    const hashes = (last.parameters as { nextKeyHashes?: string[] }).nextKeyHashes;
+    return Array.isArray(hashes) && hashes.length > 0;
   }
 
   /**

--- a/packages/sdk/src/did/WebVHManager.ts
+++ b/packages/sdk/src/did/WebVHManager.ts
@@ -2,8 +2,29 @@ import { KeyManager } from './KeyManager';
 import { multikey } from '../crypto/Multikey';
 import { Ed25519Signer } from '../crypto/Signer';
 import { DIDDocument, KeyPair, ExternalSigner, ExternalVerifier } from '../types';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { base58 } from '@scure/base';
 import * as fs from 'fs';
 import * as path from 'path';
+
+/**
+ * Compute the pre-rotation key hash for a did:key identifier.
+ * Mirrors didwebvh-ts's internal `deriveNextKeyHash`:
+ *   SHA-256(utf8(keyId)) → prepend multihash header [0x12, 0x20] → base58btc encode (no multibase prefix).
+ *
+ * @param didKeyId - The did:key identifier string, e.g. "did:key:z6Mk..."
+ * @returns Base58btc-encoded multihash string suitable for use in `nextKeyHashes`
+ */
+export function computeNextKeyHash(didKeyId: string): string {
+  const data = new TextEncoder().encode(didKeyId);
+  const digest = sha256(data);
+  // Multihash: 0x12 = sha2-256 code, 0x20 = 32 bytes (digest length)
+  const multihash = new Uint8Array(2 + digest.length);
+  multihash[0] = 0x12;
+  multihash[1] = 0x20;
+  multihash.set(digest, 2);
+  return base58.encode(multihash);
+}
 
 // Type definitions for didwebvh-ts (to avoid module resolution issues)
 interface VerificationMethod {
@@ -124,6 +145,14 @@ export interface CreateWebVHOptions {
   externalVerifier?: ExternalVerifier; // External verifier
   verificationMethods?: VerificationMethod[]; // Pre-configured verification methods
   updateKeys?: string[]; // Pre-configured update keys (e.g., ["did:key:z6Mk..."])
+  /**
+   * Enable pre-rotation mode. When true, a second "next" key pair is generated
+   * and its hash committed into `nextKeyHashes` of the initial log entry.
+   * Each subsequent rotation must be signed by the pre-committed next key.
+   * The generated `nextKeyPair` is returned in `CreateWebVHResult` and must be
+   * persisted by the caller for use in the next `rotateDIDWebVHKeys` call.
+   */
+  prerotation?: boolean;
 }
 
 export interface CreateWebVHResult {
@@ -132,16 +161,43 @@ export interface CreateWebVHResult {
   log: DIDLog;
   keyPair: KeyPair;
   logPath?: string; // Path where the DID log was saved
+  /**
+   * Present only when `prerotation: true` was passed to `createDIDWebVH`.
+   * This key pair is pre-committed (its hash stored in `nextKeyHashes`).
+   * The caller MUST persist this and pass it as `currentKeyPair` in the
+   * next `rotateDIDWebVHKeys` call to execute a valid pre-rotation.
+   */
+  nextKeyPair?: KeyPair;
 }
 
 export interface RotateWebVHKeysOptions {
   did: string;
   currentLog: DIDLog;
-  /** The current (authorized) key pair that signs the rotation entry. */
+  /**
+   * The key pair that signs the rotation entry.
+   *
+   * Non-pre-rotation mode (default): the key pair whose `did:key` is listed in
+   * the previous entry's `updateKeys`.
+   *
+   * Pre-rotation mode (`prerotation: true`): the key pair whose hash was
+   * pre-committed in the previous entry's `nextKeyHashes`. This key becomes
+   * the new `updateKey` and signs the new entry.
+   */
   currentKeyPair: KeyPair;
-  /** Optional replacement key pair; a fresh Ed25519 pair is generated if omitted. */
+  /**
+   * Non-pre-rotation mode only: optional replacement key pair; a fresh
+   * Ed25519 pair is generated if omitted.
+   * Ignored in pre-rotation mode — the next key is always freshly generated.
+   */
   newKeyPair?: KeyPair;
   outputDir?: string;
+  /**
+   * Enable pre-rotation mode. When true, `currentKeyPair` must be the
+   * pre-committed next key from the previous create/rotate result. A fresh
+   * "next-next" key is generated, its hash committed in `nextKeyHashes`,
+   * and returned as `nextKeyPair` in the result.
+   */
+  prerotation?: boolean;
 }
 
 export interface RotateWebVHKeysResult {
@@ -149,6 +205,12 @@ export interface RotateWebVHKeysResult {
   didDocument: DIDDocument;
   newKeyPair: KeyPair;
   logPath?: string;
+  /**
+   * Present only when `prerotation: true`. The freshly generated key whose
+   * hash was committed in this entry's `nextKeyHashes`. The caller MUST
+   * persist this and pass it as `currentKeyPair` in the next rotation.
+   */
+  nextKeyPair?: KeyPair;
 }
 
 export interface RecoverWebVHOptions {
@@ -200,16 +262,17 @@ export class WebVHManager {
    * @returns The created DID, document, log, and key pair (if generated)
    */
   async createDIDWebVH(options: CreateWebVHOptions): Promise<CreateWebVHResult> {
-    const { 
-      domain, 
-      keyPair: providedKeyPair, 
-      paths = [], 
-      portable = false, 
+    const {
+      domain,
+      keyPair: providedKeyPair,
+      paths = [],
+      portable = false,
       outputDir,
       externalSigner,
       externalVerifier,
       verificationMethods: providedVerificationMethods,
-      updateKeys: providedUpdateKeys
+      updateKeys: providedUpdateKeys,
+      prerotation = false,
     } = options;
 
     // Validate path segments before creating DID to prevent directory traversal
@@ -286,8 +349,21 @@ export class WebVHManager {
       updateKeys = [`did:key:${keyPair.publicKey}`]; // Use did:key format for authorization
     }
 
+    // Pre-rotation: generate the "next" key pair and commit its hash.
+    // Not supported with externalSigner (which manages its own keys externally).
+    let nextKeyPairForPrerotation: KeyPair | undefined;
+    let nextKeyHashes: string[] | undefined;
+    if (prerotation) {
+      if (externalSigner) {
+        throw new Error('prerotation is not supported with externalSigner; manage nextKeyHashes externally');
+      }
+      nextKeyPairForPrerotation = await this.keyManager.generateKeyPair('Ed25519');
+      const nextKeyId = `did:key:${nextKeyPairForPrerotation.publicKey}`;
+      nextKeyHashes = [computeNextKeyHash(nextKeyId)];
+    }
+
     // Create the DID using didwebvh-ts
-    const result = await createDID({
+    const createArgs: Record<string, unknown> = {
       domain,
       signer,
       verifier,
@@ -301,7 +377,11 @@ export class WebVHManager {
       portable,
       authentication: ['#key-0'],
       assertionMethod: ['#key-0'],
-    });
+    };
+    if (nextKeyHashes) {
+      createArgs.nextKeyHashes = nextKeyHashes;
+    }
+    const result = await createDID(createArgs);
 
     // Validate the returned DID document
     if (!this.isDIDDocument(result.doc)) {
@@ -320,6 +400,7 @@ export class WebVHManager {
       log: result.log,
       keyPair: keyPair || { publicKey: '', privateKey: '' }, // Return empty keypair if using external signer
       logPath,
+      ...(nextKeyPairForPrerotation ? { nextKeyPair: nextKeyPairForPrerotation } : {}),
     };
   }
 
@@ -554,17 +635,38 @@ export class WebVHManager {
    * authorized for the next rotation.
    */
   async rotateDIDWebVHKeys(options: RotateWebVHKeysOptions): Promise<RotateWebVHKeysResult> {
-    const { did, currentLog, currentKeyPair, newKeyPair: providedNewKeyPair, outputDir } = options;
+    const { did, currentLog, currentKeyPair, newKeyPair: providedNewKeyPair, outputDir, prerotation = false } = options;
 
-    const newKeyPair = providedNewKeyPair || await this.keyManager.generateKeyPair('Ed25519');
-    const result = await this.appendKeyChange(did, currentLog, currentKeyPair, newKeyPair);
+    let rotationResult: { didDocument: DIDDocument; log: DIDLog };
+    let newKeyPair: KeyPair;
+    let nextKeyPairOut: KeyPair | undefined;
+
+    if (prerotation) {
+      // In pre-rotation mode:
+      //   - currentKeyPair IS the pre-committed next key (signs + becomes updateKey).
+      //   - A fresh "next-next" key is generated and its hash committed.
+      //   - newKeyPair = currentKeyPair (the key that is now active).
+      newKeyPair = currentKeyPair;
+      const freshNextKeyPair = await this.keyManager.generateKeyPair('Ed25519');
+      nextKeyPairOut = freshNextKeyPair;
+      rotationResult = await this.appendKeyChangePrerotation(did, currentLog, currentKeyPair, freshNextKeyPair);
+    } else {
+      newKeyPair = providedNewKeyPair || await this.keyManager.generateKeyPair('Ed25519');
+      rotationResult = await this.appendKeyChange(did, currentLog, currentKeyPair, newKeyPair);
+    }
 
     let logPath: string | undefined;
     if (outputDir) {
-      logPath = await this.saveDIDLog(did, result.log, outputDir);
+      logPath = await this.saveDIDLog(did, rotationResult.log, outputDir);
     }
 
-    return { log: result.log, didDocument: result.didDocument, newKeyPair, logPath };
+    return {
+      log: rotationResult.log,
+      didDocument: rotationResult.didDocument,
+      newKeyPair,
+      logPath,
+      ...(nextKeyPairOut ? { nextKeyPair: nextKeyPairOut } : {}),
+    };
   }
 
   /**
@@ -656,6 +758,97 @@ export class WebVHManager {
       verifier: signer,
       updateKeys: [`did:key:${newKeyPair.publicKey}`],
       verificationMethods: [newVerificationMethod],
+      authentication: ['#key-0'],
+      assertionMethod: ['#key-0'],
+    });
+
+    if (!this.isDIDDocument(result.doc)) {
+      throw new Error('Invalid DID document returned from updateDID');
+    }
+
+    return { didDocument: result.doc, log: result.log };
+  }
+
+  /**
+   * Pre-rotation variant of appendKeyChange.
+   *
+   * In pre-rotation mode the key that was previously hashed into `nextKeyHashes`
+   * (`activeKeyPair`) becomes both:
+   *   - the signer of the new log entry (proving possession of the pre-committed key), and
+   *   - the new `updateKey` for future entries.
+   *
+   * A fresh `nextKeyPair` is generated and its hash committed in `nextKeyHashes`,
+   * continuing the pre-rotation chain.
+   *
+   * didwebvh-ts enforces this invariant: when the previous entry has non-empty
+   * `nextKeyHashes`, verification uses the new entry's `updateKeys` (not the
+   * previous ones) to check the proof. So the signer MUST be `activeKeyPair`.
+   */
+  private async appendKeyChangePrerotation(
+    did: string,
+    currentLog: DIDLog,
+    activeKeyPair: KeyPair,
+    nextKeyPair: KeyPair
+  ): Promise<{ didDocument: DIDDocument; log: DIDLog }> {
+    const mod = await import('didwebvh-ts') as unknown as {
+      updateDID: (options: Record<string, unknown>) => Promise<{
+        doc: Record<string, unknown>;
+        log: DIDLog;
+      }>;
+      prepareDataForSigning: (
+        document: Record<string, unknown>,
+        proof: Record<string, unknown>
+      ) => Promise<Uint8Array>;
+    };
+    const { updateDID, prepareDataForSigning } = mod;
+    if (typeof updateDID !== 'function') {
+      throw new Error('Failed to load didwebvh-ts: invalid module exports');
+    }
+
+    // Enforce the pre-rotation invariant at SDK level:
+    // The activeKeyPair's hash must appear in the previous entry's nextKeyHashes.
+    // (didwebvh-ts only checks this during log resolution, not at updateDID time.)
+    const lastEntry = currentLog[currentLog.length - 1];
+    const prevNextKeyHashes = (lastEntry.parameters as { nextKeyHashes?: string[] }).nextKeyHashes ?? [];
+    if (prevNextKeyHashes.length === 0) {
+      throw new Error(
+        'Pre-rotation rotation requires the current log to have nextKeyHashes committed. ' +
+        'The DID was not created with prerotation:true or the chain is broken.'
+      );
+    }
+    const activeKeyId = `did:key:${activeKeyPair.publicKey}`;
+    const activeKeyHash = computeNextKeyHash(activeKeyId);
+    if (!prevNextKeyHashes.includes(activeKeyHash)) {
+      throw new Error(
+        `Pre-rotation violation: currentKeyPair hash (${activeKeyHash}) is not in the ` +
+        `previous entry's nextKeyHashes (${prevNextKeyHashes.join(', ')}). ` +
+        'Pass the nextKeyPair returned from the previous create/rotate call.'
+      );
+    }
+
+    // The active (pre-committed) key signs the entry and becomes updateKey.
+    const activeVerificationMethod: VerificationMethod = {
+      type: 'Multikey',
+      publicKeyMultibase: activeKeyPair.publicKey,
+    };
+    const signer = new OriginalsWebVHSigner(
+      activeKeyPair.privateKey,
+      activeVerificationMethod,
+      prepareDataForSigning,
+      { verificationMethod: activeVerificationMethod }
+    );
+
+    // Commit the hash of the next key to continue the pre-rotation chain.
+    const nextKeyId = `did:key:${nextKeyPair.publicKey}`;
+    const nextKeyHashes = [computeNextKeyHash(nextKeyId)];
+
+    const result = await updateDID({
+      log: currentLog,
+      signer,
+      verifier: signer,
+      updateKeys: [`did:key:${activeKeyPair.publicKey}`],
+      nextKeyHashes,
+      verificationMethods: [activeVerificationMethod],
       authentication: ['#key-0'],
       assertionMethod: ['#key-0'],
     });

--- a/packages/sdk/tests/unit/did/webvh-prerotation.test.ts
+++ b/packages/sdk/tests/unit/did/webvh-prerotation.test.ts
@@ -167,7 +167,7 @@ describe('WebVHManager — pre-rotation key rotation chain', () => {
     expect(storedHashes![0]).toBe(expectedHash);
   }, 20000);
 
-  test('rotation to a non-pre-committed key is rejected by didwebvh-ts', async () => {
+  test('rotation with a non-pre-committed key is rejected by the SDK pre-rotation guard', async () => {
     const created = await manager.createDIDWebVH({
       domain: 'example.com',
       prerotation: true,
@@ -185,6 +185,23 @@ describe('WebVHManager — pre-rotation key rotation chain', () => {
         prerotation: true,
       })
     ).rejects.toThrow();
+  }, 20000);
+
+  test('pre-rotation on an empty DID log is rejected with a clear error', async () => {
+    const created = await manager.createDIDWebVH({
+      domain: 'example.com',
+      prerotation: true,
+    });
+    // Macroscope #212: passing an empty currentLog must not crash with a
+    // TypeError on undefined.parameters — it must throw a clear guard error.
+    await expect(
+      manager.rotateDIDWebVHKeys({
+        did: created.did,
+        currentLog: [],
+        currentKeyPair: created.nextKeyPair!,
+        prerotation: true,
+      })
+    ).rejects.toThrow('empty DID log');
   }, 20000);
 
   test('non-pre-rotation default mode still works after the pre-rotation tests', async () => {

--- a/packages/sdk/tests/unit/did/webvh-prerotation.test.ts
+++ b/packages/sdk/tests/unit/did/webvh-prerotation.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for opt-in did:webvh pre-rotation key support (#207, DEF-018).
+ *
+ * Pre-rotation security property: each log entry pre-commits the SHA-256
+ * multihash of the *next* update key. A rotation is only valid if the new
+ * updateKey's hash was committed in the previous entry's `nextKeyHashes`.
+ * This prevents a compromised current key from redirecting the rotation chain
+ * to an attacker-controlled key.
+ *
+ * API contract:
+ *   createDIDWebVH({ prerotation: true })  → { keyPair, nextKeyPair }
+ *   rotateDIDWebVHKeys({ currentKeyPair: nextKeyPair, prerotation: true })
+ *     → { newKeyPair (=currentKeyPair), nextKeyPair (fresh) }
+ *   Repeat for subsequent rotations.
+ */
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { WebVHManager, computeNextKeyHash } from '../../../src/did/WebVHManager';
+import { KeyManager } from '../../../src/did/KeyManager';
+
+describe('computeNextKeyHash', () => {
+  test('produces a non-empty base58btc string', () => {
+    const hash = computeNextKeyHash('did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK');
+    // Result is plain base58btc (no multibase 'z' prefix), length is ~46 chars for sha2-256 multihash
+    expect(typeof hash).toBe('string');
+    expect(hash.length).toBeGreaterThan(40);
+    // Should not have multibase prefix
+    expect(hash.startsWith('z')).toBe(false);
+  });
+
+  test('produces deterministic output for same input', () => {
+    const key = 'did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK';
+    expect(computeNextKeyHash(key)).toBe(computeNextKeyHash(key));
+  });
+
+  test('produces different hashes for different keys', () => {
+    const h1 = computeNextKeyHash('did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK');
+    const h2 = computeNextKeyHash('did:key:z6MkrphiqmDSy8kQ4M2GfcbgLFD3epDhQzGM3J9mHJJhE5f8');
+    expect(h1).not.toBe(h2);
+  });
+});
+
+describe('WebVHManager — pre-rotation creation', () => {
+  let manager: WebVHManager;
+
+  beforeEach(() => {
+    manager = new WebVHManager();
+  });
+
+  test('createDIDWebVH with prerotation:true returns nextKeyPair', async () => {
+    const result = await manager.createDIDWebVH({
+      domain: 'example.com',
+      prerotation: true,
+    });
+
+    expect(result.nextKeyPair).toBeDefined();
+    expect(result.nextKeyPair!.publicKey).toMatch(/^z/);
+    expect(result.nextKeyPair!.privateKey).toMatch(/^z/);
+    expect(result.nextKeyPair!.publicKey).not.toBe(result.keyPair.publicKey);
+  }, 15000);
+
+  test('createDIDWebVH with prerotation:true stores nextKeyHash in log entry', async () => {
+    const result = await manager.createDIDWebVH({
+      domain: 'example.com',
+      prerotation: true,
+    });
+
+    const firstEntry = result.log[0];
+    const storedHashes = (firstEntry.parameters as { nextKeyHashes?: string[] }).nextKeyHashes;
+    expect(Array.isArray(storedHashes)).toBe(true);
+    expect(storedHashes!.length).toBe(1);
+
+    // Verify it matches computeNextKeyHash of the returned nextKeyPair
+    const expectedHash = computeNextKeyHash(`did:key:${result.nextKeyPair!.publicKey}`);
+    expect(storedHashes![0]).toBe(expectedHash);
+  }, 15000);
+
+  test('createDIDWebVH without prerotation does not set nextKeyPair (default unchanged)', async () => {
+    const result = await manager.createDIDWebVH({
+      domain: 'example.com',
+    });
+
+    expect(result.nextKeyPair).toBeUndefined();
+
+    const firstEntry = result.log[0];
+    const storedHashes = (firstEntry.parameters as { nextKeyHashes?: string[] }).nextKeyHashes;
+    // Non-pre-rotation: nextKeyHashes is absent or empty
+    expect(!storedHashes || storedHashes.length === 0).toBe(true);
+  }, 15000);
+});
+
+describe('WebVHManager — pre-rotation key rotation chain', () => {
+  let manager: WebVHManager;
+  let keyManager: KeyManager;
+
+  beforeEach(() => {
+    manager = new WebVHManager();
+    keyManager = new KeyManager();
+  });
+
+  test('single pre-rotation rotation succeeds and returns nextKeyPair', async () => {
+    const created = await manager.createDIDWebVH({
+      domain: 'example.com',
+      prerotation: true,
+    });
+
+    // Rotate using the pre-committed nextKeyPair as currentKeyPair
+    const rotated = await manager.rotateDIDWebVHKeys({
+      did: created.did,
+      currentLog: created.log,
+      currentKeyPair: created.nextKeyPair!,
+      prerotation: true,
+    });
+
+    expect(rotated.log.length).toBe(2);
+    expect(rotated.didDocument.id).toBe(created.did);
+    // newKeyPair in pre-rotation mode is the key that just became active (=currentKeyPair)
+    expect(rotated.newKeyPair.publicKey).toBe(created.nextKeyPair!.publicKey);
+    // nextKeyPair is the freshly generated one committed for the NEXT rotation
+    expect(rotated.nextKeyPair).toBeDefined();
+    expect(rotated.nextKeyPair!.publicKey).not.toBe(created.nextKeyPair!.publicKey);
+  }, 20000);
+
+  test('3 sequential pre-rotation rotations produce a log of 4 entries', async () => {
+    const created = await manager.createDIDWebVH({
+      domain: 'example.com',
+      prerotation: true,
+    });
+
+    let log = created.log;
+    let currentKeyPair = created.nextKeyPair!; // pre-committed key becomes the signer
+
+    for (let i = 0; i < 3; i++) {
+      const rotated = await manager.rotateDIDWebVHKeys({
+        did: created.did,
+        currentLog: log,
+        currentKeyPair,
+        prerotation: true,
+      });
+      log = rotated.log;
+      currentKeyPair = rotated.nextKeyPair!;
+    }
+
+    expect(log.length).toBe(4); // 1 create + 3 rotations
+  }, 60000);
+
+  test('each rotation entry commits the next key hash correctly', async () => {
+    const created = await manager.createDIDWebVH({
+      domain: 'example.com',
+      prerotation: true,
+    });
+
+    const r1 = await manager.rotateDIDWebVHKeys({
+      did: created.did,
+      currentLog: created.log,
+      currentKeyPair: created.nextKeyPair!,
+      prerotation: true,
+    });
+
+    // The second log entry should commit r1.nextKeyPair's hash
+    const secondEntry = r1.log[1];
+    const storedHashes = (secondEntry.parameters as { nextKeyHashes?: string[] }).nextKeyHashes;
+    expect(Array.isArray(storedHashes)).toBe(true);
+    expect(storedHashes!.length).toBe(1);
+
+    const expectedHash = computeNextKeyHash(`did:key:${r1.nextKeyPair!.publicKey}`);
+    expect(storedHashes![0]).toBe(expectedHash);
+  }, 20000);
+
+  test('rotation to a non-pre-committed key is rejected by didwebvh-ts', async () => {
+    const created = await manager.createDIDWebVH({
+      domain: 'example.com',
+      prerotation: true,
+    });
+
+    // Generate an entirely different key (not the pre-committed nextKeyPair)
+    const rogue = await keyManager.generateKeyPair('Ed25519');
+
+    // Attempting rotation signed by a non-pre-committed key must throw
+    await expect(
+      manager.rotateDIDWebVHKeys({
+        did: created.did,
+        currentLog: created.log,
+        currentKeyPair: rogue, // wrong key — not the pre-committed one
+        prerotation: true,
+      })
+    ).rejects.toThrow();
+  }, 20000);
+
+  test('non-pre-rotation default mode still works after the pre-rotation tests', async () => {
+    // Regression guard: standard rotation (no prerotation flag) still works unchanged
+    const created = await manager.createDIDWebVH({ domain: 'example.com' });
+    const r1 = await manager.rotateDIDWebVHKeys({
+      did: created.did,
+      currentLog: created.log,
+      currentKeyPair: created.keyPair,
+    });
+    const r2 = await manager.rotateDIDWebVHKeys({
+      did: created.did,
+      currentLog: r1.log,
+      currentKeyPair: r1.newKeyPair,
+    });
+    expect(r2.log.length).toBe(3);
+    expect(r2.nextKeyPair).toBeUndefined();
+  }, 30000);
+});

--- a/packages/sdk/tests/unit/did/webvh-prerotation.test.ts
+++ b/packages/sdk/tests/unit/did/webvh-prerotation.test.ts
@@ -17,6 +17,7 @@
 import { describe, test, expect, beforeEach } from 'bun:test';
 import { WebVHManager, computeNextKeyHash } from '../../../src/did/WebVHManager';
 import { KeyManager } from '../../../src/did/KeyManager';
+import { Ed25519Verifier } from '../../../src/did/Ed25519Verifier';
 
 describe('computeNextKeyHash', () => {
   test('produces a non-empty base58btc string', () => {
@@ -142,6 +143,36 @@ describe('WebVHManager — pre-rotation key rotation chain', () => {
     }
 
     expect(log.length).toBe(4); // 1 create + 3 rotations
+  }, 60000);
+
+  test('independent didwebvh-ts resolution accepts the pre-rotation chain', async () => {
+    // This is the definitive cross-check that computeNextKeyHash() matches
+    // didwebvh-ts's own deriveNextKeyHash(): resolveDIDFromLog runs
+    // newKeysAreInNextKeys() during resolution, which derives the hash of each
+    // updateKey with the LIBRARY's algorithm and throws if it isn't present in
+    // the previous entry's committed nextKeyHashes. If our committed hashes were
+    // computed with a different preimage/encoding, resolution would reject the
+    // chain — so a clean resolve proves an external verifier accepts it.
+    const created = await manager.createDIDWebVH({ domain: 'example.com', prerotation: true });
+
+    let log = created.log;
+    let currentKeyPair = created.nextKeyPair!;
+    for (let i = 0; i < 2; i++) {
+      const r = await manager.rotateDIDWebVHKeys({
+        did: created.did,
+        currentLog: log,
+        currentKeyPair,
+        prerotation: true,
+      });
+      log = r.log;
+      currentKeyPair = r.nextKeyPair!;
+    }
+
+    const mod = (await import('didwebvh-ts')) as unknown as {
+      resolveDIDFromLog: (log: unknown, options: { verifier: unknown }) => Promise<{ doc: { id: string } }>;
+    };
+    const res = await mod.resolveDIDFromLog(log, { verifier: new Ed25519Verifier() });
+    expect(res.doc.id).toBe(created.did);
   }, 60000);
 
   test('each rotation entry commits the next key hash correctly', async () => {

--- a/packages/sdk/tests/unit/did/webvh-prerotation.test.ts
+++ b/packages/sdk/tests/unit/did/webvh-prerotation.test.ts
@@ -235,6 +235,45 @@ describe('WebVHManager — pre-rotation key rotation chain', () => {
     ).rejects.toThrow('empty DID log');
   }, 20000);
 
+  test('rotating a pre-rotation DID without prerotation:true is rejected (no silent corruption)', async () => {
+    // Macroscope HIGH: forgetting prerotation:true on the next rotation would run
+    // the non-pre-rotation path, set an un-committed updateKey, and corrupt the log.
+    const created = await manager.createDIDWebVH({ domain: 'example.com', prerotation: true });
+    await expect(
+      manager.rotateDIDWebVHKeys({
+        did: created.did,
+        currentLog: created.log,
+        currentKeyPair: created.nextKeyPair!,
+        // prerotation omitted (defaults false)
+      })
+    ).rejects.toThrow('pre-rotation chain');
+  }, 20000);
+
+  test('updateDIDWebVH on a pre-rotation DID is rejected', async () => {
+    // Macroscope Medium: updateDIDWebVH appends a non-pre-rotation entry.
+    const created = await manager.createDIDWebVH({ domain: 'example.com', prerotation: true });
+    await expect(
+      manager.updateDIDWebVH({
+        did: created.did,
+        currentLog: created.log,
+        updates: { service: [{ id: '#svc', type: 'X', serviceEndpoint: 'https://e.example' }] } as any,
+        signer: created.nextKeyPair!,
+      })
+    ).rejects.toThrow('does not support DIDs on a pre-rotation chain');
+  }, 20000);
+
+  test('recoverDIDWebVH on a pre-rotation DID is rejected', async () => {
+    // Macroscope Medium: recoverDIDWebVH appends a non-pre-rotation key change.
+    const created = await manager.createDIDWebVH({ domain: 'example.com', prerotation: true });
+    await expect(
+      manager.recoverDIDWebVH({
+        did: created.did,
+        currentLog: created.log,
+        signingKeyPair: created.nextKeyPair!,
+      })
+    ).rejects.toThrow('does not support DIDs on a pre-rotation chain');
+  }, 20000);
+
   test('non-pre-rotation default mode still works after the pre-rotation tests', async () => {
     // Regression guard: standard rotation (no prerotation flag) still works unchanged
     const created = await manager.createDIDWebVH({ domain: 'example.com' });


### PR DESCRIPTION
Addresses item 4 of #207 (DEF-018 follow-up).

Adds **opt-in** did:webvh pre-rotation: each entry pre-commits the hash of the next update key, so a compromised current key cannot redirect the rotation chain.

- `computeNextKeyHash(didKeyId)` — spec-correct: `SHA-256(utf8(keyId))` → multihash header `[0x12,0x20]` → base58btc.
- `CreateWebVHOptions.prerotation?` / `RotateWebVHKeysOptions.prerotation?` opt-in flags.
- `create`/`rotate` return `nextKeyPair` (caller persists it; stateless SDK) and validate that the supplied key matches the previous entry's pre-committed hash before rotating — clear error otherwise.
- Default (non-pre-rotation) behavior unchanged; `externalSigner + prerotation` rejected early with a clear error.

**Rebased onto `main`** (didwebvh-ts 2.7.5 is already there via #190, now merged) — no longer stacked.

Review fixes included: externalSigner+prerotation guard moved ahead of the externalSigner requirement check; empty-`currentLog` guard in `appendKeyChangePrerotation`; test rename to credit the SDK guard; empty-log rejection test.

Verification: `bun run lint` exit 0, `tsc` 0, did suite 281/0, full suite green after `bun run build` (the CEL-CLI subprocess tests require the built `dist/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add opt-in pre-rotation key support to `WebVHManager` for did:webvh DIDs
> - Adds `prerotation` option to `createDIDWebVH`: when enabled, generates a next key pair, commits its multihash in `nextKeyHashes`, and returns `nextKeyPair` in the result. Throws if combined with `externalSigner`.
> - Adds `prerotation` option to `rotateDIDWebVHKeys`: treats `currentKeyPair` as the pre-committed key, uses it to sign and set the new active key, generates a fresh next key, and returns `nextKeyPair` for the subsequent rotation.
> - Adds a new `computeNextKeyHash` utility that SHA-256 hashes a did:key identifier and returns a base58btc-encoded multihash string compatible with `didwebvh-ts`.
> - `updateDIDWebVH` and `recoverDIDWebVH` now throw when the latest log entry has non-empty `nextKeyHashes`, preventing corruption of an active pre-rotation chain.
> - Adds unit test coverage in [webvh-prerotation.test.ts](https://github.com/onionoriginals/sdk/pull/212/files#diff-2504883d4c6d132bd2a74e2c3c8ca7b7531248bbc6c9c0b5fb369dc02a9092e7) for creation, sequential rotations, guard enforcement, and resolver consistency.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized abfbfd7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->