### PR TITLE
fix: address five open issues not covered by #296 (#257, #266, #269, #277, #295)

### DIFF
--- a/.changeset/five-review-fixes-not-in-296.md
+++ b/.changeset/five-review-fixes-not-in-296.md
@@ -1,0 +1,10 @@
+---
+"@originals/sdk": patch
+---
+
+Fix five issues from the full codebase review not covered by the critical/high pass:
+
+- **cel**: `verifyEventLog` now requires the first event to be a `create` event, matching every state-derivation path (#295), and treats a `deactivate` event as terminal — a log with events after a `deactivate` no longer verifies (#257).
+- **did**: `DIDManager.resolveDID` routes did:btco resolution through the configured `ordinalsProvider` (via the new `OrdinalsProviderResolverAdapter`); with neither a provider nor an explicit `bitcoinRpcUrl`, it throws a structured `ORD_PROVIDER_REQUIRED` error instead of silently querying `http://localhost:3000` (#266).
+- **did**: did:btco tombstone detection scans only the marker line, so a "marker + JSON document" update whose JSON body merely contains 🔥 no longer permanently deactivates the DID (#269).
+- **core**: the `OriginalsSDK` constructor honors `config.keyStore` (an explicit `keyStore` parameter still takes precedence), so key registration no longer silently fails with `KEYSTORE_REQUIRED` far from the misconfiguration (#277).

--- a/packages/sdk/src/cel/algorithms/verifyEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/verifyEventLog.ts
@@ -619,6 +619,8 @@ async function verifyEvent(
  * - Each proof is structurally valid (type, cryptosuite, proofValue, verificationMethod, proofPurpose)
  * - Proofs use valid cryptosuite (eddsa-jcs-2022 or eddsa-rdfc-2022)
  * - The first event has no previousEvent field
+ * - The first event is a `create` event
+ * - No event follows a `deactivate` event (a deactivated log is sealed)
  * - Each subsequent event's previousEvent matches the digestMultibase of the prior event
  *
  * When no custom verifier is provided, `did:key` + `eddsa-jcs-2022` proofs
@@ -677,6 +679,31 @@ export async function verifyEventLog(
       errors: ['Invalid event log: empty events array'],
       events: [],
     };
+  }
+
+  // The first event must be a `create` event: every state-derivation path
+  // (PeerCelManager/WebVHCelManager/BtcoCelManager/CLI deriveCurrentState)
+  // requires it, so a log that "verifies" without one would be verified yet
+  // un-derivable. Fail closed.
+  if (log.events[0].type !== 'create') {
+    return {
+      verified: false,
+      errors: [`Invalid event log: first event must be a 'create' event (found '${String(log.events[0].type)}')`],
+      events: [],
+    };
+  }
+
+  // A `deactivate` event seals the log (deactivateEventLog refuses to append
+  // to a deactivated log). Enforce the same rule at verification: any event
+  // AFTER a deactivate means the sealed log was mutated, so the log must not
+  // verify — even if every signature and chain link is individually valid.
+  const deactivateIndex = log.events.findIndex(e => e.type === 'deactivate');
+  const deactivationViolated = deactivateIndex !== -1 && deactivateIndex < log.events.length - 1;
+  if (deactivationViolated) {
+    errors.push(
+      `Invalid event log: event ${deactivateIndex} is a 'deactivate' event but ` +
+      `${log.events.length - 1 - deactivateIndex} event(s) follow it; a deactivated log is sealed and must not be extended`
+    );
   }
 
   // Establish the authorized controller key from the create event (event 0):
@@ -775,7 +802,7 @@ export async function verifyEventLog(
   }
 
   return {
-    verified: allProofsValid && allChainsValid && !authorityError,
+    verified: allProofsValid && allChainsValid && !authorityError && !deactivationViolated,
     errors,
     events: eventVerifications,
   };

--- a/packages/sdk/src/core/OriginalsSDK.ts
+++ b/packages/sdk/src/core/OriginalsSDK.ts
@@ -203,7 +203,10 @@ export class OriginalsSDK {
     // Initialize managers
     this.did = new DIDManager(config, this.metrics);
     this.credentials = new CredentialManager(config, this.did, this.metrics);
-    this.lifecycle = new LifecycleManager(config, this.did, this.credentials, undefined, keyStore, this.metrics);
+    // Honor config.keyStore when no dedicated keyStore parameter is passed —
+    // OriginalsConfig declares it, so silently dropping it would type-check
+    // fine and only fail much later (credential:skipped / KEYSTORE_REQUIRED).
+    this.lifecycle = new LifecycleManager(config, this.did, this.credentials, undefined, keyStore ?? config.keyStore, this.metrics);
     this.bitcoin = new BitcoinManager(config);
     this.statusList = new StatusListManager();
     

--- a/packages/sdk/src/did/BtcoDidResolver.ts
+++ b/packages/sdk/src/did/BtcoDidResolver.ts
@@ -184,20 +184,31 @@ export class BtcoDidResolver {
         // pattern or parses to a DID document carrying the expected id.
         inscriptionData.isValidDid = matchesMarker || isDidDocumentForThisDid;
 
-        if (matchesMarker && inscriptionData.content.includes('🔥')) {
+        // The 🔥 tombstone scan must cover ONLY the marker line, never a JSON
+        // body. The combined "marker line + JSON document" form matches the
+        // start-anchored marker pattern too, so scanning the whole content
+        // would turn a legitimate document update whose JSON merely contains
+        // 🔥 (a service description, name, …) into a permanent tombstone.
+        const jsonBodyStart = inscriptionData.content.indexOf('{');
+        const markerLine = jsonBodyStart === -1
+          ? inscriptionData.content
+          : inscriptionData.content.slice(0, jsonBodyStart);
+
+        if (matchesMarker && markerLine.includes('🔥')) {
           // Deactivation tombstone: the human-readable marker form for THIS DID
           // carrying the 🔥 codepoint (e.g. "BTCO DID: did:btco:<sat> 🔥").
           //
-          // Detection keys off the marker PATTERN, not the mere presence of the
-          // emoji:
+          // Detection keys off the marker PATTERN plus the emoji ON THE MARKER
+          // LINE (the content before any JSON body):
           //  - a full DID document that happens to contain 🔥 in a field (a
-          //    service description, name, alsoKnownAs, …) does not match the
-          //    start-anchored marker pattern, so it is treated as an update
-          //    (handled below), not a tombstone;
-          //  - conversely, a genuine marker line remains a tombstone even if
+          //    service description, name, alsoKnownAs, …) does not tombstone,
+          //    whether it is bare JSON (fails the start-anchored pattern) or
+          //    preceded by a marker line (the emoji sits inside the JSON body,
+          //    not on the marker line);
+          //  - conversely, a genuine marker-line tombstone remains one even if
           //    arbitrary JSON is appended after it (which would otherwise parse
           //    to an object with the expected id and slip past a document-based
-          //    guard), because the pattern anchors at the start of the content.
+          //    guard), because the 🔥 is on the marker line itself.
           inscriptionData.didDocument = null;
           inscriptionData.deactivated = true;
           if (!inscriptionData.error) {

--- a/packages/sdk/src/did/DIDManager.ts
+++ b/packages/sdk/src/did/DIDManager.ts
@@ -4,6 +4,8 @@ import { BtcoDidResolver } from './BtcoDidResolver.js';
 import { OrdinalsClient } from '../bitcoin/OrdinalsClient.js';
 import { createBtcoDidDocument } from './createBtcoDidDocument.js';
 import { OrdinalsClientProviderAdapter } from './providers/OrdinalsClientProviderAdapter.js';
+import { OrdinalsProviderResolverAdapter } from './providers/OrdinalsProviderResolverAdapter.js';
+import { StructuredError } from '../utils/telemetry.js';
 import { multikey } from '../crypto/Multikey.js';
 import { KeyManager } from './KeyManager.js';
 import { WebVHManager, normalizeUpdateKey, assertEd25519WebVHUpdateKeys } from './WebVHManager.js';
@@ -303,26 +305,47 @@ export class DIDManager {
             }
           }
         } else if (did.startsWith('did:btco:')) {
-          const rpcUrl = this.config.bitcoinRpcUrl || 'http://localhost:3000';
-          // The network is encoded in the DID itself (did:btco:reg:/did:btco:sig:,
-          // unprefixed = mainnet), so resolution must follow the DID, not the
-          // SDK-wide config — a signet DID handed to a mainnet-configured SDK
-          // must still be treated as a signet identifier.
-          const btcoPrefix = did.match(/^did:btco:(reg|sig|test):/)?.[1];
-          const network: 'mainnet' | 'regtest' | 'signet' =
-            btcoPrefix === 'reg' ? 'regtest'
-            : btcoPrefix === 'sig' ? 'signet'
-            : btcoPrefix === 'test'
-              // OrdinalsClient has no testnet variant; fall back to the
-              // configured network (BtcoDidResolver still validates the DID
-              // against its own testnet prefix).
-              ? (this.config.network || 'mainnet')
-              : 'mainnet';
-          const client = new OrdinalsClient(rpcUrl, network);
-          const adapter = new OrdinalsClientProviderAdapter(client, rpcUrl);
-          const resolver = new BtcoDidResolver({ provider: adapter });
-          const resolved = await resolver.resolve(did);
-          result = resolved.didDocument || null;
+          if (this.config.ordinalsProvider) {
+            // The configured ordinalsProvider is the source of truth for
+            // Bitcoin state (it performed the inscriptions), so resolution
+            // must go through it — not through a freshly constructed HTTP
+            // client pointed at some unrelated endpoint.
+            const adapter = new OrdinalsProviderResolverAdapter(this.config.ordinalsProvider);
+            const resolver = new BtcoDidResolver({ provider: adapter, fetchFn: adapter.fetchContent });
+            const resolved = await resolver.resolve(did);
+            result = resolved.didDocument || null;
+          } else if (this.config.bitcoinRpcUrl) {
+            const rpcUrl = this.config.bitcoinRpcUrl;
+            // The network is encoded in the DID itself (did:btco:reg:/did:btco:sig:,
+            // unprefixed = mainnet), so resolution must follow the DID, not the
+            // SDK-wide config — a signet DID handed to a mainnet-configured SDK
+            // must still be treated as a signet identifier.
+            const btcoPrefix = did.match(/^did:btco:(reg|sig|test):/)?.[1];
+            const network: 'mainnet' | 'regtest' | 'signet' =
+              btcoPrefix === 'reg' ? 'regtest'
+              : btcoPrefix === 'sig' ? 'signet'
+              : btcoPrefix === 'test'
+                // OrdinalsClient has no testnet variant; fall back to the
+                // configured network (BtcoDidResolver still validates the DID
+                // against its own testnet prefix).
+                ? (this.config.network || 'mainnet')
+                : 'mainnet';
+            const client = new OrdinalsClient(rpcUrl, network);
+            const adapter = new OrdinalsClientProviderAdapter(client, rpcUrl);
+            const resolver = new BtcoDidResolver({ provider: adapter });
+            const resolved = await resolver.resolve(did);
+            result = resolved.didDocument || null;
+          } else {
+            // No provider and no explicit RPC URL: fail loudly. Silently
+            // defaulting to http://localhost:3000 either fails far from the
+            // cause or — worse — trusts whatever unrelated service happens to
+            // listen there as the source of DID documents.
+            throw new StructuredError(
+              'ORD_PROVIDER_REQUIRED',
+              'Resolving did:btco requires an ordinalsProvider (or an explicit bitcoinRpcUrl) to be configured. ' +
+              'Provide an ordinalsProvider when creating the SDK. See README.md for configuration examples.'
+            );
+          }
         } else if (did.startsWith('did:webvh:')) {
           try {
             const mod = await import('didwebvh-ts') as {
@@ -348,6 +371,11 @@ export class DIDManager {
           console.warn(`Unsupported DID method for resolution: ${did}`);
         }
       } catch (err) {
+        // Misconfiguration must fail loudly — swallowing it into a null would
+        // reproduce the silent-failure mode this error exists to prevent.
+        if (err instanceof StructuredError && err.code === 'ORD_PROVIDER_REQUIRED') {
+          throw err;
+        }
         // DID resolution failed
         if (this.config.enableLogging) {
           console.error('Failed to resolve DID:', err);

--- a/packages/sdk/src/did/providers/OrdinalsProviderResolverAdapter.ts
+++ b/packages/sdk/src/did/providers/OrdinalsProviderResolverAdapter.ts
@@ -1,0 +1,69 @@
+import type { OrdinalsProvider } from '../../adapters/types.js';
+import type { ResourceProviderLike } from '../BtcoDidResolver.js';
+
+/**
+ * Synthetic URL scheme for inscription content served straight from the
+ * configured OrdinalsProvider. BtcoDidResolver fetches content by URL; this
+ * adapter mints URLs in this scheme and answers them from the provider via
+ * `fetchContent`, so resolution never touches the network on its own.
+ */
+const CONTENT_URL_PREFIX = 'ordinals-provider://content/';
+
+/**
+ * Adapts the SDK-wide `config.ordinalsProvider` (adapters/OrdinalsProvider —
+ * the interface CLAUDE.md calls mandatory for Bitcoin operations) to the
+ * `ResourceProviderLike` shape BtcoDidResolver consumes.
+ *
+ * Pass the instance as the resolver's `provider` AND its `fetchContent` as the
+ * resolver's `fetchFn`, so both inscription lookup and content retrieval go
+ * through the configured provider instead of a hardcoded HTTP endpoint.
+ */
+export class OrdinalsProviderResolverAdapter implements ResourceProviderLike {
+  constructor(private readonly provider: OrdinalsProvider) {}
+
+  async getSatInfo(satNumber: string): Promise<{ inscription_ids: string[] }> {
+    const inscriptions = await this.provider.getInscriptionsBySatoshi(satNumber);
+    return { inscription_ids: inscriptions.map((i) => i.inscriptionId) };
+  }
+
+  async resolveInscription(inscriptionId: string): Promise<{ id: string; sat: number; content_type: string; content_url: string }> {
+    const inscription = await this.provider.getInscriptionById(inscriptionId);
+    if (!inscription) {
+      throw new Error(`Inscription ${inscriptionId} not found`);
+    }
+    return {
+      id: inscription.inscriptionId,
+      sat: Number(inscription.satoshi ?? 0),
+      content_type: inscription.contentType,
+      content_url: CONTENT_URL_PREFIX + encodeURIComponent(inscriptionId)
+    };
+  }
+
+  // The adapters/OrdinalsProvider interface exposes no metadata endpoint;
+  // metadata is diagnostic-only in BtcoDidResolver, so report none.
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async getMetadata(_inscriptionId: string): Promise<Record<string, unknown> | null> {
+    return null;
+  }
+
+  /**
+   * fetchFn for BtcoDidResolver: serves `ordinals-provider://content/<id>`
+   * URLs from the underlying provider. Any other URL fails closed — this
+   * adapter mints every content_url itself, so a foreign URL here would mean
+   * inscription data trying to redirect content retrieval (SSRF).
+   */
+  fetchContent = async (url: string): Promise<Response> => {
+    const respond = (ok: boolean, status: number, statusText: string, body: string): Response =>
+      ({ ok, status, statusText, text: () => Promise.resolve(body) } as unknown as Response);
+
+    if (!url.startsWith(CONTENT_URL_PREFIX)) {
+      return respond(false, 400, 'Bad Request', `Refusing to fetch non-provider content URL: ${url}`);
+    }
+    const inscriptionId = decodeURIComponent(url.slice(CONTENT_URL_PREFIX.length));
+    const inscription = await this.provider.getInscriptionById(inscriptionId);
+    if (!inscription) {
+      return respond(false, 404, 'Not Found', `Inscription ${inscriptionId} not found`);
+    }
+    return respond(true, 200, 'OK', inscription.content.toString('utf8'));
+  };
+}

--- a/packages/sdk/tests/unit/cel/verifyEventLog.test.ts
+++ b/packages/sdk/tests/unit/cel/verifyEventLog.test.ts
@@ -991,4 +991,106 @@ describe('verifyEventLog', () => {
       expect(result.events[0].witnessProofs).toBeUndefined();
     });
   });
+
+  describe('first event must be a create event (issue #295)', () => {
+    test('rejects a log whose first (and only) event is a validly-signed update', async () => {
+      const { signer } = await makeRealSigner();
+
+      // A single validly-signed `update` event with no `create` — previously
+      // this verified even though no state-derivation path can consume it.
+      const eventData = { type: 'update' as const, data: { name: 'Orphan Update' } };
+      const proof = await signer(eventData);
+      const log: EventLog = {
+        events: [{ ...eventData, proof: [proof] }],
+      };
+
+      const result = await verifyEventLog(log);
+
+      expect(result.verified).toBe(false);
+      expect(result.errors.some(e => e.includes("first event must be a 'create' event"))).toBe(true);
+    });
+
+    test('rejects an update-first log on the custom-verifier path too', async () => {
+      const eventData = { type: 'update' as const, data: { name: 'Orphan Update' } };
+      const log: EventLog = {
+        events: [{
+          ...eventData,
+          proof: [{
+            type: 'DataIntegrityProof',
+            cryptosuite: 'eddsa-jcs-2022',
+            created: new Date().toISOString(),
+            verificationMethod: structuralVm,
+            proofPurpose: 'assertionMethod',
+            proofValue: 'z' + 'a'.repeat(86),
+          }],
+        }],
+      };
+
+      const result = await verifyEventLog(log, { verifier: async () => true });
+
+      expect(result.verified).toBe(false);
+      expect(result.errors.some(e => e.includes("first event must be a 'create' event"))).toBe(true);
+    });
+
+    test('still accepts a valid create-first log', async () => {
+      const { signer, verificationMethod: vm } = await makeRealSigner();
+      const log = await createEventLog({ name: 'Valid' }, { signer, verificationMethod: vm });
+
+      const result = await verifyEventLog(log);
+      expect(result.verified).toBe(true);
+    });
+  });
+
+  describe('deactivation is terminal (issue #257)', () => {
+    async function makeDeactivatedLogWithTrailingUpdate(): Promise<EventLog> {
+      const { signer, verificationMethod: vm } = await makeRealSigner();
+      const { deactivateEventLog } = await import('../../../src/cel/algorithms/deactivateEventLog');
+      const { computeDigestMultibase } = await import('../../../src/cel/hash');
+      const { canonicalizeEntryForChain } = await import('../../../src/cel/canonicalize');
+
+      let log = await createEventLog({ name: 'Sealed Asset' }, { signer, verificationMethod: vm });
+      log = await deactivateEventLog(log, 'retired', { signer, verificationMethod: vm });
+
+      // Craft a validly-signed, correctly-chained update AFTER the deactivate —
+      // exactly what deactivateEventLog refuses to append but verification
+      // previously accepted.
+      const lastEvent = log.events[log.events.length - 1];
+      const previousEvent = computeDigestMultibase(canonicalizeEntryForChain(lastEvent));
+      const eventData = { type: 'update' as const, data: { name: 'Mutated After Seal' }, previousEvent };
+      const proof = await signer(eventData);
+      return { ...log, events: [...log.events, { ...eventData, proof: [proof] }] };
+    }
+
+    test('create → deactivate → update fails verification even when all signatures are valid', async () => {
+      const log = await makeDeactivatedLogWithTrailingUpdate();
+
+      const result = await verifyEventLog(log);
+
+      expect(result.verified).toBe(false);
+      expect(result.errors.some(e => e.includes('deactivate') && e.includes('sealed'))).toBe(true);
+    });
+
+    test('a log ending in a deactivate event still verifies', async () => {
+      const { signer, verificationMethod: vm } = await makeRealSigner();
+      const { deactivateEventLog } = await import('../../../src/cel/algorithms/deactivateEventLog');
+
+      let log = await createEventLog({ name: 'Retiring Asset' }, { signer, verificationMethod: vm });
+      log = await updateEventLog(log, { name: 'Final Form' }, { signer, verificationMethod: vm });
+      log = await deactivateEventLog(log, 'retired', { signer, verificationMethod: vm });
+
+      const result = await verifyEventLog(log);
+
+      expect(result.verified).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    test('events after deactivate fail the log on the custom-verifier path too', async () => {
+      const log = await makeDeactivatedLogWithTrailingUpdate();
+
+      const result = await verifyEventLog(log, { verifier: async () => true });
+
+      expect(result.verified).toBe(false);
+      expect(result.errors.some(e => e.includes('sealed'))).toBe(true);
+    });
+  });
 });

--- a/packages/sdk/tests/unit/core/OriginalsSDK.test.ts
+++ b/packages/sdk/tests/unit/core/OriginalsSDK.test.ts
@@ -70,6 +70,34 @@ describe('OriginalsSDK', () => {
     expect((explicit as any).config.network).toBe('signet');
   });
 
+  test('constructor honors config.keyStore (issue #277)', () => {
+    // Regression: OriginalsConfig declares keyStore, but the constructor only
+    // forwarded its second parameter — config.keyStore was silently ignored
+    // and signing later failed with KEYSTORE_REQUIRED, far from the cause.
+    const store = {
+      getPrivateKey: async () => null,
+      setPrivateKey: async () => {}
+    };
+    const sdk = new OriginalsSDK({ network: 'mainnet', defaultKeyType: 'ES256K', keyStore: store });
+    expect((sdk.lifecycle as any).keyStore).toBe(store);
+  });
+
+  test('constructor keyStore parameter takes precedence over config.keyStore', () => {
+    const configStore = {
+      getPrivateKey: async () => null,
+      setPrivateKey: async () => {}
+    };
+    const paramStore = {
+      getPrivateKey: async () => null,
+      setPrivateKey: async () => {}
+    };
+    const sdk = new OriginalsSDK(
+      { network: 'mainnet', defaultKeyType: 'ES256K', keyStore: configStore },
+      paramStore
+    );
+    expect((sdk.lifecycle as any).keyStore).toBe(paramStore);
+  });
+
   test('constructor throws error when config is null', () => {
     expect(() => new OriginalsSDK(null as any)).toThrow('Configuration object is required');
   });

--- a/packages/sdk/tests/unit/did/BtcoDidResolver.test.ts
+++ b/packages/sdk/tests/unit/did/BtcoDidResolver.test.ts
@@ -309,6 +309,46 @@ describe('BtcoDidResolver', () => {
     expect(res.didDocumentMetadata.deactivated).toBe(true);
   });
 
+  test('marker + JSON document form with 🔥 only inside the JSON body is an update, not a tombstone (issue #269)', async () => {
+    // Regression: for the combined "marker line + JSON document" form the
+    // marker pattern matches, and the 🔥 scan used to cover the ENTIRE content
+    // — so a legitimate document update whose JSON merely contained 🔥 (e.g. a
+    // service description) permanently bricked the DID. The scan must cover
+    // only the marker line (the content before the JSON body).
+    const docContent = JSON.stringify({
+      '@context': ['https://www.w3.org/ns/did/v1'],
+      id: 'did:btco:128',
+      service: [{
+        id: 'did:btco:128#drops',
+        type: 'LinkedDomains',
+        serviceEndpoint: 'https://example.com',
+        description: '🔥 drops'
+      }]
+    });
+    const inscriptionId = 'insc-marker-doc-fire';
+    provider.getSatInfo.mockResolvedValue({ inscription_ids: [inscriptionId] });
+    provider.resolveInscription.mockResolvedValue({
+      id: inscriptionId,
+      sat: 128,
+      content_type: 'application/json',
+      content_url: 'http://local/content-marker-doc-fire'
+    });
+    provider.getMetadata.mockResolvedValue(null);
+    (global as any).fetch.mockResolvedValue({
+      ok: true,
+      text: async () => `BTCO DID: did:btco:128\n${docContent}`
+    });
+
+    const resolver = new BtcoDidResolver({ provider });
+    const res = await resolver.resolve('did:btco:128');
+    const entry = (res.inscriptions as BtcoInscriptionData[])[0];
+    expect(entry.deactivated).toBeUndefined();
+    expect(entry.didDocument).not.toBeNull();
+    expect(res.didDocument).not.toBeNull();
+    expect(res.didDocument?.id).toBe('did:btco:128');
+    expect(res.didDocumentMetadata.deactivated).toBeUndefined();
+  });
+
   test('tombstone after a valid document deactivates the DID (no fallback to older document)', async () => {
     const docContent = JSON.stringify({
       '@context': ['https://www.w3.org/ns/did/v1'],

--- a/packages/sdk/tests/unit/did/DIDManager.test.ts
+++ b/packages/sdk/tests/unit/did/DIDManager.test.ts
@@ -181,14 +181,74 @@ describe('DIDManager.resolveDID catch path', () => {
 
 /** Inlined from DIDManager.resolve.defaults.part.ts */
 
-describe('DIDManager.resolveDID uses default rpcUrl and network fallbacks', () => {
-  test('falls back to http://localhost:3000 and mainnet when config missing', async () => {
+describe('DIDManager.resolveDID did:btco provider selection (issue #266)', () => {
+  test('fails loudly with ORD_PROVIDER_REQUIRED instead of defaulting to localhost:3000', async () => {
+    // Previously this silently constructed an OrdinalsClient against
+    // http://localhost:3000 — resolving against whatever unrelated service
+    // happened to listen there, or failing far from the cause with a null.
     const dm = new DIDManager({} as any);
-    const spy = spyOn(BtcoDidResolver.prototype as any, 'resolve');
-    spy.mockResolvedValueOnce({ didDocument: { '@context': ['https://www.w3.org/ns/did/v1'], id: 'did:btco:xyz' } });
-    const res = await dm.resolveDID('did:btco:xyz');
-    expect(res?.id).toBe('did:btco:xyz');
-    spy.mockRestore();
+    await expect(dm.resolveDID('did:btco:xyz')).rejects.toThrow(/ordinalsProvider/);
+  });
+
+  test('routes resolution through the configured ordinalsProvider (no HTTP)', async () => {
+    const { OrdMockProvider } = await import('../../../src/adapters/providers/OrdMockProvider');
+    const didDoc = {
+      '@context': ['https://www.w3.org/ns/did/v1'],
+      id: 'did:btco:123'
+    };
+    const provider = new OrdMockProvider({
+      inscriptionsById: new Map([[
+        'insc-1',
+        {
+          inscriptionId: 'insc-1',
+          content: Buffer.from(JSON.stringify(didDoc), 'utf8'),
+          contentType: 'application/json',
+          txid: 'tx-1',
+          vout: 0,
+          satoshi: '123'
+        }
+      ]]),
+      inscriptionsBySatoshi: new Map([['123', ['insc-1']]])
+    });
+
+    const dm = new DIDManager({
+      network: 'mainnet',
+      defaultKeyType: 'ES256K',
+      ordinalsProvider: provider
+    } as any);
+
+    const res = await dm.resolveDID('did:btco:123', { skipCache: true });
+    expect(res?.id).toBe('did:btco:123');
+  });
+
+  test('ordinalsProvider takes precedence over bitcoinRpcUrl', async () => {
+    const { OrdMockProvider } = await import('../../../src/adapters/providers/OrdMockProvider');
+    const provider = new OrdMockProvider({
+      inscriptionsById: new Map([[
+        'insc-2',
+        {
+          inscriptionId: 'insc-2',
+          content: Buffer.from(JSON.stringify({ '@context': ['https://www.w3.org/ns/did/v1'], id: 'did:btco:456' }), 'utf8'),
+          contentType: 'application/json',
+          txid: 'tx-2',
+          vout: 0,
+          satoshi: '456'
+        }
+      ]]),
+      inscriptionsBySatoshi: new Map([['456', ['insc-2']]])
+    });
+
+    // If the OrdinalsClient path were taken, resolution would issue HTTP to
+    // this unreachable URL and return null; the provider path needs no HTTP.
+    const dm = new DIDManager({
+      network: 'mainnet',
+      defaultKeyType: 'ES256K',
+      bitcoinRpcUrl: 'http://unreachable.invalid:9999',
+      ordinalsProvider: provider
+    } as any);
+
+    const res = await dm.resolveDID('did:btco:456', { skipCache: true });
+    expect(res?.id).toBe('did:btco:456');
   });
 });
 


### PR DESCRIPTION
## What

Fixes five open issues from the full-codebase review that are not addressed by #296 (which covers #236–#256) or the already-merged #297 (#259–#264): two CEL verification gaps, two did:btco resolution bugs, and a silently-ignored config field.

## Why

Each of these lets the SDK either verify something it shouldn't, brick or misresolve a DID, or fail far from the misconfiguration that caused it.

Closes #257, Closes #266, Closes #269, Closes #277, Closes #295

## How

**#257 — CEL deactivation is now terminal at verification.** `deactivateEventLog` refuses to append to a sealed log, but `verifyEventLog` accepted events *after* a `deactivate` (create → deactivate → update verified). `verifyEventLog` now fails the whole log when any event follows a `deactivate`, on both the default and custom-verifier paths.

**#295 — CEL logs must start with a `create` event.** A single validly-signed `update` event verified even though every state-derivation path (`PeerCelManager`/`WebVHCelManager`/`BtcoCelManager`/CLI) throws on it. `verifyEventLog` now fails closed when `events[0].type !== 'create'`.

**#266 — did:btco resolution uses the configured `ordinalsProvider`.** `DIDManager.resolveDID` always built a fresh HTTP `OrdinalsClient` against `bitcoinRpcUrl || 'http://localhost:3000'`, so the documented `OrdMockProvider` setup couldn't resolve DIDs it had just inscribed — and an unrelated service on port 3000 could become the trusted source of DID documents. Resolution now routes through `config.ordinalsProvider` via a new `OrdinalsProviderResolverAdapter` (inscription lookup *and* content retrieval go through the provider — no HTTP; foreign content URLs fail closed). An explicit `bitcoinRpcUrl` still selects the `OrdinalsClient` path; with neither configured, resolution throws a structured `ORD_PROVIDER_REQUIRED` error instead of silently defaulting to localhost.

**#269 — did:btco tombstone false positive.** Deactivation was detected as `matchesMarker && content.includes('🔥')`. For the combined "marker line + JSON document" form the scan covered the entire JSON body, so a legitimate document update containing 🔥 in any field (e.g. a service description) permanently bricked the DID. The 🔥 scan is now restricted to the marker line (content before the first `{`); genuine marker-line tombstones with trailing JSON still deactivate.

**#277 — `config.keyStore` is honored.** `OriginalsConfig` declares `keyStore`, but the constructor only forwarded its second parameter to `LifecycleManager`, so `new OriginalsSDK({ ..., keyStore })` type-checked and then failed much later with `KEYSTORE_REQUIRED`. The constructor now falls back to `config.keyStore`; an explicit `keyStore` parameter still takes precedence.

Non-obvious decisions:
- The unit test pinning the old localhost fallback ("falls back to http://localhost:3000 when config missing") was updated to assert the new fail-loud behavior, per the repo convention of updating tests that pin buggy behavior.
- `ORD_PROVIDER_REQUIRED` is rethrown past `resolveDID`'s catch-all so misconfiguration cannot degrade into the very silent `null` this fix removes.
- The new CEL checks apply on the custom-verifier path too: they are structural log rules, not proof semantics, so a custom verifier cannot opt out of them.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test addition or improvement

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] I have updated JSDoc comments for any changed public APIs
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Testing

- [x] Unit tests — regression tests for every issue: update-first log rejection (default + custom-verifier paths), create→deactivate→update rejection, deactivate-last still verifies, marker+JSON 🔥-in-body update, `OrdMockProvider`-backed did:btco resolution, provider precedence over `bitcoinRpcUrl`, `ORD_PROVIDER_REQUIRED`, `config.keyStore` honored and parameter precedence
- [x] Integration tests — full suite: 3276 pass / 0 new failures (the 16 CEL-CLI subprocess tests fail identically on unmodified `main` in this environment)
- [ ] Manual testing

## Screenshots / Output

```
$ bun test
 3276 pass
 71 skip
 16 fail   (pre-existing CEL-CLI subprocess tests, identical on main)
Ran 3363 tests across 173 files.

$ bun run lint
✖ 85 problems (0 errors, 85 warnings)   (identical warning count on main)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mu4stcBTpKJLbdsV25FisJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mu4stcBTpKJLbdsV25FisJ)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix five bugs in CEL verification, DID resolution, tombstone detection, and SDK constructor
> - `verifyEventLog` now rejects logs whose first event is not `create` and treats `deactivate` as terminal — any events following a deactivate set `verified=false`
> - `DIDManager.resolveDID` for `did:btco` now routes through `config.ordinalsProvider` (via the new `OrdinalsProviderResolverAdapter`) when present, falls back to `bitcoinRpcUrl`, or throws a `StructuredError` with code `ORD_PROVIDER_REQUIRED` when neither is configured
> - `BtcoDidResolver` tombstone detection now scans only the marker line for 🔥, so a combined marker+JSON inscription with 🔥 in the JSON body is treated as an update rather than a tombstone
> - `OriginalsSDK` constructor now forwards `config.keyStore` to `LifecycleManager` when no explicit `keyStore` argument is provided
> - Behavioral Change: `resolveDID` no longer falls back to `http://localhost:3000` or returns `null` when no provider is configured — it throws instead
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f8ef20b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->