### PR TITLE
fix(did): webvh update/rotate/create write paths — fixes #338, #339, #334

### DIFF
--- a/.changeset/webvh-write-path-fixes.md
+++ b/.changeset/webvh-write-path-fixes.md
@@ -1,0 +1,5 @@
+---
+"@originals/sdk": patch
+---
+
+Fix the did:webvh write paths to match the options didwebvh-ts actually consumes: `updateDIDWebVH` now translates the merged document into the named update options instead of passing an ignored `doc` (every update was a signed no-op, #338); key rotation and recovery carry forward all non-signing verification methods with their keyAgreement/capability relationships instead of wiping them, and enforce Ed25519 on the new update key (#339); the internal key-pair create/update/rotate paths publish the signing verification method as `#key-0` so the authorized `authentication`/`assertionMethod` fragments reference a VM that exists and third-party proof-purpose verification succeeds (#334). Update fields didwebvh-ts cannot express are now rejected loudly instead of silently dropped.

--- a/packages/sdk/src/did/WebVHManager.ts
+++ b/packages/sdk/src/did/WebVHManager.ts
@@ -951,11 +951,15 @@ export class WebVHManager {
     const invocation = inRelationship(doc.capabilityInvocation);
     const delegation = inRelationship(doc.capabilityDelegation);
     if (invocation && delegation) {
+      // Path-neutral error code: this helper is reached from update AND from
+      // rotation/recovery (via buildRotationDocumentOptions), so the code
+      // must describe the unexpressible document shape, not one entry path.
       throw new StructuredError(
-        'WEBVH_UNSUPPORTED_UPDATE_FIELD',
+        'WEBVH_UNSUPPORTED_DOCUMENT_SHAPE',
         `Verification method ${vm.id} is in both capabilityInvocation and capabilityDelegation; ` +
         'didwebvh-ts expresses capability relationships through a single per-VM purpose, so this ' +
-        'document shape cannot be written without silently dropping one relationship.'
+        'document shape cannot be written (on update, rotation, or recovery) without silently ' +
+        'dropping one relationship.'
       );
     }
     const purpose = invocation ? 'capabilityInvocation'

--- a/packages/sdk/src/did/WebVHManager.ts
+++ b/packages/sdk/src/did/WebVHManager.ts
@@ -1,7 +1,7 @@
 import { KeyManager } from './KeyManager.js';
 import { multikey } from '../crypto/Multikey.js';
 import { Ed25519Signer } from '../crypto/Signer.js';
-import { DIDDocument, KeyPair, ExternalSigner, ExternalVerifier } from '../types/index.js';
+import { DIDDocument, KeyPair, ExternalSigner, ExternalVerifier, VerificationMethod as DidDocVerificationMethod } from '../types/index.js';
 import { StructuredError } from '../utils/telemetry.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { base58 } from '@scure/base';
@@ -421,9 +421,14 @@ export class WebVHManager {
       // Generate or use provided key pair (Ed25519 for did:webvh)
       keyPair = providedKeyPair || await this.keyManager.generateKeyPair('Ed25519');
 
-      // Create verification methods
+      // Create verification methods. The signing VM must carry an explicit
+      // id: without one, didwebvh-ts assigns a key-derived id (e.g.
+      // '#9XCESUFW'), and the '#key-0' relationship arrays emitted below
+      // reference a fragment no verification method has — breaking
+      // third-party proof-purpose verification (issue #334).
       verificationMethods = [
         {
+          id: '#key-0',
           type: 'Multikey',
           publicKeyMultibase: keyPair.publicKey,
         }
@@ -459,6 +464,20 @@ export class WebVHManager {
       verificationMethods = [...verificationMethods, ...additionalVerificationMethods];
     }
 
+    // The authentication/assertionMethod relationships must reference a
+    // fragment that exists on the published signing VM (issue #334). The
+    // internal path pins the signing VM's id to '#key-0' above; an external
+    // caller may supply its own id — use it. When an external caller omits
+    // the id, assign '#key-0' rather than letting didwebvh-ts derive a
+    // key-based id the relationship arrays would then dangle against.
+    if (verificationMethods.length > 0 && !verificationMethods[0].id) {
+      verificationMethods = [
+        { ...verificationMethods[0], id: '#key-0' },
+        ...verificationMethods.slice(1),
+      ];
+    }
+    const signingVmId = verificationMethods[0]?.id ?? '#key-0';
+
     // Create the DID using didwebvh-ts
     const createArgs: Record<string, unknown> = {
       domain,
@@ -472,8 +491,8 @@ export class WebVHManager {
       ],
       paths,
       portable,
-      authentication: ['#key-0'],
-      assertionMethod: ['#key-0'],
+      authentication: [signingVmId],
+      assertionMethod: [signingVmId],
     };
     if (nextKeyHashes) {
       createArgs.nextKeyHashes = nextKeyHashes;
@@ -729,18 +748,27 @@ export class WebVHManager {
     const currentDoc = currentEntry.state as unknown as DIDDocument;
 
     // Merge updates with current document
-    const updatedDoc = {
+    const updatedDoc: DIDDocument = {
       ...currentDoc,
       ...updates,
       id: did, // Ensure ID doesn't change
     };
 
+    // didwebvh-ts's updateDID never reads a `doc` option: it deep-clones the
+    // last entry's state and only overlays the named options it consumes
+    // (verificationMethods, services, authentication, assertionMethod,
+    // keyAgreement, alsoKnownAs, context). Passing the merged document as
+    // `doc` made every update a signed no-op re-stating the previous state
+    // (issue #338) — translate the merged document into those named options
+    // instead.
+    const namedOptions = this.deriveUpdateOptions(updatedDoc, updates);
+
     // Update the DID using didwebvh-ts
     const result = await updateDID({
       log: currentLog,
-      doc: updatedDoc,
       signer,
       verifier: verifier || undefined,
+      ...namedOptions,
     });
 
     // Validate the returned DID document
@@ -883,6 +911,217 @@ export class WebVHManager {
   }
 
   /**
+   * True when `ref` (a relationship-array entry: a string reference or an
+   * embedded verification method) designates the verification method with the
+   * given `id`. Ids may be relative ('#key-0') or absolute ('did:…#key-0');
+   * per DID Core a relative DID URL resolves against the document id, so
+   * same-document entries are compared by fragment.
+   */
+  private refersToVM(ref: unknown, id: string | undefined): boolean {
+    const refId = typeof ref === 'string' ? ref : (ref as { id?: unknown } | null)?.id;
+    if (typeof refId !== 'string' || !id) return false;
+    if (refId === id) return true;
+    const refFragment = refId.split('#')[1];
+    const idFragment = id.split('#')[1];
+    return refFragment !== undefined && idFragment !== undefined && refFragment === idFragment;
+  }
+
+  /**
+   * Convert a DID-document verification method into the shape didwebvh-ts
+   * consumes, deriving the single-valued `purpose` didwebvh-ts uses to
+   * rebuild relationship arrays. Only the capability relationships are
+   * load-bearing here: authentication/assertionMethod/keyAgreement are pinned
+   * by explicit options wherever this is used, but capabilityInvocation and
+   * capabilityDelegation have NO option override in didwebvh-ts — they are
+   * expressible solely via a VM's purpose.
+   */
+  private toWebVHVerificationMethod(vm: DidDocVerificationMethod, doc: DIDDocument): VerificationMethod {
+    const inRelationship = (rel?: (string | DidDocVerificationMethod)[]): boolean =>
+      Array.isArray(rel) && rel.some(entry => this.refersToVM(entry, vm.id));
+
+    const invocation = inRelationship(doc.capabilityInvocation);
+    const delegation = inRelationship(doc.capabilityDelegation);
+    if (invocation && delegation) {
+      throw new StructuredError(
+        'WEBVH_UNSUPPORTED_UPDATE_FIELD',
+        `Verification method ${vm.id} is in both capabilityInvocation and capabilityDelegation; ` +
+        'didwebvh-ts expresses capability relationships through a single per-VM purpose, so this ' +
+        'document shape cannot be written without silently dropping one relationship.'
+      );
+    }
+    const purpose = invocation ? 'capabilityInvocation'
+      : delegation ? 'capabilityDelegation'
+      : inRelationship(doc.keyAgreement) ? 'keyAgreement'
+      : inRelationship(doc.assertionMethod) ? 'assertionMethod'
+      : undefined;
+    // When no relationship matches, keep any purpose already carried on the
+    // VM (docs produced by this SDK publish it) rather than clearing it.
+    return { ...vm, ...(purpose ? { purpose } : {}) };
+  }
+
+  /**
+   * Translate the merged document + requested updates into the named options
+   * didwebvh-ts's updateDID actually consumes (verified against
+   * didwebvh-ts@2.8.0): `verificationMethods`, `services`, `authentication`,
+   * `assertionMethod`, `keyAgreement`, `alsoKnownAs`, `context`. Fields the
+   * library cannot express are rejected loudly — silently dropping them is
+   * exactly the failure mode of issue #338. Fields the update does not touch
+   * are omitted so they ride the library's own carry-forward of the previous
+   * state, untouched.
+   */
+  private deriveUpdateOptions(mergedDoc: DIDDocument, updates: Partial<DIDDocument>): Record<string, unknown> {
+    const SUPPORTED_UPDATE_FIELDS = new Set([
+      '@context', 'id', 'verificationMethod', 'service', 'authentication',
+      'assertionMethod', 'keyAgreement', 'capabilityInvocation',
+      'capabilityDelegation', 'alsoKnownAs',
+    ]);
+    for (const key of Object.keys(updates)) {
+      if (!SUPPORTED_UPDATE_FIELDS.has(key)) {
+        throw new StructuredError(
+          'WEBVH_UNSUPPORTED_UPDATE_FIELD',
+          `updateDIDWebVH cannot apply updates to "${key}": didwebvh-ts updateDID has no ` +
+          'corresponding option, so the change would be silently discarded.'
+        );
+      }
+    }
+
+    const options: Record<string, unknown> = {};
+
+    if ('@context' in updates) {
+      options.context = mergedDoc['@context'];
+    }
+    if ('service' in updates) {
+      options.services = mergedDoc.service ?? [];
+    }
+    if ('alsoKnownAs' in updates) {
+      options.alsoKnownAs = mergedDoc.alsoKnownAs ?? [];
+    }
+
+    // Supplying `verificationMethods` makes updateDID REBUILD every
+    // relationship array from the VMs' single `purpose` field, so whenever the
+    // update touches the VM/relationship block, pin authentication,
+    // assertionMethod and keyAgreement to the merged document's arrays (the
+    // library applies those options after the rebuild). The capability
+    // relationships have no such option and are derived from VM purposes in
+    // toWebVHVerificationMethod.
+    const touchesVMBlock = ['verificationMethod', 'capabilityInvocation', 'capabilityDelegation']
+      .some(key => key in updates);
+    if (touchesVMBlock) {
+      const vms = mergedDoc.verificationMethod ?? [];
+      // Capability entries that reference no published VM would be silently
+      // dropped by the rebuild — refuse instead.
+      for (const relName of ['capabilityInvocation', 'capabilityDelegation'] as const) {
+        for (const entry of mergedDoc[relName] ?? []) {
+          if (!vms.some(vm => this.refersToVM(entry, vm.id))) {
+            const shown = typeof entry === 'string' ? entry : (entry as { id?: string }).id ?? JSON.stringify(entry);
+            throw new StructuredError(
+              'WEBVH_UNSUPPORTED_UPDATE_FIELD',
+              `${relName} entry ${shown} does not reference a published verificationMethod; ` +
+              'didwebvh-ts can only express capability relationships as references to verification ' +
+              'methods (via their purpose).'
+            );
+          }
+        }
+      }
+      options.verificationMethods = vms.map(vm => this.toWebVHVerificationMethod(vm, mergedDoc));
+      options.authentication = mergedDoc.authentication ?? [];
+      options.assertionMethod = mergedDoc.assertionMethod ?? [];
+      options.keyAgreement = mergedDoc.keyAgreement ?? [];
+    } else {
+      for (const rel of ['authentication', 'assertionMethod', 'keyAgreement'] as const) {
+        if (rel in updates) {
+          options[rel] = mergedDoc[rel] ?? [];
+        }
+      }
+    }
+
+    return options;
+  }
+
+  /**
+   * The updateKeys currently in force for the log: the most recent entry's
+   * explicit `updateKeys`, walking back through entries that carried the
+   * previous value forward.
+   */
+  private effectiveUpdateKeys(currentLog: DIDLog): string[] {
+    for (let i = currentLog.length - 1; i >= 0; i--) {
+      const keys = (currentLog[i].parameters as { updateKeys?: unknown } | undefined)?.updateKeys;
+      if (Array.isArray(keys)) {
+        return keys.filter((k): k is string => typeof k === 'string');
+      }
+    }
+    return [];
+  }
+
+  /**
+   * Build the verificationMethods + relationship options for a key-change
+   * entry. didwebvh-ts REPLACES the whole VM/relationship block whenever
+   * `verificationMethods` is supplied, so passing only the new signing VM
+   * wiped every carried verification method and emptied keyAgreement and the
+   * capability relationships on rotate/recover (issue #339). Carry the
+   * non-signing VMs forward with purposes derived from the current state, and
+   * re-point the signing role at the new '#key-0'.
+   *
+   * @param retiringKeys - public multikeys being rotated out, in addition to
+   *   the log's effective updateKeys (which always retire on a key change)
+   * @param newPublicKey - the incoming signing key, published as '#key-0'
+   */
+  private buildRotationDocumentOptions(
+    currentLog: DIDLog,
+    retiringKeys: string[],
+    newPublicKey: string
+  ): {
+    verificationMethods: VerificationMethod[];
+    authentication: string[];
+    assertionMethod: string[];
+    keyAgreement: string[];
+  } {
+    const state = (currentLog[currentLog.length - 1]?.state ?? {}) as unknown as DIDDocument;
+    const existingVMs = Array.isArray(state.verificationMethod) ? state.verificationMethod : [];
+
+    const retired = new Set(
+      [...this.effectiveUpdateKeys(currentLog), ...retiringKeys].map(normalizeUpdateKey)
+    );
+    const isRetired = (vm: DidDocVerificationMethod): boolean =>
+      typeof vm.publicKeyMultibase === 'string' && retired.has(vm.publicKeyMultibase);
+    const carriedVMs = existingVMs.filter(
+      vm => !isRetired(vm) && vm.publicKeyMultibase !== newPublicKey
+    );
+
+    const verificationMethods: VerificationMethod[] = [
+      { id: '#key-0', type: 'Multikey', publicKeyMultibase: newPublicKey },
+      ...carriedVMs.map(vm => this.toWebVHVerificationMethod(vm, state)),
+    ];
+
+    // Keep relationship entries that reference carried VMs; drop references
+    // to the retired key (its signing roles transfer to '#key-0') and any
+    // dangling references (e.g. the pre-#334 key-derived-id mismatch).
+    const mapRelationship = (
+      rel: (string | DidDocVerificationMethod)[] | undefined,
+      includeNewKey: boolean
+    ): string[] => {
+      const out: string[] = includeNewKey ? ['#key-0'] : [];
+      for (const entry of rel ?? []) {
+        const refId = typeof entry === 'string' ? entry : entry?.id;
+        if (typeof refId !== 'string') continue;
+        if (carriedVMs.some(vm => this.refersToVM(refId, vm.id)) && !out.includes(refId)) {
+          out.push(refId);
+        }
+      }
+      return out;
+    };
+
+    return {
+      verificationMethods,
+      // The new signing key assumes authentication + assertionMethod, exactly
+      // as createDIDWebVH assigns them to the initial signing key.
+      authentication: mapRelationship(state.authentication, true),
+      assertionMethod: mapRelationship(state.assertionMethod, true),
+      keyAgreement: mapRelationship(state.keyAgreement, false),
+    };
+  }
+
+  /**
    * Shared primitive: append a signed did:webvh log entry that replaces the
    * verification method and updateKey with `newKeyPair`, signed by
    * `currentKeyPair`.
@@ -908,6 +1147,12 @@ export class WebVHManager {
       throw new Error('Failed to load didwebvh-ts: invalid module exports');
     }
 
+    // createDIDWebVH enforces Ed25519 updateKeys; without the same assertion
+    // here a non-Ed25519 rotation key would sign successfully but leave the
+    // DID unverifiable by Ed25519Verifier — bricked for all future updates
+    // (issue #339, related gap).
+    assertEd25519WebVHUpdateKeys([newKeyPair.publicKey]);
+
     const currentVerificationMethod: VerificationMethod = {
       type: 'Multikey',
       publicKeyMultibase: currentKeyPair.publicKey,
@@ -919,19 +1164,20 @@ export class WebVHManager {
       { verificationMethod: currentVerificationMethod }
     );
 
-    const newVerificationMethod: VerificationMethod = {
-      type: 'Multikey',
-      publicKeyMultibase: newKeyPair.publicKey,
-    };
+    // Carry forward all non-signing verification methods and their
+    // relationships; only the signing key rotates (issue #339).
+    const documentOptions = this.buildRotationDocumentOptions(
+      currentLog,
+      [currentKeyPair.publicKey],
+      newKeyPair.publicKey
+    );
 
     const result = await updateDID({
       log: currentLog,
       signer,
       verifier: signer,
       updateKeys: [newKeyPair.publicKey],
-      verificationMethods: [newVerificationMethod],
-      authentication: ['#key-0'],
-      assertionMethod: ['#key-0'],
+      ...documentOptions,
     });
 
     if (!this.isDIDDocument(result.doc)) {
@@ -1000,6 +1246,10 @@ export class WebVHManager {
       );
     }
 
+    // Same Ed25519 guard as appendKeyChange: the pre-committed key becomes
+    // the updateKey, so a non-Ed25519 key would brick future updates.
+    assertEd25519WebVHUpdateKeys([activeKeyPair.publicKey]);
+
     // The active (pre-committed) key signs the entry and becomes updateKey.
     const activeVerificationMethod: VerificationMethod = {
       type: 'Multikey',
@@ -1015,15 +1265,23 @@ export class WebVHManager {
     // Commit the hash of the next key to continue the pre-rotation chain.
     const nextKeyHashes = [computeNextKeyHash(nextKeyPair.publicKey)];
 
+    // Carry forward all non-signing verification methods and their
+    // relationships (issue #339). The retiring key is the log's effective
+    // updateKey (the previously active key), which buildRotationDocumentOptions
+    // always retires; activeKeyPair is the incoming '#key-0'.
+    const documentOptions = this.buildRotationDocumentOptions(
+      currentLog,
+      [],
+      activeKeyPair.publicKey
+    );
+
     const result = await updateDID({
       log: currentLog,
       signer,
       verifier: signer,
       updateKeys: [activeKeyPair.publicKey],
       nextKeyHashes,
-      verificationMethods: [activeVerificationMethod],
-      authentication: ['#key-0'],
-      assertionMethod: ['#key-0'],
+      ...documentOptions,
     });
 
     if (!this.isDIDDocument(result.doc)) {

--- a/packages/sdk/src/did/WebVHManager.ts
+++ b/packages/sdk/src/did/WebVHManager.ts
@@ -934,6 +934,15 @@ export class WebVHManager {
    * by explicit options wherever this is used, but capabilityInvocation and
    * capabilityDelegation have NO option override in didwebvh-ts — they are
    * expressible solely via a VM's purpose.
+   *
+   * CALLER CONTRACT: every call site MUST also pass explicit
+   * `authentication`, `assertionMethod`, and `keyAgreement` options to
+   * updateDID/createDID. `authentication` is deliberately absent from the
+   * purpose chain below (didwebvh-ts already defaults purposeless VMs into
+   * `authentication`), so without the explicit override a VM that is in
+   * `authentication` AND another relationship (e.g. keyAgreement) would get
+   * the other purpose and silently drop out of the rebuilt `authentication`
+   * array.
    */
   private toWebVHVerificationMethod(vm: DidDocVerificationMethod, doc: DIDDocument): VerificationMethod {
     const inRelationship = (rel?: (string | DidDocVerificationMethod)[]): boolean =>
@@ -983,6 +992,18 @@ export class WebVHManager {
           'corresponding option, so the change would be silently discarded.'
         );
       }
+    }
+
+    // `id` is accepted only so callers may spread an existing document into
+    // `updates`; the DID identifier itself is immutable through this API
+    // (mergedDoc.id is pinned to the DID before this runs). An attempt to
+    // CHANGE it must fail loudly rather than be silently pinned back.
+    if (updates.id !== undefined && updates.id !== mergedDoc.id) {
+      throw new StructuredError(
+        'WEBVH_UNSUPPORTED_UPDATE_FIELD',
+        `updateDIDWebVH cannot change the DID id (got "${updates.id}"): the identifier is ` +
+        'immutable; moving a portable DID is not supported through this API.'
+      );
     }
 
     const options: Record<string, unknown> = {};

--- a/packages/sdk/tests/unit/did/DIDManager.test.ts
+++ b/packages/sdk/tests/unit/did/DIDManager.test.ts
@@ -55,9 +55,11 @@ describe('DIDManager', () => {
     // The peer verification method is carried over (verification-only)
     const carried = (web.verificationMethod || []).map(vm => vm.publicKeyMultibase);
     expect(carried).toContain(peer.verificationMethod![0].publicKeyMultibase);
-    // All VM ids/controllers are rooted at the new did:webvh
+    // All VM ids/controllers are rooted at the new did:webvh. A relative
+    // fragment id (e.g. the signing key's '#key-0', issue #334) resolves
+    // against the document id per DID Core, so it is equally rooted.
     for (const vm of web.verificationMethod || []) {
-      expect(vm.id!.startsWith(web.id)).toBe(true);
+      expect(vm.id!.startsWith(web.id) || vm.id!.startsWith('#')).toBe(true);
       expect(vm.controller).toBe(web.id);
     }
     // Services preserved, old DID recorded in alsoKnownAs
@@ -88,9 +90,11 @@ describe('DIDManager', () => {
       assertionMethod: ['did:peer:abc123#0']
     };
     const web = (await sdk.did.migrateToDIDWebVH(peer, 'example.com')).didDocument;
-    // No reference to the retired did:peer remains outside alsoKnownAs
+    // No reference to the retired did:peer remains outside alsoKnownAs.
+    // Relative fragment ids ('#key-0') resolve against the document id per
+    // DID Core, so they carry no did:peer reference either (issue #334).
     for (const vm of web.verificationMethod || []) {
-      expect(vm.id!.startsWith(web.id)).toBe(true);
+      expect(vm.id!.startsWith(web.id) || vm.id!.startsWith('#')).toBe(true);
       expect(vm.controller).toBe(web.id);
     }
     const rels = ([] as unknown[]).concat(web.authentication || [], web.assertionMethod || []);

--- a/packages/sdk/tests/unit/did/did-coverage.test.ts
+++ b/packages/sdk/tests/unit/did/did-coverage.test.ts
@@ -461,6 +461,12 @@ describe('DID-007 — updateDIDWebVH adds new service endpoint with signed log e
     expect(typeof proof.proofValue).toBe('string');
     expect((proof.proofValue as string).length).toBeGreaterThan(0);
 
+    // The update must actually be APPLIED — not a signed no-op re-stating the
+    // previous document (issue #338): the service must appear both in the
+    // returned document and in the new log entry's state.
+    expect(updated.didDocument.service).toEqual([newService]);
+    expect((newEntry.state as { service?: unknown }).service).toEqual([newService]);
+
     // DID id must be unchanged
     expect(updated.didDocument.id).toBe(created.did);
   }, 30000);
@@ -503,10 +509,11 @@ describe('DID-007 — updateDIDWebVH adds new service endpoint with signed log e
       },
     };
 
+    const extService = { id: `${created.did}#svc`, type: 'ExampleService', serviceEndpoint: 'https://svc.example.com' };
     const updated = await manager.updateDIDWebVH({
       did: created.did,
       currentLog: created.log,
-      updates: { service: [{ id: `${created.did}#svc`, type: 'ExampleService', serviceEndpoint: 'https://svc.example.com' }] },
+      updates: { service: [extService] },
       signer: authorizedSigner,
       verifier: authorizedVerifier,
     });
@@ -514,6 +521,12 @@ describe('DID-007 — updateDIDWebVH adds new service endpoint with signed log e
     expect(updated.log.length).toBe(created.log.length + 1);
     expect(updateCalls).toBeGreaterThan(0);
     expect(updated.didDocument.id).toBe(created.did);
+
+    // The update must actually be applied (issue #338), in both the returned
+    // document and the appended log entry's state.
+    expect(updated.didDocument.service).toEqual([extService]);
+    const lastEntry = updated.log[updated.log.length - 1];
+    expect((lastEntry.state as { service?: unknown }).service).toEqual([extService]);
   }, 30000);
 });
 

--- a/packages/sdk/tests/unit/did/did-layer-scenarios.test.ts
+++ b/packages/sdk/tests/unit/did/did-layer-scenarios.test.ts
@@ -273,6 +273,10 @@ describe('DID-007 — update did:webvh', () => {
     expect(Array.isArray(newEntry.proof)).toBe(true);
     const proof = (newEntry.proof as Record<string, unknown>[])[0];
     expect(typeof proof.proofValue).toBe('string');
+
+    // The new entry's state must actually contain the update (issue #338).
+    expect((newEntry.state as { service?: unknown }).service).toEqual([newService]);
+    expect(updated.didDocument.service).toEqual([newService]);
   }, 20000);
 
   test('update preserves DID identity (id constant across updates)', async () => {
@@ -301,21 +305,22 @@ describe('DID-007 — update did:webvh', () => {
     const extraKey = await keyManager.generateKeyPair('Ed25519');
 
     // Add a service referencing new key as a proxy for injecting new VM info
+    const extraService = {
+      id: `${created.did}#extra`,
+      type: 'ExtraService',
+      serviceEndpoint: `did:key:${extraKey.publicKey}`,
+    };
     const updated = await manager.updateDIDWebVH({
       did: created.did,
       currentLog: created.log,
-      updates: {
-        service: [{
-          id: `${created.did}#extra`,
-          type: 'ExtraService',
-          serviceEndpoint: `did:key:${extraKey.publicKey}`,
-        }],
-      },
+      updates: { service: [extraService] },
       signer: created.keyPair,
     });
 
     expect(updated.didDocument).toBeDefined();
     expect(updated.log.length).toBeGreaterThan(created.log.length);
+    // The service must actually be applied (issue #338).
+    expect(updated.didDocument.service).toEqual([extraService]);
   }, 20000);
 });
 

--- a/packages/sdk/tests/unit/did/webvh-write-paths.test.ts
+++ b/packages/sdk/tests/unit/did/webvh-write-paths.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Regression tests for the did:webvh write-path cluster (issues #338, #339,
+ * #334): WebVHManager's calls into didwebvh-ts must match the options the
+ * library actually consumes (verified against didwebvh-ts@2.8.0).
+ *
+ *  #338 — updateDIDWebVH passed `doc`, which updateDID ignores → every
+ *         update was a signed no-op re-stating the previous document.
+ *  #339 — rotate/recover passed only the new signing VM → didwebvh-ts
+ *         rebuilt the whole VM/relationship block, wiping keyAgreement,
+ *         capability relationships, and all carried verification methods.
+ *  #334 — the internal key-pair paths authorized ['#key-0'] but built the VM
+ *         without an id, so didwebvh-ts assigned a key-derived id and the
+ *         relationship arrays dangled — third-party proof-purpose
+ *         verification failed.
+ *
+ * These tests assert SEMANTICS (state round-trips through the library's own
+ * log resolution), not log length.
+ */
+import { describe, test, expect, spyOn } from 'bun:test';
+import { WebVHManager } from '../../../src/did/WebVHManager';
+import { KeyManager } from '../../../src/did/KeyManager';
+import { Ed25519Verifier } from '../../../src/did/Ed25519Verifier';
+import { OriginalsSDK } from '../../../src';
+import type { DIDDocument, VerifiableCredential } from '../../../src/types';
+
+/** Resolve a DID document from its log — the trust path a real verifier uses. */
+async function resolveFromLog(log: unknown): Promise<DIDDocument> {
+  const mod = await import('didwebvh-ts') as unknown as {
+    resolveDIDFromLog: (
+      log: unknown,
+      options?: Record<string, unknown>
+    ) => Promise<{ did: string; doc: Record<string, unknown> | null }>;
+  };
+  const resolved = await mod.resolveDIDFromLog(log, { verifier: new Ed25519Verifier() });
+  expect(resolved.doc).toBeTruthy();
+  return resolved.doc as unknown as DIDDocument;
+}
+
+/** Relationship entries as string references (embedded VMs → their id). */
+function relationshipRefs(rel?: (string | { id?: string })[]): string[] {
+  return (rel ?? []).map(e => (typeof e === 'string' ? e : e?.id ?? '')).filter(Boolean);
+}
+
+const fragmentOf = (ref: string): string | undefined => ref.split('#')[1];
+
+/** True when some entry in the relationship references the given fragment. */
+function referencesFragment(rel: (string | { id?: string })[] | undefined, fragment: string): boolean {
+  return relationshipRefs(rel).some(ref => fragmentOf(ref) === fragment);
+}
+
+describe('#338 — updateDIDWebVH applies updates through the options didwebvh-ts consumes', () => {
+  test('adding a service round-trips: returned doc, new log entry state, and log resolution', async () => {
+    const manager = new WebVHManager();
+    const created = await manager.createDIDWebVH({ domain: 'example.com' });
+
+    const newService = {
+      id: `${created.did}#files`,
+      type: 'LinkedDomains',
+      serviceEndpoint: 'https://files.example.com',
+    };
+
+    const updated = await manager.updateDIDWebVH({
+      did: created.did,
+      currentLog: created.log,
+      updates: { service: [newService] },
+      signer: created.keyPair!,
+    });
+
+    // The update must actually be applied — not a signed no-op (issue #338).
+    expect(updated.didDocument.service).toEqual([newService]);
+
+    const newEntry = updated.log[updated.log.length - 1];
+    expect((newEntry.state as { service?: unknown }).service).toEqual([newService]);
+
+    // And a conformant resolver derives the same state from the log (the
+    // resolver also injects the spec's implicit services, e.g. '#whois', so
+    // assert containment rather than equality).
+    const resolvedDoc = await resolveFromLog(updated.log);
+    expect(resolvedDoc.service).toContainEqual(newService);
+  }, 30000);
+
+  test('a service-only update leaves verification methods and relationships untouched', async () => {
+    const manager = new WebVHManager();
+    const keyManager = new KeyManager();
+    const carried = await keyManager.generateKeyPair('Ed25519');
+
+    const created = await manager.createDIDWebVH({
+      domain: 'example.com',
+      additionalVerificationMethods: [
+        { id: '#key-agreement-1', type: 'Multikey', publicKeyMultibase: carried.publicKey, purpose: 'keyAgreement' },
+      ],
+    });
+    const beforeVMs = created.didDocument.verificationMethod ?? [];
+    expect(beforeVMs.length).toBe(2);
+
+    const updated = await manager.updateDIDWebVH({
+      did: created.did,
+      currentLog: created.log,
+      updates: { service: [{ id: `${created.did}#svc`, type: 'Svc', serviceEndpoint: 'https://svc.example.com' }] },
+      signer: created.keyPair!,
+    });
+
+    const doc = updated.didDocument;
+    expect((doc.verificationMethod ?? []).length).toBe(2);
+    expect(referencesFragment(doc.keyAgreement, 'key-agreement-1')).toBe(true);
+    expect(referencesFragment(doc.authentication, 'key-0')).toBe(true);
+    expect(referencesFragment(doc.assertionMethod, 'key-0')).toBe(true);
+  }, 30000);
+
+  test('adding a verification method with keyAgreement round-trips through log resolution', async () => {
+    const manager = new WebVHManager();
+    const keyManager = new KeyManager();
+    const created = await manager.createDIDWebVH({ domain: 'example.com' });
+    const extra = await keyManager.generateKeyPair('Ed25519');
+
+    const currentDoc = created.didDocument;
+    const updated = await manager.updateDIDWebVH({
+      did: created.did,
+      currentLog: created.log,
+      updates: {
+        verificationMethod: [
+          ...(currentDoc.verificationMethod ?? []),
+          { id: '#key-1', type: 'Multikey', controller: created.did, publicKeyMultibase: extra.publicKey },
+        ],
+        keyAgreement: ['#key-1'],
+      },
+      signer: created.keyPair!,
+    });
+
+    const resolvedDoc = await resolveFromLog(updated.log);
+    const vms = resolvedDoc.verificationMethod ?? [];
+    expect(vms.some(vm => vm.publicKeyMultibase === extra.publicKey)).toBe(true);
+    expect(referencesFragment(resolvedDoc.keyAgreement, 'key-1')).toBe(true);
+    // The signing key keeps its roles.
+    expect(referencesFragment(resolvedDoc.authentication, 'key-0')).toBe(true);
+    expect(referencesFragment(resolvedDoc.assertionMethod, 'key-0')).toBe(true);
+  }, 30000);
+
+  test('rejects update fields didwebvh-ts has no option for (no silent drop)', async () => {
+    const manager = new WebVHManager();
+    const created = await manager.createDIDWebVH({ domain: 'example.com' });
+
+    await expect(manager.updateDIDWebVH({
+      did: created.did,
+      currentLog: created.log,
+      updates: { controller: ['did:example:other'] } as Partial<DIDDocument>,
+      signer: created.keyPair!,
+    })).rejects.toThrow(/cannot apply updates to "controller"/);
+  }, 30000);
+});
+
+describe('#339 — rotation/recovery preserve carried verification methods and relationships', () => {
+  async function createMultiKeyDID(manager: WebVHManager, keyManager: KeyManager) {
+    const keyAgreementKey = await keyManager.generateKeyPair('Ed25519');
+    const capabilityKey = await keyManager.generateKeyPair('Ed25519');
+    const created = await manager.createDIDWebVH({
+      domain: 'example.com',
+      additionalVerificationMethods: [
+        { id: '#key-agreement-1', type: 'Multikey', publicKeyMultibase: keyAgreementKey.publicKey, purpose: 'keyAgreement' },
+        { id: '#capability-1', type: 'Multikey', publicKeyMultibase: capabilityKey.publicKey, purpose: 'capabilityInvocation' },
+      ],
+    });
+    // Sanity: the created document holds all three VMs with their relationships.
+    const doc = created.didDocument;
+    expect((doc.verificationMethod ?? []).length).toBe(3);
+    expect(referencesFragment(doc.keyAgreement, 'key-agreement-1')).toBe(true);
+    expect(referencesFragment(doc.capabilityInvocation, 'capability-1')).toBe(true);
+    return { created, keyAgreementKey, capabilityKey };
+  }
+
+  function assertCarriedVMsSurvive(
+    doc: DIDDocument,
+    newPublicKey: string,
+    oldPublicKey: string,
+    keyAgreementPub: string,
+    capabilityPub: string
+  ) {
+    const vms = doc.verificationMethod ?? [];
+    // Rotation replaces ONLY the signing key: 3 VMs before, 3 after.
+    expect(vms.length).toBe(3);
+    expect(vms.some(vm => vm.publicKeyMultibase === newPublicKey)).toBe(true);
+    expect(vms.some(vm => vm.publicKeyMultibase === oldPublicKey)).toBe(false);
+    expect(vms.some(vm => vm.publicKeyMultibase === keyAgreementPub)).toBe(true);
+    expect(vms.some(vm => vm.publicKeyMultibase === capabilityPub)).toBe(true);
+    // Relationships survive and the signing roles move to the new key.
+    expect(referencesFragment(doc.keyAgreement, 'key-agreement-1')).toBe(true);
+    expect(referencesFragment(doc.capabilityInvocation, 'capability-1')).toBe(true);
+    expect(referencesFragment(doc.authentication, 'key-0')).toBe(true);
+    expect(referencesFragment(doc.assertionMethod, 'key-0')).toBe(true);
+    // Every relationship reference resolves to a published VM (no dangling).
+    const vmFragments = new Set(vms.map(vm => fragmentOf(vm.id ?? '')).filter(Boolean));
+    for (const rel of [doc.authentication, doc.assertionMethod, doc.keyAgreement, doc.capabilityInvocation]) {
+      for (const ref of relationshipRefs(rel)) {
+        expect(vmFragments.has(fragmentOf(ref))).toBe(true);
+      }
+    }
+  }
+
+  test('rotateDIDWebVHKeys on a multi-key DID preserves keyAgreement and capability VMs', async () => {
+    const manager = new WebVHManager();
+    const keyManager = new KeyManager();
+    const { created, keyAgreementKey, capabilityKey } = await createMultiKeyDID(manager, keyManager);
+
+    const rotated = await manager.rotateDIDWebVHKeys({
+      did: created.did,
+      currentLog: created.log,
+      currentKeyPair: created.keyPair!,
+    });
+
+    assertCarriedVMsSurvive(
+      rotated.didDocument,
+      rotated.newKeyPair.publicKey,
+      created.keyPair!.publicKey,
+      keyAgreementKey.publicKey,
+      capabilityKey.publicKey
+    );
+
+    // The rotated log must still resolve, and resolution must agree.
+    const resolvedDoc = await resolveFromLog(rotated.log);
+    assertCarriedVMsSurvive(
+      resolvedDoc,
+      rotated.newKeyPair.publicKey,
+      created.keyPair!.publicKey,
+      keyAgreementKey.publicKey,
+      capabilityKey.publicKey
+    );
+  }, 30000);
+
+  test('recoverDIDWebVH preserves carried VMs — the recovered doc matches its own KeyRecoveryCredential', async () => {
+    const manager = new WebVHManager();
+    const keyManager = new KeyManager();
+    const { created, keyAgreementKey, capabilityKey } = await createMultiKeyDID(manager, keyManager);
+
+    const recovered = await manager.recoverDIDWebVH({
+      did: created.did,
+      currentLog: created.log,
+      signingKeyPair: created.keyPair!,
+    });
+
+    assertCarriedVMsSurvive(
+      recovered.didDocument,
+      recovered.newKeyPair.publicKey,
+      created.keyPair!.publicKey,
+      keyAgreementKey.publicKey,
+      capabilityKey.publicKey
+    );
+    const resolvedDoc = await resolveFromLog(recovered.log);
+    assertCarriedVMsSurvive(
+      resolvedDoc,
+      recovered.newKeyPair.publicKey,
+      created.keyPair!.publicKey,
+      keyAgreementKey.publicKey,
+      capabilityKey.publicKey
+    );
+  }, 30000);
+
+  test('pre-rotation rotation preserves carried VMs', async () => {
+    const manager = new WebVHManager();
+    const keyManager = new KeyManager();
+    const carried = await keyManager.generateKeyPair('Ed25519');
+
+    const created = await manager.createDIDWebVH({
+      domain: 'example.com',
+      prerotation: true,
+      additionalVerificationMethods: [
+        { id: '#key-agreement-1', type: 'Multikey', publicKeyMultibase: carried.publicKey, purpose: 'keyAgreement' },
+      ],
+    });
+
+    const rotated = await manager.rotateDIDWebVHKeys({
+      did: created.did,
+      currentLog: created.log,
+      currentKeyPair: created.nextKeyPair!,
+      prerotation: true,
+    });
+
+    const doc = rotated.didDocument;
+    expect((doc.verificationMethod ?? []).some(vm => vm.publicKeyMultibase === carried.publicKey)).toBe(true);
+    expect(referencesFragment(doc.keyAgreement, 'key-agreement-1')).toBe(true);
+    expect(referencesFragment(doc.authentication, 'key-0')).toBe(true);
+
+    const resolvedDoc = await resolveFromLog(rotated.log);
+    expect(referencesFragment(resolvedDoc.keyAgreement, 'key-agreement-1')).toBe(true);
+  }, 30000);
+
+  test('rotation rejects a non-Ed25519 replacement key instead of bricking the DID', async () => {
+    const manager = new WebVHManager();
+    const keyManager = new KeyManager();
+    const created = await manager.createDIDWebVH({ domain: 'example.com' });
+    const es256k = await keyManager.generateKeyPair('ES256K');
+
+    await expect(manager.rotateDIDWebVHKeys({
+      did: created.did,
+      currentLog: created.log,
+      currentKeyPair: created.keyPair!,
+      newKeyPair: es256k,
+    })).rejects.toThrow(/Ed25519/);
+  }, 30000);
+});
+
+describe('#334 — relationship arrays reference the published signing VM', () => {
+  test('created document publishes the signing VM as #key-0 and every relationship ref resolves', async () => {
+    const manager = new WebVHManager();
+    const created = await manager.createDIDWebVH({ domain: 'example.com' });
+
+    const resolvedDoc = await resolveFromLog(created.log);
+    const vms = resolvedDoc.verificationMethod ?? [];
+    expect(vms.length).toBe(1);
+    expect(fragmentOf(vms[0].id ?? '')).toBe('key-0');
+    expect(vms[0].publicKeyMultibase).toBe(created.keyPair!.publicKey);
+
+    for (const rel of [resolvedDoc.authentication, resolvedDoc.assertionMethod]) {
+      const entries = relationshipRefs(rel);
+      expect(entries.length).toBeGreaterThan(0);
+      for (const ref of entries) {
+        expect(fragmentOf(ref)).toBe('key-0');
+      }
+    }
+  }, 30000);
+
+  test('create → resolve from log → verifyCredential succeeds (the #334 repro)', async () => {
+    const sdk = OriginalsSDK.create({ defaultKeyType: 'Ed25519' });
+    const created = await sdk.did.createDIDWebVH({ domain: 'example.com' });
+
+    // Resolve the document from the signed log — the correct trust path a
+    // third-party verifier uses — and pin DID resolution to it.
+    const resolvedDoc = await resolveFromLog(created.log);
+    const resolveSpy = spyOn(sdk.did, 'resolveDID').mockResolvedValue(resolvedDoc);
+    try {
+      const credential: VerifiableCredential = {
+        '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
+        type: ['VerifiableCredential', 'ResourceCreated'],
+        issuer: created.did,
+        issuanceDate: new Date().toISOString(),
+        credentialSubject: {
+          id: created.did,
+          resourceId: 'res-334',
+          resourceType: 'text',
+          createdAt: new Date().toISOString(),
+          creator: created.did,
+        },
+      };
+
+      const signed = await sdk.credentials.signCredential(
+        credential,
+        created.keyPair!.privateKey,
+        `${created.did}#key-0`
+      );
+      expect(signed.proof).toBeDefined();
+
+      // Before the fix, the resolved doc's assertionMethod (['#key-0'])
+      // referenced a fragment no VM had, so proof-purpose verification
+      // rejected every credential issued with the DID.
+      await expect(sdk.credentials.verifyCredential(signed)).resolves.toBe(true);
+    } finally {
+      resolveSpy.mockRestore();
+    }
+  }, 30000);
+
+  test('external-signer path without VM ids gets #key-0 assigned so relationships resolve', async () => {
+    const keyManager = new KeyManager();
+    const keyPair = await keyManager.generateKeyPair('Ed25519');
+    const mod = await import('didwebvh-ts') as unknown as {
+      prepareDataForSigning: (document: Record<string, unknown>, proof: Record<string, unknown>) => Promise<Uint8Array>;
+    };
+    const { Ed25519Signer } = await import('../../../src/crypto/Signer');
+    const { multikey } = await import('../../../src/crypto/Multikey');
+    const raw = new Ed25519Signer();
+    const externalSigner = {
+      getVerificationMethodId: () => `did:key:${keyPair.publicKey}`,
+      async sign(input: { document: Record<string, unknown>; proof: Record<string, unknown> }) {
+        const data = await mod.prepareDataForSigning(input.document, input.proof);
+        const sig: Buffer = await raw.sign(Buffer.from(data), keyPair.privateKey);
+        return { proofValue: multikey.encodeMultibase(sig) };
+      },
+    };
+    const externalVerifier = new Ed25519Verifier();
+
+    const manager = new WebVHManager();
+    const created = await manager.createDIDWebVH({
+      domain: 'example.com',
+      externalSigner,
+      externalVerifier,
+      verificationMethods: [{ type: 'Multikey', publicKeyMultibase: keyPair.publicKey }],
+      updateKeys: [keyPair.publicKey],
+    });
+
+    const resolvedDoc = await resolveFromLog(created.log);
+    const vms = resolvedDoc.verificationMethod ?? [];
+    expect(fragmentOf(vms[0].id ?? '')).toBe('key-0');
+    expect(relationshipRefs(resolvedDoc.authentication).every(ref => fragmentOf(ref) === 'key-0')).toBe(true);
+    expect(relationshipRefs(resolvedDoc.assertionMethod).every(ref => fragmentOf(ref) === 'key-0')).toBe(true);
+  }, 30000);
+});

--- a/packages/sdk/tests/unit/did/webvh-write-paths.test.ts
+++ b/packages/sdk/tests/unit/did/webvh-write-paths.test.ts
@@ -147,6 +147,29 @@ describe('#338 — updateDIDWebVH applies updates through the options didwebvh-t
       signer: created.keyPair!,
     })).rejects.toThrow(/cannot apply updates to "controller"/);
   }, 30000);
+
+  test('rejects an attempted id change; accepts a spread document carrying the same id', async () => {
+    const manager = new WebVHManager();
+    const created = await manager.createDIDWebVH({ domain: 'example.com' });
+
+    // Changing the DID id must fail loudly, not be silently pinned back.
+    await expect(manager.updateDIDWebVH({
+      did: created.did,
+      currentLog: created.log,
+      updates: { id: 'did:webvh:xyz:elsewhere.example.com' },
+      signer: created.keyPair!,
+    })).rejects.toThrow(/cannot change the DID id/);
+
+    // But spreading the current document (same id) into updates is fine.
+    const svc = { id: `${created.did}#spread`, type: 'Svc', serviceEndpoint: 'https://spread.example.com' };
+    const updated = await manager.updateDIDWebVH({
+      did: created.did,
+      currentLog: created.log,
+      updates: { id: created.did, service: [svc] },
+      signer: created.keyPair!,
+    });
+    expect(updated.didDocument.service).toEqual([svc]);
+  }, 30000);
 });
 
 describe('#339 — rotation/recovery preserve carried verification methods and relationships', () => {

--- a/packages/sdk/tests/unit/did/webvh-write-paths.test.ts
+++ b/packages/sdk/tests/unit/did/webvh-write-paths.test.ts
@@ -306,6 +306,37 @@ describe('#339 — rotation/recovery preserve carried verification methods and r
     expect(referencesFragment(resolvedDoc.keyAgreement, 'key-agreement-1')).toBe(true);
   }, 30000);
 
+  test('rotation on a doc whose carried VM is in BOTH capability relationships fails loudly (not a silent drop)', async () => {
+    const manager = new WebVHManager();
+    const keyManager = new KeyManager();
+    const carried = await keyManager.generateKeyPair('Ed25519');
+
+    const created = await manager.createDIDWebVH({
+      domain: 'example.com',
+      additionalVerificationMethods: [
+        { id: '#capability-1', type: 'Multikey', publicKeyMultibase: carried.publicKey, purpose: 'capabilityInvocation' },
+      ],
+    });
+
+    // This SDK cannot author dual capability membership, but a log written by
+    // another didwebvh-ts client can carry it. Simulate that shape in the
+    // latest entry's state: didwebvh-ts's per-VM single `purpose` cannot
+    // express it, so rotation must throw a clear error BEFORE signing rather
+    // than silently dropping one relationship.
+    const log = structuredClone(created.log);
+    const state = log[log.length - 1].state as {
+      capabilityInvocation?: string[];
+      capabilityDelegation?: string[];
+    };
+    state.capabilityDelegation = [...(state.capabilityInvocation ?? [])];
+
+    await expect(manager.rotateDIDWebVHKeys({
+      did: created.did,
+      currentLog: log,
+      currentKeyPair: created.keyPair!,
+    })).rejects.toThrow(/both capabilityInvocation and capabilityDelegation/);
+  }, 30000);
+
   test('rotation rejects a non-Ed25519 replacement key instead of bricking the DID', async () => {
     const manager = new WebVHManager();
     const keyManager = new KeyManager();


### PR DESCRIPTION
## What

Fixes the did:webvh write-path cluster in `WebVHManager`: document updates were signed no-ops, key rotation/recovery wiped carried verification methods and relationships, and created documents authorized `#key-0` while publishing the VM under a key-derived id.

## Why

All three issues share one root cause: `WebVHManager`'s calls into `didwebvh-ts` didn't match the options the library actually consumes (verified against the installed `didwebvh-ts@2.8.0` source).

Closes #338
Closes #339
Closes #334

## How

- **#338 — `updateDIDWebVH` no-op.** `didwebvh-ts` `updateDID` never reads a `doc` option: it deep-clones the last entry's state and only overlays the named options `verificationMethods`, `services`, `authentication`, `assertionMethod`, `keyAgreement`, `alsoKnownAs`, `context`. The merged document is now translated into exactly those options (`deriveUpdateOptions`). Untouched fields are omitted so they ride the library's own carry-forward. Because supplying `verificationMethods` makes the library rebuild every relationship array from each VM's single `purpose`, updates that touch the VM block pin `authentication`/`assertionMethod`/`keyAgreement` explicitly, and capability relationships (which have **no** option override) are expressed via VM purposes. Update fields the library cannot express (e.g. `controller`, dual capability membership) are rejected with a `StructuredError` instead of being silently discarded — silent dropping is exactly the failure mode being fixed.
- **#339 — rotation/recovery stripping VMs.** `appendKeyChange`/`appendKeyChangePrerotation` now build the entry via `buildRotationDocumentOptions`: all non-signing VMs are carried forward with purposes derived from the current state's relationships, references to the retired update key are re-pointed at the new `#key-0`, and `keyAgreement`/capability relationships survive. Also adds the missing `assertEd25519WebVHUpdateKeys` on the new update key in both rotation paths (create already enforced it; a non-Ed25519 rotation key produced a log unverifiable by `Ed25519Verifier`, bricking the DID).
- **#334 — dangling `#key-0`.** The internal key-pair paths now publish the signing VM with `id: '#key-0'` (create, update, rotate, and pre-rotation), so the authorized relationship fragments reference a VM that exists. External-signer VMs supplied without an id get `#key-0` assigned, and the emitted relationships use the first VM's actual id.

Non-obvious decision: relationship entries referencing retired or dangling ids are dropped during rotation (the signing roles transfer to `#key-0`), which also heals documents created before the #334 fix.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test addition or improvement

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] I have updated JSDoc comments for any changed public APIs
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Testing

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing (describe steps)

New `tests/unit/did/webvh-write-paths.test.ts` asserts **semantics** (round-trips through `didwebvh-ts`'s own `resolveDIDFromLog` with `Ed25519Verifier`), not log length:

- update adds a service → present in `updated.didDocument`, in the new log entry `state`, and in log resolution; service-only updates leave the VM/relationship block untouched; unsupported update fields are rejected
- rotation and recovery on a multi-key DID preserve keyAgreement/capability VMs and leave no dangling relationship references (including the pre-rotation path); non-Ed25519 rotation keys are rejected
- create → resolve from log → `CredentialManager.verifyCredential` on a credential issued with the DID returns `true` (the #334 repro), for both internal and external-signer creation

The existing DID-007 tests (which only counted log entries) now also assert the update was actually applied, and the two `migrateToDIDWebVH` tests accept the signing VM's relative `#key-0` id (equally rooted per DID Core).

`bun test` from `packages/sdk`: 337/337 DID tests pass; full suite matches the baseline (the only full-suite failures are pre-existing CEL-CLI subprocess flakes that also fail on `main` and pass in isolation). `bun run lint` passes.

## Screenshots / Output (if applicable)

```
bun test tests/unit/did/
 337 pass, 0 fail, 997 expect() calls
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRo7zZAEuMMi3FNAD3v3xn

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRo7zZAEuMMi3FNAD3v3xn)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix did:webvh update, rotate, and create write paths in WebVHManager
> - `updateDIDWebVH` now translates the merged DID document into `didwebvh-ts` options (services, VMs, relationships) instead of passing a `doc` field that was silently ignored, so updates are actually applied.
> - Unsupported update fields and `id` changes are rejected before signing via the new `deriveUpdateOptions` helper.
> - Key rotation and recovery (`appendKeyChange`, `rotateDIDWebVHKeys`) now carry forward non-signing verification methods and their relationships, enforce Ed25519 for new keys, and publish the signing VM as `#key-0`.
> - `createDIDWebVH` now assigns `#key-0` as the signing VM id so relationship entries are not dangling.
> - Adds a regression test suite in [`webvh-write-paths.test.ts`](https://github.com/onionoriginals/sdk/pull/354/files#diff-1538ce8b989c339dc24032e887d1bec18e010e380f8435e33d9b0d4405b8c8cb) covering create, update, rotate, recover, and end-to-end credential verify flows.
> - Behavioral Change: non-Ed25519 keys passed to rotation/recovery now throw an error rather than proceeding silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db37dfe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->