### PR TITLE
fix: correctness pass — ordinal-safe UTXO selection, canonical did:btco, strict input parsing

### DIFF
--- a/.changeset/correctness-loop-asdkdz.md
+++ b/.changeset/correctness-loop-asdkdz.md
@@ -1,0 +1,11 @@
+---
+"@originals/sdk": patch
+---
+
+Fix five correctness bugs surfaced by a fresh subsystem audit, each with regression coverage:
+
+- **Ordinal-safe UTXO selection (sat-safety).** `selectResourceUtxos` / `selectUtxosForPayment` previously excluded only UTXOs flagged with the SDK-specific `hasResource` boolean, ignoring the `inscriptions[]` array that ordinals indexers populate as well as `locked` UTXOs. An inscription-bearing wallet UTXO with no `hasResource` flag could be chosen as a plain payment input, burning the ordinal it carries. Selection now excludes inscription-bearing (`inscriptions.length > 0`) and locked UTXOs, matching the sibling `bitcoin/utxo.ts` selector.
+- **Canonical `did:btco` identifiers.** `validateSatoshiNumber` trims/normalizes before validating, so `' 42 '` and `'007'` passed while the DID was still built from the raw argument — producing an unresolvable `did:btco: 42 ` or a non-canonical `did:btco:007` that never matches the inscribed `did:btco:7`. A new `canonicalizeSatoshi()` is now used when building the DID in `createBtcoDidDocument` and the `DIDManager` keyless-fallback path.
+- **Network-aware satoshi extraction on transfer.** `LifecycleManager.transferOwnership` fell back to `asset.id.split(':')[2]`, which is the network tag (`reg`/`sig`) for `did:btco:reg:<sat>` / `did:btco:sig:<sat>` rather than the satoshi, so a regtest/signet transfer without a migration record looked up the wrong ordinal. It now uses the network-aware `parseSatoshiIdentifier`.
+- **Strict hex decoding.** `hexToBytes` accepted malformed hex (`'1g' → [0x01]`, `'aa1z' → [0xaa, 0x01]`) because the per-byte `parseInt` NaN check stops at the first invalid nibble. It now rejects any non-hex character.
+- **Strict `statusListIndex` parsing.** `parseInt('5abc', 10) === 5`, so a malformed revocation index silently targeted the wrong status-list bit in `checkStatus` / `revoke` / `suspend` / `unsuspend`. A new `parseStatusListIndex()` fails closed on non-integer input.

--- a/FOLLOWUP.md
+++ b/FOLLOWUP.md
@@ -202,3 +202,77 @@ behavior today), require a product/design decision, or would exceed the
   threaded into the inspect/migrate/transfer CLI commands — a small CLI-plumbing
   change best batched with a CLI network-config pass, and not coverable by a
   meaningful regression test until that config exists.
+
+## Iteration (branch asdkdz) deferrals
+
+## 16. `OriginalsCel.getCurrentState` on a btco log requires a `BitcoinManager` it doesn't actually need (design)
+
+- **Where:** `packages/sdk/src/cel/OriginalsCel.ts` (`btcoManager` getter, ~167-182;
+  used by `getCurrentState` at ~420) vs. `packages/sdk/src/cel/layers/BtcoCelManager.ts`
+  (`getCurrentState`, ~337).
+- **What:** The btco branch of `getCurrentState` goes through the `btcoManager`
+  getter, which throws `'BTCO operations require a BitcoinManager'` when
+  `config.btco.bitcoinManager` is absent. But `BtcoCelManager.getCurrentState`
+  is a pure read: it derives `did:btco:<sat>` from the bitcoin witness proof
+  plus the network recorded in the *signed* migration data, and only reads
+  `bitcoinManager.network` as a legacy fallback. So replaying a persisted
+  peer→webvh→btco log in a fresh SDK without a configured BitcoinManager throws,
+  even though no Bitcoin access is needed — contradicting the manager's stated
+  deterministic-replay intent.
+- **Why deferred:** It fails closed with a clear error (no wrong output), and a
+  clean fix means making `BtcoCelManager`'s read path usable without a
+  `BitcoinManager` dependency (the constructor currently requires one) — a
+  dependency-structure change to the CEL layer managers, not a minimal fix, and
+  it needs a decision on how the network fallback behaves when no manager is
+  present.
+
+## 17. `WebVHCelManager.getCurrentState` still keys migration detection off `targetDid` (latent, unreachable)
+
+- **Where:** `packages/sdk/src/cel/layers/WebVHCelManager.ts:295`
+  (`if (updateData.targetDid && updateData.layer)`).
+- **What:** Same stale pattern that was migrated to `sourceDid` in
+  `OriginalsCel.getCurrentLayer`/`BtcoCelManager` (FOLLOWUP-era fix #3 family).
+  A btco migration event carries `sourceDid`, not `targetDid`, so this manager
+  would misclassify a btco migration as a regular update.
+- **Why deferred:** Unreachable via the public API — `OriginalsCel.getCurrentState`
+  routes any log that has reached btco to `BtcoCelManager` (via `getCurrentLayer`),
+  so `WebVHCelManager.getCurrentState` only ever runs on logs whose current layer
+  is webvh (no btco migration event present). It would only bite a caller using
+  `WebVHCelManager` directly on a btco log. Because there is no public path to it,
+  a meaningful regression test cannot be written today; flagged for the next CEL
+  layer-manager consolidation.
+
+## 18. `WebvhToBtcoMigration` satoshi fallback derives a txid, not a satoshi (latent, fallback-only)
+
+- **Where:** `packages/sdk/src/migration/operations/WebvhToBtcoMigration.ts:68`
+  (`const satoshiId = inscription.satoshi || inscription.inscriptionId.split('i')[0]`).
+- **What:** When `inscription.satoshi` is absent, the fallback splits the
+  `inscriptionId` (`<txid>i<index>`) and uses the 64-hex `txid` as the satoshi,
+  which is passed to `migrateToDIDBTCO`. That is not a valid satoshi ordinal;
+  it will produce a wrong/invalid DID or throw in `validateSatoshiNumber`.
+- **Why deferred:** Fallback-only — every real/ mock ordinals provider returns a
+  `satoshi` from `inscribeData`, so this branch is effectively dead defensive
+  code today. The correct behavior (throw a clear "provider did not return a
+  satoshi" error rather than fabricating one from the txid) is a small change,
+  but it cannot be exercised without a provider that omits `satoshi`, so no
+  meaningful regression test is possible until such a provider path exists.
+
+## 19. Data Integrity `proofPurpose` is not validated at verification time (spec conformance)
+
+- **Where:** `packages/sdk/src/vc/cryptosuites/eddsa.ts` (`verifyProof`) and
+  `packages/sdk/src/vc/Verifier.ts` (`verifyCredential`/`verifyPresentation`).
+- **What:** Verification never checks that `proof.proofPurpose` matches the
+  contextually-required purpose (`assertionMethod` for credentials,
+  `authentication` for presentations), nor that the verification method is listed
+  under the corresponding relationship in the DID document. A credential signed
+  with `proofPurpose: 'authentication'` (or any string) verifies as a valid
+  assertion.
+- **Why deferred:** Exploitability is limited — `proofPurpose` is bound into the
+  signed proof-config hash (it cannot be flipped after signing), and
+  `DIDManager.resolveDID` auto-populates `assertionMethod = authentication =
+  [firstKey]`, so keys end up authorized for both purposes anyway. A correct fix
+  changes verification semantics for both credentials and presentations (which
+  legitimately use different purposes) and must thread the expected purpose
+  through both paths without breaking presentation verification — a
+  verification-contract change that warrants its own focused PR and conformance
+  tests, not a minimal in-place edit.

--- a/LOOP_LOG.md
+++ b/LOOP_LOG.md
@@ -314,3 +314,58 @@ carrying an application-defined `network` field had it silently dropped from
 `network` is consumed explicitly). Regression test: a regular update with a
 custom `network` field now preserves it. Full suite 3225 pass / 0 fail;
 typecheck clean; lint 0 errors.
+
+---
+
+# Correctness Loop Log (branch `claude/originals-sdk-correctness-asdkdz`)
+
+## Iteration 1 — 2026-07-03
+
+### Ground truth
+- Fresh branch at `origin/main` (561664d); prior correctness passes (#230, #232) already merged. No open PR for this branch, so the eval signal this iteration is the test suite + spec/protocol consistency (no PR review comments yet).
+- After `bun install` + `bun run build`: full suite **3415 pass / 0 fail / 74 skip** (182 files). `bun run typecheck` clean. `bun run lint` clean (88 warnings, 0 errors).
+
+### Audit
+Ran four parallel subsystem audits (vc/crypto, did, bitcoin, cel/lifecycle), each told to exclude the items already logged in FOLLOWUP.md. Fixed every confirmed correctness bug with a regression test that fails before / passes after.
+
+### Fixes (this iteration)
+1. **HIGH — ordinal-loss in payment UTXO selection** (`utxo-selection.ts`):
+   `selectResourceUtxos`/`selectUtxosForPayment` only excluded UTXOs flagged
+   `hasResource === true`, never the first-class `inscriptions[]` array (what ord
+   indexers actually populate) nor `locked`. A wallet UTXO carrying an inscription
+   but no `hasResource` flag would be selected as a plain payment input, burning
+   the ordinal. Now excludes inscription-bearing (via `inscriptions.length > 0`)
+   and locked UTXOs, matching the sibling `utxo.ts` selector. Regression tests in
+   `tests/unit/bitcoin/utxo-selection-new.test.ts`.
+2. **MED — non-canonical `did:btco` identifiers** (`satoshi-validation.ts`,
+   `createBtcoDidDocument.ts`, `DIDManager.ts`): `validateSatoshiNumber` trims/parses
+   before validating, so `' 42 '` and `'007'` passed, but the DID was built from the
+   raw argument → `did:btco: 42 ` (unresolvable) / `did:btco:007` (never matches the
+   inscribed `did:btco:7`). Added `canonicalizeSatoshi()` and used it in both DID-
+   building paths. Regression tests in `createBtcoDidDocument.test.ts` and
+   `DIDManager.more.test.ts`.
+3. **MED — network-blind satoshi extraction in transfer** (`LifecycleManager.ts`):
+   `transferOwnership` fell back to `asset.id.split(':')[2]`, which returns the
+   network tag `'reg'`/`'sig'` for `did:btco:reg:<sat>` / `did:btco:sig:<sat>` instead
+   of the satoshi, so a regtest/signet transfer without a migration record looked up
+   the wrong ordinal. Switched to the network-aware `parseSatoshiIdentifier`.
+   Regression test in `LifecycleManager.transfer.unit.test.ts`.
+4. **LOW — `hexToBytes` silently accepted malformed hex** (`utils/encoding.ts`):
+   the per-byte `parseInt` NaN check let `'1g'`→`[0x01]`, `'aa1z'`→`[0xaa,0x01]`
+   through. Added a strict `^[0-9a-fA-F]*$` guard. Regression tests in
+   `encoding.test.ts`.
+5. **LOW — lenient `statusListIndex` parsing** (`vc/StatusListManager.ts`,
+   `vc/CredentialManager.ts`): `parseInt('5abc', 10) === 5` silently targeted the
+   wrong revocation bit in `checkStatus`/`revoke`/`suspend`/`unsuspend`. Added a
+   strict `parseStatusListIndex()` used at all four sites. Regression tests in
+   `StatusListManager.test.ts`.
+
+### Verify
+- Full suite **3428 pass / 0 fail / 74 skip**; typecheck clean; lint clean.
+- One flaky timing-based perf guard (`did:peer creation should not regress beyond 2x baseline`) failed once under full-suite CPU contention and passed in isolation (6/6) and on re-run; unrelated to these changes (no did:peer creation code touched).
+
+### Deferred (added to FOLLOWUP.md, items 16–19)
+- 16. `OriginalsCel.getCurrentState` on a btco log requires a BitcoinManager it doesn't need (design/dependency-structure).
+- 17. `WebVHCelManager.getCurrentState` stale `targetDid` migration detection (latent, unreachable via public API).
+- 18. `WebvhToBtcoMigration` satoshi fallback derives a txid, not a satoshi (fallback-only dead path).
+- 19. Data Integrity `proofPurpose` not validated at verification time (spec conformance; needs a focused semantics change).

--- a/packages/sdk/src/bitcoin/utxo-selection.ts
+++ b/packages/sdk/src/bitcoin/utxo-selection.ts
@@ -221,8 +221,11 @@ export function selectResourceUtxos(
   });
 
   if (eligibleUtxos.length === 0) {
-    // Special error message if we have UTXOs but they all contain resources
-    if (availableUtxos.length > 0 && availableUtxos.every(u => carriesResource(u))) {
+    // Special error message only when resources are actually the disqualifier:
+    // resources are not allowed AND every available UTXO carries one. When the
+    // caller passed `allowResourceUtxos: true`, resources are not why everything
+    // was excluded (a lock or the avoid-list is), so the generic message applies.
+    if (!allowResourceUtxos && availableUtxos.length > 0 && availableUtxos.every(u => carriesResource(u))) {
       throw new Error('All available UTXOs contain resources and cannot be used for fees/payments. Please add non-resource UTXOs to your wallet.');
     }
     throw new Error('No eligible UTXOs available for selection');

--- a/packages/sdk/src/bitcoin/utxo-selection.ts
+++ b/packages/sdk/src/bitcoin/utxo-selection.ts
@@ -195,24 +195,34 @@ export function selectResourceUtxos(
   // Convert requiredAmount to bigint for compatibility with fee calculations
   const requiredAmountBigInt = BigInt(requiredAmount);
 
-  // Filter out UTXOs to avoid and those with resources if not allowed
+  // A UTXO carries an ordinal if the SDK-specific `hasResource` flag is set OR
+  // it has one or more inscriptions recorded on the outpoint. Indexers (ord)
+  // populate `inscriptions`, not `hasResource`, so both must be checked —
+  // spending an inscribed sat as a plain payment input burns/transfers the
+  // ordinal it carries.
+  const carriesResource = (utxo: ResourceUtxo): boolean =>
+    utxo.hasResource === true || (Array.isArray(utxo.inscriptions) && utxo.inscriptions.length > 0);
+
+  // Filter out UTXOs to avoid, locked UTXOs, and those with resources if not allowed
   const eligibleUtxos = availableUtxos.filter(utxo => {
     const utxoId = `${utxo.txid}:${utxo.vout}`;
     const shouldAvoid = avoidUtxoIds.includes(utxoId);
-    const containsResource = utxo.hasResource === true;
-    
+
     // Skip this UTXO if it's in the avoid list
     if (shouldAvoid) return false;
-    
+
+    // Never spend a locked UTXO — a wallet lock means it must not be used.
+    if (utxo.locked === true) return false;
+
     // Skip this UTXO if it contains a resource and we're not allowed to use resource UTXOs
-    if (containsResource && !allowResourceUtxos) return false;
-    
+    if (carriesResource(utxo) && !allowResourceUtxos) return false;
+
     return true;
   });
 
   if (eligibleUtxos.length === 0) {
     // Special error message if we have UTXOs but they all contain resources
-    if (availableUtxos.length > 0 && availableUtxos.every(u => u.hasResource)) {
+    if (availableUtxos.length > 0 && availableUtxos.every(u => carriesResource(u))) {
       throw new Error('All available UTXOs contain resources and cannot be used for fees/payments. Please add non-resource UTXOs to your wallet.');
     }
     throw new Error('No eligible UTXOs available for selection');

--- a/packages/sdk/src/did/DIDManager.ts
+++ b/packages/sdk/src/did/DIDManager.ts
@@ -15,7 +15,7 @@ import type {
   RecoverWebVHResult,
 } from './WebVHManager.js';
 import { Ed25519Signer } from '../crypto/Signer.js';
-import { validateSatoshiNumber, MAX_SATOSHI_SUPPLY } from '../utils/satoshi-validation.js';
+import { validateSatoshiNumber, canonicalizeSatoshi, MAX_SATOSHI_SUPPLY } from '../utils/satoshi-validation.js';
 import { DIDCache } from './DIDCache.js';
 import type { MetricsCollector } from '../utils/MetricsCollector.js';
 import * as fs from 'fs';
@@ -199,7 +199,7 @@ export class DIDManager {
       const prefix = network === 'mainnet' ? 'did:btco:' : network === 'regtest' ? 'did:btco:reg:' : 'did:btco:sig:';
       btcoDoc = {
         '@context': ['https://www.w3.org/ns/did/v1'],
-        id: prefix + String(satoshi)
+        id: prefix + canonicalizeSatoshi(satoshi)
       };
     }
 

--- a/packages/sdk/src/did/createBtcoDidDocument.ts
+++ b/packages/sdk/src/did/createBtcoDidDocument.ts
@@ -1,6 +1,6 @@
 import { DIDDocument, VerificationMethod } from '../types/did.js';
 import { multikey, MultikeyType } from '../crypto/Multikey.js';
-import { validateSatoshiNumber } from '../utils/satoshi-validation.js';
+import { canonicalizeSatoshi } from '../utils/satoshi-validation.js';
 
 export type BitcoinNetwork = 'mainnet' | 'regtest' | 'signet';
 
@@ -35,13 +35,17 @@ export function createBtcoDidDocument(
 	network: BitcoinNetwork,
 	params: CreateBtcoDidDocumentParams
 ): DIDDocument {
-	// Validate satNumber parameter at entry
-	const validation = validateSatoshiNumber(satNumber);
-	if (!validation.valid) {
-		throw new Error(`Invalid satoshi number: ${validation.error}`);
+	// Validate and canonicalize satNumber at entry. The canonical string (no
+	// whitespace, no leading zeros) is what gets embedded in the DID so the
+	// identifier is resolvable and matches its canonically-inscribed form.
+	let canonicalSat: string;
+	try {
+		canonicalSat = canonicalizeSatoshi(satNumber);
+	} catch (err) {
+		throw new Error(`Invalid satoshi number: ${err instanceof Error ? err.message : String(err)}`);
 	}
 
-	const did = `${getDidPrefix(network)}:${String(satNumber)}`;
+	const did = `${getDidPrefix(network)}:${canonicalSat}`;
 	const vm = buildVerificationMethod(did, params);
 
 	const document: DIDDocument = {

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -14,6 +14,7 @@ import { OriginalsAsset } from './OriginalsAsset.js';
 import { MemoryStorageAdapter } from '../storage/MemoryStorageAdapter.js';
 import { encodeBase64UrlMultibase, hexToBytes } from '../utils/encoding.js';
 import { validateBitcoinAddress } from '../utils/bitcoin-address.js';
+import { parseSatoshiIdentifier } from '../utils/satoshi-validation.js';
 import { multikey } from '../crypto/Multikey.js';
 import { EventEmitter } from '../events/EventEmitter.js';
 import type { EventHandler, EventTypeMap } from '../events/types.js';
@@ -979,7 +980,18 @@ export class LifecycleManager {
     const bm = this.deps?.bitcoinManager ?? new BitcoinManager(this.config);
     const provenance = asset.getProvenance();
     const latestMigration = provenance.migrations[provenance.migrations.length - 1];
-    const satoshi = latestMigration?.satoshi ?? (asset.id.startsWith('did:btco:') ? asset.id.split(':')[2] : '');
+    // Fall back to the satoshi encoded in the DID when no migration record is
+    // present. A plain `split(':')[2]` is network-blind — for a regtest/signet
+    // DID (`did:btco:reg:<sat>` / `did:btco:sig:<sat>`) index 2 is the network
+    // tag, not the satoshi. parseSatoshiIdentifier handles every network prefix.
+    let satoshi = latestMigration?.satoshi ?? '';
+    if (!satoshi && asset.id.startsWith('did:btco:')) {
+      try {
+        satoshi = String(parseSatoshiIdentifier(asset.id));
+      } catch {
+        satoshi = '';
+      }
+    }
     const inscription = {
       satoshi,
       inscriptionId: latestMigration?.inscriptionId ?? `insc-${satoshi || 'unknown'}`,

--- a/packages/sdk/src/utils/encoding.ts
+++ b/packages/sdk/src/utils/encoding.ts
@@ -16,14 +16,16 @@ export function hexToBytes(hex: string): Uint8Array {
   if (clean.length % 2 !== 0) {
     throw new Error('Invalid hex string length');
   }
+  // Reject any non-hex character up front. parseInt is lenient — parseInt('1g', 16)
+  // returns 1 (it stops at the first invalid nibble), so a per-byte NaN check would
+  // silently accept malformed input like '1g' or 'aa1z' and produce wrong bytes.
+  if (!/^[0-9a-fA-F]*$/.test(clean)) {
+    throw new Error('Invalid hex string');
+  }
   const out = new Uint8Array(clean.length / 2);
   for (let i = 0; i < clean.length; i += 2) {
     const byteStr = clean.substring(i, i + 2);
-    const value = parseInt(byteStr, 16);
-    if (Number.isNaN(value)) {
-      throw new Error('Invalid hex string');
-    }
-    out[i / 2] = value;
+    out[i / 2] = parseInt(byteStr, 16);
   }
   return out;
 }

--- a/packages/sdk/src/utils/satoshi-validation.ts
+++ b/packages/sdk/src/utils/satoshi-validation.ts
@@ -95,6 +95,31 @@ export function validateSatoshiNumber(satoshi: string | number): SatoshiValidati
 }
 
 /**
+ * Validates a satoshi identifier and returns its canonical decimal string form.
+ *
+ * A did:btco identifier embeds the satoshi number verbatim, so the string that
+ * gets baked into the DID must be canonical: no surrounding whitespace and no
+ * leading zeros. `validateSatoshiNumber` accepts `' 42 '` and `'007'` (it
+ * trims/parses before checking), but building a DID from the raw argument would
+ * yield an unresolvable id like `did:btco: 42 ` or a non-canonical `did:btco:007`
+ * that never matches the canonically-inscribed `did:btco:42`/`did:btco:7`.
+ *
+ * @param satoshi - The satoshi identifier to canonicalize (string or number)
+ * @returns The canonical decimal string (e.g. '42')
+ * @throws {StructuredError} If the satoshi is invalid
+ */
+export function canonicalizeSatoshi(satoshi: string | number): string {
+  const result = validateSatoshiNumber(satoshi);
+  if (!result.valid) {
+    throw new StructuredError('INVALID_SATOSHI', result.error || 'Invalid satoshi identifier');
+  }
+  // Safe: validateSatoshiNumber guarantees an all-digits string within
+  // MAX_SATOSHI_SUPPLY (2.1e15), which is below Number.MAX_SAFE_INTEGER, so the
+  // round-trip through Number is exact and simply strips whitespace/leading zeros.
+  return String(Number(String(satoshi).trim()));
+}
+
+/**
  * Parses a satoshi identifier from various formats and validates it.
  * 
  * Supported formats:

--- a/packages/sdk/src/vc/CredentialManager.ts
+++ b/packages/sdk/src/vc/CredentialManager.ts
@@ -12,7 +12,7 @@ import {
   MultiSigSignOptions,
   MultiSigVerificationResult,
 } from '../types/index.js';
-import { StatusListManager, type StatusCheckResult } from './StatusListManager.js';
+import { StatusListManager, parseStatusListIndex, type StatusCheckResult } from './StatusListManager.js';
 import { canonicalizeDocument } from '../utils/serialization.js';
 import { computeCredentialDigest } from '../utils/credential-digest.js';
 import { encodeBase64UrlMultibase, decodeBase64UrlMultibase } from '../utils/encoding.js';
@@ -1158,7 +1158,7 @@ export class CredentialManager {
       );
     }
     const manager = new StatusListManager();
-    const index = parseInt(entry.statusListIndex, 10);
+    const index = parseStatusListIndex(entry.statusListIndex);
     return manager.setStatus(statusListCredential, index, true);
   }
 
@@ -1183,7 +1183,7 @@ export class CredentialManager {
       );
     }
     const manager = new StatusListManager();
-    const index = parseInt(entry.statusListIndex, 10);
+    const index = parseStatusListIndex(entry.statusListIndex);
     return manager.setStatus(statusListCredential, index, true);
   }
 
@@ -1208,7 +1208,7 @@ export class CredentialManager {
       );
     }
     const manager = new StatusListManager();
-    const index = parseInt(entry.statusListIndex, 10);
+    const index = parseStatusListIndex(entry.statusListIndex);
     return manager.setStatus(statusListCredential, index, false);
   }
 

--- a/packages/sdk/src/vc/StatusListManager.ts
+++ b/packages/sdk/src/vc/StatusListManager.ts
@@ -36,6 +36,26 @@ export interface StatusCheckResult {
 const MINIMUM_BITSTRING_LENGTH = 131072;
 
 /**
+ * Strictly parse a `statusListIndex` string into a non-negative integer.
+ *
+ * `parseInt('5abc', 10)` returns 5 (it stops at the first non-digit) and is not
+ * NaN, so a malformed index like "5abc" would silently target bit 5 — the wrong
+ * credential slot for a revoke/suspend/check. Requiring the whole string to be
+ * digits fails closed on malformed input instead.
+ */
+export function parseStatusListIndex(value: string): number {
+  const str = typeof value === 'string' ? value.trim() : String(value);
+  if (!/^\d+$/.test(str)) {
+    throw new Error(`Invalid statusListIndex: ${value}`);
+  }
+  const index = Number(str);
+  if (!Number.isSafeInteger(index) || index < 0) {
+    throw new Error(`Invalid statusListIndex: ${value}`);
+  }
+  return index;
+}
+
+/**
  * Manages W3C Bitstring Status List credentials for credential revocation and suspension.
  *
  * Implements the W3C Verifiable Credentials Bitstring Status List v1.0 specification.
@@ -201,10 +221,7 @@ export class StatusListManager {
       );
     }
 
-    const index = parseInt(entry.statusListIndex, 10);
-    if (isNaN(index) || index < 0) {
-      throw new Error(`Invalid statusListIndex: ${entry.statusListIndex}`);
-    }
+    const index = parseStatusListIndex(entry.statusListIndex);
 
     const bitstring = StatusListManager.decodeBitstring(subject.encodedList);
     const byteIndex = Math.floor(index / 8);

--- a/packages/sdk/tests/unit/bitcoin/utxo-selection-new.test.ts
+++ b/packages/sdk/tests/unit/bitcoin/utxo-selection-new.test.ts
@@ -248,6 +248,73 @@ describe('selectResourceUtxos - Resource-Aware Selection', () => {
       expect(result.selectedUtxos[0].value).toBe(50000);
     });
 
+    test('NEVER selects UTXOs with inscriptions[] set even when hasResource is unset', () => {
+      // Regression: ord indexers populate `inscriptions`, not the SDK-specific
+      // `hasResource` flag. Selecting such a UTXO as a payment input would burn
+      // the ordinal it carries.
+      const inscribed: ResourceUtxo = {
+        txid: 'inscribed-tx',
+        vout: 0,
+        value: 100000,
+        inscriptions: ['abc123i0']
+        // note: hasResource intentionally left unset
+      };
+      const clean: ResourceUtxo = { txid: 'clean-tx', vout: 0, value: 50000 };
+
+      const result = selectResourceUtxos([inscribed, clean], {
+        requiredAmount: 5000,
+        feeRate: 1,
+        allowResourceUtxos: false
+      });
+
+      expect(result.selectedUtxos.length).toBe(1);
+      expect(result.selectedUtxos[0].txid).toBe('clean-tx');
+    });
+
+    test('throws helpful error when every UTXO is inscription-bearing via inscriptions[]', () => {
+      const utxos: ResourceUtxo[] = [
+        { txid: 'a', vout: 0, value: 10000, inscriptions: ['x-i0'] },
+        { txid: 'b', vout: 0, value: 20000, inscriptions: ['y-i0'] }
+      ];
+
+      expect(() => {
+        selectResourceUtxos(utxos, { requiredAmount: 5000, feeRate: 1 });
+      }).toThrow('All available UTXOs contain resources');
+    });
+
+    test('NEVER selects locked UTXOs (native lock handling, no avoidUtxoIds workaround)', () => {
+      const locked: ResourceUtxo = { txid: 'locked-tx', vout: 0, value: 100000, locked: true };
+      const clean: ResourceUtxo = { txid: 'clean-tx', vout: 0, value: 50000 };
+
+      const result = selectResourceUtxos([locked, clean], {
+        requiredAmount: 5000,
+        feeRate: 1
+      });
+
+      expect(result.selectedUtxos.length).toBe(1);
+      expect(result.selectedUtxos[0].txid).toBe('clean-tx');
+    });
+
+    test('selectUtxosForPayment excludes inscription-bearing UTXOs identified only by inscriptions[]', () => {
+      const inscribed: ResourceUtxo = { txid: 'inscribed', vout: 0, value: 100000, inscriptions: ['id-i0'] };
+      const clean: ResourceUtxo = { txid: 'clean', vout: 0, value: 50000 };
+
+      const result = selectUtxosForPayment([inscribed, clean], 5000, 1);
+      expect(result.selectedUtxos.every(u => u.txid === 'clean')).toBe(true);
+    });
+
+    test('allowResourceUtxos=true still permits inscription-bearing UTXOs identified by inscriptions[]', () => {
+      const inscribed: ResourceUtxo = { txid: 'inscribed', vout: 0, value: 100000, inscriptions: ['id-i0'] };
+
+      const result = selectResourceUtxos([inscribed], {
+        requiredAmount: 5000,
+        feeRate: 1,
+        allowResourceUtxos: true
+      });
+      expect(result.selectedUtxos.length).toBe(1);
+      expect(result.selectedUtxos[0].txid).toBe('inscribed');
+    });
+
     test('can use resource UTXOs when explicitly allowed', () => {
       const utxos: ResourceUtxo[] = [
         createResourceUtxo(10000, true)

--- a/packages/sdk/tests/unit/bitcoin/utxo-selection-new.test.ts
+++ b/packages/sdk/tests/unit/bitcoin/utxo-selection-new.test.ts
@@ -282,6 +282,22 @@ describe('selectResourceUtxos - Resource-Aware Selection', () => {
       }).toThrow('All available UTXOs contain resources');
     });
 
+    test('does not blame resources when locks are the disqualifier and resources are allowed', () => {
+      // Regression: with allowResourceUtxos=true, resources are not why a
+      // locked+inscribed UTXO is excluded — the lock is. The error must not
+      // advise "add non-resource UTXOs".
+      const lockedInscribed: ResourceUtxo = {
+        txid: 'li', vout: 0, value: 100000, locked: true, inscriptions: ['x-i0']
+      };
+      expect(() => {
+        selectResourceUtxos([lockedInscribed], {
+          requiredAmount: 5000,
+          feeRate: 1,
+          allowResourceUtxos: true
+        });
+      }).toThrow('No eligible UTXOs available for selection');
+    });
+
     test('NEVER selects locked UTXOs (native lock handling, no avoidUtxoIds workaround)', () => {
       const locked: ResourceUtxo = { txid: 'locked-tx', vout: 0, value: 100000, locked: true };
       const clean: ResourceUtxo = { txid: 'clean-tx', vout: 0, value: 50000 };

--- a/packages/sdk/tests/unit/did/DIDManager.more.test.ts
+++ b/packages/sdk/tests/unit/did/DIDManager.more.test.ts
@@ -35,6 +35,17 @@ describe('DIDManager additional branches', () => {
     expect(doc).toBeNull();
   });
 
+  test('migrateToDIDBTCO canonicalizes satoshi in keyless fallback (no leading zeros/whitespace)', async () => {
+    // Regression: the keyless-fallback branch built the id from the raw satoshi
+    // argument, so ' 42 ' / '007' produced unresolvable/non-canonical ids.
+    const dm = new DIDManager({ network: 'mainnet' } as any);
+    const doc = await dm.migrateToDIDBTCO({ '@context': ['https://www.w3.org/ns/did/v1'], id: 'did:webvh:x' }, ' 42 ');
+    expect(doc.id).toBe('did:btco:42');
+
+    const doc2 = await dm.migrateToDIDBTCO({ '@context': ['https://www.w3.org/ns/did/v1'], id: 'did:webvh:x' }, '007');
+    expect(doc2.id).toBe('did:btco:7');
+  });
+
   test('migrateToDIDBTCO uses first VM when present', async () => {
     const dm = new DIDManager({ network: 'mainnet' } as any);
     const pubDoc = createBtcoDidDocument('1', 'mainnet', { publicKey: new Uint8Array(32).fill(1), keyType: 'Ed25519' });

--- a/packages/sdk/tests/unit/did/createBtcoDidDocument.test.ts
+++ b/packages/sdk/tests/unit/did/createBtcoDidDocument.test.ts
@@ -63,5 +63,26 @@ describe('createBtcoDidDocument', () => {
 			createBtcoDidDocument('1', 'testnet', { publicKey: pub, keyType: 'Ed25519' })
 		).toThrow('Unsupported Bitcoin network: testnet');
 	});
+
+	it('canonicalizes a satoshi string with surrounding whitespace into a resolvable id', () => {
+		// Regression: validateSatoshiNumber trims before validating, so ' 42 ' passes,
+		// but the emitted id must not contain the raw whitespace (which would be
+		// unresolvable). Previously produced "did:btco: 42 ".
+		const pub = rangeBytes(32, 1);
+		const doc = createBtcoDidDocument(' 42 ', 'mainnet', { publicKey: pub, keyType: 'Ed25519' });
+		expect(doc.id).toBe('did:btco:42');
+		expect(doc.verificationMethod![0].id).toBe('did:btco:42#0');
+		expect(doc.verificationMethod![0].controller).toBe('did:btco:42');
+		expect(doc.authentication).toEqual(['did:btco:42#0']);
+	});
+
+	it('strips non-canonical leading zeros so the id matches the inscribed form', () => {
+		// Regression: '007' passed validation but produced "did:btco:007", which
+		// never equals the canonically-inscribed "did:btco:7".
+		const pub = rangeBytes(32, 2);
+		const doc = createBtcoDidDocument('007', 'regtest', { publicKey: pub, keyType: 'Ed25519' });
+		expect(doc.id).toBe('did:btco:reg:7');
+		expect(doc.verificationMethod![0].id).toBe('did:btco:reg:7#0');
+	});
 });
 

--- a/packages/sdk/tests/unit/lifecycle/LifecycleManager.transfer.unit.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/LifecycleManager.transfer.unit.test.ts
@@ -26,5 +26,33 @@ describe('LifecycleManager.transferOwnership unit edge cases', () => {
     expect(typeof tx.txid).toBe('string');
     expect(asset.getProvenance().transfers.length).toBe(1);
   });
+
+  test('extracts satoshi network-blindly from a regtest btco DID with no migration record', async () => {
+    // Regression: for `did:btco:reg:<sat>` the old `split(':')[2]` returned the
+    // network tag 'reg' instead of the satoshi, so the transfer looked up the
+    // wrong (nonexistent) ordinal. With no migration record present, the
+    // satoshi must come from parsing the DID network-aware.
+    let capturedInscriptionId: string | undefined;
+    const spyProvider = new MockOrdinalsProvider();
+    const origTransfer = spyProvider.transferInscription.bind(spyProvider);
+    spyProvider.transferInscription = async (inscriptionId: string, toAddress: string, options?: { feeRate?: number }) => {
+      capturedInscriptionId = inscriptionId;
+      return origTransfer(inscriptionId, toAddress, options);
+    };
+    const spySdk = OriginalsSDK.create({ network: 'regtest', ordinalsProvider: spyProvider } as any);
+
+    const asset = new OriginalsAsset(
+      [{ id: 'r', type: 'text', contentType: 'text/plain', hash: 'h' }],
+      { '@context': ['https://www.w3.org/ns/did/v1'], id: 'did:btco:reg:123456' } as any,
+      []
+    );
+    // Provenance has no migrations, so satoshi is derived from the DID.
+    expect(asset.getProvenance().migrations.length).toBe(0);
+
+    await spySdk.lifecycle.transferOwnership(asset, 'tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7');
+    // inscriptionId is derived as `insc-<satoshi>` when no migration record exists.
+    expect(capturedInscriptionId).toBe('insc-123456');
+    expect(capturedInscriptionId).not.toContain('reg');
+  });
 });
 

--- a/packages/sdk/tests/unit/utils/encoding.test.ts
+++ b/packages/sdk/tests/unit/utils/encoding.test.ts
@@ -32,6 +32,14 @@ describe('utils/encoding', () => {
     test('throws on invalid characters', () => {
       expect(() => hexToBytes('zz')).toThrow('Invalid hex string');
     });
+
+    test('rejects partial-nibble garbage instead of silently parsing a prefix', () => {
+      // Regression: parseInt('1g', 16) === 1, so a per-byte NaN check accepted
+      // '1g' as [0x01] and 'aa1z' as [0xaa, 0x01]. These must throw.
+      expect(() => hexToBytes('1g')).toThrow('Invalid hex string');
+      expect(() => hexToBytes('aa1z')).toThrow('Invalid hex string');
+      expect(() => hexToBytes('0xdeadbeeg')).toThrow('Invalid hex string');
+    });
   });
 
   describe('base64', () => {

--- a/packages/sdk/tests/unit/vc/StatusListManager.test.ts
+++ b/packages/sdk/tests/unit/vc/StatusListManager.test.ts
@@ -1,6 +1,20 @@
 import { describe, test, expect } from 'bun:test';
-import { StatusListManager } from '../../../src/vc/StatusListManager';
+import { StatusListManager, parseStatusListIndex } from '../../../src/vc/StatusListManager';
 import type { BitstringStatusListEntry, BitstringStatusListSubject } from '../../../src/types';
+
+describe('parseStatusListIndex', () => {
+  test('parses canonical non-negative integer strings', () => {
+    expect(parseStatusListIndex('0')).toBe(0);
+    expect(parseStatusListIndex('42')).toBe(42);
+    expect(parseStatusListIndex(' 7 ')).toBe(7);
+  });
+
+  test('fails closed on partially-numeric or non-numeric input (parseInt leniency)', () => {
+    for (const bad of ['5abc', 'not-a-number', '', '-1', '1.5', '0x10', 'aa1z']) {
+      expect(() => parseStatusListIndex(bad)).toThrow(/Invalid statusListIndex/);
+    }
+  });
+});
 
 describe('StatusListManager', () => {
   const manager = new StatusListManager();
@@ -284,6 +298,26 @@ describe('StatusListManager', () => {
         type: 'BitstringStatusListEntry',
         statusPurpose: 'revocation',
         statusListIndex: 'not-a-number',
+        statusListCredential: 'https://example.com/status/1',
+      };
+
+      expect(() => manager.checkStatus(entry, vc)).toThrow(/Invalid statusListIndex/);
+    });
+
+    test('rejects a partially-numeric statusListIndex instead of silently targeting a prefix bit', () => {
+      // Regression: parseInt('5abc', 10) === 5, so checkStatus would silently
+      // read bit 5 for a malformed index. It must fail closed.
+      const vc = manager.createStatusListCredential({
+        id: 'https://example.com/status/1',
+        issuer: 'did:example:issuer',
+        statusPurpose: 'revocation',
+      });
+
+      const entry: BitstringStatusListEntry = {
+        id: 'https://example.com/status/1#bad',
+        type: 'BitstringStatusListEntry',
+        statusPurpose: 'revocation',
+        statusListIndex: '5abc',
         statusListCredential: 'https://example.com/status/1',
       };
 


### PR DESCRIPTION
## What

Fixes five confirmed correctness bugs surfaced by subsystem audits (bitcoin, did, vc/crypto, cel/lifecycle). Each fix ships with a regression test that fails before the change and passes after.

## Why

Correctness pass over the SDK. The highest-impact issue is a sat-safety bug that could **burn an ordinal**: the payment UTXO selector only excluded UTXOs tagged with the SDK-specific `hasResource` flag and ignored the `inscriptions[]` array that ordinals indexers actually populate. The remaining issues produce unresolvable/non-canonical `did:btco` identifiers, spend the wrong ordinal on regtest/signet transfers, or silently accept malformed input (hex, revocation index).

## How

1. **HIGH — ordinal-loss in payment UTXO selection** (`bitcoin/utxo-selection.ts`)
   `selectResourceUtxos` / `selectUtxosForPayment` only rejected `hasResource === true`. An ord indexer populates `inscriptions[]`, not `hasResource`, so an inscription-bearing wallet UTXO could be selected as a plain payment input and burn the ordinal. Now excludes inscription-bearing (`inscriptions.length > 0`) and `locked` UTXOs, matching the sibling `bitcoin/utxo.ts` selector. The pre-existing "locked" test even worked around this via `avoidUtxoIds`; native lock handling is now honored.

2. **MED — non-canonical `did:btco` identifiers** (`utils/satoshi-validation.ts`, `did/createBtcoDidDocument.ts`, `did/DIDManager.ts`)
   `validateSatoshiNumber` trims/normalizes before validating, so `' 42 '` and `'007'` passed, but the DID was built from the raw argument → `did:btco: 42 ` (unresolvable) / `did:btco:007` (never matches the canonically-inscribed `did:btco:7`). Added `canonicalizeSatoshi()` and used it in both DID-building paths.

3. **MED — network-blind satoshi extraction in transfer** (`lifecycle/LifecycleManager.ts`)
   `transferOwnership` fell back to `asset.id.split(':')[2]`, which is the network tag (`'reg'`/`'sig'`) for `did:btco:reg:<sat>` / `did:btco:sig:<sat>`, not the satoshi — so a regtest/signet transfer without a migration record looked up the wrong ordinal. Switched to the network-aware `parseSatoshiIdentifier`.

4. **LOW — `hexToBytes` accepted malformed hex** (`utils/encoding.ts`)
   The per-byte `parseInt` NaN check let `'1g' → [0x01]` and `'aa1z' → [0xaa, 0x01]` through (parseInt stops at the first bad nibble). Added a strict `^[0-9a-fA-F]*$` guard.

5. **LOW — lenient `statusListIndex` parsing** (`vc/StatusListManager.ts`, `vc/CredentialManager.ts`)
   `parseInt('5abc', 10) === 5`, so a malformed index silently targeted the wrong revocation/suspension bit. Added a strict `parseStatusListIndex()` used by `checkStatus` / `revoke` / `suspend` / `unsuspend`.

No public API signatures changed. Four lower-priority/design items (a CEL dependency-structure cleanup, an unreachable stale-`targetDid` path, a dead migration fallback, and Data Integrity `proofPurpose` conformance) are documented in `FOLLOWUP.md` (items 16–19) rather than force-fit into this minimal pass.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test addition or improvement

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] I have updated JSDoc comments for any changed public APIs
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Testing

- [x] Unit tests — new regression tests in `utxo-selection-new.test.ts`, `createBtcoDidDocument.test.ts`, `DIDManager.more.test.ts`, `LifecycleManager.transfer.unit.test.ts`, `encoding.test.ts`, `StatusListManager.test.ts`
- [x] Integration tests — full suite run

Full suite: **3428 pass / 0 fail / 74 skip**; `bun run typecheck` clean; `bun run lint` clean. (One timing-based perf regression guard is flaky under full-suite CPU contention — passes in isolation and on re-run, and touches no code in this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLJ9GUZVAtRkyP7JUoW8Bc)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ordinal-safe UTXO selection, canonical did:btco identifiers, and strict input parsing
> - Excludes inscription-bearing and locked UTXOs by default in [`selectResourceUtxos`](https://github.com/onionoriginals/sdk/pull/233/files#diff-52ae4a428c746036f8e428fbac0838540a527ad9d9ccde6379dabfc1c6671970); error messages now distinguish lock exclusions from resource exclusions.
> - Canonicalizes satoshi strings (no leading zeros, no whitespace) in [`createBtcoDidDocument`](https://github.com/onionoriginals/sdk/pull/233/files#diff-cc310b0b395f73846970914c0e20114c44e48436810a2c62e736137ac9a365d8) and the `DIDManager` keyless-fallback path to produce well-formed `did:btco` identifiers.
> - Fixes satoshi extraction in [`LifecycleManager.transferOwnership`](https://github.com/onionoriginals/sdk/pull/233/files#diff-f7ee48c88de9ace2f72662a51534f0bbb19607128b3c2178416d1b28c87fc9e8) for regtest/signet DIDs without a migration record, replacing a string-split that returned the network tag with `parseSatoshiIdentifier`.
> - Replaces `parseInt` with a strict `parseStatusListIndex` parser in `CredentialManager` and `StatusListManager` so malformed `statusListIndex` values throw instead of silently truncating.
> - Adds a regex-based non-hex character check to [`hexToBytes`](https://github.com/onionoriginals/sdk/pull/233/files#diff-bce8e6334b950c129a0b0612dfbf796af36af5bd4dc0005f2cc3ec71b013eb3f) so inputs like `'1g'` or `'0xdeadbeeg'` throw instead of decoding a valid prefix.
> - Risk: All five fixes are fail-closed — previously-accepted malformed inputs now throw errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f13f407.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->