### PR TITLE
fix(vc): credential verification hardening — fixes #259, #260, #261, #262, #264

### DIFF
--- a/.changeset/vc-credential-hardening.md
+++ b/.changeset/vc-credential-hardening.md
@@ -1,0 +1,11 @@
+---
+"@originals/sdk": patch
+---
+
+Harden credential signing and verification, fixing five issues found in the full codebase review:
+
+- **utils**: `validateCredential` now accepts W3C VC 2.0 credentials — the `https://www.w3.org/ns/credentials/v2` context and `validFrom` as an alternative to `issuanceDate` — so the SDK's own issued credentials no longer fail deserialization and asset verification (#264).
+- **vc**: status list `encodedList` decompression (`StatusListManager.decodeBitstring`, `BitstringStatusList.decode`) is now capped at 16 MiB, rejecting gzip/DEFLATE bombs from attacker-suppliable status list credentials (#262).
+- **vc/crypto**: legacy credential and multi-sig proof signing/verification now select the signature algorithm from the key's multicodec type via the new `signerForKeyType` helper instead of `config.defaultKeyType`, so verification no longer depends on the verifier's local configuration (#261).
+- **vc**: the document loader's verification-method registry fallback for resolved DID documents is restricted to self-certifying methods (did:key/did:peer); keys removed from a hosted did:webvh or on-chain did:btco document can no longer be resurrected from the process-global registry (#260).
+- **vc**: `CredentialManager.signCredential` populates the verification method's `controller` from the resolved DID document instead of `credential.issuer`, restoring the signing-side issuer-binding guard so a key for one DID can no longer mint credentials claiming a foreign issuer; the refusal fails closed instead of falling through to legacy signing (#259).

--- a/packages/sdk/src/crypto/Signer.ts
+++ b/packages/sdk/src/crypto/Signer.ts
@@ -11,7 +11,28 @@ import { p256 } from '@noble/curves/nist.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import * as secp256k1 from '@noble/secp256k1';
 import * as ed25519 from '@noble/ed25519';
-import { multikey } from './Multikey.js';
+import { multikey, MultikeyType } from './Multikey.js';
+
+/**
+ * Return the Signer that matches a key's multicodec type. The multikey header
+ * on the key itself is authoritative for the signature algorithm — selecting a
+ * signer from local configuration instead makes verification outcomes depend
+ * on the verifier's config rather than on the credential (issue #261).
+ */
+export function signerForKeyType(type: MultikeyType): Signer {
+  switch (type) {
+    case 'Secp256k1':
+      return new ES256KSigner();
+    case 'Ed25519':
+      return new Ed25519Signer();
+    case 'P256':
+      return new ES256Signer();
+    case 'Bls12381G2':
+      return new Bls12381G2Signer();
+    default:
+      throw new Error(`No signer available for key type: ${String(type)}`);
+  }
+}
 
 export class ES256KSigner extends Signer {
   async sign(data: Buffer, privateKeyMultibase: string): Promise<Buffer> {

--- a/packages/sdk/src/utils/validation.ts
+++ b/packages/sdk/src/utils/validation.ts
@@ -31,10 +31,12 @@ export function validateCredential(vc: VerifiableCredential): boolean {
     return false;
   }
 
-  // Require VC v1 context presence
+  // Require the VC v1 or v2 credentials context. The SDK itself issues
+  // v2-context credentials (Issuer, StatusListManager), so v2 must validate.
   const contextValues = vc['@context'];
   const hasVcV1 = contextValues.includes('https://www.w3.org/2018/credentials/v1');
-  if (!hasVcV1) {
+  const hasVcV2 = contextValues.includes('https://www.w3.org/ns/credentials/v2');
+  if (!hasVcV1 && !hasVcV2) {
     return false;
   }
 
@@ -46,7 +48,11 @@ export function validateCredential(vc: VerifiableCredential): boolean {
     return false;
   }
 
-  if (!vc.issuer || (!vc.issuanceDate)) {
+  // v1 mandates issuanceDate; VC 2.0 replaced it with validFrom, so under the
+  // v2 context accept either property as the issuance timestamp.
+  const issuanceTimestamp =
+    vc.issuanceDate ?? (hasVcV2 ? (vc as { validFrom?: unknown }).validFrom : undefined);
+  if (!vc.issuer || issuanceTimestamp === undefined) {
     return false;
   }
 
@@ -63,8 +69,8 @@ export function validateCredential(vc: VerifiableCredential): boolean {
     return false;
   }
 
-  // issuanceDate should be a valid ISO timestamp
-  if (typeof vc.issuanceDate !== 'string' || Number.isNaN(Date.parse(vc.issuanceDate))) {
+  // issuanceDate / validFrom should be a valid ISO timestamp
+  if (typeof issuanceTimestamp !== 'string' || Number.isNaN(Date.parse(issuanceTimestamp))) {
     return false;
   }
 

--- a/packages/sdk/src/vc/BitstringStatusList.ts
+++ b/packages/sdk/src/vc/BitstringStatusList.ts
@@ -1,4 +1,5 @@
 import { gzipSync, gunzipSync, inflateSync } from 'node:zlib';
+import { MAX_DECOMPRESSED_BITSTRING_BYTES } from './StatusListManager.js';
 
 const MINIMUM_LIST_SIZE = 131072; // 16KB = 131072 bits per W3C spec recommendation
 
@@ -76,12 +77,24 @@ export class BitstringStatusList {
    * DEFLATE data) are still accepted.
    */
   static decode(encoded: string, length?: number): BitstringStatusList {
+    // Cap decompression: encodedList may come from an untrusted status list
+    // credential, and unbounded gunzip/inflate of a small gzip bomb can
+    // allocate gigabytes (verifier DoS).
+    const limit = { maxOutputLength: MAX_DECOMPRESSED_BITSTRING_BYTES };
     let decompressed: Uint8Array;
-    if (encoded.startsWith('u')) {
-      decompressed = new Uint8Array(gunzipSync(base64urlDecode(encoded.slice(1))));
-    } else {
-      // Legacy pre-spec encoding: bare base64url, raw DEFLATE stream.
-      decompressed = new Uint8Array(inflateSync(base64urlDecode(encoded)));
+    try {
+      if (encoded.startsWith('u')) {
+        decompressed = new Uint8Array(gunzipSync(base64urlDecode(encoded.slice(1)), limit));
+      } else {
+        // Legacy pre-spec encoding: bare base64url, raw DEFLATE stream.
+        decompressed = new Uint8Array(inflateSync(base64urlDecode(encoded), limit));
+      }
+    } catch (err) {
+      throw new Error(
+        `Invalid encoded bitstring: decompression failed or exceeded the ${MAX_DECOMPRESSED_BITSTRING_BYTES}-byte limit: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
     }
     const bitLength = length ?? decompressed.length * 8;
     const list = new BitstringStatusList(

--- a/packages/sdk/src/vc/CredentialManager.ts
+++ b/packages/sdk/src/vc/CredentialManager.ts
@@ -18,7 +18,8 @@ import { computeCredentialDigest } from '../utils/credential-digest.js';
 import { encodeBase64UrlMultibase, decodeBase64UrlMultibase } from '../utils/encoding.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { bytesToHex } from '@noble/hashes/utils.js';
-import { Signer, ES256KSigner, Ed25519Signer, ES256Signer } from '../crypto/Signer.js';
+import { signerForKeyType } from '../crypto/Signer.js';
+import { multikey } from '../crypto/Multikey.js';
 import { DIDManager } from '../did/DIDManager.js';
 import { Issuer, VerificationMethodLike } from './Issuer.js';
 import { createDocumentLoader } from './documentLoader.js';
@@ -206,12 +207,22 @@ export class CredentialManager {
         interface DocumentWithKey {
           publicKeyMultibase?: string;
           type?: string;
+          controller?: string;
         }
         const docWithKey = document as DocumentWithKey;
         if (docWithKey && docWithKey.publicKeyMultibase) {
           const vm: VerificationMethodLike = {
             id: verificationMethod,
-            controller: typeof credential.issuer === 'string' ? credential.issuer : (credential.issuer as { id?: string })?.id ?? '',
+            // The controller must come from the resolved verification method
+            // document (falling back to the VM's DID), NEVER from
+            // credential.issuer: Issuer.issueCredential's issuer-binding guard
+            // compares the credential's issuer against this value, and
+            // populating it from the issuer made that comparison
+            // issuer === issuer — dead code that let a key for did:me mint
+            // credentials claiming issuer did:victim.
+            controller: typeof docWithKey.controller === 'string' && docWithKey.controller
+              ? docWithKey.controller
+              : verificationMethod.split('#')[0],
             publicKeyMultibase: docWithKey.publicKeyMultibase,
             secretKeyMultibase: privateKeyMultibase,
             type: docWithKey.type || 'Multikey'
@@ -223,7 +234,12 @@ export class CredentialManager {
           delete (unsigned as Partial<VerifiableCredential>).proof;
           return issuer.issueCredential(unsigned, { proofPurpose: 'assertionMethod' });
         }
-      } catch {
+      } catch (e) {
+        // The issuer-binding refusal must fail closed: falling through to
+        // legacy signing here would sign the impersonating credential anyway.
+        if (e instanceof Error && e.message.includes('does not match the verification method controller')) {
+          throw e;
+        }
         // fall through to legacy signing
       }
     }
@@ -344,7 +360,6 @@ export class CredentialManager {
     const digest = Buffer.from(
       await computeCredentialDigest(credential as unknown as Record<string, unknown>, proof as unknown as Record<string, unknown>)
     );
-    const signer = this.getSigner();
     try {
       const resolvedKey = await this.resolveVerificationMethodMultibase(
         verificationMethod,
@@ -353,6 +368,10 @@ export class CredentialManager {
       if (!resolvedKey) {
         return false;
       }
+      // The resolved key's multicodec header identifies the signature
+      // algorithm; selecting it from config.defaultKeyType made verification
+      // fail whenever the verifier's config differed from the issuer's key.
+      const signer = signerForKeyType(multikey.decodePublicKey(resolvedKey).type);
       return await signer.verify(Buffer.from(digest), Buffer.from(signature), resolvedKey);
     } catch {
       return false;
@@ -453,22 +472,11 @@ export class CredentialManager {
     const digest = Buffer.from(
       await computeCredentialDigest(credential as unknown as Record<string, unknown>, proofBase as unknown as Record<string, unknown>)
     );
-    const signer = this.getSigner();
+    // Sign with the algorithm the private key actually is, not whatever
+    // config.defaultKeyType happens to be on this instance.
+    const signer = signerForKeyType(multikey.decodePrivateKey(privateKeyMultibase).type);
     const sig = await signer.sign(Buffer.from(digest), privateKeyMultibase);
     return encodeBase64UrlMultibase(sig);
-  }
-
-  private getSigner(): Signer {
-    switch (this.config.defaultKeyType) {
-      case 'ES256K':
-        return new ES256KSigner();
-      case 'Ed25519':
-        return new Ed25519Signer();
-      case 'ES256':
-        return new ES256Signer();
-      default:
-        return new ES256KSigner();
-    }
   }
 
   private async resolveVerificationMethodMultibase(

--- a/packages/sdk/src/vc/MultiSigManager.ts
+++ b/packages/sdk/src/vc/MultiSigManager.ts
@@ -13,7 +13,8 @@ import type {
 import type { OriginalsConfig } from '../types/common.js';
 import { computeCredentialDigest } from '../utils/credential-digest.js';
 import { encodeBase64UrlMultibase, decodeBase64UrlMultibase } from '../utils/encoding.js';
-import { Signer, ES256KSigner, Ed25519Signer, ES256Signer } from '../crypto/Signer.js';
+import { signerForKeyType } from '../crypto/Signer.js';
+import { multikey } from '../crypto/Multikey.js';
 import { checkCredentialValidityPeriod } from './Verifier.js';
 
 /**
@@ -214,7 +215,6 @@ export class MultiSigManager {
     }
 
     // Verify each proof individually, tracking unique signers
-    const signer = this.getSigner();
     const seenSigners = new Set<string>();
     for (const proof of proofs) {
       const vm = proof.verificationMethod;
@@ -224,7 +224,7 @@ export class MultiSigManager {
         continue;
       }
 
-      const valid = await this.verifyProof(credential, proof, signer);
+      const valid = await this.verifyProof(credential, proof);
       if (valid) {
         // Reject duplicate proofs from the same signer. Dedupe only after
         // successful verification so an invalid proof cannot consume the
@@ -529,7 +529,9 @@ export class MultiSigManager {
     };
 
     const digest = await this.computeDigest(credential, proofBase);
-    const signer = this.getSigner();
+    // Sign with the algorithm the private key actually is, not whatever
+    // config.defaultKeyType happens to be on this instance (issue #261).
+    const signer = signerForKeyType(multikey.decodePrivateKey(privateKeyMultibase).type);
     const sig = await signer.sign(Buffer.from(digest), privateKeyMultibase);
     const proofValue = encodeBase64UrlMultibase(sig);
 
@@ -572,8 +574,7 @@ export class MultiSigManager {
 
   private async verifyProof(
     credential: VerifiableCredential,
-    proof: Proof,
-    signer: Signer
+    proof: Proof
   ): Promise<boolean> {
     try {
       const { proofValue, verificationMethod } = proof;
@@ -589,6 +590,10 @@ export class MultiSigManager {
       const publicKeyMultibase = this.extractPublicKeyFromVM(verificationMethod);
       if (!publicKeyMultibase) return false;
 
+      // The key's multicodec header identifies the signature algorithm;
+      // selecting a signer from config.defaultKeyType made the verification
+      // outcome depend on the verifier's configuration (issue #261).
+      const signer = signerForKeyType(multikey.decodePublicKey(publicKeyMultibase).type);
       return await signer.verify(Buffer.from(digest), Buffer.from(signature), publicKeyMultibase);
     } catch {
       return false;
@@ -607,19 +612,6 @@ export class MultiSigManager {
   private extractProofs(credential: VerifiableCredential): Proof[] {
     if (!credential.proof) return [];
     return Array.isArray(credential.proof) ? credential.proof : [credential.proof];
-  }
-
-  private getSigner(): Signer {
-    switch (this.config.defaultKeyType) {
-      case 'ES256K':
-        return new ES256KSigner();
-      case 'Ed25519':
-        return new Ed25519Signer();
-      case 'ES256':
-        return new ES256Signer();
-      default:
-        return new ES256KSigner();
-    }
   }
 
   private generateSessionId(): string {

--- a/packages/sdk/src/vc/StatusListManager.ts
+++ b/packages/sdk/src/vc/StatusListManager.ts
@@ -35,6 +35,11 @@ export interface StatusCheckResult {
 // Minimum bitstring length per W3C spec
 const MINIMUM_BITSTRING_LENGTH = 131072;
 
+// Upper bound for decompressed encodedList payloads. A legitimate status list
+// is a few MiB at most (the spec minimum is 16 KiB); 16 MiB covers 134M
+// entries while keeping a hostile gzip bomb from exhausting memory.
+export const MAX_DECOMPRESSED_BITSTRING_BYTES = 16 * 1024 * 1024;
+
 /**
  * Strictly parse a `statusListIndex` string into a non-negative integer.
  *
@@ -333,6 +338,10 @@ export class StatusListManager {
 
   /**
    * Decode a W3C encoded bitstring (multibase base64url + GZIP).
+   *
+   * Decompression is capped: the encodedList often comes from a status list
+   * credential fetched from an attacker-suppliable URL, so unbounded gunzip
+   * would let a few-KB gzip bomb allocate gigabytes (verifier DoS).
    */
   static decodeBitstring(encoded: string): Uint8Array {
     if (!encoded || encoded[0] !== 'u') {
@@ -341,7 +350,17 @@ export class StatusListManager {
       );
     }
     const compressed = Buffer.from(encoded.slice(1), 'base64url');
-    return new Uint8Array(gunzipSync(compressed));
+    try {
+      return new Uint8Array(
+        gunzipSync(compressed, { maxOutputLength: MAX_DECOMPRESSED_BITSTRING_BYTES })
+      );
+    } catch (err) {
+      throw new Error(
+        `Invalid encoded bitstring: decompression failed or exceeded the ${MAX_DECOMPRESSED_BITSTRING_BYTES}-byte limit: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
   }
 
   private validateStatusListCredential(vc: VerifiableCredential): void {

--- a/packages/sdk/src/vc/documentLoader.ts
+++ b/packages/sdk/src/vc/documentLoader.ts
@@ -101,15 +101,23 @@ export class DocumentLoader {
         };
       }
       // Fallback ONLY when the DID document does not itself publish this
-      // verification method. The registry can never override the DID document.
-      const cached = verificationMethodRegistry.get(didUrl);
-      if (cached) {
-        assertNotRetired(cached);
-        return {
-          document: { '@context': didDocTyped['@context'], ...cached },
-          documentUrl: didUrl,
-          contextUrl: null
-        };
+      // verification method, and ONLY for self-certifying methods (did:key,
+      // did:peer) whose key material is bound into the identifier. For hosted
+      // (did:webvh) or on-chain (did:btco) methods the resolved document is
+      // authoritative: a key the controller REMOVED (a common rotation style)
+      // must not be resurrected from the process-global registry, or a
+      // rotated-out key would keep verifying signatures indefinitely.
+      const isSelfCertifyingMethod = did.startsWith('did:key:') || did.startsWith('did:peer:');
+      if (isSelfCertifyingMethod) {
+        const cached = verificationMethodRegistry.get(didUrl);
+        if (cached) {
+          assertNotRetired(cached);
+          return {
+            document: { '@context': didDocTyped['@context'], ...cached },
+            documentUrl: didUrl,
+            contextUrl: null
+          };
+        }
       }
       return {
         document: { '@context': didDocTyped['@context'], id: didUrl },

--- a/packages/sdk/tests/unit/vc/credential-hardening.test.ts
+++ b/packages/sdk/tests/unit/vc/credential-hardening.test.ts
@@ -1,0 +1,247 @@
+import { describe, test, expect, beforeAll, spyOn } from 'bun:test';
+import { gzipSync, deflateSync } from 'node:zlib';
+import { validateCredential } from '../../../src/utils/validation';
+import { StatusListManager, MAX_DECOMPRESSED_BITSTRING_BYTES } from '../../../src/vc/StatusListManager';
+import { BitstringStatusList } from '../../../src/vc/BitstringStatusList';
+import { CredentialManager } from '../../../src/vc/CredentialManager';
+import { MultiSigManager } from '../../../src/vc/MultiSigManager';
+import { KeyManager } from '../../../src/did/KeyManager';
+import { DIDManager } from '../../../src/did/DIDManager';
+import type { VerifiableCredential, OriginalsConfig } from '../../../src/types';
+
+const keyManager = new KeyManager();
+
+// ===== Issue #264: validateCredential must accept W3C VC 2.0 credentials =====
+
+describe('validateCredential VC 2.0 support (issue #264)', () => {
+  const base = {
+    type: ['VerifiableCredential'],
+    issuer: 'did:peer:issuer123',
+    credentialSubject: { id: 'did:peer:subject' },
+  };
+
+  test('accepts a v2-context credential with validFrom', () => {
+    const vc = {
+      ...base,
+      '@context': ['https://www.w3.org/ns/credentials/v2', 'https://originals.build/context'],
+      validFrom: new Date().toISOString(),
+    } as unknown as VerifiableCredential;
+    expect(validateCredential(vc)).toBe(true);
+  });
+
+  test('accepts a v2-context credential with issuanceDate', () => {
+    const vc = {
+      ...base,
+      '@context': ['https://www.w3.org/ns/credentials/v2'],
+      issuanceDate: new Date().toISOString(),
+    } as unknown as VerifiableCredential;
+    expect(validateCredential(vc)).toBe(true);
+  });
+
+  test('still accepts a v1-context credential with issuanceDate', () => {
+    const vc = {
+      ...base,
+      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      issuanceDate: new Date().toISOString(),
+    } as unknown as VerifiableCredential;
+    expect(validateCredential(vc)).toBe(true);
+  });
+
+  test('rejects a credential without a v1 or v2 credentials context', () => {
+    const vc = {
+      ...base,
+      '@context': ['https://originals.build/context'],
+      issuanceDate: new Date().toISOString(),
+    } as unknown as VerifiableCredential;
+    expect(validateCredential(vc)).toBe(false);
+  });
+
+  test('rejects a v1-only credential that has only validFrom', () => {
+    const vc = {
+      ...base,
+      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      validFrom: new Date().toISOString(),
+    } as unknown as VerifiableCredential;
+    expect(validateCredential(vc)).toBe(false);
+  });
+
+  test('rejects a v2 credential with a malformed validFrom', () => {
+    const vc = {
+      ...base,
+      '@context': ['https://www.w3.org/ns/credentials/v2'],
+      validFrom: 'not-a-date',
+    } as unknown as VerifiableCredential;
+    expect(validateCredential(vc)).toBe(false);
+  });
+});
+
+// ===== Issue #262: bounded decompression of encodedList =====
+
+describe('status list decompression bounds (issue #262)', () => {
+  // gzip of all-zero data compresses ~1000:1, so a payload twice the cap is a
+  // tiny string but would decompress past the limit.
+  const bombPlain = Buffer.alloc(MAX_DECOMPRESSED_BITSTRING_BYTES * 2);
+
+  test('StatusListManager.decodeBitstring rejects a gzip bomb', () => {
+    const bomb = 'u' + gzipSync(bombPlain).toString('base64url');
+    expect(() => StatusListManager.decodeBitstring(bomb)).toThrow(/limit/);
+  });
+
+  test('BitstringStatusList.decode rejects a gzip bomb', () => {
+    const bomb = 'u' + gzipSync(bombPlain).toString('base64url');
+    expect(() => BitstringStatusList.decode(bomb)).toThrow(/limit/);
+  });
+
+  test('BitstringStatusList.decode rejects a legacy DEFLATE bomb', () => {
+    const bomb = deflateSync(bombPlain).toString('base64url');
+    expect(() => BitstringStatusList.decode(bomb)).toThrow(/limit/);
+  });
+
+  test('a legitimate status list still round-trips', () => {
+    const list = new BitstringStatusList();
+    list.set(42);
+    const decoded = BitstringStatusList.decode(list.encode());
+    expect(decoded.get(42)).toBe(true);
+    expect(decoded.get(41)).toBe(false);
+
+    const encoded = StatusListManager.encodeBitstring(new Uint8Array(16384));
+    expect(StatusListManager.decodeBitstring(encoded).length).toBe(16384);
+  });
+});
+
+// ===== Issue #261: signature algorithm comes from the key, not local config =====
+
+describe('signer selection from key multicodec (issue #261)', () => {
+  test('legacy-signed Ed25519 credential verifies under an ES256K-default verifier', async () => {
+    const { privateKey, publicKey } = await keyManager.generateKeyPair('Ed25519');
+    const issuerDid = `did:key:${publicKey}`;
+    const vm = `${issuerDid}#${publicKey}`;
+
+    const credential: VerifiableCredential = {
+      '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
+      type: ['VerifiableCredential', 'ResourceCreated'],
+      issuer: issuerDid,
+      issuanceDate: new Date().toISOString(),
+      credentialSubject: { id: 'did:peer:subject' },
+    };
+
+    // Issuer signs on an Ed25519-default instance (no didManager -> legacy path)
+    const issuerManager = new CredentialManager({ network: 'regtest', defaultKeyType: 'Ed25519' });
+    const signed = await issuerManager.signCredential(credential, privateKey, vm);
+    expect(signed.proof).toBeDefined();
+
+    // Relying party verifies on the DEFAULT config (ES256K). Before the fix the
+    // verifier picked ES256KSigner from its own config and rejected the
+    // perfectly valid Ed25519 signature.
+    const verifierManager = new CredentialManager({ network: 'regtest', defaultKeyType: 'ES256K' });
+    expect(await verifierManager.verifyCredential(signed)).toBe(true);
+  });
+
+  test('signing side uses the private key type even when config disagrees', async () => {
+    const { privateKey, publicKey } = await keyManager.generateKeyPair('Ed25519');
+    const issuerDid = `did:key:${publicKey}`;
+    const vm = `${issuerDid}#${publicKey}`;
+
+    const credential: VerifiableCredential = {
+      '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
+      type: ['VerifiableCredential'],
+      issuer: issuerDid,
+      issuanceDate: new Date().toISOString(),
+      credentialSubject: { id: 'did:peer:subject' },
+    };
+
+    // Config says ES256K but the key is Ed25519: signing must follow the key.
+    const manager = new CredentialManager({ network: 'regtest', defaultKeyType: 'ES256K' });
+    const signed = await manager.signCredential(credential, privateKey, vm);
+    expect(await manager.verifyCredential(signed)).toBe(true);
+  });
+
+  test('multi-sig Ed25519 proofs verify under an ES256K-default verifier', async () => {
+    const [k1, k2] = await Promise.all([
+      keyManager.generateKeyPair('Ed25519'),
+      keyManager.generateKeyPair('Ed25519'),
+    ]);
+    const vms = [k1, k2].map(k => `did:key:${k.publicKey}`);
+    const policy = { required: 2, total: 2, signerVerificationMethods: vms };
+
+    const credential: VerifiableCredential = {
+      '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
+      type: ['VerifiableCredential'],
+      issuer: 'did:peer:issuer',
+      issuanceDate: new Date().toISOString(),
+      credentialSubject: { id: 'did:peer:subject' },
+    };
+
+    const signerConfig: OriginalsConfig = { network: 'regtest', defaultKeyType: 'Ed25519' };
+    const signed = await new MultiSigManager(signerConfig).signCredentialMultiSig(credential, {
+      policy,
+      privateKeys: new Map([
+        [vms[0], k1.privateKey],
+        [vms[1], k2.privateKey],
+      ]),
+    });
+
+    const verifierConfig: OriginalsConfig = { network: 'regtest', defaultKeyType: 'ES256K' };
+    const result = await new MultiSigManager(verifierConfig).verifyMultiSig(signed, policy);
+    expect(result.verified).toBe(true);
+    expect(result.validSignatures).toBe(2);
+  });
+});
+
+// ===== Issue #259: signing-side issuer-binding check must not be neutralized =====
+
+describe('signing-side issuer binding (issue #259)', () => {
+  let didManager: DIDManager;
+  let privateKey: string;
+  let publicKey: string;
+  const signerDid = 'did:peer:signer-me';
+  const vmId = `${signerDid}#key-1`;
+
+  beforeAll(async () => {
+    const pair = await keyManager.generateKeyPair('Ed25519');
+    privateKey = pair.privateKey;
+    publicKey = pair.publicKey;
+    didManager = new DIDManager({ network: 'regtest', defaultKeyType: 'Ed25519' });
+    spyOn(didManager, 'resolveDID').mockResolvedValue({
+      '@context': ['https://www.w3.org/ns/did/v1'],
+      id: signerDid,
+      verificationMethod: [
+        { id: vmId, type: 'Multikey', controller: signerDid, publicKeyMultibase: publicKey },
+      ],
+    } as any);
+  });
+
+  test('refuses to sign a credential claiming a foreign issuer', async () => {
+    const manager = new CredentialManager(
+      { network: 'regtest', defaultKeyType: 'Ed25519' },
+      didManager
+    );
+    const impersonating: VerifiableCredential = {
+      '@context': ['https://www.w3.org/ns/credentials/v2', 'https://originals.build/context'],
+      type: ['VerifiableCredential'],
+      issuer: 'did:peer:victim',
+      issuanceDate: new Date().toISOString(),
+      credentialSubject: { id: 'did:peer:subject' },
+    };
+    await expect(manager.signCredential(impersonating, privateKey, vmId)).rejects.toThrow(
+      /does not match the verification method controller/
+    );
+  });
+
+  test('still signs when the issuer controls the key', async () => {
+    const manager = new CredentialManager(
+      { network: 'regtest', defaultKeyType: 'Ed25519' },
+      didManager
+    );
+    const legitimate: VerifiableCredential = {
+      '@context': ['https://www.w3.org/ns/credentials/v2', 'https://originals.build/context'],
+      type: ['VerifiableCredential'],
+      issuer: signerDid,
+      issuanceDate: new Date().toISOString(),
+      credentialSubject: { id: 'did:peer:subject' },
+    };
+    const signed = await manager.signCredential(legitimate, privateKey, vmId);
+    expect(signed.proof).toBeDefined();
+    expect(signed.issuer).toBe(signerDid);
+  });
+});

--- a/packages/sdk/tests/unit/vc/documentLoader.test.ts
+++ b/packages/sdk/tests/unit/vc/documentLoader.test.ts
@@ -53,14 +53,35 @@ describe('documentLoader branches', () => {
     await expect(loader('did:ex:404')).rejects.toThrow('DID not resolved');
   });
 
-  test('returns cached verification method for fragment', async () => {
+  test('returns cached verification method for fragment (self-certifying method)', async () => {
     const dm = new DIDManager({} as any);
-    spyOn(dm, 'resolveDID').mockResolvedValueOnce({ '@context': ['https://www.w3.org/ns/did/v1'], id: 'did:ex:1' } as any);
+    spyOn(dm, 'resolveDID').mockResolvedValueOnce({ '@context': ['https://www.w3.org/ns/did/v1'], id: 'did:peer:reg1' } as any);
     const loader = createDocumentLoader(dm);
-    registerVerificationMethod({ id: 'did:ex:1#key-1', type: 'Multikey', controller: 'did:ex:1', publicKeyMultibase: 'zAb' });
-    const res = await loader('did:ex:1#key-1');
-    expect(res.document.id).toBe('did:ex:1#key-1');
+    registerVerificationMethod({ id: 'did:peer:reg1#key-1', type: 'Multikey', controller: 'did:peer:reg1', publicKeyMultibase: 'zAb' });
+    const res = await loader('did:peer:reg1#key-1');
+    expect(res.document.id).toBe('did:peer:reg1#key-1');
     expect(res.document.publicKeyMultibase).toBe('zAb');
+  });
+
+  test('does NOT resurrect a registry key absent from a resolved hosted-method document (issue #260)', async () => {
+    // A did:webvh controller that REMOVED a compromised key from its DID log
+    // must not have it resurrected from the process-global registry.
+    const dm = new DIDManager({} as any);
+    spyOn(dm, 'resolveDID').mockResolvedValueOnce({
+      '@context': ['https://www.w3.org/ns/did/v1'],
+      id: 'did:webvh:example.com:rotated',
+      verificationMethod: []
+    } as any);
+    const loader = createDocumentLoader(dm);
+    registerVerificationMethod({
+      id: 'did:webvh:example.com:rotated#old-key',
+      type: 'Multikey',
+      controller: 'did:webvh:example.com:rotated',
+      publicKeyMultibase: 'zRemovedKey'
+    });
+    const res = await loader('did:webvh:example.com:rotated#old-key');
+    expect(res.document.publicKeyMultibase).toBeUndefined();
+    expect(res.document.id).toBe('did:webvh:example.com:rotated#old-key');
   });
 
   test('loads base DID without fragment', async () => {
@@ -187,16 +208,16 @@ describe('documentLoader rejects retired verification methods', () => {
     const dm = new DIDManager({} as any);
     spyOn(dm, 'resolveDID').mockResolvedValueOnce({
       '@context': ['https://www.w3.org/ns/did/v1'],
-      id: 'did:ex:revcache'
+      id: 'did:peer:revcache'
     } as any);
     const loader = createDocumentLoader(dm);
     registerVerificationMethod({
-      id: 'did:ex:revcache#key-1',
+      id: 'did:peer:revcache#key-1',
       type: 'Multikey',
-      controller: 'did:ex:revcache',
+      controller: 'did:peer:revcache',
       publicKeyMultibase: 'zCached',
       revoked: '2024-01-01T00:00:00Z'
     } as any);
-    await expect(loader('did:ex:revcache#key-1')).rejects.toThrow('retired');
+    await expect(loader('did:peer:revcache#key-1')).rejects.toThrow('retired');
   });
 });


### PR DESCRIPTION
## What

Hardens the credential signing/verification stack (`src/vc/` + `src/utils/validation.ts`) by fixing five related Medium-severity issues found during the full codebase review.

## Why

These five issues all live in the same subsystem and compound each other: valid credentials were rejected (VC 2.0, algorithm-from-config), invalid ones could be produced or accepted (neutralized issuer binding, resurrected rotated-out keys), and verifiers were exposed to a decompression-bomb DoS.

Closes #259
Closes #260
Closes #261
Closes #262
Closes #264

## How

- **#264 — `validateCredential` rejects W3C VC 2.0 credentials:** `src/utils/validation.ts` now accepts the `https://www.w3.org/ns/credentials/v2` context alongside v1, and accepts `validFrom` as the issuance timestamp when the v2 context is present. The SDK's own `Issuer` and `StatusListManager` emit v2-context credentials, which previously failed `deserializeCredential` and `OriginalsAsset.verify()`.

- **#262 — decompression bomb in status list decoding:** `StatusListManager.decodeBitstring` and `BitstringStatusList.decode` (both gzip and the legacy DEFLATE path) now pass `maxOutputLength` capped at a shared 16 MiB constant (`MAX_DECOMPRESSED_BITSTRING_BYTES`) and throw a clear error on overflow. A legitimate list is a few MiB at most; previously a few-KB gzip bomb hosted at an attacker-controlled `statusListCredential` URL could force multi-GiB allocations per verification.

- **#261 — signature algorithm selected from verifier config:** added `signerForKeyType(type)` in `src/crypto/Signer.ts` and replaced the config-driven `getSigner()` in `CredentialManager` (legacy sign + verify) and `MultiSigManager` (per-proof verify + sign). The signer is now chosen from the key's multicodec header (`multikey.decodePublicKey` / `decodePrivateKey`), so a valid Ed25519-signed credential no longer fails verification just because the relying party runs the default `ES256K` config.

- **#260 — registry fallback resurrects removed keys:** in `src/vc/documentLoader.ts`, the `verificationMethodRegistry` fallback for a *resolved* DID document whose requested fragment is absent is now restricted to self-certifying methods (`did:key`/`did:peer`) — the same restriction already applied to the unresolvable-DID fallback. For hosted (`did:webvh`) or on-chain (`did:btco`) methods, the resolved document is authoritative: a key the controller removed during rotation can no longer keep verifying signatures via a stale registry entry.

- **#259 — neutralized signing-side issuer-binding check:** `CredentialManager.signCredential` populated the verification method's `controller` from `credential.issuer` — the very value `Issuer.issueCredential`'s guard compares against, making the check `issuer === issuer`. It now uses the resolved VM document's `controller` (falling back to the VM's DID), and the binding-refusal error is re-thrown instead of being swallowed by the legacy-signing fallback, so signing a credential that claims a foreign issuer fails closed.

Non-obvious decisions:
- The 16 MiB decompression cap is exported so both decoders share one constant; it covers ~134M status entries (spec minimum is 16 KiB).
- Two existing `documentLoader` tests asserted the old registry-fallback behavior using generic `did:ex:` DIDs; they were updated to `did:peer` (where the fallback legitimately applies), and a new test pins the fail-closed behavior for hosted methods.
- `MultiSigManager` keeps its `config` constructor parameter (now unused internally) to preserve the public API.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test addition or improvement

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] I have updated JSDoc comments for any changed public APIs
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Testing

- [x] Unit tests — new `tests/unit/vc/credential-hardening.test.ts` covers all five fixes (VC 2.0 acceptance/rejection matrix, gzip + legacy DEFLATE bombs plus round-trip sanity, cross-config sign/verify for single- and multi-sig, impersonating-issuer refusal + legitimate-issuer signing); `tests/unit/vc/documentLoader.test.ts` updated for the fail-closed registry behavior
- [ ] Integration tests
- [x] Manual testing — full suite: `bun test` → 3281 pass / 0 fail (173 files); `bun run lint` → 0 errors; `bun run build` → clean

## Screenshots / Output (if applicable)

```
bun test:  3281 pass, 71 skip, 0 fail — 50724 expect() calls, 173 files
bun run lint:  0 errors (85 pre-existing warnings)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKsor635MiJGnizhGF8TRJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKsor635MiJGnizhGF8TRJ)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden credential signing and verification to derive algorithms from key type rather than configuration
> - Signing and verification now derive the cryptographic algorithm from each key's multicodec type via a new `signerForKeyType` helper, removing dependence on `config.defaultKeyType` across `CredentialManager` and `MultiSigManager`.
> - The document loader restricts registry fallback to self-certifying methods (`did:key`, `did:peer`); hosted/on-chain DID methods (`did:webvh`, `did:btco`) can no longer resurrect verification methods absent from the resolved DID document.
> - `validateCredential` now accepts W3C VC 2.0 credentials by recognizing the v2 context and `validFrom` as an alternative to `issuanceDate`.
> - Decompression of encoded status list bitstrings is capped at 16 MiB in both `StatusListManager` and `BitstringStatusList`, with errors thrown on failure or overflow.
> - Risk: signing now fails closed when the credential issuer does not match the resolved verification method controller; the legacy local-signing fallback no longer applies in that case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86b29cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->