### PR TITLE
Add QuickNodeProvider for Bitcoin Ordinals integration

### DIFF
--- a/.changeset/quicknode-ordinals-provider.md
+++ b/.changeset/quicknode-ordinals-provider.md
@@ -1,0 +1,5 @@
+---
+"@originals/sdk": minor
+---
+
+Add `QuickNodeProvider`, a production `OrdinalsProvider` backed by a QuickNode Bitcoin endpoint with the Ordinals & Runes add-on. Supports inscription/sat reads (`ord_getInscription`, `ord_getContent`, `ord_getSat`), transaction broadcast (`sendrawtransaction`), confirmation status (`getrawtransaction` + `getblockheader`), and fee estimation (`estimatesmartfee`, converted to sat/vB). Inscription creation/transfer fail loudly since QuickNode does not build or sign transactions — build locally and submit via `broadcastTransaction`. `createOrdinalsProviderFromEnv()` now selects this provider when `QUICKNODE_ENDPOINT` is set.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,7 +349,7 @@ const sdk = OriginalsSDK.create({
 });
 ```
 
-**Critical**: Bitcoin operations (inscribe, transfer) require `ordinalsProvider` to be configured. Use `OrdMockProvider` for testing, `OrdinalsClient` for production.
+**Critical**: Bitcoin operations (inscribe, transfer) require `ordinalsProvider` to be configured. Use `OrdMockProvider` for testing, `QuickNodeProvider` for production reads/broadcast/status/fees (QuickNode Bitcoin endpoint with the Ordinals & Runes add-on; `createOrdinalsProviderFromEnv()` selects it when `QUICKNODE_ENDPOINT` is set). Inscription construction/signing stays local — QuickNodeProvider's `createInscription`/`transferInscription` fail loudly by design; build the transaction locally and submit via `broadcastTransaction`.
 
 ## Development Workflow
 

--- a/packages/sdk/src/adapters/index.ts
+++ b/packages/sdk/src/adapters/index.ts
@@ -2,4 +2,5 @@ export * from './types.js';
 export * from './FeeOracleMock.js';
 export * from './providers/OrdMockProvider.js';
 export * from './providers/OrdHttpProvider.js';
+export * from './providers/QuickNodeProvider.js';
 

--- a/packages/sdk/src/adapters/providers/OrdHttpProvider.ts
+++ b/packages/sdk/src/adapters/providers/OrdHttpProvider.ts
@@ -199,6 +199,13 @@ export class OrdHttpProvider implements OrdinalsProvider {
 }
 
 export async function createOrdinalsProviderFromEnv(): Promise<OrdinalsProvider> {
+  // A configured QuickNode endpoint takes precedence: it is the only
+  // env-selectable provider with real broadcast/status/fee support.
+  const quickNodeEndpoint = ((globalThis as any).process?.env?.QUICKNODE_ENDPOINT) || '';
+  if (quickNodeEndpoint) {
+    const mod = await import('./QuickNodeProvider.js');
+    return new mod.QuickNodeProvider({ endpoint: quickNodeEndpoint });
+  }
   const useLive = String(((globalThis as any).process?.env?.USE_LIVE_ORD_PROVIDER) || '').toLowerCase() === 'true';
   if (useLive) {
     const baseUrl = ((globalThis as any).process?.env?.ORD_PROVIDER_BASE_URL) || 'https://ord.example.com/api';

--- a/packages/sdk/src/adapters/providers/QuickNodeProvider.ts
+++ b/packages/sdk/src/adapters/providers/QuickNodeProvider.ts
@@ -318,12 +318,12 @@ export class QuickNodeProvider implements OrdinalsProvider {
       );
     }
     const result = await this.rpcCall<unknown>('sendrawtransaction', [txHexOrObj]);
-    // A response with neither result nor error must not become a "successful"
-    // empty txid that downstream code records as provenance.
-    if (typeof result !== 'string' || result.length === 0) {
+    // A malformed or empty result must not become a "successful" txid that
+    // downstream code records as provenance — require a real 64-char hex txid.
+    if (typeof result !== 'string' || !/^[0-9a-fA-F]{64}$/.test(result)) {
       throw new StructuredError(
         'QUICKNODE_BROADCAST_NO_TXID',
-        'QuickNodeProvider: sendrawtransaction returned no txid'
+        'QuickNodeProvider: sendrawtransaction did not return a valid 64-character hex txid'
       );
     }
     return result;

--- a/packages/sdk/src/adapters/providers/QuickNodeProvider.ts
+++ b/packages/sdk/src/adapters/providers/QuickNodeProvider.ts
@@ -137,7 +137,7 @@ export class QuickNodeProvider implements OrdinalsProvider {
       throw new StructuredError(
         'QUICKNODE_RPC_ERROR',
         `QuickNodeProvider: ${method} RPC error: ${data.error.message ?? JSON.stringify(data.error)}`,
-        { rpcCode: data.error.code, method }
+        { rpcCode: data.error.code, rpcMessage: data.error.message, method }
       );
     }
     if (!res.ok) {
@@ -149,11 +149,21 @@ export class QuickNodeProvider implements OrdinalsProvider {
     return data.result as T;
   }
 
-  /** True for RPC failures that mean "this thing does not exist" rather than a transport/config fault. */
+  /**
+   * True for RPC failures that mean "this thing does not exist" rather than a
+   * transport/config fault. Only Bitcoin Core's -5 code and ord-style
+   * "<resource> not found" messages qualify; the match is anchored to the raw
+   * RPC error message and to known resource nouns so infrastructure errors
+   * that merely contain "not found" (e.g. "API key not found", "Endpoint not
+   * found in routing table") propagate instead of masquerading as an empty
+   * data source.
+   */
   private static isNotFound(err: unknown): boolean {
     if (!(err instanceof StructuredError) || err.code !== 'QUICKNODE_RPC_ERROR') return false;
     if (err.details?.rpcCode === RPC_INVALID_ADDRESS_OR_KEY) return true;
-    return /not found/i.test(err.message);
+    const rpcMessage = err.details?.rpcMessage;
+    if (typeof rpcMessage !== 'string') return false;
+    return /^(?:inscription|sat(?:oshi)?|output|content|transaction|tx)\b[^]*\bnot found\.?$/i.test(rpcMessage.trim());
   }
 
   /**
@@ -162,8 +172,15 @@ export class QuickNodeProvider implements OrdinalsProvider {
    * a bare string or wrapped in an object). Content that doesn't decode as
    * base64 is treated as literal UTF-8 text — some gateways return text
    * inscriptions unencoded.
+   *
+   * A short alphanumeric text inscription (e.g. "text") is shape-ambiguous:
+   * it passes the base64 charset/length checks but is far more likely to be
+   * the literal content. For text-typed inscriptions the base64 reading is
+   * only trusted when the decoded bytes are themselves valid UTF-8 — literal
+   * words almost never decode to valid UTF-8, while genuinely base64-encoded
+   * text content always does. Binary content types are always base64.
    */
-  private decodeContent(result: unknown): Buffer {
+  private decodeContent(result: unknown, contentType?: string): Buffer {
     let raw: unknown = result;
     if (raw && typeof raw === 'object') {
       const obj = raw as Record<string, unknown>;
@@ -175,13 +192,15 @@ export class QuickNodeProvider implements OrdinalsProvider {
         'QuickNodeProvider: ord_getContent returned no decodable content'
       );
     }
-    let buf: Buffer;
+    let buf: Buffer | undefined;
     const compact = raw.replace(/\s+/g, '');
     if (compact.length > 0 && /^[A-Za-z0-9+/]+={0,2}$/.test(compact) && compact.length % 4 === 0) {
-      buf = Buffer.from(compact, 'base64');
-    } else {
-      buf = Buffer.from(raw, 'utf8');
+      const decoded = Buffer.from(compact, 'base64');
+      if (!QuickNodeProvider.isTextContentType(contentType) || QuickNodeProvider.isValidUtf8(decoded)) {
+        buf = decoded;
+      }
     }
+    buf ??= Buffer.from(raw, 'utf8');
     if (buf.byteLength > this.maxContentBytes) {
       throw new StructuredError(
         'QUICKNODE_CONTENT_TOO_LARGE',
@@ -189,6 +208,26 @@ export class QuickNodeProvider implements OrdinalsProvider {
       );
     }
     return buf;
+  }
+
+  private static isTextContentType(contentType?: string): boolean {
+    if (!contentType) return false;
+    const mime = contentType.split(';')[0].trim().toLowerCase();
+    return mime.startsWith('text/')
+      || mime === 'application/json'
+      || mime.endsWith('+json')
+      || mime.endsWith('+xml')
+      || mime === 'application/javascript'
+      || mime === 'image/svg+xml';
+  }
+
+  private static isValidUtf8(bytes: Buffer): boolean {
+    try {
+      new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   async getInscriptionById(id: string) {
@@ -220,7 +259,7 @@ export class QuickNodeProvider implements OrdinalsProvider {
     let content: Buffer;
     try {
       const contentResult = await this.rpcCall<unknown>('ord_getContent', [id], contentJsonCap);
-      content = this.decodeContent(contentResult);
+      content = this.decodeContent(contentResult, info.content_type || info.effective_content_type);
     } catch (err) {
       if (QuickNodeProvider.isNotFound(err)) return null;
       throw err;

--- a/packages/sdk/src/adapters/providers/QuickNodeProvider.ts
+++ b/packages/sdk/src/adapters/providers/QuickNodeProvider.ts
@@ -1,0 +1,390 @@
+import type { OrdinalsProvider } from '../types.js';
+import { StructuredError } from '../../utils/telemetry.js';
+import { validateSatoshiNumber } from '../../utils/satoshi-validation.js';
+
+export interface QuickNodeProviderOptions {
+  /**
+   * Full QuickNode endpoint URL including the token path, e.g.
+   * `https://your-endpoint-name.btc.quiknode.pro/<token>/`.
+   * The endpoint must have the "Ordinals & Runes API" add-on enabled for
+   * inscription reads (ord_* methods); standard Bitcoin Core RPC methods
+   * (sendrawtransaction, getrawtransaction, estimatesmartfee) are served by
+   * the same endpoint.
+   */
+  endpoint: string;
+  /** Request timeout in milliseconds (default: 10000). */
+  timeout?: number;
+  /** Max bytes accepted for a JSON-RPC response body (default 1 MiB). */
+  maxJsonBytes?: number;
+  /** Max bytes accepted for decoded inscription content (default 5 MiB). */
+  maxContentBytes?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_JSON_BYTES = 1 * 1024 * 1024;
+const DEFAULT_MAX_CONTENT_BYTES = 5 * 1024 * 1024;
+
+/** Bitcoin Core RPC error code for "No such mempool or blockchain transaction". */
+const RPC_INVALID_ADDRESS_OR_KEY = -5;
+
+interface JsonRpcError {
+  code?: number;
+  message?: string;
+}
+
+/**
+ * The ord server's `/inscription/:id` JSON shape, which QuickNode's
+ * Ordinals & Runes API returns as the JSON-RPC result of `ord_getInscription`.
+ */
+interface QuickNodeInscription {
+  id?: string;
+  inscription_id?: string;
+  sat?: number | string | null;
+  satpoint?: string;
+  output?: string;
+  content_type?: string;
+  effective_content_type?: string;
+  height?: number;
+  genesis_height?: number;
+  address?: string;
+  value?: number;
+}
+
+/**
+ * OrdinalsProvider backed by a QuickNode Bitcoin endpoint.
+ *
+ * Everything speaks JSON-RPC 2.0 against the single QuickNode endpoint URL:
+ * - Inscription/sat reads use the Ordinals & Runes API add-on
+ *   (`ord_getInscription`, `ord_getSat`, `ord_getContent`).
+ * - Broadcast, status and fees use standard Bitcoin Core RPC
+ *   (`sendrawtransaction`, `getrawtransaction`, `estimatesmartfee`).
+ *
+ * Write-path inscription construction (createInscription /
+ * transferInscription) is intentionally NOT implemented: QuickNode is a
+ * read/broadcast service and does not build or sign transactions. Those
+ * methods fail loudly (mirroring the OrdinalsClient/OrdHttpProvider
+ * hardening) rather than fabricating on-chain data. Build the commit/reveal
+ * or transfer transaction locally and submit it via broadcastTransaction.
+ */
+export class QuickNodeProvider implements OrdinalsProvider {
+  private readonly endpoint: string;
+  private readonly timeout: number;
+  private readonly maxJsonBytes: number;
+  private readonly maxContentBytes: number;
+
+  constructor(options: QuickNodeProviderOptions) {
+    if (!options?.endpoint) {
+      throw new StructuredError('QUICKNODE_ENDPOINT_REQUIRED', 'QuickNodeProvider requires an endpoint URL');
+    }
+    let parsed: URL;
+    try {
+      parsed = new URL(options.endpoint);
+    } catch {
+      throw new StructuredError('QUICKNODE_ENDPOINT_INVALID', `QuickNodeProvider endpoint is not a valid URL: ${options.endpoint}`);
+    }
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+      throw new StructuredError('QUICKNODE_ENDPOINT_INVALID', `QuickNodeProvider endpoint must be http(s), got ${parsed.protocol}`);
+    }
+    this.endpoint = options.endpoint;
+    this.timeout = options.timeout ?? DEFAULT_TIMEOUT_MS;
+    this.maxJsonBytes = options.maxJsonBytes ?? DEFAULT_MAX_JSON_BYTES;
+    this.maxContentBytes = options.maxContentBytes ?? DEFAULT_MAX_CONTENT_BYTES;
+  }
+
+  /**
+   * POST a JSON-RPC 2.0 request to the QuickNode endpoint, enforcing the
+   * timeout and a hard byte cap on the response — first via Content-Length
+   * (cheap early reject) and again on the materialized bytes, so a lying or
+   * absent header can't smuggle an oversized body past the cap.
+   *
+   * QuickNode (like bitcoind) may report RPC-level errors with a non-2xx
+   * status but still send a JSON body; parse the body when possible so the
+   * RPC error surfaces instead of an opaque HTTP failure.
+   */
+  private async rpcCall<T>(method: string, params: unknown[], maxBytes?: number): Promise<T> {
+    const cap = maxBytes ?? this.maxJsonBytes;
+    const res = await fetch(this.endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+      redirect: 'error',
+      signal: AbortSignal.timeout(this.timeout),
+    });
+    const lenHeader = res.headers?.get?.('content-length');
+    if (lenHeader && Number(lenHeader) > cap) {
+      throw new StructuredError(
+        'QUICKNODE_RESPONSE_TOO_LARGE',
+        `QuickNodeProvider: ${method} response exceeds ${cap} bytes (Content-Length ${lenHeader})`
+      );
+    }
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    if (bytes.byteLength > cap) {
+      throw new StructuredError(
+        'QUICKNODE_RESPONSE_TOO_LARGE',
+        `QuickNodeProvider: ${method} response body exceeds ${cap} bytes`
+      );
+    }
+    let data: { result?: T; error?: JsonRpcError | null };
+    try {
+      data = JSON.parse(new TextDecoder().decode(bytes)) as { result?: T; error?: JsonRpcError | null };
+    } catch {
+      throw new StructuredError(
+        'QUICKNODE_RPC_HTTP_ERROR',
+        `QuickNodeProvider: ${method} request failed: HTTP ${res.status} ${res.statusText}`
+      );
+    }
+    if (data.error) {
+      throw new StructuredError(
+        'QUICKNODE_RPC_ERROR',
+        `QuickNodeProvider: ${method} RPC error: ${data.error.message ?? JSON.stringify(data.error)}`,
+        { rpcCode: data.error.code, method }
+      );
+    }
+    if (!res.ok) {
+      throw new StructuredError(
+        'QUICKNODE_RPC_HTTP_ERROR',
+        `QuickNodeProvider: ${method} request failed: HTTP ${res.status} ${res.statusText}`
+      );
+    }
+    return data.result as T;
+  }
+
+  /** True for RPC failures that mean "this thing does not exist" rather than a transport/config fault. */
+  private static isNotFound(err: unknown): boolean {
+    if (!(err instanceof StructuredError) || err.code !== 'QUICKNODE_RPC_ERROR') return false;
+    if (err.details?.rpcCode === RPC_INVALID_ADDRESS_OR_KEY) return true;
+    return /not found/i.test(err.message);
+  }
+
+  /**
+   * Decode the `ord_getContent` result into raw bytes. QuickNode returns the
+   * inscription content base64-encoded inside the JSON-RPC result (either as
+   * a bare string or wrapped in an object). Content that doesn't decode as
+   * base64 is treated as literal UTF-8 text — some gateways return text
+   * inscriptions unencoded.
+   */
+  private decodeContent(result: unknown): Buffer {
+    let raw: unknown = result;
+    if (raw && typeof raw === 'object') {
+      const obj = raw as Record<string, unknown>;
+      raw = obj.content ?? obj.data ?? obj.base64 ?? null;
+    }
+    if (typeof raw !== 'string') {
+      throw new StructuredError(
+        'QUICKNODE_CONTENT_UNEXPECTED_SHAPE',
+        'QuickNodeProvider: ord_getContent returned no decodable content'
+      );
+    }
+    let buf: Buffer;
+    const compact = raw.replace(/\s+/g, '');
+    if (compact.length > 0 && /^[A-Za-z0-9+/]+={0,2}$/.test(compact) && compact.length % 4 === 0) {
+      buf = Buffer.from(compact, 'base64');
+    } else {
+      buf = Buffer.from(raw, 'utf8');
+    }
+    if (buf.byteLength > this.maxContentBytes) {
+      throw new StructuredError(
+        'QUICKNODE_CONTENT_TOO_LARGE',
+        `QuickNodeProvider: inscription content exceeds ${this.maxContentBytes} bytes`
+      );
+    }
+    return buf;
+  }
+
+  async getInscriptionById(id: string) {
+    if (!id) return null;
+    let info: QuickNodeInscription | null;
+    try {
+      info = await this.rpcCall<QuickNodeInscription | null>('ord_getInscription', [id]);
+    } catch (err) {
+      if (QuickNodeProvider.isNotFound(err)) return null;
+      throw err;
+    }
+    if (!info) return null;
+
+    // Current location comes from the satpoint ('txid:vout:offset'); fall
+    // back to the owning output ('txid:vout') if satpoint is absent.
+    let txid = 'unknown';
+    let vout = 0;
+    const location = info.satpoint || info.output;
+    if (typeof location === 'string' && location.includes(':')) {
+      const [tid, v] = location.split(':');
+      txid = tid;
+      vout = Number(v) || 0;
+    }
+
+    // Content bytes are a separate call: ord_getInscription returns metadata
+    // only. Cap the JSON-RPC body at the base64 expansion of the content cap
+    // so legitimately large inscriptions aren't rejected by the JSON cap.
+    const contentJsonCap = Math.ceil(this.maxContentBytes * 4 / 3) + 64 * 1024;
+    let content: Buffer;
+    try {
+      const contentResult = await this.rpcCall<unknown>('ord_getContent', [id], contentJsonCap);
+      content = this.decodeContent(contentResult);
+    } catch (err) {
+      if (QuickNodeProvider.isNotFound(err)) return null;
+      throw err;
+    }
+
+    const satRaw = info.sat;
+    const satoshi = satRaw === null || satRaw === undefined ? undefined : String(satRaw);
+    const blockHeight = typeof info.height === 'number'
+      ? info.height
+      : (typeof info.genesis_height === 'number' ? info.genesis_height : undefined);
+
+    return {
+      inscriptionId: info.id || info.inscription_id || id,
+      content,
+      contentType: info.content_type || info.effective_content_type || 'application/octet-stream',
+      txid,
+      vout,
+      satoshi,
+      blockHeight,
+    };
+  }
+
+  async getInscriptionsBySatoshi(satoshi: string) {
+    const validation = validateSatoshiNumber(satoshi);
+    if (!validation.valid) {
+      throw new StructuredError('QUICKNODE_INVALID_SATOSHI', `QuickNodeProvider: ${validation.error}`);
+    }
+    // Sat ordinals max out at 2,099,999,997,689,999 (< 2^53), so Number is
+    // exact here; ord_getSat expects a JSON number, not a string.
+    let info: { inscriptions?: string[]; inscription_ids?: string[] } | null;
+    try {
+      info = await this.rpcCall<{ inscriptions?: string[]; inscription_ids?: string[] } | null>(
+        'ord_getSat',
+        [Number(satoshi)]
+      );
+    } catch (err) {
+      if (QuickNodeProvider.isNotFound(err)) return [];
+      throw err;
+    }
+    const ids = Array.isArray(info?.inscriptions)
+      ? info.inscriptions
+      : (Array.isArray(info?.inscription_ids) ? info.inscription_ids : []);
+    return ids
+      .filter((x): x is string => typeof x === 'string' && x.length > 0)
+      .map((inscriptionId) => ({ inscriptionId }));
+  }
+
+  async broadcastTransaction(txHexOrObj: unknown): Promise<string> {
+    // sendrawtransaction only accepts raw transaction hex. Reject non-hex
+    // input up front instead of producing a guaranteed-invalid RPC parameter
+    // that fails far from the cause (same hardening as SignetProvider, #272).
+    if (typeof txHexOrObj !== 'string' || !/^(?:[0-9a-fA-F]{2})+$/.test(txHexOrObj)) {
+      throw new StructuredError(
+        'QUICKNODE_INVALID_TX_HEX',
+        'QuickNodeProvider.broadcastTransaction requires a raw transaction hex string (even-length hexadecimal)'
+      );
+    }
+    const result = await this.rpcCall<unknown>('sendrawtransaction', [txHexOrObj]);
+    // A response with neither result nor error must not become a "successful"
+    // empty txid that downstream code records as provenance.
+    if (typeof result !== 'string' || result.length === 0) {
+      throw new StructuredError(
+        'QUICKNODE_BROADCAST_NO_TXID',
+        'QuickNodeProvider: sendrawtransaction returned no txid'
+      );
+    }
+    return result;
+  }
+
+  async getTransactionStatus(txid: string): Promise<{ confirmed: boolean; blockHeight?: number; confirmations?: number }> {
+    if (typeof txid !== 'string' || !/^[0-9a-fA-F]{64}$/.test(txid)) {
+      throw new StructuredError(
+        'QUICKNODE_INVALID_TXID',
+        'QuickNodeProvider.getTransactionStatus requires a 64-character hex txid'
+      );
+    }
+    let tx: { confirmations?: number; blockhash?: string } | null;
+    try {
+      tx = await this.rpcCall<{ confirmations?: number; blockhash?: string } | null>(
+        'getrawtransaction',
+        [txid.toLowerCase(), true]
+      );
+    } catch (err) {
+      // -5: not in mempool or chain — an unknown tx is "not confirmed", not
+      // a transport failure.
+      if (QuickNodeProvider.isNotFound(err)) return { confirmed: false };
+      throw err;
+    }
+    if (!tx) return { confirmed: false };
+    const confirmations = typeof tx.confirmations === 'number' ? tx.confirmations : 0;
+    if (confirmations < 1) {
+      return { confirmed: false, confirmations };
+    }
+    // Verbose getrawtransaction reports blockhash but not height; resolve it
+    // via getblockheader when available. Height is optional in the provider
+    // contract, so a failure here must not mask a confirmed transaction.
+    let blockHeight: number | undefined;
+    if (tx.blockhash) {
+      try {
+        const header = await this.rpcCall<{ height?: number } | null>('getblockheader', [tx.blockhash, true]);
+        if (typeof header?.height === 'number') blockHeight = header.height;
+      } catch {
+        // best-effort only
+      }
+    }
+    return { confirmed: true, confirmations, blockHeight };
+  }
+
+  async estimateFee(blocks: number = 1): Promise<number> {
+    const target = Math.max(1, Math.floor(blocks));
+    const result = await this.rpcCall<{ feerate?: number; errors?: string[] } | null>(
+      'estimatesmartfee',
+      [target]
+    );
+    if (typeof result?.feerate !== 'number' || !(result.feerate > 0)) {
+      // estimatesmartfee returns { errors: [...] } and no feerate when the
+      // node lacks fee data. Refuse to invent a rate — fabricated fees are
+      // exactly what the OrdMockProvider replacement is meant to eliminate.
+      throw new StructuredError(
+        'QUICKNODE_FEE_ESTIMATE_UNAVAILABLE',
+        `QuickNodeProvider: estimatesmartfee returned no feerate${result?.errors?.length ? ` (${result.errors.join('; ')})` : ''}. Configure a FeeOracleAdapter or retry with a higher block target.`
+      );
+    }
+    // estimatesmartfee reports BTC/kvB; the provider contract is sat/vB.
+    return Math.max(1, Math.ceil(result.feerate * 1e5));
+  }
+
+  // QuickNode does not build or sign transactions, so inscription
+  // creation/transfer cannot be implemented against it directly. These fail
+  // loudly (mirroring OrdinalsClient/OrdHttpProvider hardening, #248/#318)
+  // instead of fabricating inscription ids or txids. Build the commit/reveal
+  // (src/bitcoin/transactions/commit.ts) or transfer (src/bitcoin/transfer.ts)
+  // transaction locally, sign it, and submit via broadcastTransaction.
+
+  createInscription(_params: { data: Buffer; contentType: string; feeRate?: number; }): Promise<{
+    inscriptionId: string;
+    revealTxId: string;
+    commitTxId?: string;
+    satoshi?: string;
+    txid?: string;
+    vout?: number;
+    blockHeight?: number;
+    content?: Buffer;
+    contentType?: string;
+    feeRate?: number;
+  }> {
+    return Promise.reject(new StructuredError(
+      'QUICKNODE_CREATE_INSCRIPTION_NOT_IMPLEMENTED',
+      'QuickNodeProvider.createInscription is not implemented: QuickNode does not construct or sign transactions, and no inscription was created. Build and sign the commit/reveal transactions locally, then submit them via broadcastTransaction.'
+    ));
+  }
+
+  transferInscription(_inscriptionId: string, _toAddress: string, _options?: { feeRate?: number }): Promise<{
+    txid: string;
+    vin: Array<{ txid: string; vout: number }>;
+    vout: Array<{ value: number; scriptPubKey: string; address?: string }>;
+    fee: number;
+    blockHeight?: number;
+    confirmations?: number;
+    satoshi?: string;
+  }> {
+    return Promise.reject(new StructuredError(
+      'QUICKNODE_TRANSFER_NOT_IMPLEMENTED',
+      'QuickNodeProvider.transferInscription is not implemented: QuickNode does not construct or sign transactions, and no transfer was broadcast. Build and sign the transfer transaction locally, then submit it via broadcastTransaction.'
+    ));
+  }
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -171,6 +171,8 @@ export { OrdMockProvider } from './adapters/providers/OrdMockProvider.js';
 export { FeeOracleMock } from './adapters/FeeOracleMock.js';
 export { SignetProvider } from './bitcoin/providers/SignetProvider.js';
 export type { SignetProviderOptions } from './bitcoin/providers/SignetProvider.js';
+export { QuickNodeProvider } from './adapters/providers/QuickNodeProvider.js';
+export type { QuickNodeProviderOptions } from './adapters/providers/QuickNodeProvider.js';
 export type { OrdinalsProvider, FeeOracleAdapter, StorageAdapter } from './adapters/types.js';
 
 // CEL (Cryptographic Event Log) exports

--- a/packages/sdk/tests/unit/adapters/QuickNodeProvider.test.ts
+++ b/packages/sdk/tests/unit/adapters/QuickNodeProvider.test.ts
@@ -1,0 +1,336 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { QuickNodeProvider } from '../../../src/adapters/providers/QuickNodeProvider';
+import { StructuredError } from '../../../src/utils/telemetry';
+
+/**
+ * QuickNodeProvider speaks JSON-RPC 2.0 against a single QuickNode endpoint:
+ * ord_* methods for Ordinals & Runes API reads, standard Bitcoin Core RPC
+ * (sendrawtransaction / getrawtransaction / estimatesmartfee) for the rest.
+ * These tests mock fetch and assert both the request wire format and the
+ * response mapping into the OrdinalsProvider contract.
+ */
+
+const ENDPOINT = 'https://example-name.btc.quiknode.pro/test-token/';
+const INSCRIPTION_ID = 'a860baeecae8c2d9fb95f09608d3b3e2bbaf207f25a6361e0d07a326906f8be6i0';
+const TXID = 'a860baeecae8c2d9fb95f09608d3b3e2bbaf207f25a6361e0d07a326906f8be6';
+
+type RpcRequest = { method: string; params: unknown[]; id: number; jsonrpc: string };
+
+interface MockRoute {
+  match: (req: RpcRequest) => boolean;
+  respond: (req: RpcRequest) => { status?: number; body?: unknown; headers?: Record<string, string> };
+}
+
+let requests: RpcRequest[];
+let routes: MockRoute[];
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(body: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  });
+}
+
+function mockRpc(method: string, result: unknown): void {
+  routes.push({ match: (r) => r.method === method, respond: () => ({ body: { jsonrpc: '2.0', id: 1, result } }) });
+}
+
+function mockRpcError(method: string, error: { code?: number; message: string }): void {
+  routes.push({ match: (r) => r.method === method, respond: () => ({ body: { jsonrpc: '2.0', id: 1, result: null, error } }) });
+}
+
+beforeEach(() => {
+  requests = [];
+  routes = [];
+  globalThis.fetch = (async (url: any, init?: any) => {
+    const req = JSON.parse(String(init?.body ?? '{}')) as RpcRequest;
+    requests.push(req);
+    const route = routes.find((r) => r.match(req));
+    if (!route) {
+      return jsonResponse({ jsonrpc: '2.0', id: 1, result: null, error: { code: -32601, message: `Method not found: ${req.method}` } });
+    }
+    const { status = 200, body, headers = {} } = route.respond(req);
+    return jsonResponse(body, status, headers);
+  }) as any;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('QuickNodeProvider constructor', () => {
+  test('requires an endpoint', () => {
+    expect(() => new QuickNodeProvider({ endpoint: '' })).toThrow(StructuredError);
+  });
+
+  test('rejects a malformed endpoint URL', () => {
+    expect(() => new QuickNodeProvider({ endpoint: 'not-a-url' })).toThrow(/not a valid URL/);
+  });
+
+  test('rejects non-http(s) protocols', () => {
+    expect(() => new QuickNodeProvider({ endpoint: 'ftp://example.com/' })).toThrow(/must be http/);
+  });
+});
+
+describe('getInscriptionById', () => {
+  const provider = () => new QuickNodeProvider({ endpoint: ENDPOINT });
+
+  test('maps ord_getInscription + ord_getContent into the provider contract', async () => {
+    mockRpc('ord_getInscription', {
+      id: INSCRIPTION_ID,
+      number: 12345,
+      sat: 125866034480298,
+      satpoint: `${TXID}:0:0`,
+      content_type: 'text/plain;charset=utf-8',
+      content_length: 5,
+      height: 767430,
+      value: 10000,
+      address: 'bc1pexample',
+    });
+    mockRpc('ord_getContent', Buffer.from('hello', 'utf8').toString('base64'));
+
+    const result = await provider().getInscriptionById(INSCRIPTION_ID);
+    expect(result).not.toBeNull();
+    expect(result!.inscriptionId).toBe(INSCRIPTION_ID);
+    expect(result!.content.toString('utf8')).toBe('hello');
+    expect(result!.contentType).toBe('text/plain;charset=utf-8');
+    expect(result!.txid).toBe(TXID);
+    expect(result!.vout).toBe(0);
+    expect(result!.satoshi).toBe('125866034480298');
+    expect(result!.blockHeight).toBe(767430);
+
+    // Wire format: JSON-RPC 2.0 with the inscription id as sole param
+    expect(requests[0]).toMatchObject({ jsonrpc: '2.0', method: 'ord_getInscription', params: [INSCRIPTION_ID] });
+    expect(requests[1]).toMatchObject({ jsonrpc: '2.0', method: 'ord_getContent', params: [INSCRIPTION_ID] });
+  });
+
+  test('parses vout from a non-zero satpoint', async () => {
+    mockRpc('ord_getInscription', { id: INSCRIPTION_ID, sat: 1, satpoint: `${TXID}:3:512`, content_type: 'text/plain' });
+    mockRpc('ord_getContent', Buffer.from('x').toString('base64'));
+    const result = await provider().getInscriptionById(INSCRIPTION_ID);
+    expect(result!.txid).toBe(TXID);
+    expect(result!.vout).toBe(3);
+  });
+
+  test('treats non-base64 content as literal UTF-8 text', async () => {
+    mockRpc('ord_getInscription', { id: INSCRIPTION_ID, sat: 1, satpoint: `${TXID}:0:0`, content_type: 'text/plain' });
+    // '{"p":"x"}' is not valid base64 (contains '{', '"', ':')
+    mockRpc('ord_getContent', '{"p":"x"}');
+    const result = await provider().getInscriptionById(INSCRIPTION_ID);
+    expect(result!.content.toString('utf8')).toBe('{"p":"x"}');
+  });
+
+  test('unwraps object-shaped content results', async () => {
+    mockRpc('ord_getInscription', { id: INSCRIPTION_ID, sat: 1, satpoint: `${TXID}:0:0`, content_type: 'image/png' });
+    mockRpc('ord_getContent', { content: Buffer.from([1, 2, 3]).toString('base64') });
+    const result = await provider().getInscriptionById(INSCRIPTION_ID);
+    expect([...result!.content]).toEqual([1, 2, 3]);
+  });
+
+  test('returns null when the inscription is not found', async () => {
+    mockRpcError('ord_getInscription', { code: -32000, message: 'inscription not found' });
+    const result = await provider().getInscriptionById(INSCRIPTION_ID);
+    expect(result).toBeNull();
+  });
+
+  test('returns null for an empty id without any RPC call', async () => {
+    const result = await provider().getInscriptionById('');
+    expect(result).toBeNull();
+    expect(requests.length).toBe(0);
+  });
+
+  test('omits satoshi when the sat is unindexed (null)', async () => {
+    mockRpc('ord_getInscription', { id: INSCRIPTION_ID, sat: null, satpoint: `${TXID}:0:0`, content_type: 'text/plain' });
+    mockRpc('ord_getContent', Buffer.from('x').toString('base64'));
+    const result = await provider().getInscriptionById(INSCRIPTION_ID);
+    expect(result!.satoshi).toBeUndefined();
+  });
+
+  test('propagates transport-level RPC failures', async () => {
+    mockRpcError('ord_getInscription', { code: -32603, message: 'internal error' });
+    await expect(provider().getInscriptionById(INSCRIPTION_ID)).rejects.toThrow(/internal error/);
+  });
+
+  test('rejects inscription content exceeding maxContentBytes', async () => {
+    const small = new QuickNodeProvider({ endpoint: ENDPOINT, maxContentBytes: 4 });
+    mockRpc('ord_getInscription', { id: INSCRIPTION_ID, sat: 1, satpoint: `${TXID}:0:0`, content_type: 'text/plain' });
+    mockRpc('ord_getContent', Buffer.from('hello world', 'utf8').toString('base64'));
+    await expect(small.getInscriptionById(INSCRIPTION_ID)).rejects.toThrow(/exceeds 4 bytes/);
+  });
+});
+
+describe('getInscriptionsBySatoshi', () => {
+  const provider = () => new QuickNodeProvider({ endpoint: ENDPOINT });
+
+  test('sends the sat as a JSON number and maps the inscriptions array', async () => {
+    mockRpc('ord_getSat', { number: 125866034480298, rarity: 'common', inscriptions: [INSCRIPTION_ID, 'otherI0id'] });
+    const result = await provider().getInscriptionsBySatoshi('125866034480298');
+    expect(result).toEqual([{ inscriptionId: INSCRIPTION_ID }, { inscriptionId: 'otherI0id' }]);
+    expect(requests[0]).toMatchObject({ method: 'ord_getSat', params: [125866034480298] });
+  });
+
+  test('supports the inscription_ids response shape', async () => {
+    mockRpc('ord_getSat', { inscription_ids: [INSCRIPTION_ID] });
+    const result = await provider().getInscriptionsBySatoshi('123');
+    expect(result).toEqual([{ inscriptionId: INSCRIPTION_ID }]);
+  });
+
+  test('returns [] when the sat has no inscriptions', async () => {
+    mockRpc('ord_getSat', { number: 123, rarity: 'common', inscriptions: [] });
+    const result = await provider().getInscriptionsBySatoshi('123');
+    expect(result).toEqual([]);
+  });
+
+  test('rejects invalid satoshi identifiers without any RPC call', async () => {
+    await expect(provider().getInscriptionsBySatoshi('sat-123')).rejects.toThrow(StructuredError);
+    await expect(provider().getInscriptionsBySatoshi('')).rejects.toThrow(StructuredError);
+    expect(requests.length).toBe(0);
+  });
+
+  test('rejects satoshi numbers above max supply', async () => {
+    await expect(provider().getInscriptionsBySatoshi('2100000000000000')).rejects.toThrow(StructuredError);
+    expect(requests.length).toBe(0);
+  });
+});
+
+describe('broadcastTransaction', () => {
+  const provider = () => new QuickNodeProvider({ endpoint: ENDPOINT });
+
+  test('submits raw hex via sendrawtransaction and returns the txid', async () => {
+    mockRpc('sendrawtransaction', TXID);
+    const txid = await provider().broadcastTransaction('0200aabb');
+    expect(txid).toBe(TXID);
+    expect(requests[0]).toMatchObject({ method: 'sendrawtransaction', params: ['0200aabb'] });
+  });
+
+  test('rejects non-hex input up front', async () => {
+    await expect(provider().broadcastTransaction('not-hex')).rejects.toThrow(/hex/);
+    await expect(provider().broadcastTransaction('abc')).rejects.toThrow(/hex/); // odd length
+    await expect(provider().broadcastTransaction({ tx: 'obj' })).rejects.toThrow(/hex/);
+    expect(requests.length).toBe(0);
+  });
+
+  test('surfaces RPC rejection (e.g. mempool rejection)', async () => {
+    mockRpcError('sendrawtransaction', { code: -26, message: 'min relay fee not met' });
+    await expect(provider().broadcastTransaction('0200aabb')).rejects.toThrow(/min relay fee not met/);
+  });
+
+  test('refuses an empty txid result instead of reporting success', async () => {
+    mockRpc('sendrawtransaction', '');
+    await expect(provider().broadcastTransaction('0200aabb')).rejects.toThrow(/no txid/);
+  });
+});
+
+describe('getTransactionStatus', () => {
+  const provider = () => new QuickNodeProvider({ endpoint: ENDPOINT });
+  const BLOCKHASH = '00000000000000000002b1c2f0dcb8f1f4a1e6d3c9a7b5e8d2f4a6c8e0b2d4f6';
+
+  test('reports a confirmed transaction with height from getblockheader', async () => {
+    mockRpc('getrawtransaction', { txid: TXID, confirmations: 3, blockhash: BLOCKHASH });
+    mockRpc('getblockheader', { hash: BLOCKHASH, height: 800000 });
+    const status = await provider().getTransactionStatus(TXID);
+    expect(status).toEqual({ confirmed: true, confirmations: 3, blockHeight: 800000 });
+    expect(requests[0]).toMatchObject({ method: 'getrawtransaction', params: [TXID, true] });
+    expect(requests[1]).toMatchObject({ method: 'getblockheader', params: [BLOCKHASH, true] });
+  });
+
+  test('still reports confirmed when getblockheader fails', async () => {
+    mockRpc('getrawtransaction', { txid: TXID, confirmations: 2, blockhash: BLOCKHASH });
+    mockRpcError('getblockheader', { code: -32603, message: 'boom' });
+    const status = await provider().getTransactionStatus(TXID);
+    expect(status.confirmed).toBe(true);
+    expect(status.confirmations).toBe(2);
+    expect(status.blockHeight).toBeUndefined();
+  });
+
+  test('reports a mempool transaction as unconfirmed', async () => {
+    mockRpc('getrawtransaction', { txid: TXID, confirmations: 0 });
+    const status = await provider().getTransactionStatus(TXID);
+    expect(status).toEqual({ confirmed: false, confirmations: 0 });
+  });
+
+  test('treats RPC -5 (unknown tx) as unconfirmed rather than an error', async () => {
+    mockRpcError('getrawtransaction', { code: -5, message: 'No such mempool or blockchain transaction' });
+    const status = await provider().getTransactionStatus(TXID);
+    expect(status).toEqual({ confirmed: false });
+  });
+
+  test('rejects malformed txids without any RPC call', async () => {
+    await expect(provider().getTransactionStatus('nope')).rejects.toThrow(StructuredError);
+    expect(requests.length).toBe(0);
+  });
+
+  test('propagates transport-level failures', async () => {
+    mockRpcError('getrawtransaction', { code: -32603, message: 'internal error' });
+    await expect(provider().getTransactionStatus(TXID)).rejects.toThrow(/internal error/);
+  });
+});
+
+describe('estimateFee', () => {
+  const provider = () => new QuickNodeProvider({ endpoint: ENDPOINT });
+
+  test('converts BTC/kvB to sat/vB, rounding up', async () => {
+    mockRpc('estimatesmartfee', { feerate: 0.00012345, blocks: 2 });
+    const fee = await provider().estimateFee(2);
+    expect(fee).toBe(13); // 0.00012345 * 1e5 = 12.345 → ceil → 13
+    expect(requests[0]).toMatchObject({ method: 'estimatesmartfee', params: [2] });
+  });
+
+  test('defaults to a 1-block target and clamps to a minimum of 1 sat/vB', async () => {
+    mockRpc('estimatesmartfee', { feerate: 0.00000001 });
+    const fee = await provider().estimateFee();
+    expect(fee).toBe(1);
+    expect(requests[0]).toMatchObject({ params: [1] });
+  });
+
+  test('fails loudly instead of inventing a rate when the node has no fee data', async () => {
+    mockRpc('estimatesmartfee', { errors: ['Insufficient data or no feerate found'] });
+    await expect(provider().estimateFee(1)).rejects.toThrow(/no feerate/);
+    await expect(provider().estimateFee(1)).rejects.toThrow(/Insufficient data/);
+  });
+});
+
+describe('write-path methods fail loudly instead of fabricating', () => {
+  const provider = () => new QuickNodeProvider({ endpoint: ENDPOINT });
+
+  test('createInscription rejects with a NOT_IMPLEMENTED StructuredError and no RPC call', async () => {
+    const err = await provider()
+      .createInscription({ data: Buffer.from('x'), contentType: 'text/plain' })
+      .then(() => null, (e: unknown) => e);
+    expect(err).toBeInstanceOf(StructuredError);
+    expect((err as StructuredError).code).toBe('QUICKNODE_CREATE_INSCRIPTION_NOT_IMPLEMENTED');
+    expect(requests.length).toBe(0);
+  });
+
+  test('transferInscription rejects with a NOT_IMPLEMENTED StructuredError and no RPC call', async () => {
+    const err = await provider()
+      .transferInscription(INSCRIPTION_ID, 'bc1pexample')
+      .then(() => null, (e: unknown) => e);
+    expect(err).toBeInstanceOf(StructuredError);
+    expect((err as StructuredError).code).toBe('QUICKNODE_TRANSFER_NOT_IMPLEMENTED');
+    expect(requests.length).toBe(0);
+  });
+});
+
+describe('response hardening', () => {
+  test('rejects oversized JSON-RPC responses', async () => {
+    const provider = new QuickNodeProvider({ endpoint: ENDPOINT, maxJsonBytes: 32 });
+    mockRpc('ord_getSat', { inscriptions: [], padding: 'x'.repeat(256) });
+    await expect(provider.getInscriptionsBySatoshi('123')).rejects.toThrow(/exceeds 32 bytes/);
+  });
+
+  test('surfaces HTTP failures with non-JSON bodies as an RPC HTTP error', async () => {
+    globalThis.fetch = (async () => new Response('<html>Bad Gateway</html>', { status: 502, statusText: 'Bad Gateway' })) as any;
+    const provider = new QuickNodeProvider({ endpoint: ENDPOINT });
+    await expect(provider.estimateFee(1)).rejects.toThrow(/HTTP 502/);
+  });
+
+  test('parses RPC error bodies delivered with non-2xx status (bitcoind style)', async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: null, error: { code: -26, message: 'txn-mempool-conflict' } }), { status: 500 })
+    ) as any;
+    const provider = new QuickNodeProvider({ endpoint: ENDPOINT });
+    await expect(provider.broadcastTransaction('0200aabb')).rejects.toThrow(/txn-mempool-conflict/);
+  });
+});

--- a/packages/sdk/tests/unit/adapters/QuickNodeProvider.test.ts
+++ b/packages/sdk/tests/unit/adapters/QuickNodeProvider.test.ts
@@ -264,7 +264,12 @@ describe('broadcastTransaction', () => {
 
   test('refuses an empty txid result instead of reporting success', async () => {
     mockRpc('sendrawtransaction', '');
-    await expect(provider().broadcastTransaction('0200aabb')).rejects.toThrow(/no txid/);
+    await expect(provider().broadcastTransaction('0200aabb')).rejects.toThrow(/txid/);
+  });
+
+  test('refuses a malformed (non-64-hex) txid result', async () => {
+    mockRpc('sendrawtransaction', 'ok');
+    await expect(provider().broadcastTransaction('0200aabb')).rejects.toThrow(/64-character hex txid/);
   });
 });
 

--- a/packages/sdk/tests/unit/adapters/QuickNodeProvider.test.ts
+++ b/packages/sdk/tests/unit/adapters/QuickNodeProvider.test.ts
@@ -113,6 +113,41 @@ describe('getInscriptionById', () => {
     expect(result!.vout).toBe(3);
   });
 
+  test('keeps a short base64-shaped text inscription literal ("text" stays "text")', async () => {
+    mockRpc('ord_getInscription', { id: INSCRIPTION_ID, sat: 1, satpoint: `${TXID}:0:0`, content_type: 'text/plain;charset=utf-8' });
+    // "text" passes the base64 charset/length checks but decodes to invalid
+    // UTF-8 — for a text-typed inscription it must be kept as the literal string.
+    mockRpc('ord_getContent', 'text');
+    const result = await provider().getInscriptionById(INSCRIPTION_ID);
+    expect(result!.content.toString('utf8')).toBe('text');
+  });
+
+  test('base64-decodes text content when the decoded bytes are valid UTF-8', async () => {
+    mockRpc('ord_getInscription', { id: INSCRIPTION_ID, sat: 1, satpoint: `${TXID}:0:0`, content_type: 'text/plain' });
+    mockRpc('ord_getContent', Buffer.from('hello world', 'utf8').toString('base64'));
+    const result = await provider().getInscriptionById(INSCRIPTION_ID);
+    expect(result!.content.toString('utf8')).toBe('hello world');
+  });
+
+  test('always base64-decodes binary content types, even short strings', async () => {
+    mockRpc('ord_getInscription', { id: INSCRIPTION_ID, sat: 1, satpoint: `${TXID}:0:0`, content_type: 'image/png' });
+    // 'text' as base64 decodes to bytes b5 eb 2d — a binary inscription must
+    // never be kept as the literal string.
+    mockRpc('ord_getContent', 'text');
+    const result = await provider().getInscriptionById(INSCRIPTION_ID);
+    expect([...result!.content]).toEqual([...Buffer.from('text', 'base64')]);
+  });
+
+  test('propagates auth/routing errors that merely contain "not found"', async () => {
+    mockRpcError('ord_getInscription', { code: -32000, message: 'API key not found' });
+    await expect(provider().getInscriptionById(INSCRIPTION_ID)).rejects.toThrow(/API key not found/);
+  });
+
+  test('propagates endpoint routing errors containing "not found"', async () => {
+    mockRpcError('ord_getInscription', { code: -32601, message: 'Endpoint not found in routing table' });
+    await expect(provider().getInscriptionById(INSCRIPTION_ID)).rejects.toThrow(/routing table/);
+  });
+
   test('treats non-base64 content as literal UTF-8 text', async () => {
     mockRpc('ord_getInscription', { id: INSCRIPTION_ID, sat: 1, satpoint: `${TXID}:0:0`, content_type: 'text/plain' });
     // '{"p":"x"}' is not valid base64 (contains '{', '"', ':')
@@ -178,6 +213,17 @@ describe('getInscriptionsBySatoshi', () => {
 
   test('returns [] when the sat has no inscriptions', async () => {
     mockRpc('ord_getSat', { number: 123, rarity: 'common', inscriptions: [] });
+    const result = await provider().getInscriptionsBySatoshi('123');
+    expect(result).toEqual([]);
+  });
+
+  test('propagates auth errors containing "not found" instead of returning []', async () => {
+    mockRpcError('ord_getSat', { code: -32000, message: 'API key not found' });
+    await expect(provider().getInscriptionsBySatoshi('123')).rejects.toThrow(/API key not found/);
+  });
+
+  test('returns [] for an ord-style "sat not found" error', async () => {
+    mockRpcError('ord_getSat', { code: -32000, message: 'sat not found' });
     const result = await provider().getInscriptionsBySatoshi('123');
     expect(result).toEqual([]);
   });


### PR DESCRIPTION
## What

Adds `QuickNodeProvider`, a new `OrdinalsProvider` implementation that speaks JSON-RPC 2.0 against QuickNode's Bitcoin endpoint. This provider enables read operations (inscriptions, sats) via the Ordinals & Runes API add-on and broadcast/status/fee operations via standard Bitcoin Core RPC methods.

## Why

QuickNode is a production-grade Bitcoin service provider that offers both Ordinals API access and standard RPC methods on a single endpoint. This provider allows SDK users to integrate with QuickNode as an alternative to running a local `ord` daemon or using other Ordinals providers. It complements existing providers (OrdMockProvider for testing, OrdinalsClient for local ord) and is now the default when `QUICKNODE_ENDPOINT` is configured.

## How

**QuickNodeProvider implementation:**
- Validates endpoint URL (https/http only) and required configuration at construction
- Implements all `OrdinalsProvider` interface methods:
  - `getInscriptionById()` - Calls `ord_getInscription` + `ord_getContent` with content decoding (base64 or UTF-8)
  - `getInscriptionsBySatoshi()` - Calls `ord_getSat` with satoshi validation
  - `broadcastTransaction()` - Calls `sendrawtransaction` with hex validation
  - `getTransactionStatus()` - Calls `getrawtransaction` + `getblockheader` for confirmation details
  - `estimateFee()` - Calls `estimatesmartfee` with BTC/kvB → sat/vB conversion
  - `createInscription()` / `transferInscription()` - Intentionally reject with clear error messages (QuickNode doesn't build/sign transactions)

**Response hardening:**
- Enforces configurable byte caps on JSON-RPC responses (default 1 MiB) via Content-Length header and materialized body
- Distinguishes "not found" errors (RPC code -5) from transport failures
- Parses RPC error bodies even on non-2xx HTTP status (bitcoind-style error reporting)
- Validates satoshi numbers and transaction hex before RPC calls

**Integration:**
- Updated `createOrdinalsProviderFromEnv()` to prefer `QUICKNODE_ENDPOINT` when configured
- Exported from `packages/sdk/src/index.ts` and `packages/sdk/src/adapters/index.ts`
- Updated CLAUDE.md documentation

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports)
- [x] I have added tests that cover my changes (336 lines of comprehensive unit tests)
- [x] All new and existing tests pass
- [x] I have updated JSDoc comments for public APIs
- [x] I have updated CLAUDE.md documentation

## Testing

Added 336 lines of unit tests in `packages/sdk/tests/unit/adapters/QuickNodeProvider.test.ts` covering:
- Constructor validation (endpoint required, URL format, protocol validation)
- `getInscriptionById()` - metadata/content mapping, satpoint parsing, content decoding (base64/UTF-8), null handling, size limits
- `getInscriptionsBySatoshi()` - satoshi validation, response shape variants, empty results
- `broadcastTransaction()` - hex validation, RPC error propagation, txid validation
- `getTransactionStatus()` - confirmation detection, block height resolution, mempool handling, RPC -5 (not found) handling
- `estimateFee()` - BTC/kvB conversion, rounding, fee data unavailability
- Write-path methods - verify they reject with NOT_IMPLEMENTED errors
- Response hardening - oversized responses, HTTP errors, RPC errors with non-2xx status

All tests use mocked fetch and verify both wire format (JSON-RPC 2.0 structure) and response mapping into the OrdinalsProvider contract.

https://claude.ai/code/session_017MoLantvcFbFUnSRDKrD9F

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `QuickNodeProvider` for Bitcoin Ordinals production reads and transaction broadcasting
> - Adds [`QuickNodeProvider`](https://github.com/onionoriginals/sdk/pull/337/files#diff-3ec4f2e71a77a110f95aa2d913ced4c9736676e1414fd638a66362d7cd8825e4), an `OrdinalsProvider` implementation backed by a QuickNode Bitcoin endpoint via JSON-RPC 2.0, supporting `getInscriptionById`, `getInscriptionsBySatoshi`, `broadcastTransaction`, `getTransactionStatus`, and `estimateFee`.
> - `createOrdinalsProviderFromEnv` in [`OrdHttpProvider.ts`](https://github.com/onionoriginals/sdk/pull/337/files#diff-efaa45312c5c1ab72016f82a8e57dd451f5a9b3c6230464c22f1ccd875cdace3) now returns a `QuickNodeProvider` when `QUICKNODE_ENDPOINT` is set, taking precedence over other env-based provider selection.
> - `createInscription` and `transferInscription` explicitly reject with `NOT_IMPLEMENTED` errors — inscription creation must be handled locally.
> - `QuickNodeProvider` and its options type are exported from the SDK's top-level public API.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 511073c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->