### PR TITLE
fix: correctness pass — ordinal-safe transfer selection, multi-sig revocation/expiry, webvh port encoding

### DIFF
--- a/.changeset/correctness-loop-osnfzp.md
+++ b/.changeset/correctness-loop-osnfzp.md
@@ -1,0 +1,9 @@
+---
+"@originals/sdk": patch
+---
+
+Fix three correctness bugs surfaced by a fresh subsystem audit, each with regression coverage:
+
+- **Ordinal-safe transfer UTXO selection (fund/ordinal loss).** `selectUtxos` (used by the public `buildTransferTransaction`) now excludes UTXOs flagged with the first-class `hasResource` marker, not just those with a populated `inscriptions` array. Previously a `ResourceUtxo` carrying an ordinal via `hasResource: true` (no `inscriptions[]`) could be picked as a fee/payment input, transferring or burning the ordinal it carries. This matches the two sibling selectors (`utxo-selection.ts` `carriesResource`, `transactions/commit.ts` `isProtected`) that already checked both markers.
+- **Multi-sig verification enforces validity window and fails closed on revocable status.** `MultiSigManager.verifyMultiSig` (and its `verifyEscrow` / `verifyCorporate` wrappers, reached via `CredentialManager.verifyCredentialMultiSig`) now rejects an expired or not-yet-valid credential even when the m-of-n threshold is met, and fails closed when the credential declares a `BitstringStatusListEntry` status it cannot check. Previously the multi-sig path only verified signatures, threshold, and timelock, so an expired or issuer-revoked m-of-n credential (governance/escrow/corporate) verified as valid — a revocation/expiry bypass relative to the single-sig path, which already enforces both.
+- **`migrateToDIDWebVH` percent-encodes a domain port.** A ported domain (e.g. `localhost:8080`) is now emitted as a single DID authority segment (`did:webvh:localhost%3A8080:slug`) instead of a literal colon. The literal colon made every consumer that splits the DID on `:` — including this SDK's own `saveDIDLog`, which does `decodeURIComponent(didParts[2])` — parse the port as a path segment, producing a malformed, non-resolvable DID.

--- a/FOLLOWUP.md
+++ b/FOLLOWUP.md
@@ -276,3 +276,46 @@ behavior today), require a product/design decision, or would exceed the
   through both paths without breaking presentation verification — a
   verification-contract change that warrants its own focused PR and conformance
   tests, not a minimal in-place edit.
+
+## 20. `MAX_SATOSHI_SUPPLY` is the theoretical cap, not the real issued supply (LOW)
+
+- **Where:** `packages/sdk/src/utils/satoshi-validation.ts:7`
+  (`MAX_SATOSHI_SUPPLY = 2_100_000_000_000_000`).
+- **What:** The bound is 21e6 × 1e8 (theoretical 21M BTC), ignoring halving
+  rounding. The real total ever issued is `2_099_999_997_690_000` sats, so the
+  highest valid ordinal is `2_099_999_997_689_999`. `validateSatoshiNumber`
+  therefore accepts ~2.31M non-existent satoshi numbers in
+  `[2_099_999_997_690_000, 2_100_000_000_000_000]`.
+- **Why deferred:** Low severity (resolution simply fails later for a
+  non-existent sat). Tightening the bound flips security/penetration tests that
+  deliberately encode `2100000000000000` as "max valid satoshi"
+  (`tests/security/bitcoin-penetration-tests.test.ts:274,526`,
+  `tests/unit/utils/utils-coverage.test.ts:178`) from valid→invalid, so it is a
+  tested-contract change plus a theoretical-vs-actual-cap decision, not a
+  one-line minimal fix. Needs its own PR that also updates those expectations.
+
+## 21. `did:btco` lifecycle binding is constructed network-blind (MEDIUM, spec ambiguity)
+
+- **Where:** `packages/sdk/src/lifecycle/LifecycleManager.ts` (inscribeOnBitcoin
+  binding) and `packages/sdk/src/lifecycle/BatchLifecycleOperations.ts` (batch
+  binding). Both build `did:btco:${satoshi}` (bare mainnet form) regardless of
+  network.
+- **What:** For a regtest/signet inscription the recorded
+  `asset.bindings['did:btco']` is the mainnet form, not `did:btco:reg:<sat>` /
+  `did:btco:sig:<sat>`. The rest of the SDK (`createBtcoDidDocument`,
+  `BtcoDidResolver`) is network-aware.
+- **Why deferred:** Requires resolving a genuine network-authority ambiguity, so
+  it is not a clearly-correct minimal fix:
+  - `webvhNetwork` always defaults to `'pichu'` (mapped → mainnet) while an
+    explicit `network` is preserved-but-warned, so the two can contradict.
+  - The inscription itself runs on `config.network` (via `BitcoinManager`), which
+    argues the binding should use `config.network`.
+  - But `DIDManager.migrateToDIDBTCO` — the canonical btco-DID builder — prefers
+    the `webvhNetwork` mapping, which yields a *different* answer (mainnet) for
+    the common `network:'regtest'` + default-pichu config.
+  - An existing test (`tests/unit/lifecycle/LifecycleManager.test.ts:44`)
+    explicitly asserts `did:btco:123` (mainnet) for a `network:'regtest'` SDK,
+    so any fix changes a tested contract.
+  Fixing this well means deciding which network is authoritative for the binding
+  and aligning `migrateToDIDBTCO`, the binding, and the test together — a design
+  decision, surfaced here rather than chosen arbitrarily.

--- a/LOOP_LOG.md
+++ b/LOOP_LOG.md
@@ -1,6 +1,41 @@
 # Correctness Loop Log
 
-Branch: `claude/originals-sdk-correctness-4pn30u`
+Branch: `claude/originals-sdk-correctness-4pn30u` (iterations 1–N, merged as #230–#233)
+Branch: `claude/originals-sdk-correctness-osnfzp` (current)
+
+## Iteration (osnfzp) 1 — 2026-07-03
+
+### Ground truth
+- Fresh clone, `bun install` + `bun run build`. Baseline fully green:
+  `bun test` 3429 pass / 0 fail / 74 skip; `bun run typecheck` clean;
+  `bun run lint` 0 errors / 87 warnings.
+- Branch was even with `origin/main` (378a445); prior correctness work #230–#233
+  already merged. No open PR for this branch — opened one this firing.
+
+### Work items (fixed, each with a regression test that fails before / passes after)
+- **utxo.ts `selectUtxos` ignored `hasResource`** (HIGH, fund/ordinal loss). Public
+  `buildTransferTransaction` could spend a `hasResource: true` ResourceUtxo (no
+  `inscriptions[]`) as a fee input. Now excludes both markers, matching the two
+  sibling selectors. Tests: `tests/unit/bitcoin/utxo.selection.test.ts` (+3).
+- **Multi-sig verification skipped revocation + expiration** (HIGH, verification
+  bypass). `MultiSigManager.verifyMultiSig` now enforces the credential validity
+  window and fails closed on a declared `BitstringStatusListEntry` it cannot
+  check. Tests: `tests/unit/vc/MultiSigManager.test.ts` (+3).
+- **`migrateToDIDWebVH` un-encoded port colon** (malformed DID). Now percent-encodes
+  the port so the authority stays one segment. Tests:
+  `tests/unit/did/DIDManager.test.ts` (+1).
+
+### Verify
+- Post-fix: `bun test` 3436 pass / 0 fail; typecheck clean; lint 0 errors / 87
+  warnings (no new). Changeset added (`.changeset/correctness-loop-osnfzp.md`, patch).
+
+### Deferred this firing (see FOLLOWUP.md #20, #21)
+- MAX_SATOSHI_SUPPLY above real issued supply (LOW; changes a tested contract).
+- Network-blind `did:btco` binding in Lifecycle/Batch (MEDIUM; network-authority
+  spec ambiguity — an existing test asserts the mainnet form for a regtest SDK).
+
+---
+
 
 ## Iteration 1 — 2026-07-02
 

--- a/packages/sdk/src/bitcoin/utxo.ts
+++ b/packages/sdk/src/bitcoin/utxo.ts
@@ -1,4 +1,4 @@
-import { DUST_LIMIT_SATS, Utxo } from '../types/index.js';
+import { DUST_LIMIT_SATS, Utxo, ResourceUtxo } from '../types/index.js';
 
 export interface FeeEstimateOptions {
   bytesPerInput?: number;
@@ -61,7 +61,15 @@ export function selectUtxos(utxos: Utxo[], options: SelectionOptions): Selection
   // Filter UTXOs based on policy
   let candidateUtxos = utxos.slice().filter(u => typeof u.value === 'number' && u.value > 0);
   const forbidInscribed = forbidInscriptionBearingInputs !== false;
-  const isInscribed = (u: Utxo): boolean => !!(u.inscriptions && u.inscriptions.length > 0);
+  // A UTXO carries an ordinal either because an inscription id is recorded on it
+  // OR because it is flagged with the first-class `hasResource` marker
+  // (ResourceUtxo). Spending such a UTXO as a plain payment/fee input transfers
+  // or burns the ordinal it carries, so both markers must exclude it. The sibling
+  // selectors in utxo-selection.ts (`carriesResource`) and transactions/commit.ts
+  // (`isProtected`) already check both; this path previously only checked
+  // `inscriptions`, letting a `hasResource: true` UTXO be spent as a fee input.
+  const isInscribed = (u: Utxo): boolean =>
+    !!(u.inscriptions && u.inscriptions.length > 0) || (u as ResourceUtxo).hasResource === true;
   // CONFLICTING_LOCKS is only an accurate diagnosis when unlocking could
   // actually help — i.e. a locked UTXO exists that selection would otherwise
   // be allowed to use. A locked UTXO that is also inscription-protected

--- a/packages/sdk/src/did/DIDManager.ts
+++ b/packages/sdk/src/did/DIDManager.ts
@@ -139,9 +139,15 @@ export class DIDManager {
       .replace(/[^a-zA-Z0-9._-]/g, '-')
       .toLowerCase();
 
+    // Percent-encode the port colon so the domain+port stays a single DID
+    // authority segment. A literal colon (e.g. `localhost:8080`) would be parsed
+    // as `authority=localhost` + `path segment=8080` by every consumer that
+    // splits the DID on ':' — including this SDK's own saveDIDLog, which does
+    // decodeURIComponent(didParts[2]) and expects the port to be encoded there.
+    const authority = portPart ? `${domainPart}%3A${portPart}` : normalized;
     const migrated: DIDDocument = {
       ...didDoc,
-      id: `did:webvh:${normalized}:${slug}`
+      id: `did:webvh:${authority}:${slug}`
     };
     return await Promise.resolve(migrated);
     }); // end track did.migrateToDIDWebVH

--- a/packages/sdk/src/vc/MultiSigManager.ts
+++ b/packages/sdk/src/vc/MultiSigManager.ts
@@ -14,6 +14,7 @@ import type { OriginalsConfig } from '../types/common.js';
 import { computeCredentialDigest } from '../utils/credential-digest.js';
 import { encodeBase64UrlMultibase, decodeBase64UrlMultibase } from '../utils/encoding.js';
 import { Signer, ES256KSigner, Ed25519Signer, ES256Signer } from '../crypto/Signer.js';
+import { checkCredentialValidityPeriod } from './Verifier.js';
 
 /**
  * MultiSigManager handles m-of-n multi-signature operations for verifiable credentials.
@@ -246,6 +247,31 @@ export class MultiSigManager {
     if (!result.verified) {
       result.errors.push(
         `Threshold not met: ${result.validSignatures}/${policy.required} valid signatures`
+      );
+    }
+
+    // Enforce the credential's validity window. A valid m-of-n proof set over an
+    // expired (or not-yet-valid) credential must not verify — the single-sig path
+    // (Verifier.verifyCredential) enforces the same window, and skipping it here
+    // let multi-sig credentials bypass expiration entirely. Applies to all
+    // multi-sig entry points (verifyMultiSig / verifyEscrow / verifyCorporate).
+    const validity = checkCredentialValidityPeriod(credential);
+    if (!validity.verified) {
+      result.verified = false;
+      result.errors.push(...(validity.errors ?? []));
+    }
+
+    // Fail closed on revocation. Single-sig verification refuses to accept a
+    // credential that declares a BitstringStatusListEntry status it cannot check;
+    // the multi-sig path has no status-list resolver, so silently ignoring a
+    // declared status would let a revoked m-of-n credential verify. Refuse
+    // instead and direct the caller to a resolver-backed status check.
+    const credentialStatus = (credential as { credentialStatus?: { type?: unknown } }).credentialStatus;
+    if (credentialStatus && credentialStatus.type === 'BitstringStatusListEntry') {
+      result.verified = false;
+      result.errors.push(
+        'Credential declares a BitstringStatusListEntry status that the multi-sig verifier cannot check. ' +
+        'Verify revocation via CredentialManager.verifyCredential with a configured statusListResolver.'
       );
     }
 

--- a/packages/sdk/tests/unit/bitcoin/utxo.selection.test.ts
+++ b/packages/sdk/tests/unit/bitcoin/utxo.selection.test.ts
@@ -46,6 +46,27 @@ describe('UTXO selection', () => {
     expect(res.selected.length).toBe(1);
   });
 
+  test('ordinal safety: hasResource-flagged inputs are excluded by default (no inscriptions[])', () => {
+    // A ResourceUtxo can carry an ordinal via the `hasResource` marker without
+    // an `inscriptions` array. Spending it as a fee/payment input would transfer
+    // or burn the ordinal, so it must be excluded like an inscription-bearing UTXO.
+    const utxos = [{ ...U(100000), hasResource: true } as Utxo];
+    expect(() => selectUtxos(utxos, { targetAmountSats: 1000, feeRateSatsPerVb: 2 })).toThrow(new UtxoSelectionError('INSUFFICIENT_FUNDS'));
+  });
+
+  test('ordinal safety: prefers a clean UTXO over a larger hasResource-flagged one', () => {
+    const resource = { ...U(100000), hasResource: true } as Utxo;
+    const clean = U(20000);
+    const res = selectUtxos([resource, clean], { targetAmountSats: 1000, feeRateSatsPerVb: 2 });
+    expect(res.selected).toEqual([clean]);
+  });
+
+  test('ordinal safety: explicit opt-out still allows spending hasResource-flagged UTXOs', () => {
+    const utxos = [{ ...U(100000), hasResource: true } as Utxo];
+    const res = selectUtxos(utxos, { targetAmountSats: 1000, feeRateSatsPerVb: 2, forbidInscriptionBearingInputs: false });
+    expect(res.selected.length).toBe(1);
+  });
+
   test('returns selection with change suppressed if dust', () => {
     const utxos = [U(10000)];
     const res = selectUtxos(utxos, { targetAmountSats: DUST_LIMIT_SATS, feeRateSatsPerVb: 1 });

--- a/packages/sdk/tests/unit/did/DIDManager.test.ts
+++ b/packages/sdk/tests/unit/did/DIDManager.test.ts
@@ -46,6 +46,21 @@ describe('DIDManager', () => {
     expect(web.service?.[0].id).toBe('#svc');
   });
 
+  test('migrateToDIDWebVH percent-encodes a domain port so it stays one authority segment', async () => {
+    const peer: DIDDocument = { '@context': ['https://www.w3.org/ns/did/v1'], id: 'did:peer:abc123' };
+    const web = await sdk.did.migrateToDIDWebVH(peer, 'localhost:8080');
+    // The port colon must be percent-encoded (%3A), otherwise splitting the DID
+    // on ':' would parse `8080` as a path segment and `localhost` as the domain.
+    expect(web.id).toBe('did:webvh:localhost%3A8080:abc123');
+    const parts = web.id.split(':');
+    // did / webvh / <authority> / <slug> — exactly one authority segment.
+    expect(parts.length).toBe(4);
+    expect(decodeURIComponent(parts[2])).toBe('localhost:8080');
+    // saveDIDLog decodes didParts[2] as the authority; the slug (not the port)
+    // must be the only path segment.
+    expect(parts.slice(3)).toEqual(['abc123']);
+  });
+
   test('migrateToDIDBTCO converts to did:btco (expected to fail until implemented)', async () => {
     const didDoc: DIDDocument = { '@context': ['https://www.w3.org/ns/did/v1'], id: 'did:webvh:example.com:xyz' };
     const btcoDoc = await sdk.did.migrateToDIDBTCO(didDoc, '123');

--- a/packages/sdk/tests/unit/vc/MultiSigManager.test.ts
+++ b/packages/sdk/tests/unit/vc/MultiSigManager.test.ts
@@ -357,6 +357,95 @@ describe('MultiSigManager', () => {
       expect(result.errors.length).toBe(0);
     });
 
+    test('rejects an expired credential even with a valid threshold proof set', async () => {
+      // A cryptographically valid m-of-n proof set over an expired credential
+      // must not verify — the single-sig path enforces the same validity window.
+      const policy: MultiSigPolicy = {
+        required: 2,
+        total: 3,
+        signerVerificationMethods: [vms[0], vms[1], vms[2]],
+      };
+
+      const expiredVC: VerifiableCredential = {
+        ...baseVC,
+        expirationDate: '2020-01-01T00:00:00Z',
+      };
+
+      const signed = await manager.signCredentialMultiSig(expiredVC, {
+        policy,
+        privateKeys: new Map([
+          [vms[0], keys[0].privateKey],
+          [vms[1], keys[1].privateKey],
+        ]),
+      });
+
+      const result = await manager.verifyMultiSig(signed, policy);
+      expect(result.verified).toBe(false);
+      // Signatures themselves are still valid; it's the expiry that fails it.
+      expect(result.validSignatures).toBe(2);
+      expect(result.errors.some(e => e.includes('expired'))).toBe(true);
+    });
+
+    test('rejects a not-yet-valid credential even with a valid threshold proof set', async () => {
+      const policy: MultiSigPolicy = {
+        required: 2,
+        total: 3,
+        signerVerificationMethods: [vms[0], vms[1], vms[2]],
+      };
+
+      const futureVC: VerifiableCredential = {
+        ...baseVC,
+        validFrom: '2999-01-01T00:00:00Z',
+      };
+
+      const signed = await manager.signCredentialMultiSig(futureVC, {
+        policy,
+        privateKeys: new Map([
+          [vms[0], keys[0].privateKey],
+          [vms[1], keys[1].privateKey],
+        ]),
+      });
+
+      const result = await manager.verifyMultiSig(signed, policy);
+      expect(result.verified).toBe(false);
+      expect(result.errors.some(e => e.includes('not yet valid'))).toBe(true);
+    });
+
+    test('fails closed on a declared BitstringStatusListEntry it cannot check', async () => {
+      // The multi-sig path has no status-list resolver. A credential that
+      // declares a revocable status must not be silently accepted (which would
+      // let a revoked credential verify); it fails closed instead.
+      const policy: MultiSigPolicy = {
+        required: 2,
+        total: 3,
+        signerVerificationMethods: [vms[0], vms[1], vms[2]],
+      };
+
+      const statusVC: VerifiableCredential = {
+        ...baseVC,
+        credentialStatus: {
+          id: 'https://example.com/status/1#0',
+          type: 'BitstringStatusListEntry',
+          statusPurpose: 'revocation',
+          statusListIndex: '0',
+          statusListCredential: 'https://example.com/status/1',
+        },
+      } as unknown as VerifiableCredential;
+
+      const signed = await manager.signCredentialMultiSig(statusVC, {
+        policy,
+        privateKeys: new Map([
+          [vms[0], keys[0].privateKey],
+          [vms[1], keys[1].privateKey],
+        ]),
+      });
+
+      const result = await manager.verifyMultiSig(signed, policy);
+      expect(result.verified).toBe(false);
+      expect(result.validSignatures).toBe(2);
+      expect(result.errors.some(e => e.includes('BitstringStatusListEntry'))).toBe(true);
+    });
+
     test('rejects when threshold not met', async () => {
       const policy: MultiSigPolicy = {
         required: 3,


### PR DESCRIPTION
## What

Three correctness bugs surfaced by a fresh subsystem audit (Bitcoin/UTXO, VC multi-sig, DID), each fixed with a regression test that fails before and passes after.

## Why

- **Ordinal/fund loss.** The public `buildTransferTransaction` → `selectUtxos` (utxo.ts) only excluded UTXOs with a populated `inscriptions` array. A `ResourceUtxo` carrying an ordinal via the first-class `hasResource: true` marker (no `inscriptions[]`) could be selected as a fee/payment input, transferring or burning the ordinal. The two sibling selectors (`utxo-selection.ts` `carriesResource`, `transactions/commit.ts` `isProtected`) already checked both markers; this path was the inconsistent one.
- **Revocation / expiry bypass.** Multi-sig verification (`MultiSigManager.verifyMultiSig`, and its `verifyEscrow` / `verifyCorporate` wrappers, reached via `CredentialManager.verifyCredentialMultiSig`) only checked signatures, threshold, and timelock. An **expired** or **issuer-revoked** m-of-n credential (governance/escrow/corporate) verified as valid — asymmetric with the single-sig path, which already enforces the validity window and fails closed on an uncheckable status.
- **Malformed did:webvh.** `migrateToDIDWebVH` interpolated a ported domain with a literal colon (`did:webvh:localhost:8080:slug`). Every consumer that splits the DID on `:` — including this SDK's own `saveDIDLog`, which does `decodeURIComponent(didParts[2])` — parsed the port as a path segment, producing a non-resolvable DID.

## How

- **utxo.ts** — `selectUtxos`'s ordinal predicate now also treats `(u as ResourceUtxo).hasResource === true` as ordinal-bearing, so `hasResource`-flagged UTXOs are excluded by default (and still spendable via the existing `forbidInscriptionBearingInputs: false` opt-out). No signature change.
- **MultiSigManager.ts** — after the threshold check, `verifyMultiSig` now (1) enforces the credential validity window via the shared `checkCredentialValidityPeriod` (reused from `Verifier.ts`, no dependency cycle), and (2) fails closed when the credential declares a `BitstringStatusListEntry` status. The multi-sig path has no status-list resolver, so rather than silently ignore a declared status (accepting a possibly-revoked credential) it refuses and points the caller to `CredentialManager.verifyCredential` with a configured `statusListResolver`. No signature change.
- **DIDManager.ts** — `migrateToDIDWebVH` percent-encodes the port colon (`localhost%3A8080`) so the authority stays one DID segment, consistent with `saveDIDLog`'s `decodeURIComponent`. No signature change.

Two related issues found in the same audit were **deliberately deferred** (recorded in `FOLLOWUP.md` #20/#21) because they change a tested contract / need a design decision rather than a minimal fix:
- `MAX_SATOSHI_SUPPLY` is the theoretical 21M-BTC cap rather than the real issued supply (LOW; flips security tests that encode the theoretical cap as "max valid").
- The `did:btco` lifecycle binding is constructed network-blind (MEDIUM; requires resolving a genuine `config.network` vs `webvhNetwork` authority ambiguity that `migrateToDIDBTCO` and an existing test currently disagree on).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test addition or improvement

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`) — 3436 pass / 0 fail / 74 skip
- [x] Linting passes (`bun run lint`) — 0 errors, 87 pre-existing warnings
- [x] I have updated JSDoc comments for any changed public APIs
- [x] My commits follow Conventional Commits format

## Testing

- [x] Unit tests — each fix ships a regression test verified to fail against the pre-fix code and pass after:
  - `tests/unit/bitcoin/utxo.selection.test.ts` (+3): `hasResource`-flagged UTXO excluded by default, clean UTXO preferred over a larger flagged one, opt-out still spends it.
  - `tests/unit/vc/MultiSigManager.test.ts` (+3): expired credential rejected despite a valid 2-of-3 proof set, not-yet-valid rejected, fails closed on a declared `BitstringStatusListEntry`.
  - `tests/unit/did/DIDManager.test.ts` (+1): ported domain yields a single percent-encoded authority segment (`did:webvh:localhost%3A8080:abc123`).
- [x] Full suite + `bun run typecheck` + `bun run lint` all green after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqtxmHS5idUWAxXN1trM6f

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqtxmHS5idUWAxXN1trM6f)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ordinal-safe UTXO selection, multi-sig expiry enforcement, and did:webvh port encoding
> - [`selectUtxos`](https://github.com/onionoriginals/sdk/pull/234/files#diff-4ac8c0d190cbfd9eba50a89348b4b43efb13879540826beee53e4f368a9cbc4b) now excludes UTXOs with `hasResource=true` when `forbidInscriptionBearingInputs` is active (the default), aligning resource-bearing UTXOs with inscription-bearing ones.
> - [`MultiSigManager.verifyMultiSig`](https://github.com/onionoriginals/sdk/pull/234/files#diff-73d4bf2ec62abe78773bd8550a69c70ad3cf21978af954c2c91edf603053d366) now enforces credential validity windows (expiry and not-yet-valid) and fails closed for credentials declaring `BitstringStatusListEntry` status, even when the signature threshold is met.
> - [`DIDManager.migrateToDIDWebVH`](https://github.com/onionoriginals/sdk/pull/234/files#diff-0b68e3306bf03372fb0185d88ef62f69cf607b0f5947f9682cd728b4b6ac87af) percent-encodes the colon in `domain:port` to `%3A`, producing a single authority segment instead of splitting the port into an extra DID path segment.
> - Risk: UTXO selection may now fail with `INSUFFICIENT_FUNDS` where it previously succeeded by spending `hasResource` UTXOs; multi-sig verification now rejects previously-accepted expired or status-listed credentials.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e8bbeb9. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->