### PR TITLE
fix(vc): bind BBS proofs to issuer/holder and fix skolemization counter collision

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -65,7 +65,7 @@ export {
 export { calculateFee } from './bitcoin/fee-calculation.js';
 export { BBSCryptosuiteUtils } from './vc/cryptosuites/bbs.js';
 export { BBSCryptosuiteManager } from './vc/cryptosuites/bbsCryptosuite.js';
-export type { BBSProofOptions, BBSDeriveOptions } from './vc/cryptosuites/bbsCryptosuite.js';
+export type { BBSProofOptions, BBSDeriveOptions, BBSVerifyOptions } from './vc/cryptosuites/bbsCryptosuite.js';
 export type { StatusListResolver } from './vc/Verifier.js';
 export { MultiSigManager } from './vc/MultiSigManager.js';
 export * from './storage/index.js';

--- a/packages/sdk/src/vc/cryptosuites/bbsCryptosuite.ts
+++ b/packages/sdk/src/vc/cryptosuites/bbsCryptosuite.ts
@@ -53,6 +53,20 @@ export interface BBSDeriveOptions {
   selectivePointers: string[];
 }
 
+export interface BBSVerifyOptions {
+  documentLoader?: (url: string) => Promise<any>;
+  /**
+   * DID expected to control the proof's verification method. When omitted,
+   * the binding is checked against the document's `issuer` (credentials) or
+   * `holder` (presentations); verification fails closed if neither is present.
+   */
+  expectedController?: string;
+  /** When set, the proof's challenge must match exactly (anti-replay). */
+  expectedChallenge?: string;
+  /** When set, the proof's domain must match exactly. */
+  expectedDomain?: string;
+}
+
 function concatBytes(a: Uint8Array, b: Uint8Array): Uint8Array {
   const out = new Uint8Array(a.length + b.length);
   out.set(a, 0);
@@ -430,18 +444,94 @@ export class BBSCryptosuiteManager {
   }
 
   /**
+   * Bind the proof's verification method to the DID that must control it: the
+   * credential `issuer` (or presentation `holder`), or an explicitly supplied
+   * `expectedController`. The signature is verified against whatever key
+   * `proof.verificationMethod` resolves to, so without this check an attacker
+   * can sign a credential naming a trusted issuer with their own key and have
+   * it verify — full issuer impersonation (issue #315). Mirrors
+   * Verifier.checkVerificationMethodController; fails closed when no expected
+   * subject can be determined. Returns an error message, or null if bound.
+   */
+  private static checkProofBinding(
+    unsecuredDocument: any,
+    proof: DataIntegrityProof,
+    expectedController?: string
+  ): string | null {
+    const verificationMethod = (proof as { verificationMethod?: unknown })?.verificationMethod;
+    if (typeof verificationMethod !== 'string' || verificationMethod.length === 0) {
+      return 'Proof is missing a verificationMethod';
+    }
+    let expected = expectedController;
+    let subjectLabel = 'expected controller';
+    if (expected === undefined) {
+      const issuer = unsecuredDocument?.issuer;
+      const holder = unsecuredDocument?.holder;
+      if (issuer !== undefined && issuer !== null) {
+        expected = typeof issuer === 'string' ? issuer : (issuer as { id?: string })?.id;
+        subjectLabel = 'issuer';
+      } else if (holder !== undefined && holder !== null) {
+        expected = typeof holder === 'string' ? holder : (holder as { id?: string })?.id;
+        subjectLabel = 'holder';
+      }
+    }
+    if (!expected) {
+      return 'Document has no issuer or holder to bind the proof to (pass expectedController to verify non-credential documents)';
+    }
+    const vmDid = verificationMethod.split('#')[0];
+    if (vmDid !== expected) {
+      return `Proof verificationMethod (${vmDid}) does not match ${subjectLabel} (${expected})`;
+    }
+    return null;
+  }
+
+  /**
+   * Enforce verifier-supplied challenge/domain expectations against the proof
+   * (anti-replay: a derived proof observed once must not be replayable to a
+   * verifier that issued a different challenge). Returns an error message, or
+   * null when all supplied expectations match.
+   */
+  private static checkProofExpectations(
+    proof: DataIntegrityProof,
+    options: BBSVerifyOptions
+  ): string | null {
+    const proofRecord = proof as unknown as { challenge?: string; domain?: string };
+    if (options.expectedChallenge !== undefined && proofRecord.challenge !== options.expectedChallenge) {
+      return 'Proof challenge mismatch (possible replay)';
+    }
+    if (options.expectedDomain !== undefined && proofRecord.domain !== options.expectedDomain) {
+      return 'Proof domain mismatch';
+    }
+    return null;
+  }
+
+  /**
    * 3.4.7 — verify a derived (selective-disclosure) proof.
    */
   static async verifyDerivedProof(
     securedDocument: any,
-    options: { documentLoader?: (url: string) => Promise<any> } = {}
-  ): Promise<{ verified: boolean; verifiedDocument: any }> {
+    options: BBSVerifyOptions = {}
+  ): Promise<{ verified: boolean; verifiedDocument: any; errors?: string[] }> {
     try {
+      const { proof, ...unsecuredDocument } = securedDocument;
+
+      const bindingError = BBSCryptosuiteManager.checkProofBinding(
+        unsecuredDocument,
+        proof,
+        options.expectedController
+      );
+      if (bindingError) {
+        return { verified: false, verifiedDocument: null, errors: [bindingError] };
+      }
+      const expectationError = BBSCryptosuiteManager.checkProofExpectations(proof, options);
+      if (expectationError) {
+        return { verified: false, verifiedDocument: null, errors: [expectationError] };
+      }
+
       const publicKey = await BBSCryptosuiteManager.resolveVerificationKey(
-        securedDocument.proof.verificationMethod,
+        proof.verificationMethod,
         options.documentLoader
       );
-      const { proof, ...unsecuredDocument } = securedDocument;
       const { bbsProof, proofHash, mandatoryHash, selectiveIndexes, presentationHeader, nonMandatory } =
         await BBSCryptosuiteManager.createVerifyData(unsecuredDocument, proof, options);
 
@@ -456,9 +546,17 @@ export class BBSCryptosuiteManager {
         disclosedMessageIndexes: selectiveIndexes
       });
 
-      return { verified, verifiedDocument: verified ? unsecuredDocument : null };
-    } catch {
-      return { verified: false, verifiedDocument: null };
+      return verified
+        ? { verified: true, verifiedDocument: unsecuredDocument }
+        : { verified: false, verifiedDocument: null, errors: ['BBS+ derived proof verification failed'] };
+    } catch (e: any) {
+      // Surface the underlying error: swallowing it makes internal failures
+      // (e.g. canonicalization bugs) indistinguishable from a bad signature.
+      return {
+        verified: false,
+        verifiedDocument: null,
+        errors: [e?.message ?? 'Unknown BBS+ derived proof verification error']
+      };
     }
   }
 
@@ -472,11 +570,28 @@ export class BBSCryptosuiteManager {
   static async verifyProof(
     document: any,
     proof: DataIntegrityProof,
-    options: { documentLoader?: (url: string) => Promise<any> } = {}
+    options: BBSVerifyOptions = {}
   ): Promise<VerificationResult> {
     try {
       if (proof.cryptosuite !== 'bbs-2023') {
         return { verified: false, errors: [`Expected bbs-2023 cryptosuite, got ${proof.cryptosuite}`] };
+      }
+
+      // Accept either an unsecured document or a secured one (proof attached):
+      // an embedded proof must never be canonicalized into the verified data.
+      const { proof: _docProof, ...unsecuredDocument } = document ?? {};
+
+      const bindingError = BBSCryptosuiteManager.checkProofBinding(
+        unsecuredDocument,
+        proof,
+        options.expectedController
+      );
+      if (bindingError) {
+        return { verified: false, errors: [bindingError] };
+      }
+      const expectationError = BBSCryptosuiteManager.checkProofExpectations(proof, options);
+      if (expectationError) {
+        return { verified: false, errors: [expectationError] };
       }
 
       const decoded = decodeMultibaseB64url(proof.proofValue);
@@ -495,12 +610,12 @@ export class BBSCryptosuiteManager {
 
       if (!isBaseProof) {
         const result = await BBSCryptosuiteManager.verifyDerivedProof(
-          { ...document, proof },
+          { ...unsecuredDocument, proof },
           options
         );
         return result.verified
           ? { verified: true }
-          : { verified: false, errors: ['BBS+ derived proof verification failed'] };
+          : { verified: false, errors: result.errors ?? ['BBS+ derived proof verification failed'] };
       }
 
       // Base proof: bind the embedded public key to the resolved DID key before
@@ -513,11 +628,11 @@ export class BBSCryptosuiteManager {
       const proofOptions: any = { ...proof };
       delete proofOptions.proofValue;
       const proofHash = sha256Of(await canonize(
-        { '@context': document['@context'], ...proofOptions },
+        { '@context': unsecuredDocument['@context'], ...proofOptions },
         { documentLoader: options.documentLoader }
       ));
 
-      const { mandatory, nonMandatory } = await BBSCryptosuiteManager.baseProofTransformation(document, {
+      const { mandatory, nonMandatory } = await BBSCryptosuiteManager.baseProofTransformation(unsecuredDocument, {
         mandatoryPointers: parsed.mandatoryPointers,
         hmacKey: toUint8(parsed.hmacKey),
         documentLoader: options.documentLoader

--- a/packages/sdk/src/vc/proofs/data-integrity.ts
+++ b/packages/sdk/src/vc/proofs/data-integrity.ts
@@ -24,6 +24,14 @@ export class DataIntegrityProofManager {
   }
 
   static async verifyProof(document: any, proof: DataIntegrityProof, options: any): Promise<VerificationResult> {
+    // Route bbs-2023 through the same hardened path as eddsa-rdfc-2022 so
+    // Verifier's issuer-binding, proofPurpose, validity-period, and status
+    // checks apply to BBS credentials too (issue #315). Dynamically imported,
+    // like CredentialManager, to keep the BBS backend lazy.
+    if (proof.cryptosuite === 'bbs-2023') {
+      const { BBSCryptosuiteManager } = await import('../cryptosuites/bbsCryptosuite.js');
+      return await BBSCryptosuiteManager.verifyProof(document, proof, options);
+    }
     if (proof.cryptosuite !== 'eddsa-rdfc-2022') {
       return { verified: false, errors: [`Unsupported cryptosuite: ${proof.cryptosuite}`] };
     }

--- a/packages/sdk/src/vc/utils/selective-disclosure.ts
+++ b/packages/sdk/src/vc/utils/selective-disclosure.ts
@@ -201,8 +201,8 @@ export function skolemizeExpandedJsonLd(
   // explicit @id (such a node never calls generateId), so a later sibling
   // branch reuses the same skolem URN and two distinct blank nodes collapse
   // into one after deskolemization (issue #316).
-  if (options.urnScheme === undefined) options.urnScheme = CUSTOM_URN_SCHEME;
-  if (options.randomString === undefined) options.randomString = crypto.randomUUID();
+  if (!options.urnScheme) options.urnScheme = CUSTOM_URN_SCHEME;
+  if (!options.randomString) options.randomString = crypto.randomUUID();
   if (options.count === undefined) options.count = 0;
 
   const generateId = (blankNodeId?: string): string => {

--- a/packages/sdk/src/vc/utils/selective-disclosure.ts
+++ b/packages/sdk/src/vc/utils/selective-disclosure.ts
@@ -194,18 +194,23 @@ export function skolemizeExpandedJsonLd(
   expanded: Record<string, unknown>[],
   options: { urnScheme?: string; randomString?: string; count?: number }
 ): any[] {
-  const localOptions = {
-    urnScheme: options.urnScheme || CUSTOM_URN_SCHEME,
-    randomString: options.randomString || crypto.randomUUID(),
-    count: options.count || 0
-  };
+  // The anonymous-node counter MUST be one shared object mutated by reference
+  // across the entire recursion (as in the di-wings reference algorithm).
+  // Copying `count` into a per-level object and writing it back only one level
+  // up loses the increments accumulated beneath any node that carries an
+  // explicit @id (such a node never calls generateId), so a later sibling
+  // branch reuses the same skolem URN and two distinct blank nodes collapse
+  // into one after deskolemization (issue #316).
+  if (options.urnScheme === undefined) options.urnScheme = CUSTOM_URN_SCHEME;
+  if (options.randomString === undefined) options.randomString = crypto.randomUUID();
+  if (options.count === undefined) options.count = 0;
 
   const generateId = (blankNodeId?: string): string => {
     if (blankNodeId) {
-      return `urn:${localOptions.urnScheme}:${blankNodeId}`;
+      return `urn:${options.urnScheme}:${blankNodeId}`;
     }
-    const id = `urn:${localOptions.urnScheme}:_${localOptions.randomString}_${localOptions.count}`;
-    options.count = ++localOptions.count; // Update the parent options count
+    const id = `urn:${options.urnScheme}:_${options.randomString}_${options.count}`;
+    options.count = (options.count as number) + 1;
     return id;
   };
 
@@ -225,11 +230,11 @@ export function skolemizeExpandedJsonLd(
       const value = (element as any)[property];
 
       if (Array.isArray(value)) {
-        skolemizedNode[property] = skolemizeExpandedJsonLd(value, localOptions);
+        skolemizedNode[property] = skolemizeExpandedJsonLd(value, options);
       } else {
         skolemizedNode[property] = skolemizeExpandedJsonLd(
           [value as Record<string, unknown>],
-          localOptions
+          options
         )[0];
       }
     }

--- a/packages/sdk/tests/unit/vc/cryptosuites/bbs.roundtrip.test.ts
+++ b/packages/sdk/tests/unit/vc/cryptosuites/bbs.roundtrip.test.ts
@@ -199,6 +199,193 @@ describe('BBS+ bbs-2023 selective disclosure round-trip', () => {
     ).rejects.toThrow(/at least one mandatory or selective pointer/i);
   });
 
+  // Regression (issue #316): an id-less credential with anonymous nested nodes
+  // across sibling branches must round-trip. The per-level skolemization
+  // counter copy collapsed distinct blank nodes into one skolem URN, so the
+  // base proof verified but the derived proof did not.
+  test('id-less credential with multiple anonymous nested nodes round-trips', async () => {
+    const { secretKey, publicKey } = await bbs.generateKeyPair({ ciphersuite: CIPHERSUITE });
+    const documentLoader = await makeLoader(publicKey);
+
+    const anonCred = {
+      '@context': [
+        'https://www.w3.org/ns/credentials/v2',
+        { '@vocab': 'https://example.org/vocab#' }
+      ],
+      type: ['VerifiableCredential'],
+      // no top-level `id`: the credential root itself is a blank node
+      issuer: 'did:example:issuer',
+      validFrom: '2024-01-01T00:00:00Z',
+      credentialSubject: {
+        id: 'did:example:subject', // @id-bearing node with anonymous descendants
+        employment: { employer: { name: 'Acme' } }
+      },
+      evidence: { note: 'anonymous sibling branch' }
+    };
+
+    const baseProof = await BBSCryptosuiteManager.createProof(anonCred, {
+      verificationMethod: vm,
+      privateKey: secretKey,
+      publicKey,
+      documentLoader,
+      mandatoryPointers
+    });
+    expect((await BBSCryptosuiteManager.verifyProof(anonCred, baseProof, { documentLoader })).verified).toBe(true);
+
+    const { document: revealed, proof: derivedProof } = await BBSCryptosuiteManager.deriveProof(
+      { ...anonCred, proof: baseProof },
+      baseProof,
+      { documentLoader, selectivePointers: ['/credentialSubject/employment'] }
+    );
+    expect(revealed.credentialSubject.employment.employer.name).toBe('Acme');
+    expect(revealed.evidence).toBeUndefined();
+
+    const result = await BBSCryptosuiteManager.verifyDerivedProof(
+      { ...revealed, proof: derivedProof },
+      { documentLoader }
+    );
+    expect(result.errors).toBeUndefined();
+    expect(result.verified).toBe(true);
+  });
+
+  // Regression (issue #315): the verification method must be controlled by the
+  // credential issuer. An attacker signing with their own key while naming a
+  // trusted issuer must be rejected on both the base and derived paths.
+  test('rejects issuer impersonation via an attacker-controlled verificationMethod', async () => {
+    const { secretKey, publicKey } = await bbs.generateKeyPair({ ciphersuite: CIPHERSUITE });
+    const attackerVm = 'did:example:attacker#bbs-key-1';
+    const publicKeyMultibase = multikey.encodePublicKey(publicKey, 'Bls12381G2');
+    const documentLoader = async (url: string) => {
+      const ctx = (PRELOADED_CONTEXTS as Record<string, unknown>)[url];
+      if (ctx) return { document: ctx, documentUrl: url, contextUrl: null };
+      if (url === attackerVm) {
+        return {
+          document: {
+            id: attackerVm,
+            type: 'Multikey',
+            controller: 'did:example:attacker',
+            publicKeyMultibase
+          },
+          documentUrl: url,
+          contextUrl: null
+        };
+      }
+      throw new Error(`Unexpected document load: ${url}`);
+    };
+
+    // Attacker signs a credential whose `issuer` names the victim, using the
+    // attacker's own key and verificationMethod.
+    const forgedProof = await BBSCryptosuiteManager.createProof(credential, {
+      verificationMethod: attackerVm,
+      privateKey: secretKey,
+      publicKey,
+      documentLoader,
+      mandatoryPointers
+    });
+
+    const baseResult = await BBSCryptosuiteManager.verifyProof(credential, forgedProof, { documentLoader });
+    expect(baseResult.verified).toBe(false);
+    expect(baseResult.errors?.[0]).toContain('does not match issuer');
+
+    const { document: revealed, proof: derivedProof } = await BBSCryptosuiteManager.deriveProof(
+      { ...credential, proof: forgedProof },
+      forgedProof,
+      { documentLoader, selectivePointers: ['/credentialSubject/name'] }
+    );
+    const derivedResult = await BBSCryptosuiteManager.verifyDerivedProof(
+      { ...revealed, proof: derivedProof },
+      { documentLoader }
+    );
+    expect(derivedResult.verified).toBe(false);
+    expect(derivedResult.errors?.[0]).toContain('does not match issuer');
+
+    const derivedViaVerifyProof = await BBSCryptosuiteManager.verifyProof(revealed, derivedProof, { documentLoader });
+    expect(derivedViaVerifyProof.verified).toBe(false);
+    expect(derivedViaVerifyProof.errors?.[0]).toContain('does not match issuer');
+  });
+
+  // Issue #315: verification fails closed when the document names no issuer or
+  // holder; expectedController is the explicit escape hatch.
+  test('fails closed without an issuer/holder unless expectedController is supplied', async () => {
+    const { secretKey, publicKey } = await bbs.generateKeyPair({ ciphersuite: CIPHERSUITE });
+    const documentLoader = await makeLoader(publicKey);
+    const { issuer: _issuer, ...issuerlessCred } = credential as any;
+
+    const baseProof = await BBSCryptosuiteManager.createProof(issuerlessCred, {
+      verificationMethod: vm,
+      privateKey: secretKey,
+      publicKey,
+      documentLoader,
+      mandatoryPointers: ['/credentialSubject/id']
+    });
+
+    const failClosed = await BBSCryptosuiteManager.verifyProof(issuerlessCred, baseProof, { documentLoader });
+    expect(failClosed.verified).toBe(false);
+    expect(failClosed.errors?.[0]).toContain('no issuer or holder');
+
+    const bound = await BBSCryptosuiteManager.verifyProof(issuerlessCred, baseProof, {
+      documentLoader,
+      expectedController: 'did:example:issuer'
+    });
+    expect(bound.verified).toBe(true);
+
+    const wrongController = await BBSCryptosuiteManager.verifyProof(issuerlessCred, baseProof, {
+      documentLoader,
+      expectedController: 'did:example:other'
+    });
+    expect(wrongController.verified).toBe(false);
+  });
+
+  // Issue #315 (related): a verifier that supplies challenge/domain
+  // expectations must reject a replayed proof carrying different values.
+  test('expectedChallenge/expectedDomain mismatches are rejected (anti-replay)', async () => {
+    const { secretKey, publicKey } = await bbs.generateKeyPair({ ciphersuite: CIPHERSUITE });
+    const documentLoader = await makeLoader(publicKey);
+
+    const baseProof = await BBSCryptosuiteManager.createProof(credential, {
+      verificationMethod: vm,
+      privateKey: secretKey,
+      publicKey,
+      documentLoader,
+      mandatoryPointers,
+      challenge: 'nonce-123',
+      domain: 'https://verifier.example'
+    });
+
+    const ok = await BBSCryptosuiteManager.verifyProof(credential, baseProof, {
+      documentLoader,
+      expectedChallenge: 'nonce-123',
+      expectedDomain: 'https://verifier.example'
+    });
+    expect(ok.verified).toBe(true);
+
+    const staleChallenge = await BBSCryptosuiteManager.verifyProof(credential, baseProof, {
+      documentLoader,
+      expectedChallenge: 'nonce-456'
+    });
+    expect(staleChallenge.verified).toBe(false);
+    expect(staleChallenge.errors?.[0]).toContain('challenge mismatch');
+
+    const { document: revealed, proof: derivedProof } = await BBSCryptosuiteManager.deriveProof(
+      { ...credential, proof: baseProof },
+      baseProof,
+      { documentLoader, selectivePointers: ['/credentialSubject/name'] }
+    );
+    const replayed = await BBSCryptosuiteManager.verifyDerivedProof(
+      { ...revealed, proof: derivedProof },
+      { documentLoader, expectedChallenge: 'nonce-456' }
+    );
+    expect(replayed.verified).toBe(false);
+    expect(replayed.errors?.[0]).toContain('challenge mismatch');
+
+    const wrongDomain = await BBSCryptosuiteManager.verifyDerivedProof(
+      { ...revealed, proof: derivedProof },
+      { documentLoader, expectedDomain: 'https://other.example' }
+    );
+    expect(wrongDomain.verified).toBe(false);
+    expect(wrongDomain.errors?.[0]).toContain('domain mismatch');
+  });
+
   // Regression: a string value that looks like a blank node ("_:...") must not
   // corrupt canonicalization (PR #219 review).
   test('a credential value that looks like a blank node still round-trips', async () => {

--- a/packages/sdk/tests/unit/vc/proofs/data-integrity.test.ts
+++ b/packages/sdk/tests/unit/vc/proofs/data-integrity.test.ts
@@ -21,4 +21,20 @@ describe('DataIntegrityProofManager branches', () => {
     expect(res.verified).toBe(false);
     expect(res.errors?.[0]).toContain('Unsupported cryptosuite');
   });
+
+  // Issue #315: bbs-2023 must be routed to the BBS cryptosuite (with its
+  // issuer↔verificationMethod binding), not rejected as unsupported.
+  test('bbs-2023 on verify dispatches to the BBS cryptosuite', async () => {
+    const res = await DataIntegrityProofManager.verifyProof(
+      { id: 'x', issuer: 'did:example:victim' },
+      {
+        type: 'DataIntegrityProof', cryptosuite: 'bbs-2023',
+        verificationMethod: 'did:example:attacker#k', proofPurpose: 'assertionMethod', proofValue: 'z'
+      } as any,
+      { documentLoader: async () => ({ document: {}, documentUrl: '', contextUrl: null }) }
+    );
+    expect(res.verified).toBe(false);
+    // Rejected by the BBS issuer-binding check, not as an unknown cryptosuite.
+    expect(res.errors?.[0]).toContain('does not match issuer');
+  });
 });

--- a/packages/sdk/tests/unit/vc/utils/selective-disclosure.test.ts
+++ b/packages/sdk/tests/unit/vc/utils/selective-disclosure.test.ts
@@ -1,0 +1,76 @@
+import { describe, test, expect } from 'bun:test';
+import { skolemizeExpandedJsonLd } from '../../../../src/vc/utils/selective-disclosure';
+
+/**
+ * Regression tests for issue #316: the skolemization counter must be threaded
+ * through the whole recursion as ONE shared mutable object. The buggy port
+ * copied `count` at each level and wrote it back only one level up, so counter
+ * increments made beneath a node with an explicit @id (which never calls
+ * generateId) were lost and a later sibling branch reused the same skolem URN —
+ * collapsing two distinct blank nodes into one after deskolemization.
+ */
+
+/** Collect every generated (anonymous) skolem @id in a skolemized document. */
+function collectGeneratedIds(node: any, randomString: string, out: string[] = []): string[] {
+  if (Array.isArray(node)) {
+    for (const item of node) collectGeneratedIds(item, randomString, out);
+  } else if (node && typeof node === 'object') {
+    const id = node['@id'];
+    if (typeof id === 'string' && id.includes(`_${randomString}_`)) out.push(id);
+    for (const [key, value] of Object.entries(node)) {
+      if (key !== '@id') collectGeneratedIds(value, randomString, out);
+    }
+  }
+  return out;
+}
+
+describe('skolemizeExpandedJsonLd anonymous-node counter (issue #316)', () => {
+  test('counter increments beneath an @id-bearing node propagate to sibling branches', () => {
+    // Branch `a` holds a node with an explicit @id whose descendant is
+    // anonymous; branch `b` holds another anonymous node. With the per-level
+    // counter copy, both anonymous nodes received `_R_0`.
+    const result = skolemizeExpandedJsonLd(
+      [{
+        '@id': 'urn:uuid:root',
+        a: [{ '@id': 'urn:root2', child: [{ v: 'x' }] }],
+        b: [{ v: 'y' }]
+      }],
+      { randomString: 'R', count: 0 }
+    );
+
+    const ids = collectGeneratedIds(result, 'R');
+    expect(ids).toHaveLength(2);
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  test('id-less root with anonymous nodes across nested branches gets unique ids', () => {
+    // Mirrors an id-less credential: the root itself is anonymous, an
+    // @id-bearing subject holds anonymous descendants, and a sibling branch is
+    // anonymous too. Every generated skolem id must be distinct.
+    const result = skolemizeExpandedJsonLd(
+      [{
+        subject: [{
+          '@id': 'did:example:subject',
+          employment: [{ employer: [{ name: [{ '@value': 'Acme' }] }] }]
+        }],
+        evidence: [{ note: [{ '@value': 'anonymous branch' }] }]
+      }],
+      { randomString: 'R', count: 0 }
+    );
+
+    // root + employment + employer + evidence = 4 anonymous nodes
+    const ids = collectGeneratedIds(result, 'R');
+    expect(ids).toHaveLength(4);
+    expect(new Set(ids).size).toBe(4);
+  });
+
+  test('explicit blank-node ids are preserved and do not consume the counter', () => {
+    const result = skolemizeExpandedJsonLd(
+      [{ '@id': '_:b99', child: [{ v: 'x' }] }],
+      { urnScheme: 'custom-scheme', randomString: 'R', count: 0 }
+    );
+    expect(result[0]['@id']).toBe('urn:custom-scheme:b99');
+    const ids = collectGeneratedIds(result, 'R');
+    expect(ids).toEqual(['urn:custom-scheme:_R_0']);
+  });
+});


### PR DESCRIPTION
## What

Fixes the two blocking findings from the re-review of #219 (BBS+ selective disclosure), targeting the PR branch:

1. **Issuer impersonation** — BBS verification never bound `proof.verificationMethod` to the credential `issuer` / presentation `holder`.
2. **Skolemization counter collision** — the anonymous-node counter in `skolemizeExpandedJsonLd` lost increments beneath `@id`-bearing nodes, collapsing distinct blank nodes into one skolem URN.

## Why

Closes #315
Closes #316

- **#315 (critical)**: `verifyProof`/`verifyDerivedProof` verified signatures against whatever key `proof.verificationMethod` resolved to. An attacker could sign a credential naming a trusted `issuer` with their own key under their own DID and have it verify — and `bbs-2023` was unreachable from the hardened `Verifier` path, so no upstream check caught it.
- **#316 (high)**: the ported algorithm copied `count` into a per-level object and wrote it back only one level up, so an id-less credential with anonymous nested nodes verified its base proof but failed its selective-disclosure round-trip (derived proof `verified: false`), and the signed RDF graph merged distinct blank nodes.

## How

**#315 — both suggested fixes:**
- `BBSCryptosuiteManager.verifyProof` and `verifyDerivedProof` now enforce `verificationMethod.split('#')[0] === issuer` (or `holder`), mirroring `Verifier.checkVerificationMethodController`. They fail closed when the document names neither; a new `expectedController` option is the explicit escape hatch for non-credential documents.
- `DataIntegrityProofManager.verifyProof` now routes `bbs-2023` to the BBS cryptosuite (dynamic import, same laziness pattern as `CredentialManager`), so `Verifier`'s issuer-binding, `proofPurpose`, validity-period, and status checks apply to BBS credentials uniformly.
- Replay hardening (the "fix alongside" note): new `expectedChallenge` / `expectedDomain` verify options — when supplied, the proof's values must match exactly, on both base and derived paths (mirrors `Verifier.verifyPresentation`).
- `verifyProof` also defensively strips an embedded `proof` from the input document, so routing the full secured credential through `DataIntegrityProofManager` never canonicalizes the proof into the verified data.

**#316:**
- `skolemizeExpandedJsonLd` now threads the single mutable `options` object through the whole recursion (restoring the di-wings shared-counter semantics) instead of copying `count` per level.
- Per the issue's diagnosability note, `verifyDerivedProof` now surfaces the caught error text in `errors` instead of swallowing it, and `verifyProof` propagates those errors.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test addition or improvement

Note: verification of BBS documents that name no issuer/holder now fails closed (previously verified). This is the intended security behavior; `expectedController` covers the legitimate case.

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] I have updated JSDoc comments for any changed public APIs
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Testing

- [x] Unit tests
  - `tests/unit/vc/utils/selective-disclosure.test.ts` (new): counter propagation across sibling branches under `@id`-bearing nodes; id-less root with anonymous nodes across nested branches; explicit blank-node ids don't consume the counter. 2 of 3 fail against the unfixed code.
  - `tests/unit/vc/cryptosuites/bbs.roundtrip.test.ts`: e2e regressions with real BLS12-381 keys — id-less credential with anonymous nested nodes round-trips (the exact #316 failure shape); issuer impersonation rejected on base, derived, and `verifyProof`-dispatch paths; fail-closed without issuer/holder + `expectedController` escape hatch; `expectedChallenge`/`expectedDomain` anti-replay. All 4 fail against the unfixed code.
  - `tests/unit/vc/proofs/data-integrity.test.ts`: `bbs-2023` dispatches to the BBS cryptosuite instead of "Unsupported cryptosuite".
- [ ] Integration tests
- [x] Manual testing: full suite `bun test` — 3399 pass / 0 fail; `bun run lint` — 0 errors; `bun run build` clean.

## Screenshots / Output (if applicable)

```
bun test (packages/sdk)      3399 pass, 71 skip, 0 fail
bun run lint                 0 errors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4nUvJtUFZXdVUFkZExW6C

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4nUvJtUFZXdVUFkZExW6C)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind BBS proofs to issuer/holder and fix skolemization counter collision
> - `BBSCryptosuiteManager.verifyProof` and `verifyDerivedProof` now enforce that the `proof.verificationMethod` DID matches the document's issuer/holder (or an explicit `expectedController`), and reject proofs whose `challenge`/`domain` don't match verifier-supplied expectations.
> - `DataIntegrityProofManager.verifyProof` now dispatches `bbs-2023` proofs to `BBSCryptosuiteManager` instead of rejecting them as unsupported.
> - Fixed a counter-collision bug in `skolemizeExpandedJsonLd` where sibling branches could produce duplicate skolem URNs; the counter now increments globally across the full traversal via a shared options object.
> - Verification errors now surface concrete failure reasons instead of generic messages.
> - Behavioral Change: BBS proof verification now fails closed if neither `issuer`/`holder` nor `expectedController` is present in the document.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c8ad1d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->