### PR TITLE
fix(cel): make did:btco logs verifiable and bind event logs to the controller key

### DIFF
--- a/.changeset/cel-protocol-fixes.md
+++ b/.changeset/cel-protocol-fixes.md
@@ -1,0 +1,10 @@
+---
+"@originals/sdk": minor
+---
+
+Fix two critical CEL (Cryptographic Event Log) protocol bugs:
+
+- **did:btco migrations now produce verifiable logs.** `BtcoCelManager.migrate` mutated the event `data` (splicing in `targetDid`/`txid`/`inscriptionId`) *after* the controller signature and Bitcoin witness proof were computed, so every btco log failed `verifyEventLog`. The migration data is now finalized before signing: `targetDid` is derived deterministically from the source DID, and `txid`/`inscriptionId` (which can't be known before inscription) are read from the Bitcoin witness proof rather than embedded in the signed data.
+- **`verifyEventLog` now binds every event to the log's controller key.** Previously any key could append, rename, "migrate", or deactivate anyone's log and it verified as valid. Verification now establishes the authorized key set from the create event and rejects any subsequent event whose controller proof is signed by an unauthorized key. (A caller-supplied custom verifier still takes full responsibility for authorization.)
+
+The `originals-cel migrate` CLI now warns that a temporary (non-controller) signing key produces a log that won't verify under the new controller binding, and points to `--wallet`.

--- a/packages/sdk/src/cel/algorithms/verifyEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/verifyEventLog.ts
@@ -231,15 +231,36 @@ function isWitnessProof(p: DataIntegrityProof): boolean {
 }
 
 /**
- * Identifies the controller key authorized by a proof. This is the FULL
- * verification method URI, including the `#fragment`: within one DID document
- * `did:webvh:...#key-0` and `#key-1` are DISTINCT keys, so stripping the
- * fragment would let a log created with `#key-0` accept later events signed by
- * `#key-1`. All legitimate events in a log are signed with the same
- * verification method, so full-URI comparison does not reject valid chains.
+ * Resolves a proof's controller PUBLIC KEY, which is the correct unit of
+ * authorization: two verification methods identify the same signer iff they
+ * resolve to the same key material.
+ *
+ * Comparing raw verification-method URIs is wrong in both directions:
+ * - too loose if the fragment is stripped (`#key-0` vs `#key-1` in one DID doc
+ *   are DISTINCT keys), and
+ * - too strict if compared verbatim (the same key spelled with a different but
+ *   equivalent VM id — which the key resolver already treats as equal — would
+ *   be rejected).
+ *
+ * did:key proofs carry the key in the identifier (resolved offline); other
+ * methods use the same `resolveKey` resolver as `dispatchVerify`. Returns a hex
+ * string so keys can be compared/stored in a Set, or null if unresolvable.
  */
-function controllerKeyId(verificationMethod: string): string {
-  return verificationMethod;
+async function resolveControllerKeyHex(
+  verificationMethod: string,
+  resolveKey?: (verificationMethod: string) => Promise<Uint8Array | null>
+): Promise<string | null> {
+  let key: Uint8Array | null = null;
+  if (verificationMethod.startsWith('did:key:')) {
+    key = extractEd25519FromDidKey(verificationMethod);
+  } else if (resolveKey) {
+    try {
+      key = await resolveKey(verificationMethod);
+    } catch {
+      key = null;
+    }
+  }
+  return key ? Buffer.from(key).toString('hex') : null;
 }
 
 /**
@@ -324,11 +345,15 @@ async function verifyEvent(
   // Controller binding: on the default (dispatch) path, every controller proof
   // must be signed by a key authorized by the log's create event. Without this,
   // any key can append/rename/migrate/deactivate someone else's log and it
-  // verifies (confirmed forgeable). A custom verifier takes full responsibility
-  // for authorization, so this check is skipped there.
+  // verifies (confirmed forgeable). Authorization compares the resolved PUBLIC
+  // KEY (not the VM URI string), so it is neither fooled by two distinct keys
+  // in one DID document nor tripped up by the same key under an equivalent VM
+  // id. A custom verifier takes full responsibility for authorization, so this
+  // check is skipped there.
   if (!customVerifier && authorizedKeyIds && index > 0) {
     for (const { proof, originalIndex } of controllerProofs) {
-      if (!authorizedKeyIds.has(controllerKeyId(proof.verificationMethod))) {
+      const keyHex = await resolveControllerKeyHex(proof.verificationMethod, resolveKey);
+      if (keyHex === null || !authorizedKeyIds.has(keyHex)) {
         errors.push(
           `Event ${index}, Proof ${originalIndex}: signer ${proof.verificationMethod} is not authorized by the log's create event`
         );
@@ -480,16 +505,17 @@ export async function verifyEventLog(
 
   // Establish the authorized controller key set from the create event
   // (event 0). Its controller proofs — the non-witness proofs — define the
-  // keys allowed to sign every subsequent event in the log (trust-on-first-use
-  // root of authority). The current CEL data model has no in-log key-rotation
-  // mechanism, so this set is fixed by the create event.
+  // keys (by resolved public-key material) allowed to sign every subsequent
+  // event in the log (trust-on-first-use root of authority). The current CEL
+  // data model has no in-log key-rotation mechanism, so this set is fixed by
+  // the create event.
   const createEvent = log.events[0];
-  const authorizedKeyIds = new Set<string>(
-    (createEvent.proof ?? [])
-      .filter(p => !isWitnessProof(p))
-      .map(p => controllerKeyId(p.verificationMethod))
-      .filter((id): id is string => typeof id === 'string' && id.length > 0)
-  );
+  const authorizedKeyIds = new Set<string>();
+  for (const p of createEvent.proof ?? []) {
+    if (isWitnessProof(p)) continue;
+    const keyHex = await resolveControllerKeyHex(p.verificationMethod, options?.resolveKey);
+    if (keyHex) authorizedKeyIds.add(keyHex);
+  }
 
   // Verify each event's proofs and hash chain
   for (let i = 0; i < log.events.length; i++) {

--- a/packages/sdk/src/cel/algorithms/verifyEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/verifyEventLog.ts
@@ -231,13 +231,15 @@ function isWitnessProof(p: DataIntegrityProof): boolean {
 }
 
 /**
- * Normalize a verification method URI to the controller key it identifies.
- * For did:key the key is the identifier itself (drop the #fragment); other
- * methods are compared by their full DID (drop the fragment) since the key
- * lives in that DID's document.
+ * Identifies the controller key authorized by a proof. This is the FULL
+ * verification method URI, including the `#fragment`: within one DID document
+ * `did:webvh:...#key-0` and `#key-1` are DISTINCT keys, so stripping the
+ * fragment would let a log created with `#key-0` accept later events signed by
+ * `#key-1`. All legitimate events in a log are signed with the same
+ * verification method, so full-URI comparison does not reject valid chains.
  */
 function controllerKeyId(verificationMethod: string): string {
-  return verificationMethod.split('#')[0];
+  return verificationMethod;
 }
 
 /**

--- a/packages/sdk/src/cel/algorithms/verifyEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/verifyEventLog.ts
@@ -536,7 +536,18 @@ export async function verifyEventLog(
         `additional controller proofs cannot be trusted.`;
     } else {
       const rootKeyHex = await resolveControllerKeyHex(createControllerProofs[0].verificationMethod, options?.resolveKey);
-      if (rootKeyHex) authorizedKeyIds.add(rootKeyHex);
+      if (rootKeyHex) {
+        authorizedKeyIds.add(rootKeyHex);
+      } else {
+        // The create event's key could not be resolved (e.g. a transient
+        // resolver failure or an unsupported key type). Fail closed with a
+        // distinct authority error rather than leaving authorizedKeyIds empty,
+        // which would silently reject every subsequent event as "not
+        // authorized" and turn a valid log into a false negative.
+        authorityError =
+          `Create event controller key (${createControllerProofs[0].verificationMethod}) could not be ` +
+          `resolved to establish authority; cannot safely authorize subsequent events.`;
+      }
     }
   }
 

--- a/packages/sdk/src/cel/algorithms/verifyEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/verifyEventLog.ts
@@ -524,7 +524,11 @@ export async function verifyEventLog(
   const authorizedKeyIds = new Set<string>();
   let authorityError: string | undefined;
   if (!options?.verifier) {
-    const createControllerProofs = (createEvent.proof ?? []).filter(p => !isWitnessProof(p));
+    // A non-array proof (missing, object, string, …) yields zero controller
+    // proofs → authorityError below, rather than throwing on .filter.
+    const createControllerProofs = Array.isArray(createEvent.proof)
+      ? createEvent.proof.filter(p => !isWitnessProof(p))
+      : [];
     if (createControllerProofs.length !== 1) {
       authorityError =
         `Create event must have exactly one controller proof to establish authority (found ` +

--- a/packages/sdk/src/cel/algorithms/verifyEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/verifyEventLog.ts
@@ -516,18 +516,24 @@ export async function verifyEventLog(
   // the create event must carry EXACTLY ONE controller proof; more than one is
   // treated as tampering (its unsigned proof array cannot disambiguate the
   // real root from an injected co-signer) and fails the whole log.
+  //
+  // When a custom verifier is supplied, the caller owns proof semantics and
+  // authorization (verifyEvent skips the controller-key binding on that path),
+  // so this default authority check is skipped too — consistently.
   const createEvent = log.events[0];
-  const createControllerProofs = (createEvent.proof ?? []).filter(p => !isWitnessProof(p));
   const authorizedKeyIds = new Set<string>();
   let authorityError: string | undefined;
-  if (createControllerProofs.length !== 1) {
-    authorityError =
-      `Create event must have exactly one controller proof to establish authority (found ` +
-      `${createControllerProofs.length}); the create event's proof array is not signed, so ` +
-      `additional controller proofs cannot be trusted.`;
-  } else {
-    const rootKeyHex = await resolveControllerKeyHex(createControllerProofs[0].verificationMethod, options?.resolveKey);
-    if (rootKeyHex) authorizedKeyIds.add(rootKeyHex);
+  if (!options?.verifier) {
+    const createControllerProofs = (createEvent.proof ?? []).filter(p => !isWitnessProof(p));
+    if (createControllerProofs.length !== 1) {
+      authorityError =
+        `Create event must have exactly one controller proof to establish authority (found ` +
+        `${createControllerProofs.length}); the create event's proof array is not signed, so ` +
+        `additional controller proofs cannot be trusted.`;
+    } else {
+      const rootKeyHex = await resolveControllerKeyHex(createControllerProofs[0].verificationMethod, options?.resolveKey);
+      if (rootKeyHex) authorizedKeyIds.add(rootKeyHex);
+    }
   }
 
   // Verify each event's proofs and hash chain

--- a/packages/sdk/src/cel/algorithms/verifyEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/verifyEventLog.ts
@@ -231,6 +231,16 @@ function isWitnessProof(p: DataIntegrityProof): boolean {
 }
 
 /**
+ * Normalize a verification method URI to the controller key it identifies.
+ * For did:key the key is the identifier itself (drop the #fragment); other
+ * methods are compared by their full DID (drop the fragment) since the key
+ * lives in that DID's document.
+ */
+function controllerKeyId(verificationMethod: string): string {
+  return verificationMethod.split('#')[0];
+}
+
+/**
  * Verifies a single event's proofs.
  *
  * Controller proofs (those without `witnessedAt`) gate the overall
@@ -255,7 +265,8 @@ async function verifyEvent(
   index: number,
   customVerifier: ((proof: DataIntegrityProof, data: unknown) => Promise<boolean>) | undefined,
   previousEvent: LogEntry | undefined,
-  resolveKey?: (verificationMethod: string) => Promise<Uint8Array | null>
+  resolveKey?: (verificationMethod: string) => Promise<Uint8Array | null>,
+  authorizedKeyIds?: Set<string>
 ): Promise<EventVerification> {
   const errors: string[] = [];
 
@@ -306,6 +317,29 @@ async function verifyEvent(
       chainValid,
       errors,
     };
+  }
+
+  // Controller binding: on the default (dispatch) path, every controller proof
+  // must be signed by a key authorized by the log's create event. Without this,
+  // any key can append/rename/migrate/deactivate someone else's log and it
+  // verifies (confirmed forgeable). A custom verifier takes full responsibility
+  // for authorization, so this check is skipped there.
+  if (!customVerifier && authorizedKeyIds && index > 0) {
+    for (const { proof, originalIndex } of controllerProofs) {
+      if (!authorizedKeyIds.has(controllerKeyId(proof.verificationMethod))) {
+        errors.push(
+          `Event ${index}, Proof ${originalIndex}: signer ${proof.verificationMethod} is not authorized by the log's create event`
+        );
+        return {
+          index,
+          type: event.type,
+          proofValid: false,
+          chainValid,
+          cryptographicallyVerified: false,
+          errors,
+        };
+      }
+    }
   }
 
   // Verify controller proofs — these gate `proofValid` and `cryptographicallyVerified`.
@@ -442,11 +476,24 @@ export async function verifyEventLog(
     };
   }
 
+  // Establish the authorized controller key set from the create event
+  // (event 0). Its controller proofs — the non-witness proofs — define the
+  // keys allowed to sign every subsequent event in the log (trust-on-first-use
+  // root of authority). The current CEL data model has no in-log key-rotation
+  // mechanism, so this set is fixed by the create event.
+  const createEvent = log.events[0];
+  const authorizedKeyIds = new Set<string>(
+    (createEvent.proof ?? [])
+      .filter(p => !isWitnessProof(p))
+      .map(p => controllerKeyId(p.verificationMethod))
+      .filter((id): id is string => typeof id === 'string' && id.length > 0)
+  );
+
   // Verify each event's proofs and hash chain
   for (let i = 0; i < log.events.length; i++) {
     const event = log.events[i];
     const previousEvent = i > 0 ? log.events[i - 1] : undefined;
-    const eventResult = await verifyEvent(event, i, options?.verifier, previousEvent, options?.resolveKey);
+    const eventResult = await verifyEvent(event, i, options?.verifier, previousEvent, options?.resolveKey, authorizedKeyIds);
     eventVerifications.push(eventResult);
 
     if (!eventResult.proofValid || !eventResult.chainValid) {

--- a/packages/sdk/src/cel/algorithms/verifyEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/verifyEventLog.ts
@@ -503,18 +503,31 @@ export async function verifyEventLog(
     };
   }
 
-  // Establish the authorized controller key set from the create event
-  // (event 0). Its controller proofs — the non-witness proofs — define the
-  // keys (by resolved public-key material) allowed to sign every subsequent
-  // event in the log (trust-on-first-use root of authority). The current CEL
-  // data model has no in-log key-rotation mechanism, so this set is fixed by
-  // the create event.
+  // Establish the authorized controller key from the create event (event 0):
+  // the trust-on-first-use root of authority. The current CEL data model has
+  // no in-log key-rotation mechanism, so this key is fixed by the create event.
+  //
+  // SECURITY: the hash chain and the controller signature cover only
+  // { type, data, previousEvent } — NOT the proof array. So an attacker can
+  // append their own valid controller proof to the create event without
+  // breaking the chain or the owner's signature. If we seeded the authorized
+  // set from ALL of the create event's controller proofs, that injected key
+  // would become authorized and could sign forged later events. To close this,
+  // the create event must carry EXACTLY ONE controller proof; more than one is
+  // treated as tampering (its unsigned proof array cannot disambiguate the
+  // real root from an injected co-signer) and fails the whole log.
   const createEvent = log.events[0];
+  const createControllerProofs = (createEvent.proof ?? []).filter(p => !isWitnessProof(p));
   const authorizedKeyIds = new Set<string>();
-  for (const p of createEvent.proof ?? []) {
-    if (isWitnessProof(p)) continue;
-    const keyHex = await resolveControllerKeyHex(p.verificationMethod, options?.resolveKey);
-    if (keyHex) authorizedKeyIds.add(keyHex);
+  let authorityError: string | undefined;
+  if (createControllerProofs.length !== 1) {
+    authorityError =
+      `Create event must have exactly one controller proof to establish authority (found ` +
+      `${createControllerProofs.length}); the create event's proof array is not signed, so ` +
+      `additional controller proofs cannot be trusted.`;
+  } else {
+    const rootKeyHex = await resolveControllerKeyHex(createControllerProofs[0].verificationMethod, options?.resolveKey);
+    if (rootKeyHex) authorizedKeyIds.add(rootKeyHex);
   }
 
   // Verify each event's proofs and hash chain
@@ -529,12 +542,17 @@ export async function verifyEventLog(
     }
   }
 
-  // Determine overall verification status (both proofs AND chain must be valid)
+  // Determine overall verification status (both proofs AND chain must be valid,
+  // and the create event must establish a single unambiguous authority key).
   const allProofsValid = eventVerifications.every(ev => ev.proofValid);
   const allChainsValid = eventVerifications.every(ev => ev.chainValid);
 
+  if (authorityError) {
+    errors.unshift(authorityError);
+  }
+
   return {
-    verified: allProofsValid && allChainsValid,
+    verified: allProofsValid && allChainsValid && !authorityError,
     errors,
     events: eventVerifications,
   };

--- a/packages/sdk/src/cel/cli/migrate.ts
+++ b/packages/sdk/src/cel/cli/migrate.ts
@@ -359,15 +359,20 @@ export async function migrateCommand(flags: MigrateFlags): Promise<MigrateResult
     const publicKeyBytes = await (ed25519 as any).getPublicKeyAsync(privateKeyBytes);
     privateKey = multikey.encodePrivateKey(privateKeyBytes as Uint8Array, 'Ed25519');
     publicKey = multikey.encodePublicKey(publicKeyBytes as Uint8Array, 'Ed25519');
-    
+
     // Never print the private key to a shared stream (stderr lands in shell
     // history, terminal transcripts, and CI logs). Write it to an owner-only
     // file and report the path instead.
     const keyBase = flags.output || flags.wallet || 'cel-migrate';
     const keyPath = `${keyBase}.key`;
     fs.writeFileSync(keyPath, JSON.stringify({ privateKey, publicKey }, null, 2), { mode: 0o600 });
-    console.error('\n⚠️  Generated temporary signing key for migration.');
-    console.error(`Private key written to ${keyPath} (mode 0600 — keep it secret).`);
+    console.error('\n⚠️  Generated a temporary signing key for this migration.');
+    console.error(
+      'This key is NOT the log\'s controller key, so verifyEventLog will reject the resulting ' +
+      "log (controller binding). To produce a verifiable log, re-run with --wallet pointing at the " +
+      'key that created the log.'
+    );
+    console.error(`Temporary private key written to ${keyPath} (mode 0600 — keep it secret).`);
     console.error(`Public Key:  ${publicKey}`);
     console.error(`To reuse this key, run with --wallet ${keyPath}\n`);
   }

--- a/packages/sdk/src/cel/cli/migrate.ts
+++ b/packages/sdk/src/cel/cli/migrate.ts
@@ -400,12 +400,12 @@ export async function migrateCommand(flags: MigrateFlags): Promise<MigrateResult
       const bitcoinManager = createMockBitcoinManager();
       const manager = new BtcoCelManager(signer, bitcoinManager);
       migratedLog = await manager.migrate(eventLog);
-      
-      // Extract target DID from migration event
-      const migrationEvent = migratedLog.events[migratedLog.events.length - 1];
-      const migrationData = migrationEvent.data as Record<string, unknown>;
-      targetDid = migrationData.targetDid as string;
-      
+
+      // The resolvable did:btco:<satoshi> is derived from the bitcoin witness
+      // proof (the satoshi is only known after inscription), surfaced via
+      // the derived state — not from the signed event data.
+      targetDid = manager.getCurrentState(migratedLog).did;
+
     } else {
       return {
         success: false,

--- a/packages/sdk/src/cel/layers/BtcoCelManager.ts
+++ b/packages/sdk/src/cel/layers/BtcoCelManager.ts
@@ -36,8 +36,13 @@ export interface BtcoCelConfig {
 export interface BtcoMigrationData {
   /** The source DID from the previous layer */
   sourceDid: string;
-  /** The new did:btco DID */
-  targetDid: string;
+  /**
+   * The resolvable did:btco:<satoshi> DID. Optional in the signed event data:
+   * the satoshi is only known after inscription, so it is carried in the
+   * bitcoin witness proof and the DID is derived from there during state
+   * derivation rather than being embedded in (and signed as part of) the data.
+   */
+  targetDid?: string;
   /** The target layer */
   layer: 'btco';
   /** The Bitcoin transaction ID anchoring the migration */
@@ -177,14 +182,15 @@ export class BtcoCelManager {
     // the witness digest both commit to {type, data, previousEvent}; mutating
     // `data` after signing (as this code previously did to splice in
     // txid/inscriptionId) invalidates both, so every btco log failed
-    // verification. The Bitcoin txid/inscriptionId cannot be known before the
-    // inscription anyway (chicken-and-egg), so they are NOT part of the signed
-    // data — they live in the bitcoin witness proof, which is added after
-    // signing and excluded from the chain digest. targetDid is derived
-    // deterministically from the source DID so it is known at signing time.
+    // verification. The Bitcoin details cannot be known before the inscription
+    // (chicken-and-egg): txid, inscriptionId AND the satoshi that forms the
+    // canonical did:btco:<sat> identifier all come from the inscription. They
+    // are therefore NOT part of the signed data — they live in the bitcoin
+    // witness proof (added after signing, excluded from the chain digest) and
+    // the resolvable targetDid is derived from the proof's satoshi at
+    // state-derivation time.
     const migrationData: BtcoMigrationData = {
       sourceDid: currentDid,
-      targetDid: this.generateBtcoDid(currentDid),
       layer: 'btco',
       migratedAt: new Date().toISOString(),
     };
@@ -212,45 +218,6 @@ export class BtcoCelManager {
         witnessedEvent,
       ],
     };
-  }
-
-  /**
-   * Generates a did:btco DID fallback from source DID
-   * 
-   * @param sourceDid - The source DID to derive from
-   * @returns A did:btco string
-   */
-  private generateBtcoDid(sourceDid: string): string {
-    // Extract identifier portion from source DID
-    let idPart: string;
-    
-    if (sourceDid.startsWith('did:webvh:')) {
-      // For webvh DIDs, extract the identifier after domain
-      const parts = sourceDid.split(':');
-      idPart = parts.length > 3 ? parts.slice(3).join('') : this.hashIdentifier(sourceDid);
-    } else {
-      // For other DIDs, create a hash-based identifier
-      idPart = this.hashIdentifier(sourceDid);
-    }
-
-    // Sanitize for DID (alphanumeric only)
-    idPart = idPart.replace(/[^a-zA-Z0-9]/g, '').substring(0, 64);
-
-    return `did:btco:${idPart}`;
-  }
-
-  /**
-   * Creates a URL-safe hash-based identifier from a string
-   */
-  private hashIdentifier(input: string): string {
-    // Simple hash for identifier generation (not cryptographic)
-    let hash = 0;
-    for (let i = 0; i < input.length; i++) {
-      const char = input.charCodeAt(i);
-      hash = ((hash << 5) - hash) + char;
-      hash = hash & hash; // Convert to 32bit integer
-    }
-    return Math.abs(hash).toString(36);
   }
 
   /**
@@ -294,20 +261,22 @@ export class BtcoCelManager {
       if (event.type === 'update') {
         const updateData = event.data as Record<string, unknown>;
         
-        // Check if this is a migration event
-        if (updateData.targetDid && updateData.layer) {
+        // Check if this is a migration event. Migration events carry a
+        // sourceDid + layer; regular updates don't. (btco migrations no longer
+        // carry targetDid in the signed data — see below.)
+        if (updateData.sourceDid && updateData.layer) {
           // Migration event - update DID and layer
-          state.did = updateData.targetDid as string;
           state.layer = updateData.layer as 'peer' | 'webvh' | 'btco';
           state.updatedAt = updateData.migratedAt as string;
-          
+
           // Store migration info in metadata
           state.metadata = state.metadata || {};
           state.metadata.sourceDid = updateData.sourceDid;
-          
-          // Store Bitcoin-specific metadata for btco layer. txid/inscriptionId
-          // are NOT part of the signed event data (they can't be known before
-          // inscription); they are read from the bitcoin witness proof.
+
+          // For btco, the Bitcoin details (txid, inscriptionId, satoshi) are
+          // NOT in the signed data — they can't be known before inscription.
+          // They are read from the bitcoin witness proof, and the resolvable
+          // did:btco:<satoshi> DID is derived from the proof's satoshi.
           if (updateData.layer === 'btco') {
             const bitcoinProof = (event.proof as ReadonlyArray<unknown> | undefined)?.find(
               (p): p is Record<string, unknown> =>
@@ -319,8 +288,20 @@ export class BtcoCelManager {
             if (bitcoinProof?.inscriptionId) {
               state.metadata.inscriptionId = bitcoinProof.inscriptionId;
             }
-          } else if (updateData.domain) {
-            state.metadata.domain = updateData.domain;
+            if (bitcoinProof?.satoshi) {
+              state.metadata.satoshi = bitcoinProof.satoshi;
+              // Canonical, resolvable did:btco identifier (numeric satoshi).
+              state.did = `did:btco:${bitcoinProof.satoshi as string}`;
+            }
+          } else {
+            // Non-btco (webvh) migrations carry their targetDid in the data
+            // (domain-derived, known at signing time).
+            if (updateData.targetDid) {
+              state.did = updateData.targetDid as string;
+            }
+            if (updateData.domain) {
+              state.metadata.domain = updateData.domain;
+            }
           }
         } else {
           // Regular update event

--- a/packages/sdk/src/cel/layers/BtcoCelManager.ts
+++ b/packages/sdk/src/cel/layers/BtcoCelManager.ts
@@ -173,10 +173,18 @@ export class BtcoCelManager {
       throw new Error('Cannot migrate a deactivated event log');
     }
 
-    // Prepare initial migration data (will be updated with Bitcoin details after witnessing)
+    // Finalize the migration data BEFORE signing. The controller signature and
+    // the witness digest both commit to {type, data, previousEvent}; mutating
+    // `data` after signing (as this code previously did to splice in
+    // txid/inscriptionId) invalidates both, so every btco log failed
+    // verification. The Bitcoin txid/inscriptionId cannot be known before the
+    // inscription anyway (chicken-and-egg), so they are NOT part of the signed
+    // data — they live in the bitcoin witness proof, which is added after
+    // signing and excluded from the chain digest. targetDid is derived
+    // deterministically from the source DID so it is known at signing time.
     const migrationData: BtcoMigrationData = {
       sourceDid: currentDid,
-      targetDid: '', // Will be set after inscription
+      targetDid: this.generateBtcoDid(currentDid),
       layer: 'btco',
       migratedAt: new Date().toISOString(),
     };
@@ -188,70 +196,22 @@ export class BtcoCelManager {
       proofPurpose: this.config.proofPurpose,
     };
 
-    // Create the update event with migration data
-    let updatedLog = await updateEventLog(webvhLog, migrationData, updateOptions);
+    // Create the (final, signed) update event with the migration data.
+    const updatedLog = await updateEventLog(webvhLog, migrationData, updateOptions);
 
-    // Add Bitcoin witness proof (REQUIRED at btco layer)
+    // Add the Bitcoin witness proof (REQUIRED at btco layer). This attests the
+    // already-signed event content and appends the txid/inscriptionId; it does
+    // not — and must not — alter the signed `data`.
     const lastEventIndex = updatedLog.events.length - 1;
-    let witnessedEvent = updatedLog.events[lastEventIndex];
-    
-    // Witness the event on Bitcoin
-    witnessedEvent = await witnessEvent(witnessedEvent, this.bitcoinWitness);
+    const witnessedEvent = await witnessEvent(updatedLog.events[lastEventIndex], this.bitcoinWitness);
 
-    // Extract Bitcoin details from the witness proof
-    const bitcoinProof = witnessedEvent.proof.find(
-      p => p.cryptosuite === 'bitcoin-ordinals-2024'
-    ) as Record<string, unknown> | undefined;
-
-    // Generate did:btco DID using inscription ID
-    let targetDid: string;
-    let txid: string | undefined;
-    let inscriptionId: string | undefined;
-
-    if (bitcoinProof) {
-      txid = bitcoinProof.txid as string;
-      inscriptionId = bitcoinProof.inscriptionId as string;
-      
-      // did:btco format uses the inscription ID for identification
-      if (inscriptionId) {
-        // Sanitize inscription ID for DID (remove special chars)
-        const sanitizedId = inscriptionId.replace(/[^a-zA-Z0-9]/g, '');
-        targetDid = `did:btco:${sanitizedId}`;
-      } else if (txid) {
-        targetDid = `did:btco:${txid}`;
-      } else {
-        // Fallback: derive from source DID
-        targetDid = this.generateBtcoDid(currentDid);
-      }
-    } else {
-      // Fallback: derive from source DID (shouldn't happen since witness is required)
-      targetDid = this.generateBtcoDid(currentDid);
-    }
-
-    // Update migration data with Bitcoin details
-    const updatedMigrationData: BtcoMigrationData = {
-      ...migrationData,
-      targetDid,
-      txid,
-      inscriptionId,
-    };
-
-    // Replace the event data with updated migration data
-    witnessedEvent = {
-      ...witnessedEvent,
-      data: updatedMigrationData,
-    };
-
-    // Replace the last event with the witnessed version
-    updatedLog = {
+    return {
       ...updatedLog,
       events: [
         ...updatedLog.events.slice(0, lastEventIndex),
         witnessedEvent,
       ],
     };
-
-    return updatedLog;
   }
 
   /**
@@ -345,13 +305,19 @@ export class BtcoCelManager {
           state.metadata = state.metadata || {};
           state.metadata.sourceDid = updateData.sourceDid;
           
-          // Store Bitcoin-specific metadata for btco layer
+          // Store Bitcoin-specific metadata for btco layer. txid/inscriptionId
+          // are NOT part of the signed event data (they can't be known before
+          // inscription); they are read from the bitcoin witness proof.
           if (updateData.layer === 'btco') {
-            if (updateData.txid) {
-              state.metadata.txid = updateData.txid;
+            const bitcoinProof = (event.proof as ReadonlyArray<unknown> | undefined)?.find(
+              (p): p is Record<string, unknown> =>
+                !!p && typeof p === 'object' && (p as Record<string, unknown>).cryptosuite === 'bitcoin-ordinals-2024'
+            );
+            if (bitcoinProof?.txid) {
+              state.metadata.txid = bitcoinProof.txid;
             }
-            if (updateData.inscriptionId) {
-              state.metadata.inscriptionId = updateData.inscriptionId;
+            if (bitcoinProof?.inscriptionId) {
+              state.metadata.inscriptionId = bitcoinProof.inscriptionId;
             }
           } else if (updateData.domain) {
             state.metadata.domain = updateData.domain;

--- a/packages/sdk/src/cel/witnesses/BitcoinWitness.ts
+++ b/packages/sdk/src/cel/witnesses/BitcoinWitness.ts
@@ -140,7 +140,20 @@ export class BitcoinWitness implements WitnessService {
           digestMultibase
         );
       }
-      
+
+      // The satoshi ordinal is the canonical did:btco:<sat> identifier and is
+      // required — without it, state derivation cannot produce a resolvable
+      // did:btco and would leave the asset's DID disagreeing with its btco
+      // layer. Fail closed here rather than emitting a log that can never
+      // yield a valid btco identifier. (did:btco requires a NUMERIC satoshi;
+      // inscriptionId/txid are not valid substitutes.)
+      if (!inscription.satoshi) {
+        throw new BitcoinWitnessError(
+          'Bitcoin inscription did not return a satoshi ordinal (required for the did:btco identifier)',
+          digestMultibase
+        );
+      }
+
       const now = new Date().toISOString();
       
       // Build the WitnessProof with Bitcoin-specific extensions

--- a/packages/sdk/tests/unit/cel/BitcoinWitness.test.ts
+++ b/packages/sdk/tests/unit/cel/BitcoinWitness.test.ts
@@ -263,6 +263,22 @@ describe('BitcoinWitness', () => {
         .rejects.toThrow('did not return a transaction ID');
     });
 
+    it('throws error when inscription returns no satoshi', async () => {
+      // Without a satoshi there is no canonical did:btco:<sat> identifier, so
+      // the witness must fail closed rather than emit a log that derives an
+      // inconsistent (webvh) DID at the btco layer.
+      const badManager = createMockBitcoinManager({
+        inscribeData: vi.fn().mockResolvedValue({
+          ...mockInscription,
+          satoshi: '',
+        }),
+      });
+      const witness = new BitcoinWitness(badManager);
+
+      await expect(witness.witness(testDigest))
+        .rejects.toThrow('did not return a satoshi ordinal');
+    });
+
     it('wraps non-Error throws', async () => {
       const errorManager = createMockBitcoinManager({
         inscribeData: vi.fn().mockRejectedValue('String error'),

--- a/packages/sdk/tests/unit/cel/BtcoCelManager.test.ts
+++ b/packages/sdk/tests/unit/cel/BtcoCelManager.test.ts
@@ -128,14 +128,18 @@ describe('BtcoCelManager', () => {
       expect((migrationData.sourceDid as string).startsWith('did:webvh:')).toBe(true);
     });
 
-    it('should include targetDid with btco format', async () => {
+    it('derives a resolvable did:btco:<satoshi> in the migrated state', async () => {
       const webvhLog = await createWebvhLog();
       const btcoLog = await manager.migrate(webvhLog);
 
+      // targetDid is NOT in the signed data (the satoshi is only known after
+      // inscription); it is derived from the bitcoin witness proof's satoshi.
       const migrationData = btcoLog.events[2].data as Record<string, unknown>;
-      expect(migrationData.targetDid).toBeDefined();
-      expect(typeof migrationData.targetDid).toBe('string');
-      expect((migrationData.targetDid as string).startsWith('did:btco:')).toBe(true);
+      expect(migrationData.targetDid).toBeUndefined();
+
+      const state = manager.getCurrentState(btcoLog);
+      expect(state.did).toBe('did:btco:1234567890');
+      expect(/^did:btco:[0-9]+$/.test(state.did)).toBe(true);
     });
 
     it('should include layer: btco in migration data', async () => {
@@ -478,13 +482,10 @@ describe('BtcoCelManager', () => {
       const btcoManager = new BtcoCelManager(createMockSigner(), createMockBitcoinManager());
       const btcoLog = await btcoManager.migrate(webvhLog);
 
-      const migrationData = btcoLog.events[2].data as Record<string, unknown>;
-      const targetDid = migrationData.targetDid as string;
-
-      // targetDid is derived deterministically from the source DID at signing
-      // time (the on-chain inscription id lives in the witness proof, since it
-      // can't be known before inscription).
-      expect(targetDid.startsWith('did:btco:')).toBe(true);
+      // The resolvable did:btco identifier is the numeric satoshi from the
+      // witness proof, surfaced via derived state.
+      const state = btcoManager.getCurrentState(btcoLog);
+      expect(state.did).toBe('did:btco:1234567890');
       const bp = bitcoinProofOf(btcoLog.events[2]);
       expect(bp?.inscriptionId).toBe('abc123def456i0');
     });

--- a/packages/sdk/tests/unit/cel/BtcoCelManager.test.ts
+++ b/packages/sdk/tests/unit/cel/BtcoCelManager.test.ts
@@ -58,6 +58,11 @@ const createPeerLog = async (): Promise<EventLog> => {
   ]);
 };
 
+
+function bitcoinProofOf(event: any): Record<string, unknown> | undefined {
+  return (event.proof as any[]).find(p => p.cryptosuite === 'bitcoin-ordinals-2024');
+}
+
 describe('BtcoCelManager', () => {
   describe('constructor', () => {
     it('should create instance with valid signer and BitcoinManager', () => {
@@ -145,16 +150,17 @@ describe('BtcoCelManager', () => {
       const webvhLog = await createWebvhLog();
       const btcoLog = await manager.migrate(webvhLog);
 
-      const migrationData = btcoLog.events[2].data as Record<string, unknown>;
-      expect(migrationData.txid).toBe('abc123def456');
+      // txid lives in the bitcoin witness proof, not the signed data
+      const bp = bitcoinProofOf(btcoLog.events[2]);
+      expect(bp?.txid).toBe('abc123def456');
     });
 
     it('should include inscriptionId in migration data', async () => {
       const webvhLog = await createWebvhLog();
       const btcoLog = await manager.migrate(webvhLog);
 
-      const migrationData = btcoLog.events[2].data as Record<string, unknown>;
-      expect(migrationData.inscriptionId).toBe('abc123def456i0');
+      const bp = bitcoinProofOf(btcoLog.events[2]);
+      expect(bp?.inscriptionId).toBe('abc123def456i0');
     });
 
     it('should include migratedAt timestamp', async () => {
@@ -474,10 +480,13 @@ describe('BtcoCelManager', () => {
 
       const migrationData = btcoLog.events[2].data as Record<string, unknown>;
       const targetDid = migrationData.targetDid as string;
-      
-      // Should contain sanitized inscription ID
+
+      // targetDid is derived deterministically from the source DID at signing
+      // time (the on-chain inscription id lives in the witness proof, since it
+      // can't be known before inscription).
       expect(targetDid.startsWith('did:btco:')).toBe(true);
-      expect(targetDid.includes('abc123def456i0')).toBe(true);
+      const bp = bitcoinProofOf(btcoLog.events[2]);
+      expect(bp?.inscriptionId).toBe('abc123def456i0');
     });
 
     it('should generate consistent DIDs for same inscription', async () => {

--- a/packages/sdk/tests/unit/cel/OriginalsCel.test.ts
+++ b/packages/sdk/tests/unit/cel/OriginalsCel.test.ts
@@ -510,7 +510,11 @@ describe('OriginalsCel', () => {
       
       const data = btcoLog.events[2].data as any;
       expect(data.layer).toBe('btco');
-      expect(data.targetDid).toMatch(/^did:btco:/);
+      // The resolvable did:btco:<satoshi> comes from the witness proof via the
+      // derived state (not the signed data — the satoshi is only known after
+      // inscription).
+      const bp = (btcoLog.events[2].proof as any[]).find(p => p.cryptosuite === 'bitcoin-ordinals-2024');
+      expect(String(bp.satoshi).length).toBeGreaterThan(0);
       expect(mockBitcoinManager.inscribeData).toHaveBeenCalled();
     });
 

--- a/packages/sdk/tests/unit/cel/cel-core-coverage.test.ts
+++ b/packages/sdk/tests/unit/cel/cel-core-coverage.test.ts
@@ -107,9 +107,12 @@ describe('CEL-CORE-012/happy – webvh→btco migration via BtcoCelManager', () 
     expect(typeof data.sourceDid).toBe('string');
     expect((data.sourceDid as string).startsWith('did:webvh:')).toBe(true);
 
-    // Target DID must be a valid btco DID.
-    expect(typeof data.targetDid).toBe('string');
-    expect((data.targetDid as string).startsWith('did:btco:')).toBe(true);
+    // targetDid is NOT in the signed data — the resolvable did:btco:<satoshi>
+    // is derived from the bitcoin witness proof's satoshi (only known after
+    // inscription).
+    expect(data.targetDid).toBeUndefined();
+    const bpCore = (finalEvent.proof as any[]).find(p => p.cryptosuite === 'bitcoin-ordinals-2024');
+    expect(String(bpCore.satoshi).length).toBeGreaterThan(0);
   });
 
   it('migration data contains Bitcoin transaction references (txid and inscriptionId)', () => {

--- a/packages/sdk/tests/unit/cel/cel-core-coverage.test.ts
+++ b/packages/sdk/tests/unit/cel/cel-core-coverage.test.ts
@@ -114,19 +114,19 @@ describe('CEL-CORE-012/happy – webvh→btco migration via BtcoCelManager', () 
 
   it('migration data contains Bitcoin transaction references (txid and inscriptionId)', () => {
     const finalEvent = btcoLog.events[btcoLog.events.length - 1];
-    const data = finalEvent.data as Record<string, unknown>;
+    // txid/inscriptionId are carried in the bitcoin witness proof (not the
+    // signed data, which can't know them before inscription).
+    const bp = (finalEvent.proof as any[]).find(p => p.cryptosuite === 'bitcoin-ordinals-2024') as Record<string, unknown>;
+    expect(bp).toBeDefined();
 
-    // txid must be a non-empty string.
-    expect(typeof data.txid).toBe('string');
-    expect((data.txid as string).length).toBeGreaterThan(0);
-
-    // inscriptionId must be a non-empty string.
-    expect(typeof data.inscriptionId).toBe('string');
-    expect((data.inscriptionId as string).length).toBeGreaterThan(0);
+    expect(typeof bp.txid).toBe('string');
+    expect((bp.txid as string).length).toBeGreaterThan(0);
+    expect(typeof bp.inscriptionId).toBe('string');
+    expect((bp.inscriptionId as string).length).toBeGreaterThan(0);
 
     // Confirm the values match what BitcoinManager returned.
-    expect(data.txid).toBe('deadbeef01020304');
-    expect(data.inscriptionId).toBe('deadbeef01020304i0');
+    expect(bp.txid).toBe('deadbeef01020304');
+    expect(bp.inscriptionId).toBe('deadbeef01020304i0');
   });
 });
 

--- a/packages/sdk/tests/unit/cel/event-log-authorization.test.ts
+++ b/packages/sdk/tests/unit/cel/event-log-authorization.test.ts
@@ -67,6 +67,10 @@ describe('CEL event-log authorization and btco verifiability', () => {
     const bp = (last.proof as any[]).find(p => p.cryptosuite === 'bitcoin-ordinals-2024');
     expect(bp.txid).toBe('abc123def456');
     expect((last.data as any).txid).toBeUndefined();
+    // targetDid is derived from the satoshi and is a resolvable numeric did:btco.
+    expect((last.data as any).targetDid).toBeUndefined();
+    const state = new BtcoCelManager(makeSigner() as any, mockBitcoin()).getCurrentState(btcoLog);
+    expect(/^did:btco:[0-9]+$/.test(state.did)).toBe(true);
   });
 
   it('rejects an event appended by a key not authorized by the create event', async () => {

--- a/packages/sdk/tests/unit/cel/event-log-authorization.test.ts
+++ b/packages/sdk/tests/unit/cel/event-log-authorization.test.ts
@@ -89,6 +89,30 @@ describe('CEL event-log authorization and btco verifiability', () => {
     expect(result.errors.some(e => /not authorized by the log's create event/.test(e))).toBe(true);
   });
 
+  it('rejects a co-signer proof appended to the create event', async () => {
+    // The create event's signature and the hash chain cover only
+    // {type,data,previousEvent}, not the proof array — so an attacker can
+    // append their own valid controller proof to event 0 (keeping the owner's)
+    // and, without this guard, become an authorized signer for later events.
+    const owner = makeSigner();
+    const log = await new PeerCelManager(owner as any).create('Owner Asset', []);
+
+    const attacker = makeSigner();
+    const ev0 = log.events[0];
+    const attackerProof = await (attacker as any)({ type: ev0.type, data: ev0.data });
+    (ev0.proof as any[]).push(attackerProof);
+
+    // Attacker appends a forged update signed with their now-"authorized" key.
+    const forged = await updateEventLog(log, { name: 'Hijacked' }, {
+      signer: attacker as any,
+      verificationMethod: 'ignored',
+    });
+
+    const result = await verifyEventLog(forged);
+    expect(result.verified).toBe(false);
+    expect(result.errors.some(e => /exactly one controller proof/.test(e))).toBe(true);
+  });
+
   it('accepts an update signed by the same controller key', async () => {
     const owner = makeSigner();
     const peer = new PeerCelManager(owner as any);

--- a/packages/sdk/tests/unit/cel/event-log-authorization.test.ts
+++ b/packages/sdk/tests/unit/cel/event-log-authorization.test.ts
@@ -99,4 +99,57 @@ describe('CEL event-log authorization and btco verifiability', () => {
     expect(result.verified).toBe(true);
     expect(result.errors).toEqual([]);
   });
+
+  // Authorization is by resolved public KEY, not the VM URI string. These two
+  // cases pin both axes for non-did:key (resolver-backed) controllers.
+  describe('key-based authorization (resolver-backed VMs)', () => {
+    // A signer that signs with `priv` but stamps an arbitrary verificationMethod.
+    function vmSigner(priv: Uint8Array, verificationMethod: string) {
+      return async (data: unknown) => {
+        const sig = await ed25519.signAsync(canonicalizeEvent(data), priv);
+        return {
+          type: 'DataIntegrityProof',
+          cryptosuite: 'eddsa-jcs-2022',
+          created: '2020-01-01T00:00:00Z',
+          verificationMethod,
+          proofPurpose: 'assertionMethod',
+          proofValue: multikey.encodeMultibase(new Uint8Array(sig)),
+        };
+      };
+    }
+
+    it('accepts the same key under a different equivalent VM id', async () => {
+      const priv = crypto.getRandomValues(new Uint8Array(32));
+      const pub = await ed25519.getPublicKeyAsync(priv);
+      // resolveKey maps BOTH VM ids to the same public key.
+      const resolveKey = async (_vm: string) => pub;
+
+      const create = new PeerCelManager(vmSigner(priv, 'did:webvh:example.com:alice#key-0') as any);
+      let log = await create.create('Asset', []);
+      log = await new PeerCelManager(vmSigner(priv, 'did:webvh:example.com:alice#key-alias') as any)
+        .update(log, { name: 'v2' });
+
+      const result = await verifyEventLog(log, { resolveKey });
+      expect(result.verified).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('rejects a different key even under the same DID document', async () => {
+      const privA = crypto.getRandomValues(new Uint8Array(32));
+      const privB = crypto.getRandomValues(new Uint8Array(32));
+      const pubA = await ed25519.getPublicKeyAsync(privA);
+      const pubB = await ed25519.getPublicKeyAsync(privB);
+      // #key-0 → A, #key-1 → B (distinct keys in the same DID document).
+      const resolveKey = async (vm: string) => (vm.endsWith('#key-1') ? pubB : pubA);
+
+      const create = new PeerCelManager(vmSigner(privA, 'did:webvh:example.com:alice#key-0') as any);
+      let log = await create.create('Asset', []);
+      log = await new PeerCelManager(vmSigner(privB, 'did:webvh:example.com:alice#key-1') as any)
+        .update(log, { name: 'hijacked' });
+
+      const result = await verifyEventLog(log, { resolveKey });
+      expect(result.verified).toBe(false);
+      expect(result.errors.some(e => /not authorized by the log's create event/.test(e))).toBe(true);
+    });
+  });
 });

--- a/packages/sdk/tests/unit/cel/event-log-authorization.test.ts
+++ b/packages/sdk/tests/unit/cel/event-log-authorization.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression tests for two CEL protocol criticals:
+ *
+ *  1. did:btco migrations must produce cryptographically verifiable logs
+ *     (event data was previously mutated after signing/witnessing).
+ *  2. verifyEventLog must bind every event to the log's controller key
+ *     (any key could previously append/rename/migrate/deactivate a log
+ *     and it verified as valid).
+ *
+ * These use REAL Ed25519 signing (the other BtcoCelManager tests use a mock
+ * signer and never exercise cryptographic verification).
+ */
+import { describe, it, expect } from 'bun:test';
+import * as ed25519 from '@noble/ed25519';
+import { multikey } from '../../../src/crypto/Multikey';
+import { canonicalizeEvent } from '../../../src/cel/canonicalize';
+import { PeerCelManager } from '../../../src/cel/layers/PeerCelManager';
+import { WebVHCelManager } from '../../../src/cel/layers/WebVHCelManager';
+import { BtcoCelManager } from '../../../src/cel/layers/BtcoCelManager';
+import { updateEventLog } from '../../../src/cel/algorithms/updateEventLog';
+import { verifyEventLog } from '../../../src/cel/algorithms/verifyEventLog';
+import type { BitcoinManager } from '../../../src/bitcoin/BitcoinManager';
+
+function makeSigner() {
+  const priv = crypto.getRandomValues(new Uint8Array(32));
+  let pubMb: string | undefined;
+  return async (data: unknown) => {
+    if (!pubMb) {
+      const pub = await ed25519.getPublicKeyAsync(priv);
+      pubMb = multikey.encodePublicKey(pub, 'Ed25519');
+    }
+    const sig = await ed25519.signAsync(canonicalizeEvent(data), priv);
+    return {
+      type: 'DataIntegrityProof',
+      cryptosuite: 'eddsa-jcs-2022',
+      created: '2020-01-01T00:00:00Z',
+      verificationMethod: `did:key:${pubMb}#${pubMb}`,
+      proofPurpose: 'assertionMethod',
+      proofValue: multikey.encodeMultibase(new Uint8Array(sig)),
+    };
+  };
+}
+
+const mockBitcoin = (): BitcoinManager => ({
+  inscribeData: async () => ({
+    txid: 'abc123def456',
+    inscriptionId: 'abc123def456i0',
+    satoshi: '1234567890',
+    blockHeight: 800000,
+  }),
+} as unknown as BitcoinManager);
+
+describe('CEL event-log authorization and btco verifiability', () => {
+  it('a real webvh→btco migration produces a verifiable log', async () => {
+    const signer = makeSigner();
+    const peer = new PeerCelManager(signer as any);
+    let log = await peer.create('Asset', [{ digestMultibase: 'uHash', mediaType: 'image/png' }]);
+    log = await new WebVHCelManager(signer as any, 'example.com').migrate(log);
+    const btcoLog = await new BtcoCelManager(signer as any, mockBitcoin()).migrate(log);
+
+    const result = await verifyEventLog(btcoLog);
+    expect(result.verified).toBe(true);
+    expect(result.errors).toEqual([]);
+
+    // Bitcoin details are carried in the witness proof, not the signed data.
+    const last = btcoLog.events[btcoLog.events.length - 1];
+    const bp = (last.proof as any[]).find(p => p.cryptosuite === 'bitcoin-ordinals-2024');
+    expect(bp.txid).toBe('abc123def456');
+    expect((last.data as any).txid).toBeUndefined();
+  });
+
+  it('rejects an event appended by a key not authorized by the create event', async () => {
+    const owner = makeSigner();
+    const log = await new PeerCelManager(owner as any).create('Owner Asset', []);
+
+    // Attacker signs an update with their own unrelated key.
+    const attacker = makeSigner();
+    const forged = await updateEventLog(log, { name: 'Stolen' }, {
+      signer: attacker as any,
+      verificationMethod: 'ignored',
+    });
+
+    const result = await verifyEventLog(forged);
+    expect(result.verified).toBe(false);
+    expect(result.errors.some(e => /not authorized by the log's create event/.test(e))).toBe(true);
+  });
+
+  it('accepts an update signed by the same controller key', async () => {
+    const owner = makeSigner();
+    const peer = new PeerCelManager(owner as any);
+    let log = await peer.create('Owner Asset', []);
+    log = await peer.update(log, { name: 'v2' });
+
+    const result = await verifyEventLog(log);
+    expect(result.verified).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+});

--- a/packages/sdk/tests/unit/cel/verifyEventLog.test.ts
+++ b/packages/sdk/tests/unit/cel/verifyEventLog.test.ts
@@ -443,6 +443,23 @@ describe('verifyEventLog', () => {
       expect(result.errors.some(e => /exactly one controller proof/.test(e))).toBe(true);
     });
 
+    test('rejects a create event with a non-array proof without crashing', async () => {
+      // A truthy-but-non-array proof (e.g. a bare object) must yield a
+      // structured failure, not a TypeError from calling .filter on it.
+      const log = {
+        events: [{
+          type: 'create',
+          data: { name: 'Test' },
+          proof: { type: 'DataIntegrityProof', proofValue: 'z...' },
+        }],
+      } as unknown as EventLog;
+
+      const result = await verifyEventLog(log);
+
+      expect(result.verified).toBe(false);
+      expect(result.errors.some(e => /exactly one controller proof/.test(e))).toBe(true);
+    });
+
     test('a custom verifier bypasses the single-controller-proof authority check', async () => {
       // With a custom verifier, the caller owns proof semantics/authorization,
       // so a legitimately multi-proof create event must not be rejected by the

--- a/packages/sdk/tests/unit/cel/verifyEventLog.test.ts
+++ b/packages/sdk/tests/unit/cel/verifyEventLog.test.ts
@@ -417,12 +417,14 @@ describe('verifyEventLog', () => {
   });
 
   describe('multiple proofs per event', () => {
-    test('verifies event with multiple valid proofs (all did:key, resolved offline)', async () => {
-      // Both proofs must pass; use real did:key signers for both controller and witness.
-      const { signer: s1, verificationMethod: vm1 } = await makeRealSigner();
-      const { signer: s2, verificationMethod: vm2 } = await makeRealSigner();
+    test('rejects a create event carrying more than one controller proof (ambiguous authority)', async () => {
+      // The create event's proof array is not signed, so a second controller
+      // proof cannot be trusted to establish authority — it is exactly how an
+      // attacker would inject a co-signer. Such a create event is rejected even
+      // when both proofs are individually valid.
+      const { signer: s1 } = await makeRealSigner();
+      const { signer: s2 } = await makeRealSigner();
 
-      // Build the event data manually — two proofs sign the same canonical payload.
       const eventData = { name: 'Test' };
       const proof1 = await s1({ type: 'create', data: eventData });
       const proof2 = await s2({ type: 'create', data: eventData });
@@ -437,8 +439,8 @@ describe('verifyEventLog', () => {
 
       const result = await verifyEventLog(log);
 
-      expect(result.verified).toBe(true);
-      expect(result.events[0].proofValid).toBe(true);
+      expect(result.verified).toBe(false);
+      expect(result.errors.some(e => /exactly one controller proof/.test(e))).toBe(true);
     });
 
     test('verifies event with one valid and one non-did:key proof (second fails closed)', async () => {

--- a/packages/sdk/tests/unit/cel/verifyEventLog.test.ts
+++ b/packages/sdk/tests/unit/cel/verifyEventLog.test.ts
@@ -443,6 +443,32 @@ describe('verifyEventLog', () => {
       expect(result.errors.some(e => /exactly one controller proof/.test(e))).toBe(true);
     });
 
+    test('fails with a distinct authority error when the create key is unresolvable', async () => {
+      // A non-did:key create proof whose resolver returns null (e.g. a transient
+      // resolver failure) must produce a clear authority error, not silently
+      // leave the authorized set empty and reject every event as "not authorized".
+      const eventData = { name: 'Test' };
+      const log: EventLog = {
+        events: [{
+          type: 'create',
+          data: eventData,
+          proof: [{
+            type: 'DataIntegrityProof',
+            cryptosuite: 'eddsa-jcs-2022',
+            created: '2020-01-01T00:00:00Z',
+            verificationMethod: 'did:webvh:example.com:alice#key-0',
+            proofPurpose: 'assertionMethod',
+            proofValue: 'zSomeSignature',
+          }],
+        }],
+      };
+
+      const result = await verifyEventLog(log, { resolveKey: async () => null });
+
+      expect(result.verified).toBe(false);
+      expect(result.errors.some(e => /could not be .*resolved to establish authority/.test(e))).toBe(true);
+    });
+
     test('rejects a create event with a non-array proof without crashing', async () => {
       // A truthy-but-non-array proof (e.g. a bare object) must yield a
       // structured failure, not a TypeError from calling .filter on it.

--- a/packages/sdk/tests/unit/cel/verifyEventLog.test.ts
+++ b/packages/sdk/tests/unit/cel/verifyEventLog.test.ts
@@ -443,6 +443,26 @@ describe('verifyEventLog', () => {
       expect(result.errors.some(e => /exactly one controller proof/.test(e))).toBe(true);
     });
 
+    test('a custom verifier bypasses the single-controller-proof authority check', async () => {
+      // With a custom verifier, the caller owns proof semantics/authorization,
+      // so a legitimately multi-proof create event must not be rejected by the
+      // default authority check before the verifier runs.
+      const { signer: s1 } = await makeRealSigner();
+      const { signer: s2 } = await makeRealSigner();
+      const eventData = { name: 'Test' };
+      const proof1 = await s1({ type: 'create', data: eventData });
+      const proof2 = await s2({ type: 'create', data: eventData });
+
+      const log: EventLog = {
+        events: [{ type: 'create', data: eventData, proof: [proof1, proof2] }],
+      };
+
+      const result = await verifyEventLog(log, { verifier: async () => true });
+
+      expect(result.verified).toBe(true);
+      expect(result.errors.some(e => /exactly one controller proof/.test(e))).toBe(false);
+    });
+
     test('verifies event with one valid and one non-did:key proof (second fails closed)', async () => {
       // Without a resolver, the did:web proof fails closed.
       const { signer: s1, verificationMethod: vm1 } = await makeRealSigner();


### PR DESCRIPTION
## What

Fixes two **critical** CEL (Cryptographic Event Log) protocol bugs found during the review that produced PR #227. Both were reproduced with runnable scripts and are now covered by regression tests. This PR is **stacked on `claude/sdk-review-fixes-7driha` (#227)** so its diff shows only the CEL changes.

1. **Every `did:btco` migration produced a cryptographically invalid log.** `BtcoCelManager.migrate` signed and witnessed the migration event, then **replaced `event.data`** with `{ targetDid, txid, inscriptionId }`. The controller signature and the Bitcoin witness digest both commit to `{ type, data, previousEvent }`, so after the mutation neither matched the stored data — `verifyEventLog` returned `verified: false` for **every** asset that reached the btco ("maximum immutability") layer.
2. **`verifyEventLog` accepted an event signed by any key.** There was no binding between an event's signing key and the log's controller, so an attacker could append / rename / "migrate" / deactivate anyone's log and it verified as valid (confirmed: a forged update returned `verified: true`).

## Why

Both are silent, high-severity: (1) makes the most permanent layer unverifiable end-to-end; (2) is a straightforward log-forgery / takeover. Existing CEL tests use mock signers and never exercised cryptographic verification, which is why neither surfaced.

## How

- **btco verifiability:** finalize the migration data *before* signing. `targetDid` is derived deterministically from the source DID (known at signing time). `txid`/`inscriptionId` — which genuinely cannot be known before the inscription exists (chicken-and-egg) — are carried in the Bitcoin witness proof (added after signing, excluded from the chain digest) and read from there during state derivation, instead of being spliced into the signed data.
- **controller binding:** `verifyEventLog` establishes the authorized controller-key set from the create event (trust-on-first-use root) and rejects any later event whose controller proof is signed by an unauthorized key. All legitimate events in a log share one controller `did:key` (the CLI and layer managers always sign with the same key), so this doesn't break valid chains. A caller-supplied custom verifier still owns authorization and is exempt.
- **CLI:** `originals-cel migrate` without `--wallet` now warns that its temporary key is not the controller key and the resulting log won't verify; pass `--wallet` with the log's controller key to produce a verifiable migration.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change) — logs signed by a non-controller key (previously "valid") now correctly fail `verifyEventLog`; btco migration data no longer carries `txid`/`inscriptionId` (they move to the witness proof)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test addition or improvement

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] I have updated JSDoc comments for any changed public APIs
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Testing

- [x] Unit tests — new `tests/unit/cel/event-log-authorization.test.ts` uses **real Ed25519 signing** to assert: a real webvh→btco migration verifies; a forged event signed by an unauthorized key is rejected; a same-key update still verifies. Existing btco tests updated to read `txid`/`inscriptionId` from the witness proof.
- [x] Integration — full suite green (`bun test`): 0 failures across unit/integration/security; the only remaining failures repo-wide are the pre-existing environment-sensitive performance-guard tests that also fail on `main`.
- [x] Manual — reproduced both bugs before the fix (btco log `verified:false`; forged log `verified:true`) and confirmed both flip after the fix.

## Screenshots / Output (if applicable)

```
# before → after
btco log:   verified:false  →  verified:true
forged log: verified:true   →  verified:false ("signer … is not authorized by the log's create event")
```

> Note: because this is stacked on #227, please merge #227 first (or retarget this to `main` after #227 merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AE3LNa25yQbCvWhva6GoiC

---
_Generated by [Claude Code](https://claude.ai/code/session_01AE3LNa25yQbCvWhva6GoiC)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix did:btco event log verification by binding events to the controller key
> - `verifyEventLog` now establishes authority from the create event by requiring exactly one controller proof and resolving its public key; subsequent events must be signed by that same authorized key or verification fails.
> - `BtcoCelManager.migrate` no longer mutates signed event data after signing; Bitcoin details (`txid`, `inscriptionId`, `satoshi`) are now stored exclusively in the Bitcoin witness proof, making the signed data verifiable.
> - `BtcoCelManager.getCurrentState` derives `did:btco:<satoshi>` and Bitcoin metadata from the witness proof rather than from signed event data.
> - `BitcoinWitness.witness` now throws if the inscription result lacks a satoshi ordinal, preventing creation of btco logs with no canonical DID.
> - Behavioral Change: `BtcoMigrationData.targetDid` is now optional and will be absent from signed btco migration data; callers must not read it from event data.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 283e663.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->