### PR TITLE
fix: resolve 14 open review issues across DID, Bitcoin, migration, VC, and infra

### DIFF
--- a/docs/LLM_AGENT_GUIDE.md
+++ b/docs/LLM_AGENT_GUIDE.md
@@ -691,9 +691,12 @@ asset.getProvenanceSummary(): { created, creator, currentLayer, migrationCount, 
 asset.queryProvenance(): ProvenanceQuery  // Fluent API for queries
 
 // Resource versioning
+// newContent must be a string: AssetResource stores inline content as a string,
+// so Buffer input throws StructuredError('BINARY_CONTENT_UNSUPPORTED') rather
+// than silently dropping the bytes. Encode binary content (e.g. base64) first.
 asset.addResourceVersion(
   resourceId: string,
-  newContent: string | Buffer,
+  newContent: string,
   contentType: string,
   changes?: string
 ): AssetResource

--- a/packages/sdk/src/bitcoin/BroadcastClient.ts
+++ b/packages/sdk/src/bitcoin/BroadcastClient.ts
@@ -41,9 +41,20 @@ export class BroadcastClient {
     let attempts = 0;
     let last: TransactionStatus = { confirmed: false };
     while (attempts < maxAttempts) {
-      last = await this.statusProvider(txid);
-      if (last.confirmed) {
-        return { txid, confirmations: last.confirmations ?? 1 };
+      // Once the broadcast succeeded, this method must resolve with the txid
+      // no matter what the status endpoint does (issue #271). A transient
+      // status failure that rejected here made callers treat the whole
+      // operation as failed and rebuild/rebroadcast a second commit tx over
+      // the same UTXOs — a double-spend race that can strand funds at a
+      // commit address whose reveal key was discarded. Count a throwing poll
+      // as an unconfirmed attempt instead.
+      try {
+        last = await this.statusProvider(txid);
+        if (last.confirmed) {
+          return { txid, confirmations: last.confirmations ?? 1 };
+        }
+      } catch {
+        // Transient status-provider failure: treat as "not yet confirmed".
       }
       await new Promise(r => setTimeout(r, interval));
       attempts++;

--- a/packages/sdk/src/bitcoin/providers/SignetProvider.ts
+++ b/packages/sdk/src/bitcoin/providers/SignetProvider.ts
@@ -6,6 +6,12 @@ export interface SignetProviderOptions {
   ordUrl: string;
   /** Optional Bitcoin Core RPC URL for wallet operations */
   bitcoinRpcUrl?: string;
+  /**
+   * Optional Bitcoin Core RPC credentials, sent as HTTP Basic auth.
+   * Stock bitcoind requires RPC auth; fetch rejects URLs with embedded
+   * credentials, so they must be supplied here instead of in bitcoinRpcUrl.
+   */
+  bitcoinRpcAuth?: { username: string; password: string };
   /** Request timeout in milliseconds (default: 10000) */
   timeout?: number;
 }
@@ -24,13 +30,26 @@ export class SignetProvider implements OrdinalsProvider {
   private readonly client: OrdinalsClient;
   private readonly ordUrl: string;
   private readonly bitcoinRpcUrl?: string;
+  private readonly bitcoinRpcAuth?: { username: string; password: string };
   private readonly timeout: number;
 
   constructor(options: SignetProviderOptions) {
     this.ordUrl = options.ordUrl.replace(/\/$/, '');
     this.bitcoinRpcUrl = options.bitcoinRpcUrl;
+    this.bitcoinRpcAuth = options.bitcoinRpcAuth;
     this.timeout = options.timeout ?? 10_000;
     this.client = new OrdinalsClient(this.ordUrl, 'signet');
+  }
+
+  private rpcHeaders(): Record<string, string> {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (this.bitcoinRpcAuth) {
+      const token = Buffer.from(
+        `${this.bitcoinRpcAuth.username}:${this.bitcoinRpcAuth.password}`
+      ).toString('base64');
+      headers['Authorization'] = `Basic ${token}`;
+    }
+    return headers;
   }
 
   async getInscriptionById(id: string) {
@@ -58,10 +77,18 @@ export class SignetProvider implements OrdinalsProvider {
         'broadcastTransaction requires bitcoinRpcUrl. Configure SignetProvider with a Bitcoin Core RPC URL.'
       );
     }
-    const txHex = typeof txHexOrObj === 'string' ? txHexOrObj : JSON.stringify(txHexOrObj);
+    // sendrawtransaction only accepts raw transaction hex. JSON.stringify-ing
+    // an object here (issue #272) produced a guaranteed-invalid RPC parameter
+    // that failed far from the cause — reject non-hex input up front instead.
+    if (typeof txHexOrObj !== 'string' || !/^(?:[0-9a-fA-F]{2})+$/.test(txHexOrObj)) {
+      throw new Error(
+        'broadcastTransaction requires a raw transaction hex string (even-length hexadecimal)'
+      );
+    }
+    const txHex = txHexOrObj;
     const res = await fetch(this.bitcoinRpcUrl, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: this.rpcHeaders(),
       body: JSON.stringify({
         jsonrpc: '2.0',
         id: 1,
@@ -70,9 +97,28 @@ export class SignetProvider implements OrdinalsProvider {
       }),
       signal: AbortSignal.timeout(this.timeout),
     });
-    const data = await res.json() as { result?: string; error?: { message: string } };
-    if (data.error) throw new Error(`Bitcoin RPC error: ${data.error.message}`);
-    return data.result ?? '';
+    // bitcoind reports RPC-level errors with non-2xx statuses but still sends
+    // a JSON body; an auth failure or proxy error may send HTML. Parse the
+    // body when possible so the RPC error surfaces, and otherwise fail with
+    // the HTTP status instead of an opaque JSON parse error.
+    let data: { result?: unknown; error?: { message?: string } };
+    try {
+      data = await res.json() as { result?: unknown; error?: { message?: string } };
+    } catch {
+      throw new Error(`Bitcoin RPC request failed: HTTP ${res.status} ${res.statusText}`);
+    }
+    if (data.error) {
+      throw new Error(`Bitcoin RPC error: ${data.error.message ?? JSON.stringify(data.error)}`);
+    }
+    if (!res.ok) {
+      throw new Error(`Bitcoin RPC request failed: HTTP ${res.status} ${res.statusText}`);
+    }
+    // A response with neither result nor error must not become a "successful"
+    // empty-string txid that downstream code records (issue #272).
+    if (typeof data.result !== 'string' || data.result.length === 0) {
+      throw new Error('Bitcoin RPC returned no txid for sendrawtransaction');
+    }
+    return data.result;
   }
 
   async getTransactionStatus(txid: string) {
@@ -98,7 +144,7 @@ export class SignetProvider implements OrdinalsProvider {
       try {
         const res = await fetch(this.bitcoinRpcUrl, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: this.rpcHeaders(),
           body: JSON.stringify({
             jsonrpc: '2.0',
             id: 1,

--- a/packages/sdk/src/did/DIDCache.ts
+++ b/packages/sdk/src/did/DIDCache.ts
@@ -93,10 +93,15 @@ export class DIDCache {
   async get(did: string): Promise<DIDDocument | null> {
     let entry = this.cache.get(did) ?? null;
 
-    // Try persistent storage fallback
+    // Try persistent storage fallback. Hydrated entries go through the same
+    // eviction guard as set()/pin(); otherwise a large persistent store could
+    // grow the in-memory map unboundedly past maxEntries (issue #291).
     if (!entry && this.storage) {
       entry = await this.storage.get(did);
       if (entry) {
+        if (!this.cache.has(did) && this.cache.size >= this.maxEntries) {
+          await this.evictLRU();
+        }
         this.cache.set(did, entry);
       }
     }
@@ -116,7 +121,10 @@ export class DIDCache {
 
     this.touchAccessOrder(did);
     this.metrics?.recordCacheHit();
-    return entry.document;
+    // Return a copy: handing out the cached object by reference would let a
+    // caller that annotates/mutates the resolved document silently poison the
+    // cache for every later resolution of this DID (issue #291).
+    return structuredClone(entry.document);
   }
 
   /**
@@ -125,7 +133,9 @@ export class DIDCache {
   async set(did: string, document: DIDDocument): Promise<void> {
     const entry: DIDCacheEntry = {
       did,
-      document,
+      // Store a copy so later caller-side mutation of the original object
+      // cannot alter what the cache serves (issue #291).
+      document: structuredClone(document),
       resolvedAt: Date.now(),
       ttlMs: this.ttlMs,
       pinned: false,
@@ -154,7 +164,7 @@ export class DIDCache {
 
     const entry: DIDCacheEntry = {
       did,
-      document: document ?? existing!.document,
+      document: document ? structuredClone(document) : existing!.document,
       resolvedAt: existing?.resolvedAt ?? Date.now(),
       ttlMs: this.ttlMs,
       pinned: true,

--- a/packages/sdk/src/did/DIDManager.ts
+++ b/packages/sdk/src/did/DIDManager.ts
@@ -213,6 +213,20 @@ export class DIDManager {
     }); // end track did.migrateToDIDWebVH
   }
 
+  /**
+   * The Bitcoin network this SDK instance is configured for, or `undefined`
+   * when neither an explicit `network` nor a `webvhNetwork` is set (the SDK's
+   * network is genuinely unknown). An explicit `network` wins over the WebVH
+   * mapping (issue #247). Single source of truth for both did:btco minting
+   * (migrateToDIDBTCO) and the cross-network resolution guard (issue #267), so
+   * the two can never disagree about which network the SDK is on.
+   */
+  private getConfiguredBitcoinNetwork(): 'mainnet' | 'regtest' | 'signet' | undefined {
+    if (this.config.network) return this.config.network;
+    if (this.config.webvhNetwork) return getBitcoinNetworkForWebVH(this.config.webvhNetwork);
+    return undefined;
+  }
+
   async migrateToDIDBTCO(didDoc: DIDDocument, satoshi: string): Promise<DIDDocument> {
     return this.track('did.migrateToDIDBTCO', async () => {
     // Validate satoshi parameter
@@ -237,14 +251,7 @@ export class DIDManager {
     // inscriptions (issue #247). The WebVH mapping (magby→regtest,
     // cleffa→signet, pichu→mainnet) applies only when no explicit Bitcoin
     // network was configured.
-    let network: 'mainnet' | 'regtest' | 'signet';
-    if (this.config.network) {
-      network = this.config.network;
-    } else if (this.config.webvhNetwork) {
-      network = getBitcoinNetworkForWebVH(this.config.webvhNetwork);
-    } else {
-      network = 'mainnet';
-    }
+    const network: 'mainnet' | 'regtest' | 'signet' = this.getConfiguredBitcoinNetwork() ?? 'mainnet';
 
     // Try to carry over the first multikey VM if present
     const firstVm = didDoc.verificationMethod?.[0];
@@ -325,17 +332,18 @@ export class DIDManager {
             const btcoNetworkPrefix = did.match(/^did:btco:(reg|sig|test):/)?.[1];
             // 'test' (testnet) has no OrdinalsClient/config counterpart;
             // preserve existing pass-through behavior for it.
-            if (btcoNetworkPrefix !== 'test') {
+            //
+            // Only reject when the SDK's network is actually known. If neither
+            // `network` nor `webvhNetwork` is configured, the provider's chain
+            // is genuinely unknown, so defaulting to mainnet and rejecting a
+            // reg/sig DID would be a false positive — fall through and let the
+            // provider answer (its own resolution still validates the DID).
+            const providerNetwork = this.getConfiguredBitcoinNetwork();
+            if (btcoNetworkPrefix !== 'test' && providerNetwork) {
               const didNetwork: 'mainnet' | 'regtest' | 'signet' =
                 btcoNetworkPrefix === 'reg' ? 'regtest'
                 : btcoNetworkPrefix === 'sig' ? 'signet'
                 : 'mainnet';
-              const providerNetwork: 'mainnet' | 'regtest' | 'signet' =
-                this.config.network
-                  ? this.config.network
-                  : this.config.webvhNetwork
-                    ? getBitcoinNetworkForWebVH(this.config.webvhNetwork)
-                    : 'mainnet';
               if (didNetwork !== providerNetwork) {
                 throw new StructuredError(
                   'BTCO_NETWORK_MISMATCH',

--- a/packages/sdk/src/did/DIDManager.ts
+++ b/packages/sdk/src/did/DIDManager.ts
@@ -317,6 +317,34 @@ export class DIDManager {
           }
         } else if (did.startsWith('did:btco:')) {
           if (this.config.ordinalsProvider) {
+            // The configured ordinalsProvider is pinned to one Bitcoin
+            // network, so a DID whose encoded network differs must be
+            // rejected before querying (issue #267): otherwise an attacker
+            // can inscribe "did:btco:reg:N" content on mainnet sat N and have
+            // it resolve — and be cached — as the regtest DID.
+            const btcoNetworkPrefix = did.match(/^did:btco:(reg|sig|test):/)?.[1];
+            // 'test' (testnet) has no OrdinalsClient/config counterpart;
+            // preserve existing pass-through behavior for it.
+            if (btcoNetworkPrefix !== 'test') {
+              const didNetwork: 'mainnet' | 'regtest' | 'signet' =
+                btcoNetworkPrefix === 'reg' ? 'regtest'
+                : btcoNetworkPrefix === 'sig' ? 'signet'
+                : 'mainnet';
+              const providerNetwork: 'mainnet' | 'regtest' | 'signet' =
+                this.config.network
+                  ? this.config.network
+                  : this.config.webvhNetwork
+                    ? getBitcoinNetworkForWebVH(this.config.webvhNetwork)
+                    : 'mainnet';
+              if (didNetwork !== providerNetwork) {
+                throw new StructuredError(
+                  'BTCO_NETWORK_MISMATCH',
+                  `Cannot resolve ${did}: the DID targets the ${didNetwork} network but the configured ` +
+                  `ordinalsProvider serves ${providerNetwork}. Configure an SDK instance for ${didNetwork} ` +
+                  'to resolve this DID.'
+                );
+              }
+            }
             // The configured ordinalsProvider is the source of truth for
             // Bitcoin state (it performed the inscriptions), so resolution
             // must go through it — not through a freshly constructed HTTP
@@ -384,7 +412,8 @@ export class DIDManager {
       } catch (err) {
         // Misconfiguration must fail loudly — swallowing it into a null would
         // reproduce the silent-failure mode this error exists to prevent.
-        if (err instanceof StructuredError && err.code === 'ORD_PROVIDER_REQUIRED') {
+        if (err instanceof StructuredError &&
+            (err.code === 'ORD_PROVIDER_REQUIRED' || err.code === 'BTCO_NETWORK_MISMATCH')) {
           throw err;
         }
         // DID resolution failed
@@ -583,7 +612,9 @@ export class DIDManager {
     verifier?: ExternalVerifier;
     outputDir?: string;
   }): Promise<{ didDocument: DIDDocument; log: DIDLog; logPath?: string }> {
-    return this.getWebVHManager().updateDIDWebVH(options);
+    const result = await this.getWebVHManager().updateDIDWebVH(options);
+    await this.invalidateCachedDID(options.did);
+    return result;
   }
 
   /**
@@ -593,7 +624,9 @@ export class DIDManager {
    * updateKey authorized for the next rotation.
    */
   async rotateDIDWebVHKeys(options: RotateWebVHKeysOptions): Promise<RotateWebVHKeysResult> {
-    return this.getWebVHManager().rotateDIDWebVHKeys(options);
+    const result = await this.getWebVHManager().rotateDIDWebVHKeys(options);
+    await this.invalidateCachedDID(options.did);
+    return result;
   }
 
   /**
@@ -602,7 +635,24 @@ export class DIDManager {
    * additionally emits a W3C KeyRecoveryCredential documenting the event.
    */
   async recoverDIDWebVH(options: RecoverWebVHOptions): Promise<RecoverWebVHResult> {
-    return this.getWebVHManager().recoverDIDWebVH(options);
+    const result = await this.getWebVHManager().recoverDIDWebVH(options);
+    await this.invalidateCachedDID(options.did);
+    return result;
+  }
+
+  /**
+   * Drop the cached document for a DID after a successful mutation
+   * (update/rotate/recover). Without this, resolveDID keeps serving the
+   * pre-mutation document — including a compromised key after recovery —
+   * for up to the cache TTL (issue #268). Best-effort: a failing cache
+   * backend must not fail the mutation that already succeeded.
+   */
+  private async invalidateCachedDID(did: string): Promise<void> {
+    try {
+      await this.cache.delete(did);
+    } catch {
+      // best-effort cache invalidation
+    }
   }
 
   /** Lazily instantiate the WebVHManager used for rotation/recovery primitives. */

--- a/packages/sdk/src/kinds/validators/base.ts
+++ b/packages/sdk/src/kinds/validators/base.ts
@@ -216,8 +216,11 @@ export abstract class BaseKindValidator<K extends OriginalKind> implements KindV
         if (!resource.contentType || !ValidationUtils.isValidMimeType(resource.contentType)) {
           errors.push(ValidationUtils.error('INVALID_CONTENT_TYPE', `Resource at index ${i} must have a valid MIME contentType`, `${resourcePath}.contentType`, resource.contentType));
         }
-        if (!resource.hash || typeof resource.hash !== 'string' || !/^[0-9a-fA-F]+$/.test(resource.hash)) {
-          errors.push(ValidationUtils.error('INVALID_RESOURCE_HASH', `Resource at index ${i} must have a valid hex hash`, `${resourcePath}.hash`));
+        // Resource hashes are SHA-256 digests: exactly 64 hex characters.
+        // Accepting any non-empty hex ("abc") let malformed manifests pass
+        // validation (issue #292).
+        if (!resource.hash || typeof resource.hash !== 'string' || !/^[0-9a-fA-F]{64}$/.test(resource.hash)) {
+          errors.push(ValidationUtils.error('INVALID_RESOURCE_HASH', `Resource at index ${i} must have a valid 64-character hex SHA-256 hash`, `${resourcePath}.hash`));
         }
       }
       

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -27,7 +27,7 @@ import {
   type BatchInscriptionOptions,
 } from './BatchOperations.js';
 import { BatchLifecycleOperations } from './BatchLifecycleOperations.js';
-import { validateAndNormalizeDomain } from './domainUtils.js';
+import { validateAndNormalizeDomain, tryValidateDomain, safeDecodeURIComponent } from './domainUtils.js';
 import { 
   type OriginalKind, 
   type OriginalManifest, 
@@ -637,15 +637,62 @@ export class LifecycleManager {
   }
 
   private parseWebVHDid(did: string): { domain: string; userPath: string } {
+    if (!did.startsWith('did:webvh:')) {
+      throw new StructuredError('INVALID_DID', 'Invalid did:webvh format: must start with did:webvh:');
+    }
     const parts = did.split(':');
     if (parts.length < 4) {
       throw new StructuredError('INVALID_DID', 'Invalid did:webvh format: must include domain and user path');
     }
-    
-    const domain = decodeURIComponent(parts[2]);
-    const userPath = parts.slice(3).join('/');
-    
-    return { domain, userPath };
+
+    // Two shapes reach this method and the domain lives in a different
+    // position in each:
+    //   - canonical resolved/migrated DID: did:webvh:{SCID}:{domain}[:paths]
+    //     (the SCID at parts[2] is a dotless multibase string, never a domain)
+    //   - the domain shorthand built by extractPublisherInfo:
+    //     did:webvh:{domain}:user
+    // Disambiguate by asking whether parts[2] is itself a valid domain: a real
+    // domain has a dot or is `localhost`, so it validates; a SCID does not.
+    // This keeps the storage layout aligned with WebVHManager.saveDIDLog
+    // (domain-first, SCID excluded), which the old parts[2]-is-domain
+    // assumption broke.
+    let domainIndex: number;
+    let normalizedDomain: string;
+    const decodedSegment2 = safeDecodeURIComponent(parts[2]);
+    const domainFromSegment2 = tryValidateDomain(decodedSegment2);
+    if (domainFromSegment2 !== null) {
+      domainIndex = 2;
+      normalizedDomain = domainFromSegment2;
+    } else {
+      // parts[2] is a SCID; the domain is the next segment.
+      normalizedDomain = validateAndNormalizeDomain(safeDecodeURIComponent(parts[3]));
+      domainIndex = 3;
+    }
+
+    // Every path segment after the domain feeds directly into storage keys
+    // (`${domain}/${userPath}/...`), so validate each the same way
+    // WebVHManager.saveDIDLog does (issue #274). Without this, a DID like
+    // did:webvh:{SCID}:example.com:..:..:x — or a segment that percent-decodes
+    // to `..` — lets path-hierarchy-backed storage adapters write outside
+    // their root.
+    const segments = parts.slice(domainIndex + 1);
+    for (const rawSegment of segments) {
+      const segment = safeDecodeURIComponent(rawSegment);
+      if (
+        rawSegment === '' ||
+        segment === '' ||
+        segment === '.' ||
+        segment === '..' ||
+        segment.includes('/') ||
+        segment.includes('\\') ||
+        segment.includes('\0')
+      ) {
+        throw new StructuredError('INVALID_DID', `Invalid did:webvh path segment: ${rawSegment}`);
+      }
+    }
+    const userPath = segments.join('/');
+
+    return { domain: normalizedDomain, userPath };
   }
 
   private async publishResources(

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -735,7 +735,12 @@ export class LifecycleManager {
       const hashBytes = hexToBytes(resource.hash);
       const multibase = encodeBase64UrlMultibase(hashBytes);
       const resourceUrl = `${publisherDid}/resources/${multibase}`;
-      const relativePath = `${userPath}/resources/${multibase}`;
+      // A canonical did:webvh with no user path (did:webvh:{SCID}:{domain})
+      // yields an empty userPath; omit it so the storage key is
+      // `${domain}/resources/...` rather than `${domain}//resources/...`.
+      const relativePath = userPath
+        ? `${userPath}/resources/${multibase}`
+        : `resources/${multibase}`;
 
       // Hash-only resources (content hosted elsewhere) cannot be published:
       // writing the hash string as the body would serve bytes that fail the

--- a/packages/sdk/src/lifecycle/OriginalsAsset.ts
+++ b/packages/sdk/src/lifecycle/OriginalsAsset.ts
@@ -5,6 +5,7 @@ import {
   LayerType 
 } from '../types/index.js';
 import { validateDIDDocument, validateCredential, hashResource } from '../utils/validation.js';
+import { StructuredError } from '../utils/telemetry.js';
 import { CredentialManager } from '../vc/CredentialManager.js';
 import { DIDManager } from '../did/DIDManager.js';
 import { ProvenanceQuery, Migration, Transfer } from './ProvenanceQuery.js';
@@ -385,11 +386,15 @@ export class OriginalsAsset {
    * Creates a new AssetResource with incremented version number and links it to the previous version.
    * 
    * @param resourceId - The logical resource ID
-   * @param newContent - The new content (string or Buffer)
+   * @param newContent - The new content. Must be a string: AssetResource can
+   *   only carry inline string content, so Buffer input is rejected rather
+   *   than silently reduced to a hash-only version (issue #276). For binary
+   *   resources, pass the content as a string in a text-safe encoding you
+   *   control, or manage the bytes externally and reference them by hash.
    * @param contentType - The content type
    * @param changes - Optional description of changes
    * @returns The newly created AssetResource
-   * @throws Error if content is unchanged or resource not found
+   * @throws Error if content is unchanged, resource not found, or newContent is a Buffer
    */
   addResourceVersion(
     resourceId: string,
@@ -397,6 +402,18 @@ export class OriginalsAsset {
     contentType: string,
     changes?: string
   ): AssetResource {
+    // AssetResource.content is a string; a Buffer used to be silently dropped
+    // (only its hash was stored), unrecoverably losing the binary content
+    // while the caller believed it was versioned (issue #276). Fail loudly
+    // instead.
+    if (typeof newContent !== 'string') {
+      throw new StructuredError(
+        'BINARY_CONTENT_UNSUPPORTED',
+        'addResourceVersion cannot store binary (Buffer) content inline: AssetResource.content is a string. ' +
+        'Encode the content as a string (e.g. base64) and handle decoding at publish time, ' +
+        'or host the bytes externally and reference them by hash.'
+      );
+    }
     // Find the current version of the resource by id
     const currentResources = this.resources.filter(r => r.id === resourceId);
     if (currentResources.length === 0) {
@@ -411,9 +428,7 @@ export class OriginalsAsset {
     })[0];
     
     // Compute new hash
-    const contentBuffer = typeof newContent === 'string' 
-      ? Buffer.from(newContent, 'utf-8')
-      : newContent;
+    const contentBuffer = Buffer.from(newContent, 'utf-8');
     const newHash = hashResource(contentBuffer);
     
     // Check if content has actually changed
@@ -426,7 +441,7 @@ export class OriginalsAsset {
     const newResource: AssetResource = {
       id: resourceId,
       type: currentResource.type,
-      content: typeof newContent === 'string' ? newContent : undefined,
+      content: newContent,
       contentType,
       hash: newHash,
       size: contentBuffer.length,

--- a/packages/sdk/src/lifecycle/domainUtils.ts
+++ b/packages/sdk/src/lifecycle/domainUtils.ts
@@ -47,7 +47,21 @@ export function validateAndNormalizeDomain(domain: string): string {
 
   // Allow localhost and IP addresses for development.
   const isLocalhost = domainPart === 'localhost';
+  // Anything shaped like a dotted quad must be a REAL IPv4 address: without
+  // the octet range check, 999.999.999.999 was accepted (and would otherwise
+  // also slip through the hostname regex below, which allows all-numeric
+  // labels), so junk did:webvh:999.999.999.999:user DIDs were constructible
+  // (issue #292).
   const isIP = /^(\d{1,3}\.){3}\d{1,3}$/.test(domainPart);
+  if (isIP) {
+    const octetsValid = domainPart.split('.').every(octet => parseInt(octet, 10) <= 255);
+    if (!octetsValid) {
+      throw new StructuredError(
+        'INVALID_DOMAIN',
+        `Invalid domain format: ${domain} - IPv4 octets must be in the range 0-255`
+      );
+    }
+  }
 
   if (!isLocalhost && !isIP) {
     const label = '[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?';
@@ -61,4 +75,30 @@ export function validateAndNormalizeDomain(domain: string): string {
   }
 
   return normalized;
+}
+
+/**
+ * Like {@link validateAndNormalizeDomain} but returns `null` instead of
+ * throwing when the input is not a valid domain. Useful when a caller needs to
+ * probe whether a string is a domain (e.g. disambiguating a did:webvh segment
+ * that could be either a domain or a SCID).
+ */
+export function tryValidateDomain(domain: string): string | null {
+  try {
+    return validateAndNormalizeDomain(domain);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Decode a percent-encoded URI component, throwing a StructuredError with a
+ * clear code on malformed input rather than a bare URIError.
+ */
+export function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    throw new StructuredError('INVALID_DID', `Malformed percent-encoding in DID segment: ${value}`);
+  }
 }

--- a/packages/sdk/src/migration/MigrationManager.ts
+++ b/packages/sdk/src/migration/MigrationManager.ts
@@ -26,6 +26,7 @@ import { PeerToWebvhMigration } from './operations/PeerToWebvhMigration.js';
 import { WebvhToBtcoMigration } from './operations/WebvhToBtcoMigration.js';
 import { PeerToBtcoMigration } from './operations/PeerToBtcoMigration.js';
 import { EventEmitter } from '../events/EventEmitter.js';
+import type { EventHandler, EventTypeMap } from '../events/types.js';
 
 export class MigrationManager {
   private static instance: MigrationManager | null = null;
@@ -101,8 +102,32 @@ export class MigrationManager {
         throw new Error('Configuration and managers required for first initialization');
       }
       MigrationManager.instance = new MigrationManager(config, didManager, credentialManager, bitcoinManager);
+      return MigrationManager.instance;
     }
-    return MigrationManager.instance;
+
+    // Already initialized: passing DIFFERENT dependencies must fail loudly.
+    // Silently returning the old instance discarded a newly supplied
+    // bitcoinManager (every btco migration then throws "Bitcoin manager
+    // required") or kept a different network's config for the process
+    // lifetime (issue #280). Same-reference calls remain idempotent; call
+    // resetInstance() first to deliberately reconfigure.
+    const instance = MigrationManager.instance;
+    const mismatches: string[] = [];
+    if (config !== undefined && config !== instance.config) mismatches.push('config');
+    if (didManager !== undefined && didManager !== instance.didManager) mismatches.push('didManager');
+    if (credentialManager !== undefined && credentialManager !== instance.credentialManager) {
+      mismatches.push('credentialManager');
+    }
+    if (bitcoinManager !== undefined && bitcoinManager !== instance.bitcoinManager) {
+      mismatches.push('bitcoinManager');
+    }
+    if (mismatches.length > 0) {
+      throw new Error(
+        `MigrationManager is already initialized with different dependencies (${mismatches.join(', ')}); ` +
+        'the new values would be silently ignored. Call MigrationManager.resetInstance() first to reconfigure.'
+      );
+    }
+    return instance;
   }
 
   /**
@@ -110,6 +135,39 @@ export class MigrationManager {
    */
   static resetInstance(): void {
     MigrationManager.instance = null;
+  }
+
+  /**
+   * Subscribe to migration events (migration:started, migration:completed,
+   * migration:failed, migration:quarantine, ...).
+   *
+   * The internal emitter used to be completely inaccessible, so every emitted
+   * event — including migration:quarantine, which by definition means "manual
+   * intervention required" — was dispatched into the void (issue #282).
+   *
+   * @returns An unsubscribe function
+   */
+  on<K extends keyof EventTypeMap>(
+    eventType: K,
+    handler: EventHandler<EventTypeMap[K]>
+  ): () => void {
+    return this.eventEmitter.on(eventType, handler);
+  }
+
+  /** Subscribe to a migration event for a single emission. */
+  once<K extends keyof EventTypeMap>(
+    eventType: K,
+    handler: EventHandler<EventTypeMap[K]>
+  ): () => void {
+    return this.eventEmitter.once(eventType, handler);
+  }
+
+  /** Unsubscribe a handler registered with on()/once(). */
+  off<K extends keyof EventTypeMap>(
+    eventType: K,
+    handler: EventHandler<EventTypeMap[K]>
+  ): void {
+    this.eventEmitter.off(eventType, handler);
   }
 
   /**

--- a/packages/sdk/src/migration/audit/AuditLogger.ts
+++ b/packages/sdk/src/migration/audit/AuditLogger.ts
@@ -38,15 +38,17 @@ export class AuditLogger implements IAuditLogger {
     const signature = await this.signAuditRecord(record);
     const signedRecord = { ...record, signature };
 
-    // Store by source DID
+    // Store an independent deep copy per DID key. Sharing one mutable object
+    // between the sourceDid and targetDid entries meant tampering via one
+    // DID's history silently altered the other's (issue #281).
     const existingRecords = this.auditRecords.get(record.sourceDid) || [];
-    existingRecords.push(signedRecord);
+    existingRecords.push(structuredClone(signedRecord));
     this.auditRecords.set(record.sourceDid, existingRecords);
 
     // Also store by target DID if available
     if (record.targetDid) {
       const targetRecords = this.auditRecords.get(record.targetDid) || [];
-      targetRecords.push(signedRecord);
+      targetRecords.push(structuredClone(signedRecord));
       this.auditRecords.set(record.targetDid, targetRecords);
     }
 
@@ -55,11 +57,16 @@ export class AuditLogger implements IAuditLogger {
   }
 
   /**
-   * Get migration history for a DID
+   * Get migration history for a DID.
+   *
+   * Returns deep copies: handing out the live internal array/objects let any
+   * caller pop records or rewrite finalState/targetDid in place, corrupting
+   * the "append-only" log for every future reader (issue #281).
    */
   // eslint-disable-next-line @typescript-eslint/require-await
   async getMigrationHistory(did: string): Promise<MigrationAuditRecord[]> {
-    return this.auditRecords.get(did) || [];
+    const records = this.auditRecords.get(did) || [];
+    return records.map(record => structuredClone(record));
   }
 
   /**
@@ -77,7 +84,8 @@ export class AuditLogger implements IAuditLogger {
         const dedupKey = record.signature || `${record.migrationId}-${record.timestamp}-${record.finalState}`;
         if (!seen.has(dedupKey)) {
           seen.add(dedupKey);
-          allRecords.push(record);
+          // Deep copy for the same reason as getMigrationHistory (issue #281).
+          allRecords.push(structuredClone(record));
         }
       }
     }

--- a/packages/sdk/src/resources/ResourceManager.ts
+++ b/packages/sdk/src/resources/ResourceManager.ts
@@ -219,10 +219,20 @@ export class ResourceManager {
 
     // Determine content type (use provided or inherit from previous)
     const contentType = options?.contentType || currentVersion.contentType;
-    
+
     // Validate new content type if changed
     if (options?.contentType && !this.isValidMimeType(options.contentType)) {
       throw new Error(`Invalid MIME type format: ${options.contentType}`);
+    }
+
+    // Enforce the same allowedContentTypes allowlist as createResource; only
+    // checking the MIME *format* here let updateResource smuggle in content
+    // types the manager was configured to reject, producing versions its own
+    // validateResource then flags invalid (issue #292).
+    if (options?.contentType &&
+        this.config.allowedContentTypes.length > 0 &&
+        !this.config.allowedContentTypes.includes(options.contentType)) {
+      throw new Error(`Content type not allowed: ${options.contentType}. Allowed types: ${this.config.allowedContentTypes.join(', ')}`);
     }
 
     // Create new version
@@ -576,14 +586,20 @@ export class ResourceManager {
       this.resources.set(resourceId, versions);
     }
 
-    // Check if this version already exists (by hash)
-    const existingVersion = versions.find(v => v.hash === assetResource.hash);
+    // Check if this exact version already exists. Dedup must compare
+    // (version, hash) — not hash alone — because a legitimate history can
+    // revert content to an earlier state (v1=A, v2=B, v3=A). Hash-only dedup
+    // silently discarded such reverted versions on the export/import
+    // round-trip, breaking the version chain (issue #275).
+    const version = assetResource.version || 1;
+    const existingVersion = versions.find(
+      v => v.hash === assetResource.hash && (v.version || 1) === version
+    );
     if (existingVersion) {
       return existingVersion;
     }
 
     // Add to version array (maintain order by version number)
-    const version = assetResource.version || 1;
     const insertIndex = versions.findIndex(v => (v.version || 1) > version);
     if (insertIndex === -1) {
       versions.push(assetResource);

--- a/packages/sdk/src/utils/MetricsCollector.ts
+++ b/packages/sdk/src/utils/MetricsCollector.ts
@@ -304,6 +304,14 @@ export class MetricsCollector {
     const escapeLabelValue = (value: string): string =>
       value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
 
+    // `# HELP` text uses a narrower escape set than label values (backslash and
+    // newline only — quotes are literal in HELP), but it must still be escaped:
+    // an operation name containing a newline would otherwise split the HELP
+    // line and corrupt the whole exposition (same failure class as the label
+    // values above).
+    const escapeHelpText = (value: string): string =>
+      value.replace(/\\/g, '\\\\').replace(/\n/g, '\\n');
+
     // Asset metrics
     lines.push('# HELP originals_assets_created_total Total number of assets created');
     lines.push('# TYPE originals_assets_created_total counter');
@@ -365,13 +373,14 @@ export class MetricsCollector {
 
     for (const [operation, opMetrics] of Object.entries(metrics.operationTimes)) {
       const safeOpName = safeNameFor.get(operation)!;
+      const helpOp = escapeHelpText(operation);
 
-      lines.push(`# HELP originals_operation_${safeOpName}_total Total number of ${operation} operations`);
+      lines.push(`# HELP originals_operation_${safeOpName}_total Total number of ${helpOp} operations`);
       lines.push(`# TYPE originals_operation_${safeOpName}_total counter`);
       lines.push(`originals_operation_${safeOpName}_total ${opMetrics.count}`);
       lines.push('');
 
-      lines.push(`# HELP originals_operation_${safeOpName}_duration_milliseconds Duration of ${operation} operations`);
+      lines.push(`# HELP originals_operation_${safeOpName}_duration_milliseconds Duration of ${helpOp} operations`);
       lines.push(`# TYPE originals_operation_${safeOpName}_duration_milliseconds summary`);
       lines.push(`originals_operation_${safeOpName}_duration_milliseconds{quantile="0.0"} ${opMetrics.minTime}`);
       lines.push(`originals_operation_${safeOpName}_duration_milliseconds{quantile="0.5"} ${opMetrics.avgTime}`);
@@ -380,7 +389,7 @@ export class MetricsCollector {
       lines.push(`originals_operation_${safeOpName}_duration_milliseconds_count ${opMetrics.count}`);
       lines.push('');
 
-      lines.push(`# HELP originals_operation_${safeOpName}_errors_total Total number of errors in ${operation} operations`);
+      lines.push(`# HELP originals_operation_${safeOpName}_errors_total Total number of errors in ${helpOp} operations`);
       lines.push(`# TYPE originals_operation_${safeOpName}_errors_total counter`);
       lines.push(`originals_operation_${safeOpName}_errors_total ${opMetrics.errorCount}`);
       lines.push('');

--- a/packages/sdk/src/utils/MetricsCollector.ts
+++ b/packages/sdk/src/utils/MetricsCollector.ts
@@ -296,7 +296,14 @@ export class MetricsCollector {
   private exportPrometheus(): string {
     const lines: string[] = [];
     const metrics = this.getMetrics();
-    
+
+    // Prometheus exposition-format label escaping. Every interpolated label
+    // value (operation names, error codes, migration layers) must go through
+    // this — an unescaped `"`, `\`, or newline yields malformed output that
+    // breaks the whole scrape (issue #292).
+    const escapeLabelValue = (value: string): string =>
+      value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
+
     // Asset metrics
     lines.push('# HELP originals_assets_created_total Total number of assets created');
     lines.push('# TYPE originals_assets_created_total counter');
@@ -313,7 +320,7 @@ export class MetricsCollector {
     lines.push('# TYPE originals_assets_migrated_total counter');
     for (const [transition, count] of Object.entries(metrics.assetsMigrated)) {
       const [from, to] = transition.split('→');
-      lines.push(`originals_assets_migrated_total{from="${from}",to="${to}"} ${count}`);
+      lines.push(`originals_assets_migrated_total{from="${escapeLabelValue(from)}",to="${escapeLabelValue(to)}"} ${count}`);
     }
     lines.push('');
     
@@ -321,8 +328,7 @@ export class MetricsCollector {
     lines.push('# HELP originals_operation_total Total number of operations by name');
     lines.push('# TYPE originals_operation_total counter');
     for (const [operation, opMetrics] of Object.entries(metrics.operationTimes)) {
-      const escaped = operation.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
-      lines.push(`originals_operation_total{operation="${escaped}"} ${opMetrics.count}`);
+      lines.push(`originals_operation_total{operation="${escapeLabelValue(operation)}"} ${opMetrics.count}`);
     }
     lines.push('');
 
@@ -384,7 +390,7 @@ export class MetricsCollector {
     lines.push('# HELP originals_errors_total Total number of errors by code');
     lines.push('# TYPE originals_errors_total counter');
     for (const [code, count] of Object.entries(metrics.errors)) {
-      lines.push(`originals_errors_total{code="${code}"} ${count}`);
+      lines.push(`originals_errors_total{code="${escapeLabelValue(code)}"} ${count}`);
     }
     lines.push('');
     

--- a/packages/sdk/src/utils/satoshi-validation.ts
+++ b/packages/sdk/src/utils/satoshi-validation.ts
@@ -1,10 +1,13 @@
 import { StructuredError } from './telemetry.js';
 
 /**
- * Maximum number of satoshis in Bitcoin's total supply (21 million BTC)
- * 21,000,000 BTC * 100,000,000 satoshis/BTC = 2,100,000,000,000,000 satoshis
+ * The highest ordinal number a satoshi can have. Because of block-reward
+ * rounding at each halving, total supply never reaches the nominal 21M BTC
+ * (2,100,000,000,000,000 sats); the last satoshi ever mined is ordinal
+ * 2,099,999,997,689,999. Using the nominal figure over-accepted ~2.3M
+ * non-existent sat numbers (issue #292).
  */
-export const MAX_SATOSHI_SUPPLY = 2_100_000_000_000_000;
+export const MAX_SATOSHI_SUPPLY = 2_099_999_997_689_999;
 
 /**
  * Validation result interface for satoshi number validation
@@ -114,7 +117,7 @@ export function canonicalizeSatoshi(satoshi: string | number): string {
     throw new StructuredError('INVALID_SATOSHI', result.error || 'Invalid satoshi identifier');
   }
   // Safe: validateSatoshiNumber guarantees an all-digits string within
-  // MAX_SATOSHI_SUPPLY (2.1e15), which is below Number.MAX_SAFE_INTEGER, so the
+  // MAX_SATOSHI_SUPPLY (~2.1e15), which is below Number.MAX_SAFE_INTEGER, so the
   // round-trip through Number is exact and simply strips whitespace/leading zeros.
   return String(Number(String(satoshi).trim()));
 }

--- a/packages/sdk/src/vc/MultiSigManager.ts
+++ b/packages/sdk/src/vc/MultiSigManager.ts
@@ -439,6 +439,22 @@ export class MultiSigManager {
       throw new Error(`Contribution from ${vm} has an invalid proof and was rejected`);
     }
 
+    // Re-check the invariants that were validated before the `await` above.
+    // Because this method is now async, the duplicate-signer check and the
+    // push are no longer atomic: a concurrently-interleaved addContribution()
+    // for the same signer could have run its check (also seeing no duplicate)
+    // and pushed while we awaited verifyProof. Without this re-check both
+    // would push, letting one physical key count twice toward the m-of-n
+    // threshold. Re-validate against the now-current session state.
+    // Cast: TS narrows session.status to the pre-await value, but a concurrent
+    // finalizeSession() may have moved it to 'finalized' during the await.
+    if ((session.status as MultiSigSession['status']) === 'finalized') {
+      throw new Error(`MultiSig session ${sessionId} has already been finalized`);
+    }
+    if (session.contributions.some(c => c.proof.verificationMethod === vm)) {
+      throw new Error(`Signer ${vm} has already contributed to this session`);
+    }
+
     session.contributions.push(contribution);
 
     // Check if threshold is met

--- a/packages/sdk/src/vc/MultiSigManager.ts
+++ b/packages/sdk/src/vc/MultiSigManager.ts
@@ -387,7 +387,7 @@ export class MultiSigManager {
    * @param contribution - The signature contribution
    * @returns Updated session status
    */
-  addContribution(sessionId: string, contribution: SignatureContribution): MultiSigSession {
+  async addContribution(sessionId: string, contribution: SignatureContribution): Promise<MultiSigSession> {
     const session = this.sessions.get(sessionId);
     if (!session) {
       throw new Error(`MultiSig session ${sessionId} not found`);
@@ -418,6 +418,25 @@ export class MultiSigManager {
     );
     if (existingContribution) {
       throw new Error(`Signer ${vm} has already contributed to this session`);
+    }
+
+    // Verify the contribution actually signs the session document before it
+    // counts toward the threshold (issue #287). Accepting unverified proofs
+    // let a garbage contribution drive the session to a false "finalized"
+    // state — and, because the duplicate check above keys on the signer,
+    // permanently blocked that signer's corrected resubmission. Rejecting
+    // here (before pushing) keeps the slot free for a valid retry.
+    if (!this.didManager) {
+      throw new Error(
+        'Cannot verify contribution: MultiSigManager requires a DIDManager to verify session contributions'
+      );
+    }
+    const proofValid = await this.verifyProof(
+      session.document as unknown as VerifiableCredential,
+      contribution.proof
+    );
+    if (!proofValid) {
+      throw new Error(`Contribution from ${vm} has an invalid proof and was rejected`);
     }
 
     session.contributions.push(contribution);

--- a/packages/sdk/tests/security/bitcoin-penetration-tests.test.ts
+++ b/packages/sdk/tests/security/bitcoin-penetration-tests.test.ts
@@ -271,7 +271,7 @@ describe('Bitcoin Penetration Tests - Security Audit', () => {
     });
 
     it('should handle maximum valid satoshi', () => {
-      const maxValidSatoshi = '2100000000000000'; // Exactly 21M BTC
+      const maxValidSatoshi = '2099999997689999'; // The last satoshi ordinal ever mined
 
       const result = validateSatoshiNumber(maxValidSatoshi);
       expect(result.valid).toBe(true);
@@ -523,7 +523,7 @@ describe('Bitcoin Penetration Tests - Security Audit', () => {
     });
 
     it('should handle maximum valid satoshi number', () => {
-      const maxSatoshi = '2100000000000000';
+      const maxSatoshi = '2099999997689999';
       const result = validateSatoshiNumber(maxSatoshi);
       expect(result.valid).toBe(true);
 

--- a/packages/sdk/tests/security/multi-issue-review-regressions.test.ts
+++ b/packages/sdk/tests/security/multi-issue-review-regressions.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Regression tests for the multi-issue review sweep. Per CLAUDE.md,
+ * security-sensitive code requires coverage under tests/security/ — these
+ * exercise each fix from the attacker's / failure side. Broader behavioral
+ * coverage lives in the unit suites.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { DIDCache } from '../../src/did/DIDCache';
+import { MultiSigManager } from '../../src/vc/MultiSigManager';
+import { DIDManager } from '../../src/did/DIDManager';
+import { KeyManager } from '../../src/did/KeyManager';
+import { AuditLogger } from '../../src/migration/audit/AuditLogger';
+import { validateAndNormalizeDomain } from '../../src/lifecycle/domainUtils';
+import { validateSatoshiNumber, MAX_SATOSHI_SUPPLY } from '../../src/utils/satoshi-validation';
+import { MetricsCollector } from '../../src/utils/MetricsCollector';
+import type { DIDDocument } from '../../src/types';
+import type { MultiSigPolicy, OriginalsConfig, VerifiableCredential } from '../../src/types';
+import { MigrationStateEnum } from '../../src/migration/types';
+
+describe('DID cache returns copies, not internal references (issue #291)', () => {
+  test('mutating a resolved document does not poison the cache', async () => {
+    const cache = new DIDCache();
+    const doc: DIDDocument = {
+      '@context': ['https://www.w3.org/ns/did/v1'],
+      id: 'did:webvh:example.com:alice',
+      verificationMethod: [{ id: '#k1', type: 'Multikey', controller: 'did:webvh:example.com:alice', publicKeyMultibase: 'zABC' }],
+    } as unknown as DIDDocument;
+
+    await cache.set('did:webvh:example.com:alice', doc);
+
+    const first = await cache.get('did:webvh:example.com:alice');
+    expect(first).not.toBeNull();
+    // Attacker/caller mutates the object handed back by resolveDID.
+    (first as unknown as { id: string }).id = 'did:webvh:evil.example:mallory';
+    (first!.verificationMethod as unknown[]).length = 0;
+
+    const second = await cache.get('did:webvh:example.com:alice');
+    expect(second!.id).toBe('did:webvh:example.com:alice');
+    expect((second!.verificationMethod as unknown[]).length).toBe(1);
+  });
+
+  test('mutating the object passed to set() does not alter the cached copy', async () => {
+    const cache = new DIDCache();
+    const doc: DIDDocument = {
+      '@context': ['https://www.w3.org/ns/did/v1'],
+      id: 'did:peer:123',
+    } as unknown as DIDDocument;
+    await cache.set('did:peer:123', doc);
+    (doc as unknown as { id: string }).id = 'did:peer:tampered';
+
+    const cached = await cache.get('did:peer:123');
+    expect(cached!.id).toBe('did:peer:123');
+  });
+});
+
+describe('Multi-sig sessions reject unverified contributions (issue #287)', () => {
+  const config: OriginalsConfig = { network: 'regtest', defaultKeyType: 'Ed25519' };
+  const baseVC: VerifiableCredential = {
+    '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
+    type: ['VerifiableCredential'],
+    issuer: 'did:peer:issuer',
+    issuanceDate: new Date().toISOString(),
+    credentialSubject: { id: 'did:peer:subject' },
+  } as unknown as VerifiableCredential;
+
+  test('a garbage proof is rejected and does not consume the signer slot', async () => {
+    const km = new KeyManager();
+    const keys = await Promise.all([km.generateKeyPair('Ed25519'), km.generateKeyPair('Ed25519')]);
+    const vms = keys.map(k => `did:key:${k.publicKey}#${k.publicKey}`);
+    const mgr = new MultiSigManager(config, new DIDManager(config));
+
+    const policy: MultiSigPolicy = { required: 1, total: 2, signerVerificationMethods: vms };
+    const session = mgr.createSession(baseVC, policy);
+
+    // A well-formed contribution shape whose proofValue is garbage.
+    const garbage = {
+      proof: {
+        type: 'DataIntegrityProof',
+        cryptosuite: 'eddsa-rdfc-2022',
+        proofPurpose: 'assertionMethod',
+        verificationMethod: vms[0],
+        proofValue: 'z' + 'A'.repeat(80),
+      },
+      signerIndex: 0,
+      signedAt: new Date().toISOString(),
+    } as never;
+
+    await expect(mgr.addContribution(session.id, garbage)).rejects.toThrow(/invalid proof/i);
+    // The garbage never landed, so the session is not falsely finalized...
+    expect(mgr.getSession(session.id)!.contributions.length).toBe(0);
+
+    // ...and the same signer can still submit a genuine contribution.
+    const good = await mgr.createContribution(session.id, keys[0].privateKey, vms[0]);
+    const updated = await mgr.addContribution(session.id, good);
+    expect(updated.contributions.length).toBe(1);
+    expect(updated.status).toBe('threshold_met');
+  });
+});
+
+describe('Migration audit log is tamper-resistant (issue #281)', () => {
+  const config = { network: 'regtest' } as unknown as OriginalsConfig;
+
+  const makeRecord = (sourceDid: string, targetDid: string) => ({
+    migrationId: 'mig-1',
+    timestamp: 1_700_000_000_000,
+    initiator: 'tester',
+    sourceDid,
+    sourceLayer: 'peer' as const,
+    targetDid,
+    targetLayer: 'webvh' as const,
+    finalState: MigrationStateEnum.COMPLETED,
+    validationResults: { valid: true, errors: [] } as never,
+    costActual: {} as never,
+    duration: 5,
+    errors: [],
+    metadata: {},
+  });
+
+  test('getMigrationHistory returns copies; caller mutation cannot corrupt the log', async () => {
+    const logger = new AuditLogger(config);
+    await logger.logMigration(makeRecord('did:peer:src', 'did:webvh:example.com:dst') as never);
+
+    const history = await logger.getMigrationHistory('did:peer:src');
+    expect(history.length).toBe(1);
+    // Tamper with the returned records.
+    history.pop();
+    const again = await logger.getMigrationHistory('did:peer:src');
+    expect(again.length).toBe(1);
+
+    again[0].finalState = MigrationStateEnum.FAILED;
+    const third = await logger.getMigrationHistory('did:peer:src');
+    expect(third[0].finalState).toBe(MigrationStateEnum.COMPLETED);
+  });
+
+  test('records are not shared between the source and target DID histories', async () => {
+    const logger = new AuditLogger(config);
+    await logger.logMigration(makeRecord('did:peer:src', 'did:webvh:example.com:dst') as never);
+
+    const srcHistory = await logger.getMigrationHistory('did:peer:src');
+    srcHistory[0].targetDid = 'did:webvh:evil:pwned';
+
+    const dstHistory = await logger.getMigrationHistory('did:webvh:example.com:dst');
+    expect(dstHistory[0].targetDid).toBe('did:webvh:example.com:dst');
+  });
+});
+
+describe('Domain validation rejects malformed IPv4 (issue #292)', () => {
+  test('out-of-range octets are rejected', () => {
+    expect(() => validateAndNormalizeDomain('999.999.999.999')).toThrow(/0-255|Invalid domain/);
+    expect(() => validateAndNormalizeDomain('256.1.1.1')).toThrow(/0-255|Invalid domain/);
+  });
+
+  test('valid IPv4 and hostnames still pass', () => {
+    expect(validateAndNormalizeDomain('192.168.1.1')).toBe('192.168.1.1');
+    expect(validateAndNormalizeDomain('example.com')).toBe('example.com');
+    expect(validateAndNormalizeDomain('localhost')).toBe('localhost');
+  });
+});
+
+describe('Satoshi upper bound excludes non-existent ordinals (issue #292)', () => {
+  test('the nominal 21M-BTC figure is now rejected', () => {
+    expect(MAX_SATOSHI_SUPPLY).toBe(2_099_999_997_689_999);
+    expect(validateSatoshiNumber('2100000000000000').valid).toBe(false);
+  });
+
+  test('the true last ordinal is accepted', () => {
+    expect(validateSatoshiNumber('2099999997689999').valid).toBe(true);
+  });
+});
+
+describe('publishToWeb rejects path-traversal in did:webvh (issue #274)', () => {
+  test('a did:webvh whose path segments contain ".." is rejected', async () => {
+    const { OriginalsSDK } = await import('../../src');
+    const { MemoryStorageAdapter } = await import('../../src/storage/MemoryStorageAdapter');
+    const sdk = OriginalsSDK.create({ storageAdapter: new MemoryStorageAdapter(), network: 'regtest' });
+    const asset = await sdk.lifecycle.createAsset([
+      { id: 'r1', type: 'text', content: 'hello', contentType: 'text/plain', hash: 'a'.repeat(64) },
+    ]);
+
+    // A crafted SCID-form DID with traversal segments after the domain.
+    const malicious = 'did:webvh:QmSCIDplaceholderplaceholderplaceholder:example.com:..:..:etc';
+    await expect(sdk.lifecycle.publishToWeb(asset, malicious)).rejects.toThrow(/path segment|Invalid did:webvh/i);
+  });
+
+  test('a domain that percent-decodes to a traversal path is rejected', async () => {
+    const { OriginalsSDK } = await import('../../src');
+    const { MemoryStorageAdapter } = await import('../../src/storage/MemoryStorageAdapter');
+    const sdk = OriginalsSDK.create({ storageAdapter: new MemoryStorageAdapter(), network: 'regtest' });
+    const asset = await sdk.lifecycle.createAsset([
+      { id: 'r1', type: 'text', content: 'hello', contentType: 'text/plain', hash: 'a'.repeat(64) },
+    ]);
+
+    // did:webvh:{SCID}:{domain} where the domain decodes to '../../etc'.
+    const malicious = 'did:webvh:QmSCIDplaceholderplaceholderplaceholder:..%2F..%2Fetc';
+    await expect(sdk.lifecycle.publishToWeb(asset, malicious)).rejects.toThrow(/Invalid domain|Invalid did:webvh/i);
+  });
+});
+
+describe('did:btco resolution rejects cross-network DIDs (issue #267)', () => {
+  test('a regtest DID resolved against a mainnet provider is rejected before querying', async () => {
+    const { OrdMockProvider } = await import('../../src/adapters/providers/OrdMockProvider');
+    const provider = new OrdMockProvider();
+    const dm = new DIDManager({ network: 'mainnet', ordinalsProvider: provider } as unknown as OriginalsConfig);
+
+    await expect(dm.resolveDID('did:btco:reg:12345')).rejects.toThrow(/network/i);
+  });
+
+  test('a matching-network DID is not rejected by the cross-network guard', async () => {
+    const { OrdMockProvider } = await import('../../src/adapters/providers/OrdMockProvider');
+    const provider = new OrdMockProvider();
+    const dm = new DIDManager({ network: 'regtest', ordinalsProvider: provider } as unknown as OriginalsConfig);
+
+    // No inscription exists, so this resolves to null — but it must NOT throw a
+    // network-mismatch error (the guard should pass for a regtest DID on a
+    // regtest-configured SDK).
+    const doc = await dm.resolveDID('did:btco:reg:12345');
+    expect(doc).toBeNull();
+  });
+});
+
+describe('Prometheus label values are escaped (issue #292)', () => {
+  test('an error code containing a quote/backslash/newline cannot break exposition', () => {
+    const metrics = new MetricsCollector();
+    metrics.recordError('bad"code\\with\nnewline');
+    const out = metrics.export('prometheus');
+    const line = out.split('\n').find(l => l.startsWith('originals_errors_total{'));
+    expect(line).toBeDefined();
+    // The raw control/quote characters must not appear unescaped in the label.
+    expect(line).toContain('code="bad\\"code\\\\with\\nnewline"');
+    expect(line).not.toContain('\n' + 'newline');
+  });
+});

--- a/packages/sdk/tests/security/multi-issue-review-regressions.test.ts
+++ b/packages/sdk/tests/security/multi-issue-review-regressions.test.ts
@@ -96,6 +96,32 @@ describe('Multi-sig sessions reject unverified contributions (issue #287)', () =
     expect(updated.contributions.length).toBe(1);
     expect(updated.status).toBe('threshold_met');
   });
+
+  test('concurrent contributions from the same signer cannot both land (TOCTOU)', async () => {
+    const km = new KeyManager();
+    const keys = await Promise.all([km.generateKeyPair('Ed25519'), km.generateKeyPair('Ed25519')]);
+    const vms = keys.map(k => `did:key:${k.publicKey}#${k.publicKey}`);
+    const mgr = new MultiSigManager(config, new DIDManager(config));
+
+    const policy: MultiSigPolicy = { required: 2, total: 2, signerVerificationMethods: vms };
+    const session = mgr.createSession(baseVC, policy);
+
+    // Two valid contributions from the SAME signer, submitted concurrently.
+    // The async verify step opens a window between the duplicate check and the
+    // push; the re-check must ensure only one survives so a single key cannot
+    // count twice toward the threshold.
+    const c1 = await mgr.createContribution(session.id, keys[0].privateKey, vms[0]);
+    const c2 = await mgr.createContribution(session.id, keys[0].privateKey, vms[0]);
+
+    const results = await Promise.allSettled([
+      mgr.addContribution(session.id, c1),
+      mgr.addContribution(session.id, c2),
+    ]);
+    const fulfilled = results.filter(r => r.status === 'fulfilled').length;
+    expect(fulfilled).toBe(1);
+    expect(mgr.getSession(session.id)!.contributions.length).toBe(1);
+    expect(mgr.getSession(session.id)!.status).toBe('collecting');
+  });
 });
 
 describe('Migration audit log is tamper-resistant (issue #281)', () => {
@@ -229,5 +255,20 @@ describe('Prometheus label values are escaped (issue #292)', () => {
     // The raw control/quote characters must not appear unescaped in the label.
     expect(line).toContain('code="bad\\"code\\\\with\\nnewline"');
     expect(line).not.toContain('\n' + 'newline');
+  });
+
+  test('an operation name with a newline does not split the # HELP line', () => {
+    const metrics = new MetricsCollector();
+    metrics.recordOperation('op\ninjected', 5, true);
+    const out = metrics.export('prometheus');
+    // The per-operation HELP lines must carry the escaped name on one physical
+    // line (raw newline replaced with the literal \n escape).
+    const perOpHelp = out.split('\n').filter(l => l.startsWith('# HELP originals_operation_op_injected'));
+    expect(perOpHelp.length).toBeGreaterThan(0);
+    for (const line of perOpHelp) {
+      expect(line).toContain('op\\ninjected');
+    }
+    // The injected fragment must not appear as its own stray line.
+    expect(out.split('\n').some(l => l === 'injected operations')).toBe(false);
   });
 });

--- a/packages/sdk/tests/unit/bitcoin/BroadcastClient.test.ts
+++ b/packages/sdk/tests/unit/bitcoin/BroadcastClient.test.ts
@@ -48,5 +48,37 @@ describe('BroadcastClient', () => {
     const res = await bc.broadcastAndConfirm('hex');
     expect(res).toEqual({ txid: 'txid-5', confirmations: 1 });
   });
+
+  test('broadcastAndConfirm never loses the txid when status polling throws (issue #271)', async () => {
+    // The tx broadcast succeeds; every status poll then fails transiently.
+    // The method must still resolve with the txid so the caller does NOT treat
+    // the operation as failed and rebroadcast a second commit over the same
+    // UTXOs (a double-spend / fund-loss race).
+    const broadcaster = mock(async (_: string) => 'txid-broadcast');
+    let polls = 0;
+    const status = mock(async (_: string) => {
+      polls++;
+      throw new Error('status endpoint 500');
+    });
+    const bc = new BroadcastClient(broadcaster, status);
+    const res = await bc.broadcastAndConfirm('hex', { pollIntervalMs: 1, maxAttempts: 3 });
+    expect(res.txid).toBe('txid-broadcast');
+    expect(res.confirmations).toBe(0);
+    expect(polls).toBe(3); // a throwing poll counts as an unconfirmed attempt
+    expect(broadcaster).toHaveBeenCalledTimes(1); // broadcast is never retried
+  });
+
+  test('broadcastAndConfirm confirms once the status endpoint recovers (issue #271)', async () => {
+    const broadcaster = mock(async (_: string) => 'txid-recover');
+    let polls = 0;
+    const status = mock(async (_: string) => {
+      polls++;
+      if (polls < 2) throw new Error('transient failure');
+      return { confirmed: true, confirmations: 4 };
+    });
+    const bc = new BroadcastClient(broadcaster, status);
+    const res = await bc.broadcastAndConfirm('hex', { pollIntervalMs: 1, maxAttempts: 5 });
+    expect(res).toEqual({ txid: 'txid-recover', confirmations: 4 });
+  });
 });
 

--- a/packages/sdk/tests/unit/bitcoin/SignetProvider.broadcast.test.ts
+++ b/packages/sdk/tests/unit/bitcoin/SignetProvider.broadcast.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Regression tests for SignetProvider.broadcastTransaction hardening (issue #272):
+ * non-hex input rejection, HTTP-error handling, empty-result rejection, and
+ * optional RPC auth.
+ */
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { SignetProvider } from '../../../src/bitcoin/providers/SignetProvider';
+
+const realFetch = globalThis.fetch;
+afterEach(() => { globalThis.fetch = realFetch; });
+
+const rawTxHex = '02000000000101abcdef';
+
+describe('SignetProvider.broadcastTransaction (issue #272)', () => {
+  test('rejects a non-hex / object payload before hitting the network', async () => {
+    let called = false;
+    globalThis.fetch = (async () => { called = true; return new Response('{}'); }) as typeof fetch;
+    const provider = new SignetProvider({ ordUrl: 'http://ord', bitcoinRpcUrl: 'http://rpc' });
+
+    await expect(provider.broadcastTransaction({ not: 'hex' } as unknown as string))
+      .rejects.toThrow(/hex string/i);
+    expect(called).toBe(false);
+  });
+
+  test('rejects odd-length / invalid hex', async () => {
+    const provider = new SignetProvider({ ordUrl: 'http://ord', bitcoinRpcUrl: 'http://rpc' });
+    await expect(provider.broadcastTransaction('abc')).rejects.toThrow(/hex string/i);
+    await expect(provider.broadcastTransaction('zz')).rejects.toThrow(/hex string/i);
+  });
+
+  test('throws (not returns "") when the RPC response has neither result nor error', async () => {
+    globalThis.fetch = (async () => new Response(JSON.stringify({ id: 1 }), { status: 200 })) as typeof fetch;
+    const provider = new SignetProvider({ ordUrl: 'http://ord', bitcoinRpcUrl: 'http://rpc' });
+    await expect(provider.broadcastTransaction(rawTxHex)).rejects.toThrow(/no txid/i);
+  });
+
+  test('surfaces an HTTP error with a non-JSON body instead of an opaque parse error', async () => {
+    globalThis.fetch = (async () => new Response('<html>401 Unauthorized</html>', { status: 401, statusText: 'Unauthorized' })) as typeof fetch;
+    const provider = new SignetProvider({ ordUrl: 'http://ord', bitcoinRpcUrl: 'http://rpc' });
+    await expect(provider.broadcastTransaction(rawTxHex)).rejects.toThrow(/HTTP 401/);
+  });
+
+  test('surfaces a JSON-RPC error message', async () => {
+    globalThis.fetch = (async () => new Response(JSON.stringify({ error: { message: 'bad-txns-inputs-missingorspent' } }), { status: 500 })) as typeof fetch;
+    const provider = new SignetProvider({ ordUrl: 'http://ord', bitcoinRpcUrl: 'http://rpc' });
+    await expect(provider.broadcastTransaction(rawTxHex)).rejects.toThrow(/bad-txns-inputs-missingorspent/);
+  });
+
+  test('returns the txid on success', async () => {
+    globalThis.fetch = (async () => new Response(JSON.stringify({ result: 'deadbeeftxid' }), { status: 200 })) as typeof fetch;
+    const provider = new SignetProvider({ ordUrl: 'http://ord', bitcoinRpcUrl: 'http://rpc' });
+    await expect(provider.broadcastTransaction(rawTxHex)).resolves.toBe('deadbeeftxid');
+  });
+
+  test('sends HTTP Basic auth when bitcoinRpcAuth is configured', async () => {
+    let seenAuth: string | null = null;
+    globalThis.fetch = (async (_url: string, init: RequestInit) => {
+      seenAuth = (init.headers as Record<string, string>)['Authorization'] ?? null;
+      return new Response(JSON.stringify({ result: 'txid' }), { status: 200 });
+    }) as unknown as typeof fetch;
+    const provider = new SignetProvider({
+      ordUrl: 'http://ord',
+      bitcoinRpcUrl: 'http://rpc',
+      bitcoinRpcAuth: { username: 'user', password: 'pass' },
+    });
+    await provider.broadcastTransaction(rawTxHex);
+    expect(seenAuth).toBe('Basic ' + Buffer.from('user:pass').toString('base64'));
+  });
+});

--- a/packages/sdk/tests/unit/kinds/KindRegistry.test.ts
+++ b/packages/sdk/tests/unit/kinds/KindRegistry.test.ts
@@ -19,7 +19,7 @@ const createResource = (id: string, type = 'code', contentType = 'application/ja
   id,
   type,
   contentType,
-  hash: 'abcdef1234567890',
+  hash: 'a'.repeat(64),
 });
 
 describe('KindRegistry', () => {

--- a/packages/sdk/tests/unit/kinds/validators.test.ts
+++ b/packages/sdk/tests/unit/kinds/validators.test.ts
@@ -26,7 +26,7 @@ const createResource = (id: string, type = 'code', contentType = 'application/ja
   id,
   type,
   contentType,
-  hash: 'abcdef1234567890',
+  hash: 'a'.repeat(64),
 });
 
 describe('ValidationUtils', () => {

--- a/packages/sdk/tests/unit/lifecycle/ResourceVersioning.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/ResourceVersioning.test.ts
@@ -355,7 +355,7 @@ describe('OriginalsAsset - Resource Versioning', () => {
     expect(newResource.hash).not.toBe(hash1);
   });
 
-  test('versioning works with Buffer content', () => {
+  test('addResourceVersion rejects Buffer content instead of silently dropping it (issue #276)', () => {
     const buffer1 = Buffer.from('binary content 1', 'utf-8');
     const resources: AssetResource[] = [
       {
@@ -365,13 +365,13 @@ describe('OriginalsAsset - Resource Versioning', () => {
         hash: hashResource(buffer1)
       }
     ];
-    
+
     const asset = new OriginalsAsset(resources, buildDid('did:peer:xyz'), emptyCreds);
     const buffer2 = Buffer.from('binary content 2', 'utf-8');
-    const newResource = asset.addResourceVersion('res1', buffer2, 'application/octet-stream');
-    
-    expect(newResource.version).toBe(2);
-    expect(newResource.hash).toBe(hashResource(buffer2));
+    // Buffer content used to be accepted but only its hash was stored — the
+    // bytes were unrecoverably lost. It now throws so the loss is impossible.
+    expect(() => asset.addResourceVersion('res1', buffer2, 'application/octet-stream'))
+      .toThrow(/binary \(Buffer\) content/);
   });
 
   test('versioning works across all layers (did:peer)', () => {

--- a/packages/sdk/tests/unit/migration/MigrationManager.reconfig-events.test.ts
+++ b/packages/sdk/tests/unit/migration/MigrationManager.reconfig-events.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Regression tests for MigrationManager singleton reconfiguration (issue #280)
+ * and event subscription (issue #282).
+ */
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { MigrationManager } from '../../../src/migration/MigrationManager';
+import { DIDManager } from '../../../src/did/DIDManager';
+import { CredentialManager } from '../../../src/vc/CredentialManager';
+import type { OriginalsConfig } from '../../../src/types';
+
+const config: OriginalsConfig = {
+  network: 'regtest',
+  webvhNetwork: 'magby',
+  defaultKeyType: 'Ed25519',
+  enableLogging: false,
+};
+
+describe('MigrationManager singleton reconfiguration (issue #280)', () => {
+  afterEach(() => MigrationManager.resetInstance());
+
+  test('re-initializing with different dependencies throws instead of silently ignoring them', () => {
+    const didManager = new DIDManager(config);
+    const credentialManager = new CredentialManager(config, didManager);
+    MigrationManager.getInstance(config, didManager, credentialManager);
+
+    // A different config (e.g. a mainnet SDK) must not be silently discarded.
+    const otherConfig: OriginalsConfig = { ...config, network: 'mainnet', webvhNetwork: 'pichu' };
+    expect(() => MigrationManager.getInstance(otherConfig, didManager, credentialManager))
+      .toThrow(/already initialized/i);
+  });
+
+  test('calling getInstance() with the same references is idempotent', () => {
+    const didManager = new DIDManager(config);
+    const credentialManager = new CredentialManager(config, didManager);
+    const a = MigrationManager.getInstance(config, didManager, credentialManager);
+    const b = MigrationManager.getInstance(config, didManager, credentialManager);
+    expect(a).toBe(b);
+  });
+
+  test('calling getInstance() with no args returns the existing instance', () => {
+    const didManager = new DIDManager(config);
+    const credentialManager = new CredentialManager(config, didManager);
+    const a = MigrationManager.getInstance(config, didManager, credentialManager);
+    const b = MigrationManager.getInstance();
+    expect(a).toBe(b);
+  });
+
+  test('resetInstance() allows deliberate reconfiguration', () => {
+    const didManager = new DIDManager(config);
+    const credentialManager = new CredentialManager(config, didManager);
+    MigrationManager.getInstance(config, didManager, credentialManager);
+    MigrationManager.resetInstance();
+
+    const otherConfig: OriginalsConfig = { ...config, network: 'mainnet', webvhNetwork: 'pichu' };
+    expect(() => MigrationManager.getInstance(otherConfig, didManager, credentialManager)).not.toThrow();
+  });
+});
+
+describe('MigrationManager exposes event subscription (issue #282)', () => {
+  afterEach(() => MigrationManager.resetInstance());
+
+  test('on()/off() are available so migration events are observable', () => {
+    const didManager = new DIDManager(config);
+    const credentialManager = new CredentialManager(config, didManager);
+    const mgr = MigrationManager.getInstance(config, didManager, credentialManager);
+
+    expect(typeof mgr.on).toBe('function');
+    expect(typeof mgr.off).toBe('function');
+    expect(typeof mgr.once).toBe('function');
+
+    let received = 0;
+    const handler = () => { received++; };
+    const unsubscribe = mgr.on('migration:quarantine', handler);
+    // Subscribing returns an unsubscribe function.
+    expect(typeof unsubscribe).toBe('function');
+    unsubscribe();
+    // After unsubscribing, off() is a no-op that does not throw.
+    expect(() => mgr.off('migration:quarantine', handler)).not.toThrow();
+    expect(received).toBe(0);
+  });
+});

--- a/packages/sdk/tests/unit/resources/ResourceManager.test.ts
+++ b/packages/sdk/tests/unit/resources/ResourceManager.test.ts
@@ -675,6 +675,47 @@ describe('ResourceManager', () => {
       expect(history[0].version).toBe(1);
       expect(history[1].version).toBe(2);
     });
+
+    it('preserves a version that reverts to an earlier hash (issue #275)', () => {
+      // A legitimate history can revert content: v1=A, v2=B, v3=A. Dedup by
+      // hash alone silently dropped v3 on the export/import round-trip and
+      // broke the version chain. Dedup on (version, hash) keeps it.
+      const hashA = manager.hashContent('A');
+      const hashB = manager.hashContent('B');
+      const mk = (version: number, hash: string, prev?: string): Resource => ({
+        id: 'reverting',
+        type: 'text',
+        contentType: 'text/plain',
+        hash,
+        size: 1,
+        version,
+        previousVersionHash: prev,
+        createdAt: new Date().toISOString(),
+      });
+
+      manager.importResource(mk(1, hashA));
+      manager.importResource(mk(2, hashB, hashA));
+      manager.importResource(mk(3, hashA, hashB)); // reverts to A's content
+
+      const history = manager.getResourceHistory('reverting');
+      expect(history).toHaveLength(3);
+      expect(history.map(v => v.version)).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe('updateResource content-type allowlist (issue #292)', () => {
+    it('rejects a disallowed content type instead of producing an invalid version', () => {
+      const restricted = new ResourceManager({ allowedContentTypes: ['text/plain'] });
+      const v1 = restricted.createResource('hello', {
+        id: 'r1',
+        type: 'text',
+        contentType: 'text/plain',
+      });
+
+      expect(() =>
+        restricted.updateResource(v1, 'new bytes', { contentType: 'application/x-anything' })
+      ).toThrow(/not allowed/i);
+    });
   });
 
   describe('exportResources', () => {

--- a/packages/sdk/tests/unit/utils/utils-coverage.test.ts
+++ b/packages/sdk/tests/unit/utils/utils-coverage.test.ts
@@ -174,8 +174,8 @@ describe('[UTILS-VERIFY-008] parseSatoshiIdentifier', () => {
   });
 
   test('returns the maximum supply satoshi', () => {
-    // 2,100,000,000,000,000
-    expect(parseSatoshiIdentifier('2100000000000000')).toBe(2_100_000_000_000_000);
+    // 2,099,999,997,689,999 — the last satoshi ordinal ever mined
+    expect(parseSatoshiIdentifier('2099999997689999')).toBe(2_099_999_997_689_999);
   });
 
   test('throws for an invalid did:btco network prefix', () => {

--- a/packages/sdk/tests/unit/vc/MultiSigManager.test.ts
+++ b/packages/sdk/tests/unit/vc/MultiSigManager.test.ts
@@ -765,13 +765,13 @@ describe('MultiSigManager', () => {
 
       // First contribution
       const c1 = await manager.createContribution(session.id, keys[0].privateKey, vms[0]);
-      const updated1 = manager.addContribution(session.id, c1);
+      const updated1 = await manager.addContribution(session.id, c1);
       expect(updated1.status).toBe('collecting');
       expect(updated1.contributions.length).toBe(1);
 
       // Second contribution - meets threshold
       const c2 = await manager.createContribution(session.id, keys[1].privateKey, vms[1]);
-      const updated2 = manager.addContribution(session.id, c2);
+      const updated2 = await manager.addContribution(session.id, c2);
       expect(updated2.status).toBe('threshold_met');
       expect(updated2.contributions.length).toBe(2);
     });
@@ -785,11 +785,11 @@ describe('MultiSigManager', () => {
 
       const session = manager.createSession(baseVC, policy);
       const c1 = await manager.createContribution(session.id, keys[0].privateKey, vms[0]);
-      manager.addContribution(session.id, c1);
+      await manager.addContribution(session.id, c1);
 
       // Try to add another contribution from the same signer
       const c1dup = await manager.createContribution(session.id, keys[0].privateKey, vms[0]);
-      expect(() => manager.addContribution(session.id, c1dup)).toThrow(/already contributed/);
+      await expect(manager.addContribution(session.id, c1dup)).rejects.toThrow(/already contributed/);
     });
 
     test('rejects unauthorized signer contribution', async () => {
@@ -817,10 +817,10 @@ describe('MultiSigManager', () => {
       const session = manager.createSession(baseVC, policy);
 
       const c1 = await manager.createContribution(session.id, keys[0].privateKey, vms[0]);
-      manager.addContribution(session.id, c1);
+      await manager.addContribution(session.id, c1);
 
       const c2 = await manager.createContribution(session.id, keys[1].privateKey, vms[1]);
-      manager.addContribution(session.id, c2);
+      await manager.addContribution(session.id, c2);
 
       const signed = manager.finalizeSession(session.id);
       expect(signed.proof).toBeDefined();
@@ -841,7 +841,7 @@ describe('MultiSigManager', () => {
 
       const session = manager.createSession(baseVC, policy);
       const c1 = await manager.createContribution(session.id, keys[0].privateKey, vms[0]);
-      manager.addContribution(session.id, c1);
+      await manager.addContribution(session.id, c1);
 
       expect(() => manager.finalizeSession(session.id)).toThrow(/1\/2 signatures collected/);
     });
@@ -857,7 +857,7 @@ describe('MultiSigManager', () => {
       const session = manager.createSession(baseVC, policy);
       const c1 = await manager.createContribution(session.id, keys[0].privateKey, vms[0]);
 
-      expect(() => manager.addContribution(session.id, c1)).toThrow(/expired/);
+      await expect(manager.addContribution(session.id, c1)).rejects.toThrow(/expired/);
     });
 
     test('rejects contribution to finalized session', async () => {
@@ -869,11 +869,11 @@ describe('MultiSigManager', () => {
 
       const session = manager.createSession(baseVC, policy);
       const c1 = await manager.createContribution(session.id, keys[0].privateKey, vms[0]);
-      manager.addContribution(session.id, c1);
+      await manager.addContribution(session.id, c1);
       manager.finalizeSession(session.id);
 
       const c2 = await manager.createContribution(session.id, keys[1].privateKey, vms[1]);
-      expect(() => manager.addContribution(session.id, c2)).toThrow(/finalized/);
+      await expect(manager.addContribution(session.id, c2)).rejects.toThrow(/finalized/);
     });
 
     test('getSession returns undefined for unknown session', () => {

--- a/packages/sdk/tests/unit/vc/vc-coverage.test.ts
+++ b/packages/sdk/tests/unit/vc/vc-coverage.test.ts
@@ -222,13 +222,13 @@ describe('VC-006/happy – multi-sig session collects m-of-n and threshold passe
 
     // First signer contributes
     const c1 = await mgr.createContribution(session.id, keys[0].privateKey, vms[0]);
-    const s1 = mgr.addContribution(session.id, c1);
+    const s1 = await mgr.addContribution(session.id, c1);
     expect(s1.status).toBe('collecting');
     expect(s1.contributions).toHaveLength(1);
 
     // Second signer hits threshold
     const c2 = await mgr.createContribution(session.id, keys[1].privateKey, vms[1]);
-    const s2 = mgr.addContribution(session.id, c2);
+    const s2 = await mgr.addContribution(session.id, c2);
     expect(s2.status).toBe('threshold_met');
     expect(s2.contributions).toHaveLength(2);
 
@@ -275,7 +275,7 @@ describe('VC-006/error – finalize before threshold throws insufficient-signatu
 
     const session = mgr.createSession(baseVC, policy);
     const c1 = await mgr.createContribution(session.id, keys[0].privateKey, vms[0]);
-    mgr.addContribution(session.id, c1);
+    await mgr.addContribution(session.id, c1);
     // Only 1 contribution; threshold is 2
 
     expect(() => mgr.finalizeSession(session.id)).toThrow(/Cannot finalize/);

--- a/viewer/server.js
+++ b/viewer/server.js
@@ -113,10 +113,10 @@ setInterval(() => {
   }
 }, 15000);
 
+// No CORS headers: the UI is served same-origin from this server. A wildcard
+// Access-Control-Allow-Origin let any web page open in the developer's
+// browser read the full agent transcript via fetch('http://localhost:3333/stream').
 const server = createServer((req, res) => {
-  // CORS headers
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  
   if (req.url === '/') {
     // Serve HTML
     res.writeHead(200, { 'Content-Type': 'text/html' });
@@ -157,7 +157,10 @@ const server = createServer((req, res) => {
   }
 });
 
-server.listen(PORT, () => {
+// Bind to loopback only: the log stream is the developer's full session
+// transcript (can include env output, tokens, code) and /clear lets anyone
+// truncate it — neither belongs on the LAN.
+server.listen(PORT, '127.0.0.1', () => {
   console.log(`\n🎬 Agent Viewer running at http://localhost:${PORT}\n`);
   console.log(`Watching: ${LOG_FILE}`);
   console.log(`\nMake sure to run ./loop.sh to see output.\n`);


### PR DESCRIPTION
## What

Resolves a batch of 14 coherent, well-scoped issues from the codebase review, spanning DID resolution/caching, Bitcoin broadcasting, migration safety, multi-sig VC signing, and infra/validation hardening. Each fix ships with unit and/or security regression tests.

## Why

These are the independent, low-risk issues that could be fixed together without touching the larger architectural reworks (e.g. #279/#283/#300). Grouping them keeps each fix small and reviewable while clearing a chunk of the backlog.

Closes #267
Closes #268
Closes #271
Closes #272
Closes #274
Closes #275
Closes #276
Closes #280
Closes #281
Closes #282
Closes #286
Closes #287
Closes #291
Closes #292

## How

**DID**
- **#267** `resolveDID` rejects `did:btco` DIDs whose encoded network (`reg`/`sig`/unprefixed) doesn't match the configured `ordinalsProvider`'s network, before querying — closing the cross-network identity-spoofing hole. `testnet` (`test:`) is preserved as pass-through since there's no client/config counterpart.
- **#268** `updateDIDWebVH` / `rotateDIDWebVHKeys` / `recoverDIDWebVH` invalidate the cache entry after a successful log append, so a compromised key's document stops resolving after recovery instead of lingering for the cache TTL.
- **#291** `DIDCache` deep-clones documents on `set`/`get`/`pin` (caller mutation can no longer poison the cache), and the storage-fallback insert now runs the same `evictLRU` guard as `set()`/`pin()`.

**Bitcoin**
- **#271** `BroadcastClient.broadcastAndConfirm` wraps the status poll in try/catch: once the tx is broadcast, a transient status failure counts as an unconfirmed attempt and the method still resolves with the txid, instead of rejecting and inviting a fund-losing rebroadcast.
- **#272** `SignetProvider.broadcastTransaction` validates that the payload is even-length hex, checks `res.ok`, throws when the RPC response carries neither `result` nor `error` (no more empty-string "success"), and supports optional HTTP Basic RPC auth via `bitcoinRpcAuth`.

**Lifecycle / resources**
- **#274** `publishToWeb`'s `parseWebVHDid` now validates the domain (`validateAndNormalizeDomain`) and every path segment, using a SCID-aware parse that mirrors `WebVHManager.saveDIDLog` (handling both the canonical `did:webvh:{SCID}:{domain}[:paths]` and the `did:webvh:{domain}:user` shorthand). This also fixes a latent positional bug where the SCID was treated as the domain.
- **#275** `ResourceManager.importResource` dedups on `(version, hash)` instead of hash alone, so a version that legitimately reverts to an earlier hash (v1=A, v2=B, v3=A) survives the export/import round-trip.
- **#276** `OriginalsAsset.addResourceVersion` throws on `Buffer` input rather than silently storing only the hash and discarding the bytes.

**Migration**
- **#280** `MigrationManager.getInstance` throws when re-initialized with different dependencies (config/managers/bitcoinManager) instead of silently returning the stale singleton; same-reference calls stay idempotent.
- **#281** `AuditLogger` stores an independent deep copy per DID key and returns deep copies from `getMigrationHistory` / `getSystemMigrationLogs`, so the append-only log can't be mutated in place or cross-corrupted between source/target DIDs.
- **#282** `MigrationManager` exposes `on()` / `once()` / `off()` delegating to its internal emitter, so migration events — including `migration:quarantine` — are observable.

**VC**
- **#287** `MultiSigManager.addContribution` verifies each contribution's proof over the session document before accepting it toward the threshold; a garbage proof is rejected and does not consume the signer's slot. `addContribution` is now `async` (call sites updated).

**Infra / validation roundup (#292)**
- `viewer/server.js` binds `127.0.0.1` and drops the wildcard `Access-Control-Allow-Origin` (**#286**).
- Manifest resource hashes require a 64-char hex SHA-256.
- `MAX_SATOSHI_SUPPLY` uses the true last ordinal (`2_099_999_997_689_999`).
- `ResourceManager.updateResource` enforces the `allowedContentTypes` allowlist.
- Domain validation bounds IPv4 octets to 0–255.
- Prometheus exposition escapes all interpolated label values (error codes, migration layers, operation names).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test addition or improvement

> Two small behavior changes are technically breaking: `MultiSigManager.addContribution` is now `async`, and `addResourceVersion` rejects `Buffer` input (previously it silently dropped the bytes).

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] I have updated JSDoc comments for any changed public APIs
- [x] My commits follow Conventional Commits format

## Testing

- [x] Unit tests — new suites for `MigrationManager` reconfig/events, `SignetProvider` broadcast, and additions to `BroadcastClient`, `ResourceManager`, `ResourceVersioning`, multi-sig session tests.
- [x] Security tests — new `tests/security/multi-issue-review-regressions.test.ts` covering DID cache isolation, cross-network btco rejection, path traversal, audit-log tamper resistance, multi-sig unverified-contribution rejection, IPv4/satoshi bounds, and Prometheus label escaping.

**Result:** typecheck clean, `bun run lint` clean (0 errors, no new warnings), and the full unit + security + integration suite passes except the 16 pre-existing CEL-CLI subprocess tests, which fail identically on `main` (environmental, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcunnL6RiRLDa9L9WPKytW)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix 14 review issues across DID cache, Bitcoin, VC, migration, and resource validation
> - **DIDCache**: `get`, `set`, and `pin` now store and return `structuredClone` copies, preventing external mutation of cached documents; `get` also evicts LRU entries when hydrating from persistent storage.
> - **DIDManager**: `resolveDID` now throws `BTCO_NETWORK_MISMATCH` when a `did:btco` DID targets a different Bitcoin network than the SDK is configured for; WebVH update/rotate/recover operations now invalidate stale cache entries.
> - **MultiSigManager.addContribution**: Made async and now verifies the proof via `didManager` before accepting; includes post-await rechecks to prevent duplicate contributions and finalized-state races.
> - **SignetProvider.broadcastTransaction**: Rejects non-hex inputs, requires HTTP OK with a string txid, surfaces RPC/HTTP errors, and supports optional Basic auth via new `bitcoinRpcAuth` option.
> - **BroadcastClient.broadcastAndConfirm**: Transient status-provider failures during polling are now caught and treated as unconfirmed, rather than rejecting the operation.
> - **AuditLogger**: `logMigration`, `getMigrationHistory`, and `getSystemMigrationLogs` now store and return `structuredClone` copies to prevent mutation of internal audit records.
> - **MigrationManager**: Subsequent constructor calls with different dependency instances now throw instead of silently returning a mismatched singleton; adds `on`/`once`/`off` event subscription methods.
> - **ResourceManager**: `updateResource` enforces `allowedContentTypes`; `importResource` deduplicates by `(version, hash)` pair to preserve content-revert versions.
> - **Satoshi validation**: `MAX_SATOSHI_SUPPLY` corrected to `2,099,999,997,689,999`; hash validation tightened to exactly 64 hex characters.
> - **Viewer server**: Removes permissive CORS header and binds to loopback-only, preventing remote network access.
> - Risk: `addContribution` is now async — callers must `await` it; `MAX_SATOSHI_SUPPLY` change may reject previously-accepted satoshi identifiers above the new bound.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1994aa4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->