### PR TITLE
fix(cel): recover satoshi in BitcoinWitness before failing closed

### DIFF
--- a/.changeset/btco-witness-satoshi-recovery.md
+++ b/.changeset/btco-witness-satoshi-recovery.md
@@ -1,0 +1,5 @@
+---
+"@originals/sdk": patch
+---
+
+Fix `BitcoinWitness.witness()` breaking btco witnessing with providers that don't return a satoshi from `createInscription` (e.g. the shipped `OrdHttpProvider`). The witness now recovers the satoshi via `getSatoshiFromInscription` before failing closed, so a successful inscription no longer throws "did not return a satoshi ordinal". It still fails closed when the satoshi is genuinely unavailable, since `did:btco` requires a numeric satoshi.

--- a/packages/sdk/src/cel/witnesses/BitcoinWitness.ts
+++ b/packages/sdk/src/cel/witnesses/BitcoinWitness.ts
@@ -144,12 +144,20 @@ export class BitcoinWitness implements WitnessService {
       // The satoshi ordinal is the canonical did:btco:<sat> identifier and is
       // required — without it, state derivation cannot produce a resolvable
       // did:btco and would leave the asset's DID disagreeing with its btco
-      // layer. Fail closed here rather than emitting a log that can never
-      // yield a valid btco identifier. (did:btco requires a NUMERIC satoshi;
-      // inscriptionId/txid are not valid substitutes.)
-      if (!inscription.satoshi) {
+      // layer. Some providers (e.g. OrdHttpProvider) don't return the satoshi
+      // from createInscription, so make a best-effort recovery by looking it
+      // up from the inscription id before failing.
+      let satoshi = inscription.satoshi;
+      if (!satoshi) {
+        satoshi = (await this.bitcoinManager.getSatoshiFromInscription(inscription.inscriptionId)) ?? '';
+      }
+      // Fail closed if it's still unavailable rather than emitting a log that
+      // can never yield a valid btco identifier. (did:btco requires a NUMERIC
+      // satoshi; inscriptionId/txid are not valid substitutes.)
+      if (!satoshi) {
         throw new BitcoinWitnessError(
-          'Bitcoin inscription did not return a satoshi ordinal (required for the did:btco identifier)',
+          'Bitcoin inscription did not return a satoshi ordinal, and it could not be ' +
+            'resolved from the inscription id (required for the did:btco identifier)',
           digestMultibase
         );
       }
@@ -167,7 +175,7 @@ export class BitcoinWitness implements WitnessService {
         witnessedAt: now,
         txid: inscription.txid,
         blockHeight: inscription.blockHeight,
-        satoshi: inscription.satoshi,
+        satoshi,
         inscriptionId: inscription.inscriptionId,
       };
       

--- a/packages/sdk/tests/unit/cel/BitcoinWitness.test.ts
+++ b/packages/sdk/tests/unit/cel/BitcoinWitness.test.ts
@@ -29,10 +29,14 @@ describe('BitcoinWitness', () => {
   const createMockBitcoinManager = (
     overrides: Partial<{
       inscribeData: typeof mockBitcoinManager.inscribeData;
+      getSatoshiFromInscription: typeof mockBitcoinManager.getSatoshiFromInscription;
     }> = {}
   ) => {
     const mockBitcoinManager = {
       inscribeData: vi.fn().mockResolvedValue(mockInscription),
+      // Default: no satoshi recoverable from the inscription id (providers that
+      // do supply satoshi never hit this path).
+      getSatoshiFromInscription: vi.fn().mockResolvedValue(null),
       ...overrides,
     } as unknown as BitcoinManager;
     return mockBitcoinManager;
@@ -263,7 +267,7 @@ describe('BitcoinWitness', () => {
         .rejects.toThrow('did not return a transaction ID');
     });
 
-    it('throws error when inscription returns no satoshi', async () => {
+    it('throws when inscription has no satoshi and it cannot be recovered', async () => {
       // Without a satoshi there is no canonical did:btco:<sat> identifier, so
       // the witness must fail closed rather than emit a log that derives an
       // inconsistent (webvh) DID at the btco layer.
@@ -272,11 +276,29 @@ describe('BitcoinWitness', () => {
           ...mockInscription,
           satoshi: '',
         }),
+        getSatoshiFromInscription: vi.fn().mockResolvedValue(null),
       });
       const witness = new BitcoinWitness(badManager);
 
       await expect(witness.witness(testDigest))
         .rejects.toThrow('did not return a satoshi ordinal');
+    });
+
+    it('recovers the satoshi from the inscription id when inscribeData omits it', async () => {
+      // Providers like OrdHttpProvider don't return satoshi from
+      // createInscription; the witness looks it up before failing.
+      const manager = createMockBitcoinManager({
+        inscribeData: vi.fn().mockResolvedValue({
+          ...mockInscription,
+          satoshi: '',
+        }),
+        getSatoshiFromInscription: vi.fn().mockResolvedValue('9876543210'),
+      });
+      const witness = new BitcoinWitness(manager);
+
+      const proof = await witness.witness(testDigest);
+      expect(proof.satoshi).toBe('9876543210');
+      expect(manager.getSatoshiFromInscription).toHaveBeenCalledWith('abc123i0');
     });
 
     it('wraps non-Error throws', async () => {


### PR DESCRIPTION
## What

Follow-up to #228. `BitcoinWitness.witness()` now recovers the satoshi ordinal from the inscription id before failing, instead of hard-failing whenever `inscription.satoshi` is empty.

## Why

#228 (merged) added a required-satoshi check to `BitcoinWitness.witness()` so a btco log can't be created without the canonical `did:btco:<sat>` identifier. But the shipped `OrdHttpProvider.createInscription()` returns no `satoshi` field, and immediately after inscription the indexer fallback in `inscribeData` can still come back empty. With that provider a fully successful, confirmed inscription would throw `"did not return a satoshi ordinal"`, breaking **every** btco witness call at runtime. (Flagged by Macroscope on #228 after it had already merged.)

## How

Before failing, the witness makes a best-effort recovery via `bitcoinManager.getSatoshiFromInscription(inscriptionId)` and uses the recovered value in the emitted proof. It still fails closed when the satoshi is genuinely unavailable — `did:btco` requires a **numeric** satoshi, and `inscriptionId`/`txid` are not valid substitutes (they'd reintroduce the non-resolvable-DID bug fixed earlier in the #228 series). Providers that already return a satoshi (`OrdMockProvider`, `OrdinalsClient`) never hit the recovery path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test addition or improvement

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] I have updated JSDoc comments for any changed public APIs
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Testing

- [x] Unit tests — `tests/unit/cel/BitcoinWitness.test.ts`: added a case where `inscribeData` omits the satoshi but `getSatoshiFromInscription` recovers it (proof carries the recovered satoshi), and kept the fail-closed case where it's genuinely unrecoverable. Full CEL suite green (693 pass / 0 fail).
- [ ] Integration tests
- [x] Manual testing (describe steps) — traced the `OrdHttpProvider` path: `createInscription` returns no satoshi → `inscribeData` fallback returns `''` → before this fix `witness()` threw; after, it resolves the satoshi (or fails closed only when truly absent).

## Screenshots / Output (if applicable)

```
# OrdHttpProvider btco witness
before → after
witness(): throws "did not return a satoshi ordinal"  →  proof.satoshi resolved via getSatoshiFromInscription
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AE3LNa25yQbCvWhva6GoiC

---
_Generated by [Claude Code](https://claude.ai/code/session_01AE3LNa25yQbCvWhva6GoiC)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Recover satoshi from inscription ID in `BitcoinWitness.witness` before failing
> When an ordinals provider omits the satoshi field in `createInscription`, `BitcoinWitness.witness()` now calls `getSatoshiFromInscription` to look it up by inscription ID before throwing. If the lookup succeeds, proof construction proceeds normally; if it returns null, the method still throws with an updated error message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a52ee5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->