### PR TITLE
fix: correctness pass — revocation fail-closed, VC issuer binding, resource version lookup, btco tombstone/network, multibase decode

### DIFF
--- a/.changeset/correctness-loop-n08sq0.md
+++ b/.changeset/correctness-loop-n08sq0.md
@@ -1,0 +1,12 @@
+---
+"@originals/sdk": minor
+---
+
+Fix six correctness bugs surfaced by a fresh subsystem audit, each with regression coverage. Two change verification behavior toward fail-closed:
+
+- **Revocation fail-open (security).** `CredentialManager.verifyCredentialWithStatus` now fails closed (`verified: false`) when a credential declares a `BitstringStatusListEntry` that cannot be evaluated — no status list supplied, or `checkStatus` throws (purpose mismatch, out-of-range index, corrupt list). Previously it returned `verified: true` / `revoked: false`, so a caller could treat a possibly-revoked credential as valid. Determinable revoked/suspended states are unchanged.
+- **Issuer binding on the legacy verify path.** The legacy `verifyCredential` path now rejects a signed credential that has no issuer to bind the signing key to, matching the Data Integrity path (which already fails closed). Previously a self-certifying `did:key` credential with no `issuer` verified unconditionally.
+- **Resource version lookup.** `ResourceManager.getResourceVersion` now matches by stored version number instead of array position, so non-contiguous histories (e.g. importing v1 then v3) return the correct version rather than aliasing or dropping one.
+- **`did:btco` tombstone detection.** `BtcoDidResolver` no longer misclassifies a valid DID document that merely contains the 🔥 codepoint in a field as a deactivation tombstone; only the human-readable marker form deactivates a DID.
+- **Network-scoped `did:btco` in CEL state.** `BtcoCelManager.getCurrentState` now derives the network-scoped identifier (`did:btco:reg:` / `did:btco:sig:` for regtest/signet) from the inscribing `BitcoinManager` instead of always emitting the mainnet form.
+- **Multibase decoding.** `multikey.decodeMultibase` now accepts `u` (base64url) in addition to `z` (base58btc), matching the CEL proof structural check so a spec-valid base64url signature is no longer rejected. Unknown prefixes still fail closed.

--- a/FOLLOWUP.md
+++ b/FOLLOWUP.md
@@ -127,3 +127,78 @@ behavior today), require a product/design decision, or would exceed the
   fix: options include re-creating affected DIDs, or upstream didwebvh-ts
   accepting the legacy prefixed form during verification for backward
   compatibility. New logs created by the SDK now use the spec format.
+
+## Iteration (branch n08sq0) deferrals
+
+## 12. `did:webvh` resolution is hardcoded to `Ed25519Verifier` — non-Ed25519 did:webvh DIDs are unresolvable (design)
+
+- **Where:** `packages/sdk/src/did/DIDManager.ts` (`resolveDID`, the `did:webvh`
+  branch passes `{ verifier: new Ed25519Verifier() }`).
+- **What:** The did:webvh create path accepts arbitrary `externalSigner` /
+  `verificationMethods` / `updateKeys` (Turnkey, AWS KMS, HSM) with no key-type
+  enforcement (`WebVHManager.ts:336-360`), but resolution only wires an
+  Ed25519 verifier. A did:webvh published with a secp256k1/P-256 external signer
+  verifies with its external verifier yet `resolveDID` returns `null` — the DID
+  appears not to exist.
+- **Why deferred:** This is a design decision about whether did:webvh is
+  Ed25519-only (the SDK's internal signing path is) or must support multiple
+  algorithms. The correct fix is either (a) reject non-Ed25519
+  `verificationMethods`/`updateKeys` up front in the create/update paths, or
+  (b) dispatch a verifier by the log key's multicodec at resolution time — a new
+  multi-algorithm verifier component. Both change the documented capability
+  surface and warrant a dedicated decision + tests rather than a minimal fix.
+
+## 13. CEL create-event controller key is not bound to a self-certifying `data.did` (threat-model / TOFU)
+
+- **Where:** `packages/sdk/src/cel/algorithms/verifyEventLog.ts` (authorized-key
+  seeding from the create event's controller proof; no comparison against
+  `createEvent.data.did`).
+- **What:** For `did:peer` (numalgo-4) and `did:key`, the identifier embeds the
+  controller's public key, so the create key ↔ DID binding is checkable offline.
+  `verifyEventLog` never checks it, so an attacker can copy a victim's create
+  event `data` verbatim, re-sign event 0 with their own key as the single
+  controller proof, append attacker-signed events, and the log verifies — a
+  "valid" provenance log for the victim's DID actually controlled by the
+  attacker's key.
+- **Why deferred:** The code's stated model is explicit trust-on-first-use (the
+  create event is the root of authority; external identity binding is the
+  resolver's job — comment at verifyEventLog.ts ~506-522). Whether to add a
+  self-certifying `create-key == key-in-data.did` check for peer/key DIDs is a
+  threat-model decision, distinct from FOLLOWUP #3 (btco witness anchoring).
+
+## 14. `batchInscribeOnBitcoin({ singleTransaction: true })` collapses N assets onto one Bitcoin identity + no per-item atomicity (design / API)
+
+- **Where:** `packages/sdk/src/lifecycle/BatchLifecycleOperations.ts` (the
+  `singleTransaction` path: one `inscribeData` call, then a migrate loop that
+  sets every asset's `did:btco` binding to `did:btco:<sameSat>`).
+- **What:** All assets in a single-transaction batch receive the same
+  `inscriptionId`/`satoshi` and therefore the same `did:btco:<sat>` identity.
+  Since a did:btco identity is satoshi-scoped, the batched assets share one
+  on-chain identity; worse, `transferOwnership` reads `latestMigration.satoshi`,
+  so transferring one asset moves the UTXO the others also claim. The path also
+  hand-rolls its migrate loop without `BatchOperationExecutor` isolation: a
+  mid-loop `migrate()` throw (e.g. a mixed batch with an already-btco asset)
+  leaves the inscription broadcast and some assets mutated while the thrown
+  `BatchError` reports `successful: 0`.
+- **Why deferred:** Single-transaction batching is an intentional cost-saving
+  mode; whether it should assign distinct sub-identities (e.g. per-index
+  inscription offsets) or be documented as identity-sharing — and how partial
+  failure after broadcast should be reported — are product/design decisions that
+  change batch semantics and the public result shape, not a minimal fix.
+
+## 15. CEL CLI `migrate`/`transfer` display helpers emit a network-less `did:btco:<sat>` (minor, latent)
+
+- **Where:** `packages/sdk/src/cel/cli/migrate.ts` (`resolveMigrationDid`) and
+  `packages/sdk/src/cel/cli/transfer.ts` derive `did:btco:${satoshi}` for
+  human-readable output.
+- **What:** Companion to the programmatic fix in `BtcoCelManager.getCurrentState`
+  (now network-scoped via the inscribing `BitcoinManager`). The CLI helpers are
+  pure functions over an event log, and the btco migration event does not carry
+  the Bitcoin network in its signed data, so they cannot derive the correct
+  `sig`/`reg` prefix without the CLI being told the configured network via a
+  flag/config.
+- **Why deferred:** These are display-only paths (the resolvable identity comes
+  from `getCurrentState`, which is fixed). A correct fix needs a network source
+  threaded into the inspect/migrate/transfer CLI commands — a small CLI-plumbing
+  change best batched with a CLI network-config pass, and not coverable by a
+  meaningful regression test until that config exists.

--- a/LOOP_LOG.md
+++ b/LOOP_LOG.md
@@ -272,3 +272,36 @@ each with a regression test that fails before the fix and passes after
 - Typecheck clean; lint 0 errors (87 pre-existing warnings, none added).
 - No open PR for this branch — will push and open one. All fixes strengthen or
   preserve verification; none weaken validation or skip crypto checks.
+
+## Iteration 2 — 2026-07-03 (Macroscope review on PR #232)
+
+Opened PR #232; subscribed to activity and armed an hourly self check-in. All
+CI checks green (typecheck, lint, tests, coverage, ESM, changeset). Macroscope
+Correctness Check posted three Medium findings — all valid, all fixed with
+regression tests (each verified to fail against the iteration-1 commit):
+
+1. **CEL btco DID was runtime-config-dependent** (BtcoCelManager): iteration 1's
+   network fix derived the prefix from `this.bitcoinManager.network` at replay
+   time, so replaying a persisted regtest/signet log under a differently
+   configured SDK silently rewrote `state.did`. Now the network is recorded in
+   the SIGNED migration data (known before inscription, unlike the satoshi) and
+   read back during replay, with a runtime-config fallback only for legacy logs.
+   State derivation is deterministic from the log. Tests: network recorded in
+   signed data + replay under a mainnet manager still yields did:btco:reg:.
+2. **`decodeMultibase` silently accepted malformed base64url** (Multikey):
+   `Buffer.from('@@@','base64url')` returns empty instead of throwing, so a
+   malformed `u` payload decoded to an empty array (the `z` branch throws). Now
+   validates `^[A-Za-z0-9_-]+$` before decoding; malformed/empty `u` throws.
+   Test: 'u@@@', 'u', 'u====' all throw.
+3. **Tombstone guard bypass** (BtcoDidResolver): iteration 1's
+   `!isDidDocumentForThisDid` guard could be evaded by appending a minimal
+   `{"id":"<did>"}` object after a "BTCO DID: … 🔥" marker — it parsed to a
+   matching-id object, skipped the tombstone branch, and fell back to an older
+   document. Switched tombstone detection to the start-anchored marker PATTERN
+   (`didPattern.test && includes('🔥')`), which correctly classifies both a
+   DID-document-containing-🔥 (not a tombstone) and a marker-with-appended-JSON
+   (a tombstone). Test: marker + appended JSON still deactivates.
+
+### Result
+- Full suite: **3224 pass / 0 fail / 71 skip**. Typecheck clean; lint 0 errors.
+- Replied to all three review threads with the fixing commit SHA.

--- a/LOOP_LOG.md
+++ b/LOOP_LOG.md
@@ -192,3 +192,22 @@ Branch: `claude/originals-sdk-correctness-ws3gte` (continuation after #230 merge
 
 ### Result
 - Full turbo suite green (0 fail), typecheck clean, lint 0 errors.
+
+---
+
+Branch: `claude/originals-sdk-correctness-n08sq0` (fresh off main @ 738dec2, includes merged #230 + #231)
+
+## Iteration 1 — 2026-07-03
+
+### Ground truth
+- Fresh clone; `bun install`, then `bun run build` (dist was missing → 16 CEL-CLI
+  subprocess tests fail without it; environment-only, no code issue).
+- Full suite after build: **3216 pass / 0 fail / 71 skip** across 171 files.
+- `bun run typecheck`: clean. `bun run lint`: 0 errors (87 pre-existing warnings).
+- No open PR for this branch; branch tip == origin/main (738dec2).
+
+### Work
+- Baseline green. Launched 4 parallel subsystem correctness audits
+  (vc/crypto, did, cel/anchoring, lifecycle/migration/storage) instructed to
+  skip everything already in FOLLOWUP.md and to report only concrete,
+  reachable, reproducible bugs. Triage of results pending.

--- a/LOOP_LOG.md
+++ b/LOOP_LOG.md
@@ -305,3 +305,12 @@ regression tests (each verified to fail against the iteration-1 commit):
 ### Result
 - Full suite: **3224 pass / 0 fail / 71 skip**. Typecheck clean; lint 0 errors.
 - Replied to all three review threads with the fixing commit SHA.
+
+### Iteration 2 follow-up (2nd Macroscope round)
+Macroscope flagged one more Medium: iteration-2's fix added `network` to the
+GLOBAL metadata-exclusion list, so an ordinary (non-migration) update event
+carrying an application-defined `network` field had it silently dropped from
+`state.metadata`. Scoped the exclusion to btco migration events only (where
+`network` is consumed explicitly). Regression test: a regular update with a
+custom `network` field now preserves it. Full suite 3225 pass / 0 fail;
+typecheck clean; lint 0 errors.

--- a/LOOP_LOG.md
+++ b/LOOP_LOG.md
@@ -211,3 +211,64 @@ Branch: `claude/originals-sdk-correctness-n08sq0` (fresh off main @ 738dec2, inc
   (vc/crypto, did, cel/anchoring, lifecycle/migration/storage) instructed to
   skip everything already in FOLLOWUP.md and to report only concrete,
   reachable, reproducible bugs. Triage of results pending.
+
+### Audit + fixes (iteration 1)
+Four parallel subsystem audits (vc/crypto, did, cel/anchoring, lifecycle/
+migration/storage) instructed to skip FOLLOWUP.md items and report only
+concrete, reachable, reproducible bugs. Fixed six confirmed correctness bugs,
+each with a regression test that fails before the fix and passes after
+(verified by stashing the src changes and re-running):
+
+1. **MED (revocation bypass) — `verifyCredentialWithStatus` failed OPEN**
+   (`src/vc/CredentialManager.ts`): when a credential declared a
+   `BitstringStatusListEntry` that could not be evaluated (no status list
+   supplied, or `checkStatus` threw on purpose-mismatch / out-of-range index /
+   corrupt list), it left `verified: true` / `revoked: false` and returned only
+   an error string — a caller gating on `verified`/`revoked` would accept a
+   possibly-revoked credential. Now fails closed (`verified = false`),
+   mirroring the Data Integrity path. Determinable revoked/suspended still
+   leave `verified` true. Test: StatusListManager.test.ts.
+2. **LOW (binding inconsistency) — legacy `verifyCredential` accepted an
+   issuer-less self-signed did:key credential** (`resolveVerificationMethodMultibase`):
+   the issuer-binding guards were gated on a truthy `issuerDid`, so a credential
+   with no issuer + a self-certifying did:key VM verified unconditionally, while
+   the DI path fails closed. Added an explicit fail-closed guard on missing
+   issuer. Test: CredentialManager.test.ts.
+3. **LOW-MED (version-history correctness) — `ResourceManager.getResourceVersion`
+   indexed positionally** (`versions[version-1]`): `importResource` inserts by
+   version number and permits gaps, so importing v1 then v3 made
+   `getResourceVersion(id,2)` return v3 and `(id,3)` return null. Now matches by
+   stored version number. Test: ResourceManager.test.ts.
+4. **LOW (spec-fidelity) — `BtcoDidResolver` misclassified a DID document
+   containing 🔥 as a deactivation tombstone**: deactivation was gated on a raw
+   `content.includes('🔥')`, so a valid DID document carrying the emoji in any
+   field (service description, name, …) was tombstoned. Now excludes content
+   that parses to a valid DID document for the DID; only the human-readable
+   marker form deactivates. Test: BtcoDidResolver.test.ts.
+5. **MED (correctness) — CEL btco state derivation emitted a network-less
+   `did:btco:<sat>` on regtest/signet** (`BtcoCelManager.getCurrentState`): the
+   identifier was hardcoded to the mainnet form, so a regtest/signet asset
+   pointed at the mainnet ordinals namespace. Now network-scoped
+   (`did:btco:reg:` / `did:btco:sig:`) via the inscribing `BitcoinManager`
+   (added a `network` getter). Test: BtcoCelManager.test.ts. The CLI display
+   helpers (migrate/transfer) remain network-agnostic — deferred (FOLLOWUP #15).
+6. **LOW (interop false-negative) — `multikey.decodeMultibase` rejected `u`
+   base64url** while the CEL structural check accepts a `u` proofValue: a
+   spec-valid base64url signature passed the structural gate but failed to
+   decode and was rejected. `decodeMultibase` now accepts both `z` (base58btc)
+   and `u` (base64url); unknown prefixes still fail closed. Test:
+   Multikey.test.ts.
+
+### Deferred (added to FOLLOWUP.md, items 12–15)
+- did:webvh resolution hardcoded to Ed25519Verifier (multi-algo design decision).
+- CEL create-event key not bound to self-certifying data.did (TOFU threat-model).
+- single-transaction batch inscription shares one btco identity + no per-item
+  atomicity (batch-semantics design decision).
+- CEL CLI migrate/transfer display emit network-less btco DID (CLI plumbing;
+  network not in the log).
+
+### Result
+- Full suite: **3222 pass / 0 fail / 71 skip** (was 3216; +6 regression tests).
+- Typecheck clean; lint 0 errors (87 pre-existing warnings, none added).
+- No open PR for this branch — will push and open one. All fixes strengthen or
+  preserve verification; none weaken validation or skip crypto checks.

--- a/packages/sdk/src/bitcoin/BitcoinManager.ts
+++ b/packages/sdk/src/bitcoin/BitcoinManager.ts
@@ -26,6 +26,15 @@ export class BitcoinManager {
     this.ord = config.ordinalsProvider;
   }
 
+  /**
+   * The Bitcoin network this manager operates on. Exposed so callers that
+   * derive `did:btco` identifiers (which are network-scoped) can produce the
+   * correct network prefix rather than assuming mainnet.
+   */
+  get network(): OriginalsConfig['network'] {
+    return this.config.network;
+  }
+
   private async resolveFeeRate(targetBlocks = 1, provided?: number): Promise<number | undefined> {
     // 1) An explicitly provided fee rate always wins: estimators must not
     // silently override what the caller asked to pay.

--- a/packages/sdk/src/cel/layers/BtcoCelManager.ts
+++ b/packages/sdk/src/cel/layers/BtcoCelManager.ts
@@ -367,9 +367,16 @@ export class BtcoCelManager {
           }
         }
         
-        // Store other fields in metadata
+        // Store other fields in metadata. `network` is consumed (and stored)
+        // explicitly only for btco migration events, so exclude it here for
+        // those events alone — for an ordinary update, an application-defined
+        // `network` field must still flow through to metadata.
+        const excludedKeys = ['name', 'resources', 'updatedAt', 'did', 'layer', 'creator', 'createdAt', 'sourceDid', 'targetDid', 'domain', 'migratedAt', 'txid', 'inscriptionId'];
+        if (updateData.sourceDid && updateData.layer === 'btco') {
+          excludedKeys.push('network');
+        }
         for (const [key, value] of Object.entries(updateData)) {
-          if (!['name', 'resources', 'updatedAt', 'did', 'layer', 'creator', 'createdAt', 'sourceDid', 'targetDid', 'domain', 'migratedAt', 'txid', 'inscriptionId', 'network'].includes(key)) {
+          if (!excludedKeys.includes(key)) {
             state.metadata = state.metadata || {};
             state.metadata[key] = value;
           }

--- a/packages/sdk/src/cel/layers/BtcoCelManager.ts
+++ b/packages/sdk/src/cel/layers/BtcoCelManager.ts
@@ -226,8 +226,24 @@ export class BtcoCelManager {
   }
 
   /**
+   * The network-scoped did:btco prefix for the configured Bitcoin network.
+   * Mainnet is bare (`did:btco`); signet/regtest carry `sig`/`reg` segments.
+   * Mirrors DIDManager / createBtcoDidDocument so all btco identifiers agree.
+   */
+  private btcoDidPrefix(): string {
+    switch (this.bitcoinManager.network) {
+      case 'signet':
+        return 'did:btco:sig';
+      case 'regtest':
+        return 'did:btco:reg';
+      default:
+        return 'did:btco';
+    }
+  }
+
+  /**
    * Derives the current asset state by replaying all events in the log.
-   * 
+   *
    * @param log - The event log to derive state from
    * @returns The current AssetState derived from replaying events
    */
@@ -295,8 +311,13 @@ export class BtcoCelManager {
             }
             if (bitcoinProof?.satoshi) {
               state.metadata.satoshi = bitcoinProof.satoshi;
-              // Canonical, resolvable did:btco identifier (numeric satoshi).
-              state.did = `did:btco:${bitcoinProof.satoshi as string}`;
+              // Canonical, resolvable did:btco identifier. The identifier is
+              // network-scoped: only mainnet is bare (`did:btco:<sat>`), while
+              // signet/regtest carry a prefix (`did:btco:sig:` / `did:btco:reg:`),
+              // matching DIDManager/createBtcoDidDocument. Deriving the network
+              // from the inscribing BitcoinManager avoids pointing a regtest/
+              // signet asset at the mainnet ordinals namespace.
+              state.did = `${this.btcoDidPrefix()}:${bitcoinProof.satoshi as string}`;
             }
           } else {
             // Non-btco (webvh) migrations carry their targetDid in the data

--- a/packages/sdk/src/cel/layers/BtcoCelManager.ts
+++ b/packages/sdk/src/cel/layers/BtcoCelManager.ts
@@ -45,6 +45,15 @@ export interface BtcoMigrationData {
   targetDid?: string;
   /** The target layer */
   layer: 'btco';
+  /**
+   * The Bitcoin network the inscription is made on, recorded at migration time.
+   * The network is known before inscription (unlike the satoshi), so it lives in
+   * the SIGNED migration data — this lets state derivation reconstruct the
+   * network-scoped did:btco identifier deterministically from the log rather
+   * than from the replaying SDK's runtime config. Absent on logs created before
+   * this field existed.
+   */
+  network?: 'mainnet' | 'regtest' | 'signet';
   /** The Bitcoin transaction ID anchoring the migration */
   txid?: string;
   /** The inscription ID on Bitcoin */
@@ -197,6 +206,12 @@ export class BtcoCelManager {
     const migrationData: BtcoMigrationData = {
       sourceDid: currentDid,
       layer: 'btco',
+      // Record the network in the SIGNED data. The satoshi is not yet known
+      // (it comes from the inscription, via the witness proof), but the network
+      // is known now — recording it here keeps state derivation deterministic:
+      // replaying the log yields the same network-scoped did:btco identifier
+      // regardless of the SDK's configured network.
+      network: this.bitcoinManager.network,
       migratedAt: new Date().toISOString(),
     };
 
@@ -230,8 +245,8 @@ export class BtcoCelManager {
    * Mainnet is bare (`did:btco`); signet/regtest carry `sig`/`reg` segments.
    * Mirrors DIDManager / createBtcoDidDocument so all btco identifiers agree.
    */
-  private btcoDidPrefix(): string {
-    switch (this.bitcoinManager.network) {
+  private btcoDidPrefix(network: string | undefined): string {
+    switch (network) {
       case 'signet':
         return 'did:btco:sig';
       case 'regtest':
@@ -314,10 +329,14 @@ export class BtcoCelManager {
               // Canonical, resolvable did:btco identifier. The identifier is
               // network-scoped: only mainnet is bare (`did:btco:<sat>`), while
               // signet/regtest carry a prefix (`did:btco:sig:` / `did:btco:reg:`),
-              // matching DIDManager/createBtcoDidDocument. Deriving the network
-              // from the inscribing BitcoinManager avoids pointing a regtest/
-              // signet asset at the mainnet ordinals namespace.
-              state.did = `${this.btcoDidPrefix()}:${bitcoinProof.satoshi as string}`;
+              // matching DIDManager/createBtcoDidDocument. The network is read
+              // from the SIGNED migration data so replaying a persisted log is
+              // deterministic — the DID does not change with the replaying SDK's
+              // configured network. Fall back to the inscribing manager's network
+              // only for legacy logs written before the network was recorded.
+              const network = (updateData.network as string | undefined) ?? this.bitcoinManager.network;
+              state.metadata.network = network;
+              state.did = `${this.btcoDidPrefix(network)}:${bitcoinProof.satoshi as string}`;
             }
           } else {
             // Non-btco (webvh) migrations carry their targetDid in the data
@@ -350,7 +369,7 @@ export class BtcoCelManager {
         
         // Store other fields in metadata
         for (const [key, value] of Object.entries(updateData)) {
-          if (!['name', 'resources', 'updatedAt', 'did', 'layer', 'creator', 'createdAt', 'sourceDid', 'targetDid', 'domain', 'migratedAt', 'txid', 'inscriptionId'].includes(key)) {
+          if (!['name', 'resources', 'updatedAt', 'did', 'layer', 'creator', 'createdAt', 'sourceDid', 'targetDid', 'domain', 'migratedAt', 'txid', 'inscriptionId', 'network'].includes(key)) {
             state.metadata = state.metadata || {};
             state.metadata[key] = value;
           }

--- a/packages/sdk/src/crypto/Multikey.ts
+++ b/packages/sdk/src/crypto/Multikey.ts
@@ -161,10 +161,21 @@ export const multikey = {
   },
 
   decodeMultibase: (encoded: string): Uint8Array => {
-    if (!encoded || encoded[0] !== 'z') {
-      throw new Error('Invalid Multibase encoding: only z-base58btc is supported');
+    if (!encoded || encoded.length < 2) {
+      throw new Error('Invalid Multibase encoding');
     }
-    return base58.decode(encoded.slice(1));
+    // Support the two multibase prefixes the SDK actually emits/accepts:
+    //   'z' = base58btc, 'u' = base64url (no padding).
+    // The CEL structural check accepts a 'u' proofValue as well, so decoding
+    // must accept it too — otherwise a spec-valid base64url signature passes the
+    // structural gate but fails to decode and is rejected as unverifiable.
+    if (encoded[0] === 'z') {
+      return base58.decode(encoded.slice(1));
+    }
+    if (encoded[0] === 'u') {
+      return new Uint8Array(Buffer.from(encoded.slice(1), 'base64url'));
+    }
+    throw new Error('Invalid Multibase encoding: only z-base58btc and u-base64url are supported');
   },
 
   decodePublicKey: (publicKeyMultibase: string): { key: Uint8Array; type: MultikeyType } => {

--- a/packages/sdk/src/crypto/Multikey.ts
+++ b/packages/sdk/src/crypto/Multikey.ts
@@ -173,7 +173,16 @@ export const multikey = {
       return base58.decode(encoded.slice(1));
     }
     if (encoded[0] === 'u') {
-      return new Uint8Array(Buffer.from(encoded.slice(1), 'base64url'));
+      // Validate before decoding. `Buffer.from(..., 'base64url')` silently drops
+      // invalid characters (e.g. "@@@" -> empty buffer) instead of throwing, so
+      // malformed input would otherwise be accepted as an empty result — unlike
+      // the base58 branch, which throws. Reject anything that is not non-empty
+      // unpadded base64url.
+      const payload = encoded.slice(1);
+      if (!/^[A-Za-z0-9_-]+$/.test(payload)) {
+        throw new Error('Invalid Multibase encoding: malformed u-base64url payload');
+      }
+      return new Uint8Array(Buffer.from(payload, 'base64url'));
     }
     throw new Error('Invalid Multibase encoding: only z-base58btc and u-base64url are supported');
   },

--- a/packages/sdk/src/did/BtcoDidResolver.ts
+++ b/packages/sdk/src/did/BtcoDidResolver.ts
@@ -170,17 +170,31 @@ export class BtcoDidResolver {
         // and forge signatures on this did:btco identity.
         const documentFromContent = this.parseDidDocumentFromContent(inscriptionData.content);
 
+        // A content blob carries THIS DID as a full DID document when it parses
+        // to a document whose id equals the expected DID.
+        const isDidDocumentForThisDid =
+          documentFromContent !== null && documentFromContent.id === expectedDid;
+
         // A content blob "is a DID" if it either matches the human-readable
         // pattern or parses to a DID document carrying the expected id.
         inscriptionData.isValidDid =
-          didPattern.test(inscriptionData.content) ||
-          (documentFromContent !== null && documentFromContent.id === expectedDid);
+          didPattern.test(inscriptionData.content) || isDidDocumentForThisDid;
 
-        if (inscriptionData.isValidDid && inscriptionData.content.includes('🔥')) {
-          // Deactivation marker on an inscription that actually carries THIS
-          // DID: the DID is tombstoned. An unrelated later inscription on the
-          // same sat that merely contains the emoji must NOT deactivate a live
-          // DID, so this is gated behind isValidDid.
+        if (
+          inscriptionData.isValidDid &&
+          !isDidDocumentForThisDid &&
+          inscriptionData.content.includes('🔥')
+        ) {
+          // Deactivation tombstone: the human-readable marker form for THIS DID
+          // carrying the 🔥 codepoint (e.g. "BTCO DID: did:btco:<sat> 🔥").
+          //
+          // Two guards matter here:
+          //  - `isValidDid`: an unrelated later inscription on the same sat that
+          //    merely contains the emoji must NOT deactivate a live DID.
+          //  - `!isDidDocumentForThisDid`: a full DID *document* that happens to
+          //    contain 🔥 somewhere in a field (a service description, name,
+          //    alsoKnownAs, …) is an update, not a tombstone. Only the marker
+          //    form deactivates; a valid document is handled as an update below.
           inscriptionData.didDocument = null;
           inscriptionData.deactivated = true;
           if (!inscriptionData.error) {

--- a/packages/sdk/src/did/BtcoDidResolver.ts
+++ b/packages/sdk/src/did/BtcoDidResolver.ts
@@ -175,26 +175,29 @@ export class BtcoDidResolver {
         const isDidDocumentForThisDid =
           documentFromContent !== null && documentFromContent.id === expectedDid;
 
+        // The content matches the human-readable BTCO marker line for THIS DID
+        // (e.g. "BTCO DID: did:btco:<sat>"). The pattern is start-anchored, so a
+        // full DID document (JSON, or "BTCO DID: {…}") does not match it.
+        const matchesMarker = didPattern.test(inscriptionData.content);
+
         // A content blob "is a DID" if it either matches the human-readable
         // pattern or parses to a DID document carrying the expected id.
-        inscriptionData.isValidDid =
-          didPattern.test(inscriptionData.content) || isDidDocumentForThisDid;
+        inscriptionData.isValidDid = matchesMarker || isDidDocumentForThisDid;
 
-        if (
-          inscriptionData.isValidDid &&
-          !isDidDocumentForThisDid &&
-          inscriptionData.content.includes('🔥')
-        ) {
+        if (matchesMarker && inscriptionData.content.includes('🔥')) {
           // Deactivation tombstone: the human-readable marker form for THIS DID
           // carrying the 🔥 codepoint (e.g. "BTCO DID: did:btco:<sat> 🔥").
           //
-          // Two guards matter here:
-          //  - `isValidDid`: an unrelated later inscription on the same sat that
-          //    merely contains the emoji must NOT deactivate a live DID.
-          //  - `!isDidDocumentForThisDid`: a full DID *document* that happens to
-          //    contain 🔥 somewhere in a field (a service description, name,
-          //    alsoKnownAs, …) is an update, not a tombstone. Only the marker
-          //    form deactivates; a valid document is handled as an update below.
+          // Detection keys off the marker PATTERN, not the mere presence of the
+          // emoji:
+          //  - a full DID document that happens to contain 🔥 in a field (a
+          //    service description, name, alsoKnownAs, …) does not match the
+          //    start-anchored marker pattern, so it is treated as an update
+          //    (handled below), not a tombstone;
+          //  - conversely, a genuine marker line remains a tombstone even if
+          //    arbitrary JSON is appended after it (which would otherwise parse
+          //    to an object with the expected id and slip past a document-based
+          //    guard), because the pattern anchors at the start of the content.
           inscriptionData.didDocument = null;
           inscriptionData.deactivated = true;
           if (!inscriptionData.error) {

--- a/packages/sdk/src/resources/ResourceManager.ts
+++ b/packages/sdk/src/resources/ResourceManager.ts
@@ -295,10 +295,15 @@ export class ResourceManager {
    */
   getResourceVersion(resourceId: string, version: number): Resource | null {
     const versions = this.resources.get(resourceId);
-    if (!versions || version < 1 || version > versions.length) {
+    if (!versions || version < 1) {
       return null;
     }
-    return versions[version - 1];
+    // Match by the stored version number rather than by array position.
+    // importResource inserts versions by sorted version number and permits
+    // gaps (e.g. importing v1 then v3), so positional indexing would return the
+    // wrong version (or null for a version that is present but non-contiguous).
+    // A resource with no explicit version defaults to 1 (mirrors importResource).
+    return versions.find(v => (v.version ?? 1) === version) ?? null;
   }
 
   /**

--- a/packages/sdk/src/vc/CredentialManager.ts
+++ b/packages/sdk/src/vc/CredentialManager.ts
@@ -391,6 +391,14 @@ export class CredentialManager {
     const status = credential.credentialStatus as BitstringStatusListEntry | undefined;
     if (status?.type === 'BitstringStatusListEntry') {
       if (!statusListCredential) {
+        // Fail closed: the credential declares a status entry but no status
+        // list was supplied to evaluate it. Leaving `verified: true` here would
+        // report an unknown revocation state as "valid", so a caller gating on
+        // `verified`/`revoked` would accept a possibly-revoked credential. This
+        // mirrors the fail-closed policy of the Data Integrity path
+        // (Verifier.verifyCredential), which rejects a credential whose declared
+        // status cannot be checked.
+        verified = false;
         errors.push('Credential has a BitstringStatusListEntry but no status list credential was provided');
       } else {
         try {
@@ -405,6 +413,11 @@ export class CredentialManager {
             }
           }
         } catch (err) {
+          // Fail closed: a status entry that cannot be evaluated (purpose
+          // mismatch, out-of-range index, corrupt encodedList) must not be
+          // treated as "not revoked". Determinable states (revoked/suspended)
+          // are reported via their own flags and leave `verified` untouched.
+          verified = false;
           errors.push(`Status check error: ${err instanceof Error ? err.message : String(err)}`);
         }
       }
@@ -461,6 +474,16 @@ export class CredentialManager {
     const issuerDid = typeof issuer === 'string' ? issuer : issuer?.id;
 
     if (typeof verificationMethod !== 'string') {
+      return null;
+    }
+
+    // Fail closed when there is no issuer to bind the key to. Without a named
+    // issuer we cannot confirm the signing key is authorized for the
+    // credential, so returning any key here (e.g. a self-certifying did:key)
+    // would accept an unbindable self-signed credential. The Data Integrity
+    // path rejects this same case — see Verifier.checkVerificationMethodController,
+    // which fails when the credential is missing an issuer.
+    if (!issuerDid) {
       return null;
     }
 

--- a/packages/sdk/tests/unit/cel/BtcoCelManager.test.ts
+++ b/packages/sdk/tests/unit/cel/BtcoCelManager.test.ts
@@ -142,6 +142,30 @@ describe('BtcoCelManager', () => {
       expect(/^did:btco:[0-9]+$/.test(state.did)).toBe(true);
     });
 
+    it('derives a network-scoped did:btco identifier for non-mainnet networks', async () => {
+      // Regression: getCurrentState hardcoded the mainnet form `did:btco:<sat>`.
+      // On regtest/signet the identifier must carry the network segment
+      // (`did:btco:reg:` / `did:btco:sig:`), matching DIDManager and
+      // createBtcoDidDocument — otherwise a regtest/signet asset resolves
+      // against the mainnet ordinals namespace.
+      const regtestBitcoin = {
+        inscribeData: vi.fn().mockResolvedValue({
+          txid: 'abc123def456',
+          inscriptionId: 'abc123def456i0',
+          satoshi: '1234567890',
+          blockHeight: 800000,
+        }),
+        network: 'regtest',
+      } as unknown as BitcoinManager;
+      const regtestManager = new BtcoCelManager(createMockSigner(), regtestBitcoin);
+
+      const webvhLog = await createWebvhLog();
+      const btcoLog = await regtestManager.migrate(webvhLog);
+
+      const state = regtestManager.getCurrentState(btcoLog);
+      expect(state.did).toBe('did:btco:reg:1234567890');
+    });
+
     it('should include layer: btco in migration data', async () => {
       const webvhLog = await createWebvhLog();
       const btcoLog = await manager.migrate(webvhLog);

--- a/packages/sdk/tests/unit/cel/BtcoCelManager.test.ts
+++ b/packages/sdk/tests/unit/cel/BtcoCelManager.test.ts
@@ -422,6 +422,24 @@ describe('BtcoCelManager', () => {
       expect(state.updatedAt).toBeDefined();
     });
 
+    it('preserves an application-defined `network` field on an ordinary update', async () => {
+      // Regression: `network` was added to the global metadata exclusion list, so
+      // an ordinary (non-migration) update event carrying an application-defined
+      // `network` field had it silently dropped from state.metadata. The
+      // exclusion must apply only to btco migration events, where `network` is
+      // consumed explicitly.
+      const log = {
+        events: [
+          { type: 'create', data: { did: 'did:peer:abc', name: 'A', layer: 'peer', resources: [] } },
+          { type: 'update', data: { name: 'B', network: 'my-app-network', updatedAt: '2020-01-01T00:00:00.000Z' } },
+        ],
+      } as unknown as EventLog;
+
+      const state = manager.getCurrentState(log);
+      expect(state.metadata?.network).toBe('my-app-network');
+      expect(state.name).toBe('B');
+    });
+
     it('should not be deactivated after migration', async () => {
       const webvhLog = await createWebvhLog();
       const btcoLog = await manager.migrate(webvhLog);

--- a/packages/sdk/tests/unit/cel/BtcoCelManager.test.ts
+++ b/packages/sdk/tests/unit/cel/BtcoCelManager.test.ts
@@ -164,6 +164,39 @@ describe('BtcoCelManager', () => {
 
       const state = regtestManager.getCurrentState(btcoLog);
       expect(state.did).toBe('did:btco:reg:1234567890');
+      // The network is recorded in the SIGNED migration data.
+      const migrationData = btcoLog.events[2].data as Record<string, unknown>;
+      expect(migrationData.network).toBe('regtest');
+    });
+
+    it('derives the btco network from the log, not the replaying SDK config', async () => {
+      // Regression: deriving the network from `this.bitcoinManager.network` at
+      // replay time made state derivation environment-dependent — replaying a
+      // persisted regtest log under a mainnet-configured SDK rewrote the DID to
+      // the mainnet form. The network is recorded in the signed data, so replay
+      // must be deterministic regardless of the replaying manager's network.
+      const regtestBitcoin = {
+        inscribeData: vi.fn().mockResolvedValue({
+          txid: 'abc123def456',
+          inscriptionId: 'abc123def456i0',
+          satoshi: '1234567890',
+          blockHeight: 800000,
+        }),
+        network: 'regtest',
+      } as unknown as BitcoinManager;
+      const regtestManager = new BtcoCelManager(createMockSigner(), regtestBitcoin);
+      const webvhLog = await createWebvhLog();
+      const btcoLog = await regtestManager.migrate(webvhLog);
+
+      // Replay the SAME persisted log under a mainnet-configured manager.
+      const mainnetBitcoin = {
+        inscribeData: vi.fn(),
+        network: 'mainnet',
+      } as unknown as BitcoinManager;
+      const mainnetManager = new BtcoCelManager(createMockSigner(), mainnetBitcoin);
+
+      const state = mainnetManager.getCurrentState(btcoLog);
+      expect(state.did).toBe('did:btco:reg:1234567890');
     });
 
     it('should include layer: btco in migration data', async () => {

--- a/packages/sdk/tests/unit/crypto/Multikey.test.ts
+++ b/packages/sdk/tests/unit/crypto/Multikey.test.ts
@@ -90,6 +90,13 @@ describe('Multikey encode/decode', () => {
 
     // An unsupported multibase prefix still fails closed.
     expect(() => multikey.decodeMultibase('x' + Buffer.from(raw).toString('hex'))).toThrow();
+
+    // Malformed base64url must throw rather than silently decode to empty:
+    // Buffer.from(..., 'base64url') drops invalid chars instead of erroring, so
+    // the payload is validated first.
+    expect(() => multikey.decodeMultibase('u@@@')).toThrow();
+    expect(() => multikey.decodeMultibase('u')).toThrow();
+    expect(() => multikey.decodeMultibase('u====')).toThrow();
   });
 
   test('encode/decode Bls12381G2', () => {

--- a/packages/sdk/tests/unit/crypto/Multikey.test.ts
+++ b/packages/sdk/tests/unit/crypto/Multikey.test.ts
@@ -74,6 +74,24 @@ describe('Multikey encode/decode', () => {
     expect(() => multikey.decodePrivateKey(mb)).toThrow('Unsupported key type');
   });
 
+  test('decodeMultibase accepts both z-base58btc and u-base64url', () => {
+    // Regression: decodeMultibase only accepted the 'z' (base58btc) prefix and
+    // threw for 'u' (base64url), even though the CEL structural check accepts a
+    // 'u' proofValue. A spec-valid base64url signature therefore passed the
+    // structural gate but failed to decode and was rejected as unverifiable.
+    const raw = new Uint8Array([0x00, 0x11, 0x22, 0x33, 0xff, 0xaa, 0x55]);
+
+    const zEncoded = multikey.encodeMultibase(raw); // 'z' + base58btc
+    expect(zEncoded[0]).toBe('z');
+    expect(Array.from(multikey.decodeMultibase(zEncoded))).toEqual(Array.from(raw));
+
+    const uEncoded = 'u' + Buffer.from(raw).toString('base64url');
+    expect(Array.from(multikey.decodeMultibase(uEncoded))).toEqual(Array.from(raw));
+
+    // An unsupported multibase prefix still fails closed.
+    expect(() => multikey.decodeMultibase('x' + Buffer.from(raw).toString('hex'))).toThrow();
+  });
+
   test('encode/decode Bls12381G2', () => {
     const blsPub = new Uint8Array(96).map((_, i) => (i + 5) & 0xff);
     const blsPriv = new Uint8Array(32).map((_, i) => (i + 6) & 0xff);

--- a/packages/sdk/tests/unit/did/BtcoDidResolver.test.ts
+++ b/packages/sdk/tests/unit/did/BtcoDidResolver.test.ts
@@ -234,6 +234,50 @@ describe('BtcoDidResolver', () => {
     expect(res.didDocumentMetadata.deactivated).toBeUndefined();
   });
 
+  test('a valid DID document containing 🔥 in a field is an update, not a tombstone', async () => {
+    // Regression: deactivation was gated on content.includes('🔥'), so a full
+    // DID document that merely carried the emoji in a field (a service
+    // description, name, alsoKnownAs, …) was misclassified as a deactivation
+    // tombstone — nulling the document and reporting the DID as deactivated.
+    // Only the human-readable marker form ("BTCO DID: did:btco:<sat> 🔥")
+    // deactivates a DID; a valid document is an update.
+    const docContent = JSON.stringify({
+      '@context': ['https://www.w3.org/ns/did/v1'],
+      id: 'did:btco:128',
+      verificationMethod: [{
+        id: 'did:btco:128#key-0',
+        type: 'Multikey',
+        controller: 'did:btco:128',
+        publicKeyMultibase: 'z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK'
+      }],
+      service: [{
+        id: 'did:btco:128#site',
+        type: 'LinkedDomains',
+        serviceEndpoint: 'https://example.com',
+        description: 'My hot 🔥 collection'
+      }]
+    });
+    const inscriptionId = 'insc-doc-fire';
+    provider.getSatInfo.mockResolvedValue({ inscription_ids: [inscriptionId] });
+    provider.resolveInscription.mockResolvedValue({
+      id: inscriptionId,
+      sat: 128,
+      content_type: 'application/json',
+      content_url: 'http://local/content-doc-fire'
+    });
+    provider.getMetadata.mockResolvedValue(null);
+    (global as any).fetch.mockResolvedValue({ ok: true, text: async () => docContent });
+
+    const resolver = new BtcoDidResolver({ provider });
+    const res = await resolver.resolve('did:btco:128');
+    const entry = (res.inscriptions as BtcoInscriptionData[])[0];
+    expect(entry.deactivated).toBeUndefined();
+    expect(entry.didDocument).not.toBeNull();
+    expect(res.didDocument).not.toBeNull();
+    expect(res.didDocument?.id).toBe('did:btco:128');
+    expect(res.didDocumentMetadata.deactivated).toBeUndefined();
+  });
+
   test('tombstone after a valid document deactivates the DID (no fallback to older document)', async () => {
     const docContent = JSON.stringify({
       '@context': ['https://www.w3.org/ns/did/v1'],

--- a/packages/sdk/tests/unit/did/BtcoDidResolver.test.ts
+++ b/packages/sdk/tests/unit/did/BtcoDidResolver.test.ts
@@ -278,6 +278,37 @@ describe('BtcoDidResolver', () => {
     expect(res.didDocumentMetadata.deactivated).toBeUndefined();
   });
 
+  test('a marker tombstone with arbitrary JSON appended still deactivates (no document-guard bypass)', async () => {
+    // Regression: a document-based tombstone guard could be bypassed by
+    // appending a minimal object with the expected id after the marker line —
+    // e.g. "BTCO DID: did:btco:128 🔥\n{\"id\":\"did:btco:128\"}". That parses to
+    // an object whose id matches, which would slip past a `!isDidDocument` guard
+    // and fall back to an older document instead of reporting deactivation.
+    // Tombstone detection keys off the start-anchored marker pattern, so the
+    // trailing JSON does not matter.
+    const inscriptionId = 'insc-marker-json';
+    provider.getSatInfo.mockResolvedValue({ inscription_ids: [inscriptionId] });
+    provider.resolveInscription.mockResolvedValue({
+      id: inscriptionId,
+      sat: 128,
+      content_type: 'text/plain',
+      content_url: 'http://local/content-marker-json'
+    });
+    provider.getMetadata.mockResolvedValue(null);
+    (global as any).fetch.mockResolvedValue({
+      ok: true,
+      text: async () => 'BTCO DID: did:btco:128 🔥\n{"id":"did:btco:128"}'
+    });
+
+    const resolver = new BtcoDidResolver({ provider });
+    const res = await resolver.resolve('did:btco:128');
+    const entry = (res.inscriptions as BtcoInscriptionData[])[0];
+    expect(entry.deactivated).toBe(true);
+    expect(entry.didDocument).toBeNull();
+    expect(res.didDocument).toBeNull();
+    expect(res.didDocumentMetadata.deactivated).toBe(true);
+  });
+
   test('tombstone after a valid document deactivates the DID (no fallback to older document)', async () => {
     const docContent = JSON.stringify({
       '@context': ['https://www.w3.org/ns/did/v1'],

--- a/packages/sdk/tests/unit/resources/ResourceManager.test.ts
+++ b/packages/sdk/tests/unit/resources/ResourceManager.test.ts
@@ -302,6 +302,41 @@ describe('ResourceManager', () => {
       expect(manager.getResourceVersion(v1.id, 0)).toBeNull();
       expect(manager.getResourceVersion(v1.id, 5)).toBeNull();
     });
+
+    it('should look up by version number for non-contiguous histories', () => {
+      // Regression: getResourceVersion indexed positionally (versions[version-1]),
+      // but importResource inserts by version number and permits gaps. Importing
+      // v1 then v3 (v2 never imported) produced versions = [v1, v3]; the old
+      // getter returned v3 for version 2 (wrong) and null for version 3 (present
+      // but non-contiguous). The lookup must match by the stored version number.
+      const v1: Resource = {
+        id: 'gapped',
+        type: 'text',
+        contentType: 'text/plain',
+        hash: manager.hashContent('v1'),
+        size: 2,
+        version: 1,
+        createdAt: new Date().toISOString(),
+      };
+      const v3: Resource = {
+        id: 'gapped',
+        type: 'text',
+        contentType: 'text/plain',
+        hash: manager.hashContent('v3'),
+        size: 2,
+        version: 3,
+        createdAt: new Date().toISOString(),
+      };
+
+      manager.importResource(v1);
+      manager.importResource(v3);
+
+      expect(manager.getResourceVersion('gapped', 1)?.hash).toBe(v1.hash);
+      // v2 was never imported: it must be reported as absent, not aliased to v3.
+      expect(manager.getResourceVersion('gapped', 2)).toBeNull();
+      // v3 is present even though the history is non-contiguous.
+      expect(manager.getResourceVersion('gapped', 3)?.hash).toBe(v3.hash);
+    });
   });
 
   describe('getCurrentVersion', () => {

--- a/packages/sdk/tests/unit/vc/CredentialManager.test.ts
+++ b/packages/sdk/tests/unit/vc/CredentialManager.test.ts
@@ -80,6 +80,44 @@ describe('CredentialManager', () => {
     await expect(sdkES256K.credentials.verifyCredential(freshSigned)).resolves.toBe(true);
   });
 
+  test('legacy verifyCredential rejects a signed credential with no issuer to bind to', async () => {
+    // Regression: resolveVerificationMethodMultibase gated its issuer-binding
+    // guards on `issuerDid` being truthy, so a credential with NO issuer and a
+    // self-certifying did:key verification method returned the key
+    // unconditionally and verified true — an unbindable self-signed credential.
+    // The Data Integrity path fails closed on a missing issuer; the legacy path
+    // must too.
+    const sdkES256K = OriginalsSDK.create({ defaultKeyType: 'ES256K' });
+    const sk = secp256k1.utils.randomPrivateKey();
+    const pk = secp256k1.getPublicKey(sk, true);
+    const skMb = multikey.encodePrivateKey(sk, 'Secp256k1');
+    const pkMb = multikey.encodePublicKey(pk, 'Secp256k1');
+
+    // Sign a credential that carries NO issuer (the digest is computed over the
+    // issuer-less credential both when signing and verifying, so the signature
+    // itself is valid — only the issuer binding is missing).
+    const vcNoIssuer: any = { ...baseVC };
+    delete vcNoIssuer.issuer;
+    const signed = await sdkES256K.credentials.signCredential(
+      vcNoIssuer,
+      skMb,
+      `did:key:${pkMb}`
+    );
+    expect((signed.proof as any).cryptosuite).toBeUndefined(); // legacy proof
+    // Nothing binds the signing key to a credential issuer -> must not verify.
+    await expect(sdkES256K.credentials.verifyCredential(signed)).resolves.toBe(false);
+
+    // The same signature with the issuer present (and equal to the did:key)
+    // still verifies, proving the rejection is due to the missing binding.
+    const vcWithIssuer = { ...baseVC, issuer: `did:key:${pkMb}` };
+    const signedBound = await sdkES256K.credentials.signCredential(
+      vcWithIssuer,
+      skMb,
+      `did:key:${pkMb}`
+    );
+    await expect(sdkES256K.credentials.verifyCredential(signedBound)).resolves.toBe(true);
+  });
+
   test('createPresentation bundles VCs (expected to fail until implemented)', async () => {
     const pres = await sdk.credentials.createPresentation([baseVC], 'did:peer:holder');
     expect(pres.verifiableCredential.length).toBeGreaterThan(0);

--- a/packages/sdk/tests/unit/vc/StatusListManager.test.ts
+++ b/packages/sdk/tests/unit/vc/StatusListManager.test.ts
@@ -719,6 +719,74 @@ describe('StatusListManager', () => {
       expect(result.errors.some(e => e.includes('no status list credential was provided'))).toBe(true);
     });
 
+    test('verifyCredentialWithStatus fails closed when a declared status cannot be evaluated', async () => {
+      // Regression: when a credential declared a BitstringStatusListEntry that
+      // could not be evaluated (no status list supplied, or checkStatus threw),
+      // verifyCredentialWithStatus left `verified: true` / `revoked: false` and
+      // reported only an error string. A caller gating on `verified`/`revoked`
+      // would treat a possibly-revoked credential as valid. It must fail closed,
+      // mirroring the Data Integrity path (Verifier.verifyCredential).
+      const { OriginalsSDK } = await import('../../../src');
+      const { multikey } = await import('../../../src/crypto/Multikey');
+      const ed = await import('@noble/ed25519');
+      const sdk = OriginalsSDK.create({ defaultKeyType: 'Ed25519' });
+
+      const sk = ed.utils.randomPrivateKey();
+      const pk = await ed.getPublicKeyAsync(sk);
+      const skMb = multikey.encodePrivateKey(sk, 'Ed25519');
+      const pkMb = multikey.encodePublicKey(pk, 'Ed25519');
+      const issuer = `did:key:${pkMb}`;
+
+      const statusListVC = sdk.statusList.createStatusListCredential({
+        id: 'https://example.com/status/failclosed/1',
+        issuer,
+        statusPurpose: 'revocation',
+      });
+      const entry = sdk.statusList.allocateStatusEntry(
+        'https://example.com/status/failclosed/1',
+        7,
+        'revocation'
+      );
+
+      const unsignedVc = {
+        '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
+        type: ['VerifiableCredential'],
+        issuer,
+        issuanceDate: new Date().toISOString(),
+        credentialSubject: { id: 'did:example:subject' },
+        credentialStatus: entry,
+      };
+      const signed = await sdk.credentials.signCredential(unsignedVc as any, skMb, issuer);
+
+      // Baseline: with the correct (unrevoked) status list, it verifies.
+      const ok = await sdk.credentials.verifyCredentialWithStatus(signed, statusListVC);
+      expect(ok.verified).toBe(true);
+      expect(ok.revoked).toBe(false);
+
+      // Fail closed #1: status declared but no status list supplied.
+      const noList = await sdk.credentials.verifyCredentialWithStatus(signed);
+      expect(noList.verified).toBe(false);
+      expect(noList.errors.some(e => e.includes('no status list credential was provided'))).toBe(true);
+
+      // Fail closed #2: an unevaluable status (purpose mismatch -> checkStatus
+      // throws) must not be treated as "not revoked".
+      const suspensionList = sdk.statusList.createStatusListCredential({
+        id: 'https://example.com/status/failclosed/suspension',
+        issuer,
+        statusPurpose: 'suspension',
+      });
+      const mismatch = await sdk.credentials.verifyCredentialWithStatus(signed, suspensionList);
+      expect(mismatch.verified).toBe(false);
+      expect(mismatch.errors.some(e => e.includes('Status check error'))).toBe(true);
+
+      // Determinable revocation still leaves the signature valid: `revoked`
+      // carries the status, `verified` stays true (the signature is genuine).
+      const revokedList = sdk.statusList.setStatus(statusListVC, 7, true);
+      const revoked = await sdk.credentials.verifyCredentialWithStatus(signed, revokedList);
+      expect(revoked.revoked).toBe(true);
+      expect(revoked.verified).toBe(true);
+    });
+
     test('SDK exposes statusList on top-level instance', async () => {
       const { OriginalsSDK, StatusListManager } = await import('../../../src');
       const sdk = OriginalsSDK.create();


### PR DESCRIPTION
## What

Fixes six confirmed correctness bugs surfaced by a fresh four-subsystem audit (VC/crypto, DID, CEL/anchoring, lifecycle/migration/storage). Each bug ships with a regression test that fails before the fix and passes after (verified by stashing the source changes and re-running).

## Why

The SDK's correctness is judged by the test suite and consistency with the protocol spec. Two of these are security-relevant (revocation could fail open; the legacy verify path accepted an unbindable self-signed credential), and one produces an incorrect resolvable DID on non-mainnet networks.

## How

| Sev | Bug | Fix |
|-----|-----|-----|
| MED (revocation bypass) | `CredentialManager.verifyCredentialWithStatus` returned `verified: true` / `revoked: false` when a declared `BitstringStatusListEntry` could not be evaluated (no status list supplied, or `checkStatus` threw on purpose-mismatch / out-of-range index / corrupt list). | Fail closed (`verified = false`), mirroring the Data Integrity path. Determinable revoked/suspended states still report via their flags and leave `verified` untouched. |
| LOW | Legacy `verifyCredential` accepted an issuer-less self-signed `did:key` credential because the issuer-binding guards were gated on a truthy `issuerDid`. | Added an explicit fail-closed guard on missing issuer, matching `Verifier.checkVerificationMethodController`. |
| LOW-MED | `ResourceManager.getResourceVersion` indexed positionally (`versions[version-1]`); `importResource` permits gaps, so importing v1 then v3 returned v3 for version 2 and null for version 3. | Match by stored version number. |
| LOW | `BtcoDidResolver` treated any valid DID document containing the 🔥 codepoint in a field as a deactivation tombstone (raw `content.includes('🔥')`). | Exclude content that parses to a valid DID document for the DID; only the human-readable marker form deactivates. |
| MED | `BtcoCelManager.getCurrentState` emitted a network-less `did:btco:<sat>` on regtest/signet, pointing the asset at the mainnet ordinals namespace. | Derive the network-scoped prefix (`did:btco:reg:` / `did:btco:sig:`) from the inscribing `BitcoinManager` (added a `network` getter). |
| LOW (interop) | `multikey.decodeMultibase` rejected `u` base64url while the CEL proof structural check accepts a `u` proofValue, so a spec-valid base64url signature was rejected as unverifiable. | Accept both `z` (base58btc) and `u` (base64url); unknown prefixes still fail closed. |

**Non-obvious decisions:** determinable revocation still leaves `verified: true` (the signature is genuine — `revoked` carries the status); only *indeterminate* status flips `verified` to `false`. Deferred items requiring product/design decisions are documented in `FOLLOWUP.md` (items 12–15): multi-algorithm did:webvh resolution, TOFU create-key↔DID binding, single-transaction batch identity sharing, and the CLI btco network-display gap.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test addition or improvement

Note: two fixes tighten verification toward fail-closed. A caller that (incorrectly) relied on `verifyCredentialWithStatus` returning `verified: true` for an unevaluable status, or on the legacy path accepting an issuer-less credential, will now see `false`. A `minor` changeset is included.

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`) — 3222 pass / 0 fail / 71 skip
- [x] Linting passes (`bun run lint`) — 0 errors (87 pre-existing warnings, none added)
- [x] I have updated JSDoc comments for any changed public APIs
- [x] My commits follow Conventional Commits format

## Testing

- [x] Unit tests — new regression tests in `CredentialManager.test.ts`, `StatusListManager.test.ts`, `ResourceManager.test.ts`, `BtcoDidResolver.test.ts`, `BtcoCelManager.test.ts`, `Multikey.test.ts`
- [x] Integration tests — full suite green after `bun run build`
- [x] Each regression test confirmed to fail against the pre-fix source and pass after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjvMAGRPtSYx6aFNsA7WMc

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjvMAGRPtSYx6aFNsA7WMc)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix revocation fail-closed, VC issuer binding, resource version lookup, btco tombstone, and multibase decode
> - `CredentialManager.verifyCredentialWithStatus` now returns `verified=false` when declared status cannot be evaluated (missing status list or thrown error), instead of passing verification silently.
> - `CredentialManager.resolveVerificationMethodMultibase` rejects credentials with no issuer, preventing acceptance of unbound self-signed credentials.
> - `ResourceManager.getResourceVersion` looks up by stored version number instead of positional index, fixing incorrect results for non-contiguous version histories.
> - `BtcoDidResolver` tightens tombstone detection to require both the human-readable marker and the 🔥 codepoint, preventing valid DID documents containing 🔥 from being misclassified as deactivations.
> - `BtcoCelManager` derives network-scoped `did:btco` identifiers (e.g. `did:btco:sig` for signet) from signed log data, making resolution deterministic across network contexts.
> - `decodeMultibase` in [Multikey.ts](https://github.com/onionoriginals/sdk/pull/232/files#diff-c7d6acd1bedd9b6311d9e8ec9b1ad83b20b87f43e8be4813194bb12177f7fea7) now accepts `u` (base64url) prefixes and throws on malformed payloads instead of decoding to empty.
> - Risk: revocation and issuer-binding changes are fail-closed — previously passing credentials may now fail verification.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a3ab9b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->