### PR TITLE
fix(vc): resolve open BBS+ review threads (controller binding, changeset semver)

### DIFF
--- a/.changeset/bbs-selective-disclosure-cryptosuite.md
+++ b/.changeset/bbs-selective-disclosure-cryptosuite.md
@@ -1,5 +1,7 @@
 ---
-"@originals/sdk": minor
+"@originals/sdk": major
 ---
 
-Implement the BBS+ selective-disclosure cryptosuite (`bbs-2023`), replacing the `BbsSimple` stub. `BBSCryptosuiteManager` now signs, verifies, and derives selective-disclosure proofs over real BLS12-381 keys via `@digitalbazaar/bbs-signatures`, with the W3C Data Integrity selective-disclosure pipeline (skolemization, HMAC-shuffled label maps, JSON-Pointer selection) in `vc/utils/selective-disclosure.ts`. Verification keys always resolve from the DID document via the document loader (fail-closed), never from the attacker-controlled proof. `BbsSimple` and its export are removed.
+Implement the BBS+ selective-disclosure cryptosuite (`bbs-2023`), replacing the `BbsSimple` stub. `BBSCryptosuiteManager` now signs, verifies, and derives selective-disclosure proofs over real BLS12-381 keys via `@digitalbazaar/bbs-signatures`, with the W3C Data Integrity selective-disclosure pipeline (skolemization, HMAC-shuffled label maps, JSON-Pointer selection) in `vc/utils/selective-disclosure.ts`. Verification keys always resolve from the DID document via the document loader (fail-closed), never from the attacker-controlled proof.
+
+BREAKING: the `BbsSimple` class and its root export (`export { BbsSimple } from '@originals/sdk'`) are removed. It was a non-functional stub that threw from every method; consumers should use `BBSCryptosuiteManager` instead.

--- a/packages/sdk/src/vc/cryptosuites/bbsCryptosuite.ts
+++ b/packages/sdk/src/vc/cryptosuites/bbsCryptosuite.ts
@@ -479,7 +479,11 @@ export class BBSCryptosuiteManager {
       return 'Document has no issuer or holder to bind the proof to (pass expectedController to verify non-credential documents)';
     }
     const vmDid = verificationMethod.split('#')[0];
-    if (vmDid !== expected) {
+    // Compare on DID identity: `expected` may be a full verification-method URL
+    // (with a #fragment) when supplied as expectedController, so strip its
+    // fragment too before comparing.
+    const expectedDid = expected.split('#')[0];
+    if (vmDid !== expectedDid) {
       return `Proof verificationMethod (${vmDid}) does not match ${subjectLabel} (${expected})`;
     }
     return null;

--- a/packages/sdk/tests/unit/vc/cryptosuites/bbs.roundtrip.test.ts
+++ b/packages/sdk/tests/unit/vc/cryptosuites/bbs.roundtrip.test.ts
@@ -334,6 +334,16 @@ describe('BBS+ bbs-2023 selective disclosure round-trip', () => {
       expectedController: 'did:example:other'
     });
     expect(wrongController.verified).toBe(false);
+
+    // A full verification-method URL (with #fragment) is a valid
+    // expectedController: binding is on DID identity, so the fragment on the
+    // expected value must not cause a spurious mismatch against the
+    // fragment-stripped proof.verificationMethod.
+    const boundWithFragment = await BBSCryptosuiteManager.verifyProof(issuerlessCred, baseProof, {
+      documentLoader,
+      expectedController: 'did:example:issuer#bbs-key-1'
+    });
+    expect(boundWithFragment.verified).toBe(true);
   });
 
   // Issue #315 (related): a verifier that supplies challenge/domain


### PR DESCRIPTION
Addresses the two open review threads on #219.

## Fixes

- **P2 — controller binding rejected valid proofs** (`packages/sdk/src/vc/cryptosuites/bbsCryptosuite.ts`)
  `checkProofBinding` compared the fragment-stripped `proof.verificationMethod` against a raw `expectedController`. When a caller passed a full verification-method URL (e.g. `did:example:issuer#bbs-key-1`) as `expectedController`, a valid proof was rejected because `did:example:issuer` can never equal `did:example:issuer#bbs-key-1`. Both sides are now fragment-stripped so binding is on DID identity. Regression test added — confirmed it fails without the fix and passes with it.

- **P1 — changeset semver mismatch** (`.changeset/bbs-selective-disclosure-cryptosuite.md`)
  Removing the root `BbsSimple` export is a breaking change, but the changeset declared `minor`. Bumped to `major` and documented the removal (migration: use `BBSCryptosuiteManager`).

## Gates

- `bun run typecheck` — pass
- `bun run lint` — 0 errors (92 pre-existing warnings, unchanged)
- BBS suites — 32 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Har7qYndrTE8t6UseYnE8T

---
_Generated by [Claude Code](https://claude.ai/code/session_01Har7qYndrTE8t6UseYnE8T)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix BBS+ controller binding to strip `#fragment` from `expectedController` before comparison
> - Fixes a bug in `BBSCryptosuiteManager` where `verifyProof` would incorrectly fail controller binding when `expectedController` was passed as a full verification-method URL (e.g. `did:example:123#key-1`). The fix strips any `#fragment` from `expectedController` before comparing against the DID extracted from the proof's `verificationMethod`.
> - Bumps the `@originals/sdk` changeset release from minor to major with an explicit `BREAKING` note clarifying that the `BbsSimple` class and its root export are removed.
> - Adds a round-trip test in [bbs.roundtrip.test.ts](https://github.com/onionoriginals/sdk/pull/325/files#diff-1eefe0706c5cefd65a3abe76b48e63a7cb49068c985295b9b9d6d708ebf856e4) asserting that verification succeeds when `expectedController` includes a `#fragment`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized defa44f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->