### PR TITLE
fix(release): pin human-id to 4.1.1 so changeset publish works on Node

### DIFF
--- a/.changeset/ci-changesets-token.md
+++ b/.changeset/ci-changesets-token.md
@@ -1,4 +1,0 @@
----
----
-
-ci: use a PAT (with GITHUB_TOKEN fallback) for the changesets Version PR so its branch push triggers `ci.yml`, and exempt the `changeset-release/main` PR from the changeset-required check by branch as well as bot author. No package changes.

--- a/bun.lock
+++ b/bun.lock
@@ -11,11 +11,11 @@
     },
     "packages/auth": {
       "name": "@originals/auth",
-      "version": "1.9.0",
+      "version": "2.0.0",
       "dependencies": {
         "@noble/ed25519": "^2.0.0",
         "@noble/hashes": "^2.0.1",
-        "@originals/sdk": "^1.4.4",
+        "@originals/sdk": "^2.0.0",
         "@turnkey/sdk-server": "^5.0.0",
         "jsonwebtoken": "^9.0.2",
       },
@@ -41,7 +41,7 @@
     },
     "packages/sdk": {
       "name": "@originals/sdk",
-      "version": "1.9.0",
+      "version": "2.0.0",
       "bin": {
         "originals-cel": "./dist/cel/cli/index.js",
       },
@@ -78,6 +78,9 @@
         "typescript": "^5.0.0",
       },
     },
+  },
+  "overrides": {
+    "human-id": "4.1.1",
   },
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
@@ -690,7 +693,7 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
-    "human-id": ["human-id@4.2.0", "", { "bin": { "human-id": "dist/cli.js" } }, "sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA=="],
+    "human-id": ["human-id@4.1.1", "", { "bin": { "human-id": "dist/cli.js" } }, "sha512-3gKm/gCSUipeLsRYZbbdA1BD83lBoWUkZ7G9VFrhWPAU76KwYo5KR8V28bpoPm/ygy0x5/GCbpRQdY7VLYCoIg=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "@changesets/cli": "^2.27.10",
     "turbo": "^2.3.3"
   },
+  "overrides": {
+    "human-id": "4.1.1"
+  },
   "engines": {
     "node": ">=20.10.0"
   },


### PR DESCRIPTION
Fixes the failed 2.0.0 publish.

## Root cause
`changeset publish` failed with **ERR_REQUIRE_ESM**: `@changesets/write@0.4.0` does `require('human-id')`, but **human-id@4.2.0** (satisfying its `^4.1.1` range) is **ESM-only**, and the publish job runs on **Node 20.10** where `require()` of an ES module throws. Bun masked it locally (and Node ≥22 supports require(ESM), which is why it's version-specific).

## Fix
- Pin `human-id` to **4.1.1** (last CJS build) via `overrides`. Verified after a clean install: `@changesets/write` resolves `human-id@4.1.1 (cjs)`, so `require()` works on any Node.
- Remove the leftover empty changeset from #217 so `main` has no pending changesets — the release workflow then proceeds to the env-gated **publish of the already-staged 2.0.0** rather than holding a Version PR.

## Notes
- No package code changes → no changeset (the 2.0.0 CHANGELOG is already on main). The non-blocking "Changeset present" check will be red by design; `main` isn't protected so it doesn't block.
- After merge: the release run reaches the publish job (waiting for your npm-publish approval); approving it ships 2.0.0 with the working human-id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin `human-id` to 4.1.1 so changeset publish works on Node
> Version 4.2.0 of `human-id` uses ESM-only syntax that breaks `changeset publish` under Node. Adds an overrides entry in [package.json](https://github.com/onionoriginals/sdk/pull/218/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to force-resolve `human-id` to 4.1.1 across the dependency tree.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 037c819.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->