### PR TITLE
fix: verify content hashes at publish, SSRF-harden OrdinalsClient, script-class-aware fee sizing — fixes #347, #343, #344

### DIFF
--- a/.changeset/provenance-soundness-fixes.md
+++ b/.changeset/provenance-soundness-fixes.md
@@ -1,0 +1,9 @@
+---
+"@originals/sdk": patch
+---
+
+Three provenance/money-safety fixes:
+
+- Verify inline resource content against its declared hash in `createAsset`, `publishResources`, and `inscribeOnBitcoin`, rejecting with `RESOURCE_HASH_MISMATCH` before anything is written, attested, or inscribed (#347).
+- SSRF-harden `OrdinalsClient` (the SignetProvider read path): pin indexer-supplied `content_url` to the configured endpoint's origin, refuse redirects, bound request time, cap response sizes, and cap/batch per-satoshi content downloads (#343).
+- Size transaction inputs by script class (P2WPKH 68 vB, P2TR 57.5 vB, P2WSH a conservative 120 vB) and outputs by destination address class in all fee estimators, so P2WSH-funded commits no longer underpay the requested fee rate and stall (#344).

--- a/packages/sdk/src/bitcoin/OrdinalsClient.ts
+++ b/packages/sdk/src/bitcoin/OrdinalsClient.ts
@@ -227,10 +227,22 @@ export class OrdinalsClient {
       return null;
     }
     assertContentLengthWithin(res, this.maxJsonBytes);
-    let text = (await res.text()).trim();
-    if (text.length > this.maxJsonBytes) {
-      return null;
+    // Materialize bytes when possible so the cap counts BYTES: text.length
+    // counts UTF-16 code units, so multi-byte content could consume up to 4x
+    // the cap when a malicious indexer omits/understates Content-Length.
+    let rawText: string;
+    if (typeof (res as { arrayBuffer?: unknown }).arrayBuffer === 'function') {
+      const bytes = new Uint8Array(await res.arrayBuffer());
+      if (bytes.byteLength > this.maxJsonBytes) {
+        return null;
+      }
+      rawText = new TextDecoder().decode(bytes);
+    } else {
+      // Test doubles may implement only text(); the Content-Length check
+      // above is the only cap available in that case.
+      rawText = await res.text();
     }
+    let text = rawText.trim();
     if (text.startsWith('"') && text.endsWith('"')) {
       try {
         text = JSON.parse(text);

--- a/packages/sdk/src/bitcoin/OrdinalsClient.ts
+++ b/packages/sdk/src/bitcoin/OrdinalsClient.ts
@@ -3,11 +3,99 @@ import { decode as decodeCbor } from '../utils/cbor.js';
 import { hexToBytes } from '../utils/encoding.js';
 import { StructuredError } from '../utils/telemetry.js';
 
+/** Max bytes accepted for a JSON indexer response (default 1 MiB). */
+const DEFAULT_MAX_JSON_BYTES = 1 * 1024 * 1024;
+/** Max bytes accepted for fetched inscription content (default 5 MiB). */
+const DEFAULT_MAX_CONTENT_BYTES = 5 * 1024 * 1024;
+/** Per-request timeout (default 10 s). */
+const DEFAULT_TIMEOUT_MS = 10_000;
+/** Max inscriptions resolved (content downloaded) per satoshi (default 100). */
+const DEFAULT_MAX_INSCRIPTIONS_PER_SAT = 100;
+/** Content downloads per batch when resolving a satoshi's inscriptions. */
+const SAT_RESOLVE_BATCH_SIZE = 8;
+
+export interface OrdinalsClientOptions {
+  /** Per-request timeout in milliseconds. */
+  timeoutMs?: number;
+  /** Max bytes accepted for a JSON indexer response. */
+  maxJsonBytes?: number;
+  /** Max bytes accepted for fetched inscription content. */
+  maxContentBytes?: number;
+  /** Max inscriptions resolved per satoshi before failing loudly. */
+  maxInscriptionsPerSat?: number;
+}
+
+/**
+ * Reject a candidate URL whose scheme is not http(s) or whose origin differs
+ * from the configured endpoint's, and return its RESOLVED ABSOLUTE form. The
+ * ord endpoint's JSON is attacker-controllable (a compromised/malicious
+ * indexer), so a `content_url` it returns must never be followed to an
+ * arbitrary host or scheme — that is a Server-Side Request Forgery vector
+ * (e.g. http://169.254.169.254/… cloud metadata, file:///…). Relative URLs
+ * resolve against the endpoint and stay same-origin. Mirrors the #265/#322
+ * hardening in OrdHttpProvider and OrdinalsClientProviderAdapter, which
+ * protected the adapter but left this client exposed on the SignetProvider
+ * read path (issue #343).
+ */
+function resolveSameOrigin(candidate: string, baseUrl: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate, baseUrl);
+  } catch {
+    throw new Error(`OrdinalsClient: malformed content_url '${candidate}'`);
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(
+      `OrdinalsClient: refusing non-http(s) content_url scheme '${parsed.protocol}' (possible SSRF)`
+    );
+  }
+  const baseOrigin = new URL(baseUrl).origin;
+  if (parsed.origin !== baseOrigin) {
+    throw new Error(
+      `OrdinalsClient: refusing to fetch content_url from origin ${parsed.origin}, ` +
+      `which differs from the configured endpoint origin ${baseOrigin} (possible SSRF)`
+    );
+  }
+  return parsed.toString();
+}
+
+/** Early reject via the Content-Length header when the server declares one. */
+function assertContentLengthWithin(res: { headers?: { get?: (name: string) => string | null } }, maxBytes: number): void {
+  const lenHeader = res.headers?.get?.('content-length');
+  if (lenHeader && Number(lenHeader) > maxBytes) {
+    throw new Error(`OrdinalsClient: response exceeds ${maxBytes} bytes (Content-Length ${lenHeader})`);
+  }
+}
+
 export class OrdinalsClient {
+  private readonly timeoutMs: number;
+  private readonly maxJsonBytes: number;
+  private readonly maxContentBytes: number;
+  private readonly maxInscriptionsPerSat: number;
+
   constructor(
     private rpcUrl: string,
-    private network: 'mainnet' | 'regtest' | 'signet'
-  ) {}
+    private network: 'mainnet' | 'regtest' | 'signet',
+    options: OrdinalsClientOptions = {}
+  ) {
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.maxJsonBytes = options.maxJsonBytes ?? DEFAULT_MAX_JSON_BYTES;
+    this.maxContentBytes = options.maxContentBytes ?? DEFAULT_MAX_CONTENT_BYTES;
+    this.maxInscriptionsPerSat = options.maxInscriptionsPerSat ?? DEFAULT_MAX_INSCRIPTIONS_PER_SAT;
+  }
+
+  /**
+   * Hardened fetch defaults: never follow a redirect (a same-origin URL must
+   * not 30x resolution off the pinned origin) and bound the request time so a
+   * stalling endpoint cannot hang resolution indefinitely.
+   */
+  private fetchInit(extra?: RequestInit): RequestInit {
+    return {
+      redirect: 'error',
+      signal: AbortSignal.timeout(this.timeoutMs),
+      ...(extra ?? {})
+    };
+  }
 
   async getInscriptionById(id: string): Promise<OrdinalsInscription | null> {
     if (!id) return null;
@@ -17,7 +105,25 @@ export class OrdinalsClient {
   async getInscriptionsBySatoshi(satoshi: string): Promise<OrdinalsInscription[]> {
     const info = await this.getSatInfo(satoshi);
     if (!info.inscription_ids.length) return [];
-    const inscriptions = await Promise.all(info.inscription_ids.map(id => this.resolveInscription(id)));
+    // Resolving an inscription downloads its full content, so a heavily
+    // reinscribed satoshi must not translate into unbounded downloads
+    // (memory DoS — issue #343). Fail loudly above the cap rather than
+    // silently truncating, which could hide the inscription a caller is
+    // looking for; raise maxInscriptionsPerSat to opt into more.
+    if (info.inscription_ids.length > this.maxInscriptionsPerSat) {
+      throw new StructuredError(
+        'ORD_TOO_MANY_INSCRIPTIONS',
+        `Satoshi ${satoshi} carries ${info.inscription_ids.length} inscriptions, above the configured ` +
+        `cap of ${this.maxInscriptionsPerSat}. Raise maxInscriptionsPerSat to resolve this satoshi.`
+      );
+    }
+    // Bounded concurrency: download content in small batches instead of one
+    // Promise.all over every inscription on the sat.
+    const inscriptions: Array<OrdinalsInscription | null> = [];
+    for (let i = 0; i < info.inscription_ids.length; i += SAT_RESOLVE_BATCH_SIZE) {
+      const batch = info.inscription_ids.slice(i, i + SAT_RESOLVE_BATCH_SIZE);
+      inscriptions.push(...await Promise.all(batch.map(id => this.resolveInscription(id))));
+    }
     return inscriptions.filter((x): x is OrdinalsInscription => x !== null);
   }
 
@@ -68,11 +174,21 @@ export class OrdinalsClient {
     const info = await this.fetchJson<any>(`/inscription/${identifier}`);
     if (!info) return null;
 
-    // Fetch content bytes
-    const contentUrl = info.content_url || `${this.rpcUrl}/content/${identifier}`;
-    const contentRes = await fetch(String(contentUrl));
+    // Fetch content bytes. content_url comes from the (untrusted) indexer
+    // response: pin it to the configured endpoint's origin before fetching
+    // (SSRF guard), refuse redirects, bound the request time, and cap the
+    // downloaded size.
+    const contentUrl = resolveSameOrigin(
+      String(info.content_url || `${this.rpcUrl}/content/${identifier}`),
+      this.rpcUrl
+    );
+    const contentRes = await fetch(contentUrl, this.fetchInit());
     if (!contentRes.ok) throw new Error(`Failed to fetch inscription content: ${contentRes.status}`);
+    assertContentLengthWithin(contentRes, this.maxContentBytes);
     const contentArrayBuf = await contentRes.arrayBuffer();
+    if (contentArrayBuf.byteLength > this.maxContentBytes) {
+      throw new Error(`OrdinalsClient: inscription content exceeds ${this.maxContentBytes} bytes`);
+    }
     const content = Buffer.from(new Uint8Array(contentArrayBuf));
 
     // owner_output may be 'txid:vout'
@@ -103,11 +219,18 @@ export class OrdinalsClient {
   async getMetadata(inscriptionId: string): Promise<Record<string, unknown> | null> {
     if (!inscriptionId) return null;
     const base = this.rpcUrl.replace(/\/$/, '');
-    const res = await fetch(`${base}/r/metadata/${inscriptionId}`, { headers: { 'Accept': 'application/json' } });
+    const res = await fetch(
+      `${base}/r/metadata/${inscriptionId}`,
+      this.fetchInit({ headers: { 'Accept': 'application/json' } })
+    );
     if (!res.ok) {
       return null;
     }
+    assertContentLengthWithin(res, this.maxJsonBytes);
     let text = (await res.text()).trim();
+    if (text.length > this.maxJsonBytes) {
+      return null;
+    }
     if (text.startsWith('"') && text.endsWith('"')) {
       try {
         text = JSON.parse(text);
@@ -125,12 +248,27 @@ export class OrdinalsClient {
 
   private async fetchJson<T>(path: string): Promise<T | null> {
     const url = `${this.rpcUrl.replace(/\/$/, '')}${path}`;
-    const res = await fetch(url, { headers: { 'Accept': 'application/json' } });
+    // The JSON response is as attacker-controllable as the content fetch:
+    // refuse redirects, bound the request time, and cap the accepted size.
+    const res = await fetch(url, this.fetchInit({ headers: { 'Accept': 'application/json' } }));
     if (!res.ok) return null;
-    const body: any = await res.json();
+    assertContentLengthWithin(res, this.maxJsonBytes);
+    let body: any;
+    if (typeof (res as { arrayBuffer?: unknown }).arrayBuffer === 'function') {
+      // Materialize the bytes so the cap holds even when the server omits or
+      // understates Content-Length.
+      const bytes = new Uint8Array(await res.arrayBuffer());
+      if (bytes.byteLength > this.maxJsonBytes) {
+        throw new Error(`OrdinalsClient: JSON response exceeds ${this.maxJsonBytes} bytes`);
+      }
+      body = JSON.parse(new TextDecoder().decode(bytes));
+    } else {
+      // Test doubles may implement only json(); the Content-Length check
+      // above is the only cap available in that case.
+      body = await res.json();
+    }
     // Accept { data: T } or T
     return (body && typeof body === 'object' && 'data' in body) ? body.data : body;
   }
 }
-
 

--- a/packages/sdk/src/bitcoin/PSBTBuilder.ts
+++ b/packages/sdk/src/bitcoin/PSBTBuilder.ts
@@ -1,5 +1,11 @@
 import type { Utxo } from '../types/bitcoin.js';
-import { isSegwitScriptPubKey, isProtectedUtxo } from './utxo.js';
+import {
+  isSegwitScriptPubKey,
+  isProtectedUtxo,
+  inputVBytesForScriptPubKey,
+  outputVBytesForAddress,
+  P2WPKH_INPUT_VBYTES
+} from './utxo.js';
 
 export interface PsbtOutput {
   address: string;
@@ -29,21 +35,22 @@ export interface BuildPsbtResult {
   changeOutput?: PsbtOutput;
 }
 
-function estimateVBytes(inputs: Utxo[], outputs: number): number {
-  const overhead = 10;       // base tx overhead
-  const segwitInSize = 68;   // rough P2WPKH/any-segwit input size
-  const legacyInSize = 148;  // legacy P2PKH sizing
-  const outSize = 31;        // P2WPKH output size
-  // build() rejects UTXOs with a KNOWN non-segwit scriptPubKey up front, so
-  // an input without a scriptPubKey is assumed segwit here — charging it at
-  // legacy width would over-estimate fees and spuriously fail (or over-fund)
-  // selections made from valid segwit UTXOs that simply omit the field. The
-  // legacy size is only applied defensively if a non-segwit script slips in.
+function estimateVBytes(inputs: Utxo[], outputVBytes: number[]): number {
+  const overhead = 10; // base tx overhead
+  // Inputs are sized by script class (P2WPKH 68, P2TR 57.5, P2WSH a
+  // conservative 120) — a flat P2WPKH assumption underpays the requested fee
+  // rate for P2WSH inputs (issue #344). build() rejects UTXOs with a KNOWN
+  // non-segwit scriptPubKey up front, so an input without a scriptPubKey is
+  // assumed P2WPKH here — charging it at legacy width would over-estimate
+  // fees and spuriously fail (or over-fund) selections made from valid
+  // segwit UTXOs that simply omit the field. The legacy size is only applied
+  // defensively if a non-segwit script slips in.
   const inputSize = inputs.reduce(
-    (sum, u) => sum + (!u.scriptPubKey || isSegwitScriptPubKey(u.scriptPubKey) ? segwitInSize : legacyInSize),
+    (sum, u) => sum + (u.scriptPubKey ? inputVBytesForScriptPubKey(u.scriptPubKey) : P2WPKH_INPUT_VBYTES),
     0
   );
-  return Math.ceil(overhead + inputSize + outputs * outSize);
+  const outputSize = outputVBytes.reduce((sum, v) => sum + v, 0);
+  return Math.ceil(overhead + inputSize + outputSize);
 }
 
 export class PSBTBuilder {
@@ -78,6 +85,11 @@ export class PSBTBuilder {
     // Sort UTXOs ascending by value for simple greedy selection
     const sorted = [...spendable].sort((a, b) => a.value - b.value);
 
+    // Outputs (and the potential change output) are sized by their address's
+    // script class — a P2TR/P2WSH output is 43 vB, not the 31 vB of P2WPKH.
+    const outputSizes = outputs.map(o => outputVBytesForAddress(o.address));
+    const changeSize = outputVBytesForAddress(changeAddress);
+
     // Start with smallest set to cover target + estimated fee; refine iteratively
     const targetValue = outputs.reduce((s, o) => s + o.value, 0);
     let selected: Utxo[] = [];
@@ -89,7 +101,7 @@ export class PSBTBuilder {
       for (const u of sorted) {
         selected.push(u);
         total += u.value;
-        const vbytes = estimateVBytes(selected, outputs.length + 1); // +1 potential change
+        const vbytes = estimateVBytes(selected, [...outputSizes, changeSize]); // + potential change
         const fee = Math.ceil(vbytes * feeRate);
         if (total >= targetValue + fee) break;
       }
@@ -97,13 +109,13 @@ export class PSBTBuilder {
     };
 
     pick();
-    const initialVBytes = estimateVBytes(selected, outputs.length + 1);
+    const initialVBytes = estimateVBytes(selected, [...outputSizes, changeSize]);
     let fee = Math.ceil(initialVBytes * feeRate);
     let change = total - targetValue - fee;
     let includeChange = change >= this.dustLimit;
 
     // Re-estimate once we know whether change is included
-    const finalVBytes = estimateVBytes(selected, outputs.length + (includeChange ? 1 : 0));
+    const finalVBytes = estimateVBytes(selected, includeChange ? [...outputSizes, changeSize] : outputSizes);
     fee = Math.ceil(finalVBytes * feeRate);
     change = total - targetValue - fee;
     includeChange = change >= this.dustLimit;

--- a/packages/sdk/src/bitcoin/transactions/commit.ts
+++ b/packages/sdk/src/bitcoin/transactions/commit.ts
@@ -13,7 +13,7 @@ import { schnorr } from '@noble/curves/secp256k1.js';
 import { Utxo, ResourceUtxo } from '../../types/bitcoin.js';
 import { calculateFee } from '../fee-calculation.js';
 import { selectUtxos, SimpleUtxoSelectionOptions } from '../utxo-selection.js';
-import { isSegwitScriptPubKey } from '../utxo.js';
+import { isSegwitScriptPubKey, inputVBytesForScriptPubKey, outputVBytesForAddress } from '../utxo.js';
 import { validateBitcoinAddress } from '../../utils/bitcoin-address.js';
 
 // Define minimum dust limit (satoshis)
@@ -117,22 +117,28 @@ export interface CommitTransactionResult {
 }
 
 /**
- * Estimates the size of a commit transaction
+ * Estimates the size of a commit transaction.
  *
- * @param inputCount - Number of transaction inputs
+ * Inputs are sized by script class (P2WPKH 68 vB, P2TR 57.5 vB, P2WSH a
+ * conservative 120 vB) rather than assuming P2WPKH for every segwit input —
+ * a 2-of-3 P2WSH input is ~105 vB, so the old flat 68 vB built commits that
+ * paid below the requested fee rate and could stall in the mempool with the
+ * reveal key stranded in memory (issue #344). When uncertain, overestimate.
+ *
+ * @param inputs - The UTXOs funding the transaction
  * @param outputCount - Number of transaction outputs (including commit and change)
+ * @param changeOutputVBytes - Size of one change output, per the change address's script class
  * @returns Estimated transaction size in virtual bytes
  */
-function estimateCommitTxSize(inputCount: number, outputCount: number): number {
+function estimateCommitTxSize(inputs: Utxo[], outputCount: number, changeOutputVBytes: number): number {
   // Transaction overhead
   const overhead = 10.5;
 
-  // P2WPKH inputs (assuming most common case)
-  const inputSize = 68 * inputCount;
+  const inputSize = inputs.reduce((sum, u) => sum + inputVBytesForScriptPubKey(u.scriptPubKey), 0);
 
-  // P2TR output for commit and P2WPKH for change
+  // P2TR output for commit; change output sized by the change address type
   const commitOutputSize = 43; // P2TR output
-  const changeOutputSize = outputCount > 1 ? 31 * (outputCount - 1) : 0; // P2WPKH outputs for change
+  const changeOutputSize = outputCount > 1 ? changeOutputVBytes * (outputCount - 1) : 0;
 
   return Math.ceil(overhead + inputSize + commitOutputSize + changeOutputSize);
 }
@@ -414,8 +420,17 @@ export async function createCommitTransaction(
   let estimatedFee = 0;
   let iteration = 0;
 
-  // Start with initial estimate (1 input, 2 outputs)
-  let targetAmount = commitOutputValue + Number(calculateFee(estimateCommitTxSize(1, 2), feeRate));
+  // Change output sized by the change address's script class (P2WPKH 31 vB,
+  // P2TR/P2WSH 43 vB) instead of a flat P2WPKH assumption.
+  const changeOutputVBytes = outputVBytesForAddress(changeAddress);
+
+  // Start with initial estimate (1 input, 2 outputs). The input is not known
+  // yet, so seed with the widest input class present among the candidates —
+  // a conservative seed only affects the first selection pass; the loop
+  // below re-estimates from the actually selected UTXOs.
+  const widestInputVBytes = Math.max(...validUtxos.map(u => inputVBytesForScriptPubKey(u.scriptPubKey)));
+  const initialVBytes = Math.ceil(10.5 + widestInputVBytes + 43 + changeOutputVBytes);
+  let targetAmount = commitOutputValue + Number(calculateFee(initialVBytes, feeRate));
 
   while (iteration < MAX_SELECTION_ITERATIONS) {
     iteration++;
@@ -437,10 +452,10 @@ export async function createCommitTransaction(
       );
     }
 
-    // Calculate accurate fee based on actual selected input count
-    // Assume 2 outputs (commit + change) for now - we'll adjust later if no change
-    const actualInputCount = selectedUtxos.length;
-    const estimatedVBytes = estimateCommitTxSize(actualInputCount, 2);
+    // Calculate accurate fee based on the actually selected inputs (sized by
+    // script class). Assume 2 outputs (commit + change) for now - we'll
+    // adjust later if no change
+    const estimatedVBytes = estimateCommitTxSize(selectedUtxos, 2, changeOutputVBytes);
     estimatedFee = Number(calculateFee(estimatedVBytes, feeRate));
 
     // Check if we need to account for no change output
@@ -450,7 +465,7 @@ export async function createCommitTransaction(
     if (potentialChange < MIN_DUST_LIMIT) {
       // No change output, recalculate fee with 1 output
       finalOutputCount = 1;
-      const adjustedVBytes = estimateCommitTxSize(actualInputCount, finalOutputCount);
+      const adjustedVBytes = estimateCommitTxSize(selectedUtxos, finalOutputCount, changeOutputVBytes);
       estimatedFee = Number(calculateFee(adjustedVBytes, feeRate));
     }
 
@@ -521,7 +536,6 @@ export async function createCommitTransaction(
   }
 
   // Step 8: Calculate final fee based on actual transaction structure
-  const actualInputCount = tx.inputsLength;
 
   // Determine if we'll have a change output
   const preliminaryChange = totalInputValue - commitOutputValue - estimatedFee;
@@ -529,7 +543,7 @@ export async function createCommitTransaction(
   const finalOutputCount = willHaveChange ? 2 : 1;
 
   // Calculate final fee with correct output count
-  const finalVBytes = estimateCommitTxSize(actualInputCount, finalOutputCount);
+  const finalVBytes = estimateCommitTxSize(selectedUtxos, finalOutputCount, changeOutputVBytes);
   const finalFee = Number(calculateFee(finalVBytes, feeRate));
 
   // CRITICAL: Final validation that inputs cover outputs + fees

--- a/packages/sdk/src/bitcoin/utxo-selection.ts
+++ b/packages/sdk/src/bitcoin/utxo-selection.ts
@@ -15,15 +15,18 @@ import {
   ResourceUtxoSelectionResult 
 } from '../types/bitcoin.js';
 import { calculateFee } from './fee-calculation.js';
-import { carriesOrdinal, isProtectedUtxo } from './utxo.js';
+import { carriesOrdinal, isProtectedUtxo, inputVBytesForScriptPubKey } from './utxo.js';
 
 // Minimum dust limit for Bitcoin outputs (546 satoshis)
 const MIN_DUST_LIMIT = DUST_LIMIT_SATS;
 
 /**
- * Estimates transaction size in vbytes based on input and output counts
- * This is a simplified calculation, and actual size may vary based on script types
- * 
+ * Estimates transaction size in vbytes based on input and output counts.
+ * This is a simplified COUNT-BASED calculation that assumes P2WPKH for every
+ * input; prefer estimateTransactionSizeForUtxos when the funding UTXOs are
+ * available, since a P2WSH input is ~105 vB and charging it at 68 vB builds
+ * transactions that pay below the requested fee rate (issue #344).
+ *
  * @param inputCount Number of inputs in the transaction
  * @param outputCount Number of outputs in the transaction
  * @returns Estimated transaction size in vbytes
@@ -34,6 +37,21 @@ export function estimateTransactionSize(inputCount: number, outputCount: number)
   // Each input: ~68 vbytes (P2WPKH)
   // Each output: ~31 vbytes
   return 10 + (inputCount * 68) + (outputCount * 31);
+}
+
+/**
+ * Estimates transaction size in vbytes for a concrete set of funding UTXOs,
+ * sizing each input by its scriptPubKey's script class (P2WPKH 68, P2TR 57.5,
+ * P2WSH conservative 120; inputs without a scriptPubKey are charged at
+ * conservative legacy width so the quote never underpays).
+ *
+ * @param inputs UTXOs funding the transaction
+ * @param outputCount Number of outputs in the transaction
+ * @returns Estimated transaction size in vbytes
+ */
+export function estimateTransactionSizeForUtxos(inputs: Utxo[], outputCount: number): number {
+  const inputSize = inputs.reduce((sum, u) => sum + inputVBytesForScriptPubKey(u.scriptPubKey), 0);
+  return Math.ceil(10 + inputSize + (outputCount * 31));
 }
 
 /**
@@ -276,20 +294,20 @@ export function selectResourceUtxos(
     eligibleUtxos.sort((a, b) => b.value - a.value);
   }
 
-  // Initial fee estimation (1 input, 2 outputs - payment and change)
-  let estimatedVbytes = estimateTransactionSize(1, 2);
-  let estimatedFee = calculateFee(estimatedVbytes, feeRate);
-  
-  // Target amount including estimated fee
-  let targetAmount = requiredAmountBigInt + estimatedFee;
-  
-  // Select UTXOs
+  // Select UTXOs. Fees are estimated from the concrete UTXOs being
+  // considered, sized by script class (issue #344): a flat P2WPKH assumption
+  // underpays the requested rate for P2WSH-funded wallets.
   const selectedUtxos: ResourceUtxo[] = [];
   let totalSelectedValue = 0n;
-  
-  // First pass: try to find a single UTXO that covers the amount
-  const singleUtxo = eligibleUtxos.find(utxo => BigInt(utxo.value) >= targetAmount);
-  
+
+  // First pass: try to find a single UTXO that covers the amount plus the
+  // fee that spending that specific UTXO would incur (2 outputs: payment + change)
+  const singleUtxo = eligibleUtxos.find(utxo =>
+    BigInt(utxo.value) >= requiredAmountBigInt + calculateFee(estimateTransactionSizeForUtxos([utxo], 2), feeRate)
+  );
+
+  let estimatedVbytes: number;
+  let estimatedFee: bigint;
   if (singleUtxo) {
     selectedUtxos.push(singleUtxo);
     totalSelectedValue = BigInt(singleUtxo.value);
@@ -298,20 +316,20 @@ export function selectResourceUtxos(
     for (const utxo of eligibleUtxos) {
       selectedUtxos.push(utxo);
       totalSelectedValue += BigInt(utxo.value);
-      
+
       // Recalculate fee as we add more inputs
-      estimatedVbytes = estimateTransactionSize(selectedUtxos.length, 2);
+      estimatedVbytes = estimateTransactionSizeForUtxos(selectedUtxos, 2);
       estimatedFee = calculateFee(estimatedVbytes, feeRate);
-      targetAmount = requiredAmountBigInt + estimatedFee;
-      
+      const targetAmount = requiredAmountBigInt + estimatedFee;
+
       if (totalSelectedValue >= targetAmount) {
         break;
       }
     }
   }
-  
-  // Final fee calculation based on actual number of inputs
-  estimatedVbytes = estimateTransactionSize(selectedUtxos.length, 2);
+
+  // Final fee calculation based on the actually selected inputs
+  estimatedVbytes = estimateTransactionSizeForUtxos(selectedUtxos, 2);
   estimatedFee = calculateFee(estimatedVbytes, feeRate);
   
   // Check if we have enough funds

--- a/packages/sdk/src/bitcoin/utxo-selection.ts
+++ b/packages/sdk/src/bitcoin/utxo-selection.ts
@@ -15,7 +15,7 @@ import {
   ResourceUtxoSelectionResult 
 } from '../types/bitcoin.js';
 import { calculateFee } from './fee-calculation.js';
-import { carriesOrdinal, isProtectedUtxo, inputVBytesForScriptPubKey } from './utxo.js';
+import { carriesOrdinal, isProtectedUtxo, inputVBytesForScriptPubKey, WITNESS_32B_OUTPUT_VBYTES } from './utxo.js';
 
 // Minimum dust limit for Bitcoin outputs (546 satoshis)
 const MIN_DUST_LIMIT = DUST_LIMIT_SATS;
@@ -43,7 +43,11 @@ export function estimateTransactionSize(inputCount: number, outputCount: number)
  * Estimates transaction size in vbytes for a concrete set of funding UTXOs,
  * sizing each input by its scriptPubKey's script class (P2WPKH 68, P2TR 57.5,
  * P2WSH conservative 120; inputs without a scriptPubKey are charged at
- * conservative legacy width so the quote never underpays).
+ * conservative legacy width so the quote never underpays). Output addresses
+ * are not known at this call site, so each output is charged the largest
+ * standard output size (43 vB, P2TR/P2WSH) — same safe direction: a P2WPKH
+ * output merely overpays 12 vB, whereas charging 31 vB would underpay the
+ * requested rate for P2TR/P2WSH destinations.
  *
  * @param inputs UTXOs funding the transaction
  * @param outputCount Number of outputs in the transaction
@@ -51,7 +55,7 @@ export function estimateTransactionSize(inputCount: number, outputCount: number)
  */
 export function estimateTransactionSizeForUtxos(inputs: Utxo[], outputCount: number): number {
   const inputSize = inputs.reduce((sum, u) => sum + inputVBytesForScriptPubKey(u.scriptPubKey), 0);
-  return Math.ceil(10 + inputSize + (outputCount * 31));
+  return Math.ceil(10 + inputSize + (outputCount * WITNESS_32B_OUTPUT_VBYTES));
 }
 
 /**

--- a/packages/sdk/src/bitcoin/utxo.ts
+++ b/packages/sdk/src/bitcoin/utxo.ts
@@ -70,6 +70,90 @@ export const DEFAULT_FEE_ESTIMATE: Required<FeeEstimateOptions> = {
  */
 export const UNCLASSIFIED_INPUT_VBYTES = 148;
 
+/** Script classes the fee estimators can size. */
+export type ScriptClass = 'p2wpkh' | 'p2wsh' | 'p2tr' | 'segwit-other' | 'legacy' | 'unknown';
+
+/** P2WPKH input: 41 vB base + ~107-byte witness (sig + pubkey) / 4 ≈ 68 vB. */
+export const P2WPKH_INPUT_VBYTES = 68;
+/** P2TR key-path input: 41 vB base + 66-byte witness (schnorr sig) / 4 = 57.5 vB. */
+export const P2TR_INPUT_VBYTES = 57.5;
+/**
+ * P2WSH input, sized conservatively. The witness carries the full witness
+ * script plus its stack arguments, so the true size depends on the script: a
+ * 2-of-3 CHECKMULTISIG spend is ~105 vB (2×72-byte sigs + 105-byte script,
+ * witness-discounted). 120 vB covers that common worst case with margin —
+ * underestimating here builds transactions that pay BELOW the requested fee
+ * rate and stall in the mempool (issue #344), so when uncertain we overpay.
+ */
+export const P2WSH_INPUT_VBYTES = 120;
+
+/** P2WPKH output: 8 (value) + 1 (script len) + 22 (script) = 31 vB. */
+export const P2WPKH_OUTPUT_VBYTES = 31;
+/** P2WSH / P2TR output: 8 + 1 + 34 = 43 vB. Also the conservative default. */
+export const WITNESS_32B_OUTPUT_VBYTES = 43;
+/** Legacy P2PKH output: 8 + 1 + 25 = 34 vB. */
+export const P2PKH_OUTPUT_VBYTES = 34;
+/** Legacy P2SH output: 8 + 1 + 23 = 32 vB. */
+export const P2SH_OUTPUT_VBYTES = 32;
+
+/**
+ * Classify a scriptPubKey by script class so fee estimators can size the
+ * input's witness correctly instead of assuming P2WPKH for every segwit
+ * program (issue #344 — that assumption underpays for P2WSH).
+ */
+export function classifyScriptPubKey(scriptPubKeyHex?: string): ScriptClass {
+  if (!scriptPubKeyHex) return 'unknown';
+  if (!isSegwitScriptPubKey(scriptPubKeyHex)) return 'legacy';
+  const hex = scriptPubKeyHex.toLowerCase();
+  const versionByte = parseInt(hex.slice(0, 2), 16);
+  const pushLength = parseInt(hex.slice(2, 4), 16);
+  if (versionByte === 0x00 && pushLength === 20) return 'p2wpkh';
+  if (versionByte === 0x00 && pushLength === 32) return 'p2wsh';
+  if (versionByte === 0x51 && pushLength === 32) return 'p2tr';
+  return 'segwit-other';
+}
+
+/**
+ * Virtual size to charge for spending an input with the given scriptPubKey.
+ * Sizes are per script class; anything unclassifiable is charged at the
+ * largest plausible width so the resulting fee never pays below the
+ * requested rate (an overpay is bounded; an underpay strands the tx).
+ */
+export function inputVBytesForScriptPubKey(scriptPubKeyHex?: string): number {
+  switch (classifyScriptPubKey(scriptPubKeyHex)) {
+    case 'p2wpkh': return P2WPKH_INPUT_VBYTES;
+    case 'p2tr': return P2TR_INPUT_VBYTES;
+    case 'p2wsh': return P2WSH_INPUT_VBYTES;
+    // Future witness versions / non-standard v0 programs: witness shape is
+    // unknown, so charge the conservative P2WSH width.
+    case 'segwit-other': return P2WSH_INPUT_VBYTES;
+    default: return UNCLASSIFIED_INPUT_VBYTES;
+  }
+}
+
+/**
+ * Virtual size of an output paying the given address, classified by address
+ * form (bech32 witness version + program length, or base58 prefix). Unknown
+ * or unparseable addresses are charged at the largest standard output size
+ * (43 vB) so the estimate errs toward overpaying rather than underpaying.
+ */
+export function outputVBytesForAddress(address?: string): number {
+  if (!address) return WITNESS_32B_OUTPUT_VBYTES;
+  const addr = address.toLowerCase();
+  const sep = addr.lastIndexOf('1');
+  if (/^(bc1|tb1|bcrt1)/.test(addr) && sep > 0) {
+    const data = addr.slice(sep + 1);
+    // bech32 data part: 1 version char + program (20 bytes → 32 chars,
+    // 32 bytes → 52 chars) + 6 checksum chars.
+    if (data.length === 39 && data.startsWith('q')) return P2WPKH_OUTPUT_VBYTES;
+    return WITNESS_32B_OUTPUT_VBYTES;
+  }
+  // Base58: mainnet P2PKH '1', testnet P2PKH 'm'/'n'; mainnet P2SH '3', testnet P2SH '2'.
+  if (/^[1mn]/.test(addr)) return P2PKH_OUTPUT_VBYTES;
+  if (/^[32]/.test(addr)) return P2SH_OUTPUT_VBYTES;
+  return WITNESS_32B_OUTPUT_VBYTES;
+}
+
 /**
  * True when a scriptPubKey hex string is a segwit witness program
  * (v0 P2WPKH/P2WSH, v1 P2TR, or any future v2–v16 program): a version opcode
@@ -153,20 +237,30 @@ export function selectUtxos(utxos: Utxo[], options: SelectionOptions): Selection
   // Sort largest first to reduce change outputs and input count
   candidateUtxos.sort((a, b) => b.value - a.value);
 
-  // Per-input sizing: verified segwit inputs use the (possibly overridden)
-  // bytesPerInput; unclassified inputs (no scriptPubKey) are priced at
-  // conservative legacy width unless the caller explicitly overrode
-  // bytesPerInput (an explicit override applies to every input).
+  // Per-input sizing: verified segwit inputs are priced by script class
+  // (P2WPKH 68, P2TR 57.5, P2WSH conservative 120 — issue #344: charging
+  // P2WPKH width for a P2WSH input underpays the requested fee rate);
+  // unclassified inputs (no scriptPubKey) are priced at conservative legacy
+  // width. An explicit bytesPerInput override applies to every input.
   const est = { ...DEFAULT_FEE_ESTIMATE, ...feeEstimate };
   const perInputOverridden = feeEstimate?.bytesPerInput !== undefined;
   const inputVBytes = (u: Utxo): number =>
-    perInputOverridden || (u.scriptPubKey && isSegwitScriptPubKey(u.scriptPubKey))
-      ? est.bytesPerInput
-      : UNCLASSIFIED_INPUT_VBYTES;
+    perInputOverridden ? est.bytesPerInput : inputVBytesForScriptPubKey(u.scriptPubKey);
+  // The change output is sized by the change address's script class when one
+  // is provided (a P2TR/P2WSH change output is 43 vB, not the P2WPKH-ish
+  // default); an explicit bytesPerOutput override applies to every output.
+  const perOutputOverridden = feeEstimate?.bytesPerOutput !== undefined;
+  const changeOutputVBytes = !perOutputOverridden && options.changeAddress
+    ? outputVBytesForAddress(options.changeAddress)
+    : est.bytesPerOutput;
   const feeForSelection = (numOutputs: number): number => {
+    // numOutputs is 1 (recipient only) or 2 (recipient + change).
+    const outputBytes = numOutputs >= 2
+      ? (numOutputs - 1) * est.bytesPerOutput + changeOutputVBytes
+      : numOutputs * est.bytesPerOutput;
     const bytes = est.baseTxBytes
       + selected.reduce((sum, u) => sum + inputVBytes(u), 0)
-      + numOutputs * est.bytesPerOutput;
+      + outputBytes;
     return Math.ceil(bytes * feeRateSatsPerVb);
   };
 

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -12,6 +12,7 @@ import { DIDManager } from '../did/DIDManager.js';
 import { CredentialManager } from '../vc/CredentialManager.js';
 import { OriginalsAsset } from './OriginalsAsset.js';
 import { encodeBase64UrlMultibase, hexToBytes } from '../utils/encoding.js';
+import { hashResource } from '../utils/validation.js';
 import { validateBitcoinAddress } from '../utils/bitcoin-address.js';
 import { parseSatoshiIdentifier } from '../utils/satoshi-validation.js';
 import { btcoDidPrefix } from '../cel/btcoDid.js';
@@ -249,6 +250,12 @@ export class LifecycleManager {
         if (!/^[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]{0,126}\/[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]{0,126}$/.test(resource.contentType)) {
           throw new StructuredError('INVALID_RESOURCE', `Invalid resource: invalid contentType MIME format: ${resource.contentType}`);
         }
+        // Inline content must actually match its declared hash: everything
+        // downstream (publication credentials, resource URLs, inscription
+        // manifests) attests the DECLARED hash, so accepting mismatched
+        // content here would let a signed attestation claim integrity that
+        // was never true (issue #347).
+        this.assertContentMatchesDeclaredHash(resource, 'createAsset');
       }
     
     // Create a proper DID:peer document with verification methods
@@ -792,6 +799,29 @@ export class LifecycleManager {
     }
   }
 
+  /**
+   * Verify that a resource's inline content actually hashes to its declared
+   * hash. The SDK's integrity semantics (OriginalsAsset.verify,
+   * addResourceVersion) define a resource hash as sha256 over the UTF-8
+   * bytes of `content`. Publication writes content to a key derived from the
+   * DECLARED hash, sets resource.url, and mints a signed ResourceMigrated
+   * credential — none of which is sound if the bytes don't match (issue
+   * #347). Hash-only resources (no inline content) are not checkable here
+   * and are skipped.
+   */
+  private assertContentMatchesDeclaredHash(resource: AssetResource, operation: string): void {
+    if (typeof resource.content !== 'string') return;
+    const computed = hashResource(Buffer.from(resource.content, 'utf8'));
+    if (computed.toLowerCase() !== resource.hash.toLowerCase()) {
+      throw new StructuredError(
+        'RESOURCE_HASH_MISMATCH',
+        `Resource ${resource.id}: content does not match its declared hash ` +
+        `(declared ${resource.hash}, computed ${computed}). Refusing to ${operation}: ` +
+        `attesting a hash the bytes do not match would break provenance.`
+      );
+    }
+  }
+
   private async publishResources(
     asset: OriginalsAsset,
     publisherDid: string,
@@ -850,6 +880,12 @@ export class LifecycleManager {
         });
         continue;
       }
+
+      // Verify the bytes against the declared hash BEFORE writing anything or
+      // attesting anything: the storage key, resource.url, resource:published
+      // event and the ResourceMigrated credential all assert the declared
+      // hash (issue #347).
+      this.assertContentMatchesDeclaredHash(resource, 'publish');
 
       const data = Buffer.from(resource.content);
 
@@ -1106,6 +1142,12 @@ export class LifecycleManager {
     this.inFlightAssets.add(asset.id);
     try {
     const bitcoinManager = this.deps?.bitcoinManager ?? new BitcoinManager(this.config);
+    // The manifest permanently records each resource's declared hash on
+    // Bitcoin; verify inline content against it first so a mismatched hash
+    // is never inscribed (issue #347).
+    for (const res of asset.resources) {
+      this.assertContentMatchesDeclaredHash(res, 'inscribe on Bitcoin');
+    }
     const manifest = {
       assetId: asset.id,
       resources: asset.resources.map(res => ({ id: res.id, hash: res.hash, contentType: res.contentType, url: res.url })),

--- a/packages/sdk/tests/integration/BatchOperations.test.ts
+++ b/packages/sdk/tests/integration/BatchOperations.test.ts
@@ -16,6 +16,11 @@ import { StorageAdapter as ConfigStorageAdapter } from '../../src/adapters/types
 import { MockKeyStore } from '../mocks/MockKeyStore';
 import type { BatchResult } from '../../src/lifecycle/BatchOperations';
 import { KeyManager } from '../../src/did/KeyManager';
+import { createHash as __cryptoCreateHash } from 'crypto';
+// Real content hash — createAsset/publish now verify content against the
+// declared hash (issue #347), so fixtures must declare the true sha256.
+const contentHash = (c: string) => __cryptoCreateHash('sha256').update(c, 'utf8').digest('hex');
+
 
 function makeHash(prefix: string): string {
   const hexOnly = prefix.split('').map(c => {
@@ -91,13 +96,13 @@ describe('Batch Operations Integration', () => {
     test('should create multiple assets successfully', async () => {
       const resourcesList = [
         [
-          { id: 'res1', type: 'image', contentType: 'image/png', hash: makeHash('img1'), content: 'image1' }
+          { id: 'res1', type: 'image', contentType: 'image/png', hash: contentHash('image1'), content: 'image1' }
         ],
         [
-          { id: 'res2', type: 'text', contentType: 'text/plain', hash: makeHash('txt1'), content: 'text1' }
+          { id: 'res2', type: 'text', contentType: 'text/plain', hash: contentHash('text1'), content: 'text1' }
         ],
         [
-          { id: 'res3', type: 'data', contentType: 'application/json', hash: makeHash('json1'), content: '{"key":"value"}' }
+          { id: 'res3', type: 'data', contentType: 'application/json', hash: contentHash('{"key":"value"}'), content: '{"key":"value"}' }
         ]
       ];
 
@@ -131,11 +136,11 @@ describe('Batch Operations Integration', () => {
     test('should continue on error when specified', async () => {
       const resourcesList = [
         [
-          { id: 'res1', type: 'image', contentType: 'image/png', hash: makeHash('img1'), content: 'image1' }
+          { id: 'res1', type: 'image', contentType: 'image/png', hash: contentHash('image1'), content: 'image1' }
         ],
         [], // This will fail validation at runtime
         [
-          { id: 'res3', type: 'text', contentType: 'text/plain', hash: makeHash('txt1'), content: 'text1' }
+          { id: 'res3', type: 'text', contentType: 'text/plain', hash: contentHash('text1'), content: 'text1' }
         ]
       ];
 
@@ -159,7 +164,7 @@ describe('Batch Operations Integration', () => {
       });
 
       const resourcesList = [
-        [{ id: 'res1', type: 'image', contentType: 'image/png', hash: makeHash('img1'), content: 'image1' }]
+        [{ id: 'res1', type: 'image', contentType: 'image/png', hash: contentHash('image1'), content: 'image1' }]
       ];
 
       await sdk.lifecycle.batchCreateAssets(resourcesList);
@@ -182,7 +187,7 @@ describe('Batch Operations Integration', () => {
       const assets: OriginalsAsset[] = [];
       for (let i = 0; i < 3; i++) {
         const asset = await sdk.lifecycle.createAsset([
-          { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: makeHash(`txt${i}`), content: `text${i}` }
+          { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: contentHash(`text${i}`), content: `text${i}` }
         ]);
         assets.push(asset);
       }
@@ -202,7 +207,7 @@ describe('Batch Operations Integration', () => {
 
     test('should validate domain format', async () => {
       const asset = await sdk.lifecycle.createAsset([
-        { id: 'res1', type: 'text', contentType: 'text/plain', hash: makeHash('txt1'), content: 'text1' }
+        { id: 'res1', type: 'text', contentType: 'text/plain', hash: contentHash('text1'), content: 'text1' }
       ]);
 
       await expect(
@@ -220,7 +225,7 @@ describe('Batch Operations Integration', () => {
       });
 
       const asset = await sdk.lifecycle.createAsset([
-        { id: 'res1', type: 'text', contentType: 'text/plain', hash: makeHash('txt1'), content: 'text1' }
+        { id: 'res1', type: 'text', contentType: 'text/plain', hash: contentHash('text1'), content: 'text1' }
       ]);
 
       await sdk.lifecycle.batchPublishToWeb([asset], 'example.com');
@@ -235,7 +240,7 @@ describe('Batch Operations Integration', () => {
       const assets: OriginalsAsset[] = [];
       for (let i = 0; i < 3; i++) {
         const asset = await sdk.lifecycle.createAsset([
-          { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: makeHash(`txt${i}`), content: `text${i}` }
+          { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: contentHash(`text${i}`), content: `text${i}` }
         ]);
         assets.push(asset);
       }
@@ -264,7 +269,7 @@ describe('Batch Operations Integration', () => {
       const assets: OriginalsAsset[] = [];
       for (let i = 0; i < 3; i++) {
         const asset = await sdk.lifecycle.createAsset([
-          { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: makeHash(`txt${i}`), content: `text${i}` }
+          { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: contentHash(`text${i}`), content: `text${i}` }
         ]);
         assets.push(asset);
       }
@@ -294,7 +299,7 @@ describe('Batch Operations Integration', () => {
       const assets: OriginalsAsset[] = [];
       for (let i = 0; i < 3; i++) {
         const asset = await sdk.lifecycle.createAsset([
-          { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: makeHash(`txt${i}`), content: `text${i}` }
+          { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: contentHash(`text${i}`), content: `text${i}` }
         ]);
         const inscribed = await sdk.lifecycle.inscribeOnBitcoin(asset, 5);
         assets.push(inscribed);
@@ -320,7 +325,7 @@ describe('Batch Operations Integration', () => {
 
     test('should validate Bitcoin addresses', async () => {
       const asset = await sdk.lifecycle.createAsset([
-        { id: 'res1', type: 'text', contentType: 'text/plain', hash: makeHash('txt1'), content: 'text1' }
+        { id: 'res1', type: 'text', contentType: 'text/plain', hash: contentHash('text1'), content: 'text1' }
       ]);
       const inscribed = await sdk.lifecycle.inscribeOnBitcoin(asset, 5);
 
@@ -335,7 +340,7 @@ describe('Batch Operations Integration', () => {
 
     test('should validate assets are inscribed', async () => {
       const asset = await sdk.lifecycle.createAsset([
-        { id: 'res1', type: 'text', contentType: 'text/plain', hash: makeHash('txt1'), content: 'text1' }
+        { id: 'res1', type: 'text', contentType: 'text/plain', hash: contentHash('text1'), content: 'text1' }
       ]);
 
       const transfers = [
@@ -352,7 +357,7 @@ describe('Batch Operations Integration', () => {
     test('should execute full lifecycle with batch operations', async () => {
       // Phase 1: Batch create
       const resourcesList = Array.from({ length: 5 }, (_, i) => [
-        { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: makeHash(`txt${i}`), content: `text${i}` }
+        { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: contentHash(`text${i}`), content: `text${i}` }
       ]);
 
       const createResult = await sdk.lifecycle.batchCreateAssets(resourcesList);
@@ -399,7 +404,7 @@ describe('Batch Operations Integration', () => {
   describe('Performance and Scalability', () => {
     test('should handle large batches efficiently', async () => {
       const resourcesList = Array.from({ length: 50 }, (_, i) => [
-        { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: makeHash(`txt${i}`), content: `text${i}` }
+        { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: contentHash(`text${i}`), content: `text${i}` }
       ]);
 
       const startTime = Date.now();
@@ -419,7 +424,7 @@ describe('Batch Operations Integration', () => {
       const assets: OriginalsAsset[] = [];
       for (let i = 0; i < 20; i++) {
         const asset = await sdk.lifecycle.createAsset([
-          { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: makeHash(`txt${i}`), content: `text${i}` }
+          { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: contentHash(`text${i}`), content: `text${i}` }
         ]);
         assets.push(asset);
       }

--- a/packages/sdk/tests/integration/CompleteLifecycle.e2e.test.ts
+++ b/packages/sdk/tests/integration/CompleteLifecycle.e2e.test.ts
@@ -28,6 +28,11 @@ import { OrdMockProvider } from '../../src/adapters/providers/OrdMockProvider';
 import { StorageAdapter as ConfigStorageAdapter } from '../../src/adapters/types';
 import { MockKeyStore } from '../mocks/MockKeyStore';
 import { KeyManager } from '../../src/did/KeyManager';
+import { createHash as __cryptoCreateHash } from 'crypto';
+// Real content hash — createAsset/publish now verify content against the
+// declared hash (issue #347), so fixtures must declare the true sha256.
+const contentHash = (c: string) => __cryptoCreateHash('sha256').update(c, 'utf8').digest('hex');
+
 
 /**
  * Helper to generate valid SHA-256 hashes (64 hex characters)
@@ -128,14 +133,14 @@ describe('E2E Integration: Complete Lifecycle Flow', () => {
           id: 'resource-1',
           type: 'image',
           contentType: 'image/png',
-          hash: 'deadbeef1234567890abcdef1234567890abcdef1234567890abcdef12345678',
+          hash: 'cef9d30aa874f055b67820f138fe0efc59511dfd10e16dfd187611f202ce4420',
           content: 'mock-image-data'
         },
         {
           id: 'resource-2',
           type: 'text',
           contentType: 'text/plain',
-          hash: 'cafebabe1234567890abcdef1234567890abcdef1234567890abcdef12345678',
+          hash: 'b5434f89a784a99900d2c801ad5988cfe8bee61fbc98c44577f8f8d8fe4b0d94',
           content: 'Hello, Originals Protocol!'
         }
       ];
@@ -293,7 +298,7 @@ describe('E2E Integration: Complete Lifecycle Flow', () => {
           id: 'resource-direct',
           type: 'data',
           contentType: 'application/json',
-          hash: 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+          hash: '40b61fe1b15af0a4d5402735b26343e8cf8a045f4d81710e6108a21d91eaf366',
           content: '{"test": "data"}'
         }
       ];
@@ -393,7 +398,7 @@ describe('E2E Integration: Complete Lifecycle Flow', () => {
       
       // Verify fee oracle is used in lifecycle
       const asset = await sdk.lifecycle.createAsset([
-        { id: 'fee-test', type: 'data', contentType: 'text/plain', hash: makeHash('fee123'), content: 'test' }
+        { id: 'fee-test', type: 'data', contentType: 'text/plain', hash: contentHash('test'), content: 'test' }
       ]);
       
       const btcoAsset = await sdk.lifecycle.inscribeOnBitcoin(asset, undefined);
@@ -447,7 +452,7 @@ describe('E2E Integration: Complete Lifecycle Flow', () => {
           id: 'adapter-integration',
           type: 'text',
           contentType: 'text/html',
-          hash: makeHash('html123456789abcdef1234567890abcdef1234567890abcdef12'),
+          hash: contentHash('<html><body>Test</body></html>'),
           content: '<html><body>Test</body></html>'
         }
       ]);
@@ -470,7 +475,7 @@ describe('E2E Integration: Complete Lifecycle Flow', () => {
 
     test('adapters work together in inscribeOnBitcoin', async () => {
       const asset = await sdk.lifecycle.createAsset([
-        { id: 'btc-test', type: 'data', contentType: 'application/json', hash: makeHash('btc123'), content: '{}' }
+        { id: 'btc-test', type: 'data', contentType: 'application/json', hash: contentHash('{}'), content: '{}' }
       ]);
 
       // Inscribe without specifying fee rate - should use oracle
@@ -490,7 +495,7 @@ describe('E2E Integration: Complete Lifecycle Flow', () => {
   describe('Error Handling and Edge Cases', () => {
     test('throws error when transferring non-btco asset', async () => {
       const asset = await sdk.lifecycle.createAsset([
-        { id: 'error-test', type: 'data', contentType: 'text/plain', hash: makeHash('err123'), content: 'test' }
+        { id: 'error-test', type: 'data', contentType: 'text/plain', hash: contentHash('test'), content: 'test' }
       ]);
 
       // Try to transfer peer layer asset
@@ -507,7 +512,7 @@ describe('E2E Integration: Complete Lifecycle Flow', () => {
 
     test('handles multiple transfers correctly', async () => {
       const asset = await sdk.lifecycle.createAsset([
-        { id: 'multi-transfer', type: 'data', contentType: 'text/plain', hash: makeHash('multi123'), content: 'test' }
+        { id: 'multi-transfer', type: 'data', contentType: 'text/plain', hash: contentHash('test'), content: 'test' }
       ]);
 
       const btcoAsset = await sdk.lifecycle.inscribeOnBitcoin(asset, 5);
@@ -538,10 +543,10 @@ describe('E2E Integration: Complete Lifecycle Flow', () => {
 
     test('handles multiple resources with different content types', async () => {
       const resources: AssetResource[] = [
-        { id: 'img', type: 'image', contentType: 'image/jpeg', hash: makeHash('img123'), content: 'jpeg-data' },
-        { id: 'txt', type: 'text', contentType: 'text/plain', hash: makeHash('txt123'), content: 'text-data' },
-        { id: 'json', type: 'data', contentType: 'application/json', hash: makeHash('json123'), content: '{"key":"value"}' },
-        { id: 'html', type: 'document', contentType: 'text/html', hash: makeHash('html123'), content: '<div>test</div>' }
+        { id: 'img', type: 'image', contentType: 'image/jpeg', hash: contentHash('jpeg-data'), content: 'jpeg-data' },
+        { id: 'txt', type: 'text', contentType: 'text/plain', hash: contentHash('text-data'), content: 'text-data' },
+        { id: 'json', type: 'data', contentType: 'application/json', hash: contentHash('{"key":"value"}'), content: '{"key":"value"}' },
+        { id: 'html', type: 'document', contentType: 'text/html', hash: contentHash('<div>test</div>'), content: '<div>test</div>' }
       ];
 
       const asset = await sdk.lifecycle.createAsset(resources);
@@ -568,7 +573,7 @@ describe('E2E Integration: Complete Lifecycle Flow', () => {
 
     test('preserves bindings throughout lifecycle', async () => {
       const asset = await sdk.lifecycle.createAsset([
-        { id: 'binding-test', type: 'data', contentType: 'text/plain', hash: makeHash('bind123'), content: 'test' }
+        { id: 'binding-test', type: 'data', contentType: 'text/plain', hash: contentHash('test'), content: 'test' }
       ]);
 
       // After webvh
@@ -600,7 +605,7 @@ describe('E2E Integration: Complete Lifecycle Flow', () => {
           id: 'large-resource',
           type: 'data',
           contentType: 'application/octet-stream',
-          hash: makeHash('large123456789abcdef1234567890abcdef1234567890abcdef1'),
+          hash: contentHash(largeContent),
           content: largeContent
         }
       ];
@@ -626,7 +631,7 @@ describe('E2E Integration: Complete Lifecycle Flow', () => {
         id: `resource-${i}`,
         type: 'data',
         contentType: 'text/plain',
-        hash: makeHash(`res${i}`),
+        hash: contentHash(`Content ${i}`),
         content: `Content ${i}`
       }));
 
@@ -660,7 +665,7 @@ describe('E2E Integration: Complete Lifecycle Flow', () => {
   describe('Provenance Chain Validation', () => {
     test('maintains complete audit trail with all metadata', async () => {
       const asset = await sdk.lifecycle.createAsset([
-        { id: 'audit-test', type: 'data', contentType: 'text/plain', hash: makeHash('audit123'), content: 'test' }
+        { id: 'audit-test', type: 'data', contentType: 'text/plain', hash: contentHash('test'), content: 'test' }
       ]);
 
       const startTime = Date.now();
@@ -706,7 +711,7 @@ describe('E2E Integration: Complete Lifecycle Flow', () => {
 
     test('timestamps are monotonically increasing', async () => {
       const asset = await sdk.lifecycle.createAsset([
-        { id: 'time-test', type: 'data', contentType: 'text/plain', hash: makeHash('time123'), content: 'test' }
+        { id: 'time-test', type: 'data', contentType: 'text/plain', hash: contentHash('test'), content: 'test' }
       ]);
 
       await new Promise(resolve => setTimeout(resolve, 10)); // Small delay

--- a/packages/sdk/tests/integration/DidPeerToWebVhFlow.test.ts
+++ b/packages/sdk/tests/integration/DidPeerToWebVhFlow.test.ts
@@ -35,14 +35,14 @@ describe('DID Peer to WebVH Publication Flow', () => {
         id: 'resource-1',
         type: 'data',
         contentType: 'text/plain',
-        hash: 'abc123def456',
+        hash: '86c08faf3a17b36d3922b3b012d0b9188724aef3356336e0fc518c1f04bac2af',
         content: 'Hello, World! This is test content.'
       },
       {
         id: 'resource-2',
         type: 'metadata',
         contentType: 'application/json',
-        hash: 'aea789ab',
+        hash: '84560ef4bdb3414957ce03b69503ff86804fed1ba7e71cd76008134b35c737fb',
         content: JSON.stringify({ title: 'Test Asset', version: '1.0' })
       }
     ];
@@ -186,7 +186,7 @@ describe('DID Peer to WebVH Publication Flow', () => {
         id: 'res-format-test',
         type: 'data',
         contentType: 'application/octet-stream',
-        hash: 'e5a1234560',
+        hash: '81303f93ff97cf116ed9b3343e7b5029c5ed9aa3151f9be8adfa0fd53dfc764b',
         content: 'test data for URL format verification'
       }
     ];
@@ -221,7 +221,7 @@ describe('DID Peer to WebVH Publication Flow', () => {
         id: 'binding-test',
         type: 'data',
         contentType: 'text/plain',
-        hash: 'b1d1234560',
+        hash: '0508c90ba760ab4f833db3263ec28084a2ff11ed9b78b3069b6100366c5ca7fa',
         content: 'binding test content'
       }
     ];
@@ -254,28 +254,28 @@ describe('DID Peer to WebVH Publication Flow', () => {
         id: 'multi-1',
         type: 'data',
         contentType: 'text/plain',
-        hash: 'a51001',
+        hash: 'd1988cd3019824f075f61677e1a6f54b16035868488e4051757dde53adeef80f',
         content: 'content 1'
       },
       {
         id: 'multi-2',
         type: 'data',
         contentType: 'application/json',
-        hash: 'a51002',
+        hash: '9724c1e20e6e3e4d7f57ed25f9d4efb006e508590d528c90da597f6a775c13e5',
         content: '{"key": "value"}'
       },
       {
         id: 'multi-3',
         type: 'metadata',
         contentType: 'text/html',
-        hash: 'a51003',
+        hash: '5f1abb282216d522dc687b9b43746439b6f1702f800316a47cb306396fe8039c',
         content: '<html><body>test</body></html>'
       },
       {
         id: 'multi-4',
         type: 'data',
         contentType: 'image/svg+xml',
-        hash: 'a51004',
+        hash: 'b12e0d83ce2357d80b89c57694814d0a3abdaf8c40724f2049af8b7f01b7812b',
         content: '<svg></svg>'
       }
     ];
@@ -305,7 +305,7 @@ describe('DID Peer to WebVH Publication Flow', () => {
         id: 'preserve-test',
         type: 'data',
         contentType: 'text/markdown',
-        hash: 'e5e1ea00',
+        hash: 'cc56914595e92466c95951c3f888fbf7f9fc43b0d13bcd2e9bcb4ecf4993008c',
         content: '# Test Document\nThis should be preserved.'
       }
     ];

--- a/packages/sdk/tests/integration/Events.test.ts
+++ b/packages/sdk/tests/integration/Events.test.ts
@@ -13,6 +13,11 @@ import { MockKeyStore } from '../mocks/MockKeyStore';
 import { MemoryStorageAdapter } from '../../src/storage/MemoryStorageAdapter';
 import { OrdMockProvider } from '../../src/adapters/providers/OrdMockProvider';
 import { KeyManager } from '../../src/did/KeyManager';
+import { createHash as __cryptoCreateHash } from 'crypto';
+// Real content hash — createAsset/publish now verify content against the
+// declared hash (issue #347), so fixtures must declare the true sha256.
+const contentHash = (c: string) => __cryptoCreateHash('sha256').update(c, 'utf8').digest('hex');
+
 
 // Helper to create a valid hash
 function makeHash(prefix: string): string {
@@ -82,7 +87,7 @@ describe('Integration: Event System', () => {
           id: 'resource-1',
           type: 'text',
           contentType: 'text/plain',
-          hash: makeHash('deadbeef'),
+          hash: contentHash('Hello, World!'),
           content: 'Hello, World!'
         }
       ];
@@ -116,7 +121,7 @@ describe('Integration: Event System', () => {
 
     test('asset:created reaches pre-subscribed lifecycle handlers; asset-level post-await does not (#293)', async () => {
       const resources: AssetResource[] = [
-        { id: 'resource-1', type: 'text', contentType: 'text/plain', hash: makeHash('cafe01'), content: 'x' }
+        { id: 'resource-1', type: 'text', contentType: 'text/plain', hash: contentHash('x'), content: 'x' }
       ];
       const lifecycleEvents: string[] = [];
       // Supported path: subscribe on the LifecycleManager emitter before creating.
@@ -144,14 +149,14 @@ describe('Integration: Event System', () => {
           id: 'resource-1',
           type: 'text',
           contentType: 'text/plain',
-          hash: makeHash('abc123'),
+          hash: contentHash('Test'),
           content: 'Test'
         },
         {
           id: 'resource-2',
           type: 'image',
           contentType: 'image/png',
-          hash: makeHash('def456'),
+          hash: contentHash('Image data'),
           content: 'Image data'
         }
       ];
@@ -174,7 +179,7 @@ describe('Integration: Event System', () => {
           id: 'resource-1',
           type: 'text',
           contentType: 'text/plain',
-          hash: makeHash('migrate'),
+          hash: contentHash('Migrate test'),
           content: 'Migrate test'
         }
       ];
@@ -205,7 +210,7 @@ describe('Integration: Event System', () => {
           id: 'resource-1',
           type: 'text',
           contentType: 'text/plain',
-          hash: makeHash('btco'),
+          hash: contentHash('Bitcoin test'),
           content: 'Bitcoin test'
         }
       ];
@@ -240,7 +245,7 @@ describe('Integration: Event System', () => {
           id: 'resource-1',
           type: 'text',
           contentType: 'text/plain',
-          hash: makeHash('transfer'),
+          hash: contentHash('Transfer test'),
           content: 'Transfer test'
         }
       ];
@@ -275,14 +280,14 @@ describe('Integration: Event System', () => {
           id: 'resource-1',
           type: 'text',
           contentType: 'text/plain',
-          hash: makeHash('pub1'),
+          hash: contentHash('Resource 1'),
           content: 'Resource 1'
         },
         {
           id: 'resource-2',
           type: 'text',
           contentType: 'text/plain',
-          hash: makeHash('pub2'),
+          hash: contentHash('Resource 2'),
           content: 'Resource 2'
         }
       ];
@@ -312,7 +317,7 @@ describe('Integration: Event System', () => {
           id: 'resource-1',
           type: 'text',
           contentType: 'text/plain',
-          hash: makeHash('cred'),
+          hash: contentHash('Credential test'),
           content: 'Credential test'
         }
       ];
@@ -343,7 +348,7 @@ describe('Integration: Event System', () => {
           id: 'resource-1',
           type: 'text',
           contentType: 'text/plain',
-          hash: makeHash('complete'),
+          hash: contentHash('Complete lifecycle'),
           content: 'Complete lifecycle'
         }
       ];
@@ -379,7 +384,7 @@ describe('Integration: Event System', () => {
           id: 'resource-1',
           type: 'text',
           contentType: 'text/plain',
-          hash: makeHash('cleanup'),
+          hash: contentHash('Cleanup test'),
           content: 'Cleanup test'
         }
       ];
@@ -406,7 +411,7 @@ describe('Integration: Event System', () => {
           id: 'resource-1',
           type: 'text',
           contentType: 'text/plain',
-          hash: makeHash('once'),
+          hash: contentHash('Once test'),
           content: 'Once test'
         }
       ];
@@ -433,7 +438,7 @@ describe('Integration: Event System', () => {
           id: 'resource-1',
           type: 'text',
           contentType: 'text/plain',
-          hash: makeHash('timing'),
+          hash: contentHash('Timing test'),
           content: 'Timing test'
         }
       ];

--- a/packages/sdk/tests/integration/TelemetryIntegration.test.ts
+++ b/packages/sdk/tests/integration/TelemetryIntegration.test.ts
@@ -65,7 +65,7 @@ describe('Telemetry Integration', () => {
           id: 'test-resource',
           type: 'text',
           contentType: 'text/plain',
-          hash: 'abc123',
+          hash: 'a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e',
           content: 'Hello World'
         }
       ];
@@ -101,7 +101,7 @@ describe('Telemetry Integration', () => {
           id: 'test-resource',
           type: 'text',
           contentType: 'text/plain',
-          hash: 'abc123',
+          hash: 'a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e',
           content: 'Hello World'
         }
       ];
@@ -142,7 +142,7 @@ describe('Telemetry Integration', () => {
           id: 'test-resource',
           type: 'text',
           contentType: 'text/plain',
-          hash: 'abc123',
+          hash: 'a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e',
           content: 'Hello World'
         }
       ];
@@ -175,7 +175,7 @@ describe('Telemetry Integration', () => {
           id: 'test-resource',
           type: 'text',
           contentType: 'text/plain',
-          hash: 'abc123',
+          hash: 'a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e',
           content: 'Hello World'
         }
       ];
@@ -200,7 +200,7 @@ describe('Telemetry Integration', () => {
           id: 'test-resource',
           type: 'text',
           contentType: 'text/plain',
-          hash: 'abc123',
+          hash: 'a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e',
           content: 'Hello World'
         }
       ];
@@ -227,7 +227,7 @@ describe('Telemetry Integration', () => {
           id: 'test-resource',
           type: 'text',
           contentType: 'text/plain',
-          hash: 'abc123',
+          hash: 'a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e',
           content: 'Hello World'
         }
       ];
@@ -348,7 +348,7 @@ describe('Telemetry Integration', () => {
           id: 'test-resource',
           type: 'text',
           contentType: 'text/plain',
-          hash: 'abc123',
+          hash: 'a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e',
           content: 'Hello World'
         }
       ];

--- a/packages/sdk/tests/integration/WebVhPublish.test.ts
+++ b/packages/sdk/tests/integration/WebVhPublish.test.ts
@@ -14,7 +14,7 @@ describe('WebVH publish end-to-end', () => {
 
   test('createAsset → publishToWeb yields did:webvh and provenance event', async () => {
     const resources: AssetResource[] = [
-      { id: 'r1', type: 'data', contentType: 'text/plain', hash: 'abc123', content: 'hello' }
+      { id: 'r1', type: 'data', contentType: 'text/plain', hash: '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824', content: 'hello' }
     ];
 
     const asset = await sdk.lifecycle.createAsset(resources);

--- a/packages/sdk/tests/integration/migration/MigrationLifecycle.test.ts
+++ b/packages/sdk/tests/integration/migration/MigrationLifecycle.test.ts
@@ -34,7 +34,7 @@ function makeSdk() {
 // Helper to create a fresh peer DID
 async function makePeerDid(sdk: OriginalsSDK, id = 'res-1') {
   return sdk.did.createDIDPeer([
-    { id, type: 'Image', contentType: 'image/png', hash: 'abc123', content: 'test-data' }
+    { id, type: 'Image', contentType: 'image/png', hash: 'a186000422feab857329c684e9fe91412b1a5db084100b37a98cfc95b62aa867', content: 'test-data' }
   ]);
 }
 
@@ -517,7 +517,7 @@ describe('CORE-MIG-EVENTS-012 — batch:failed event emitted with error and part
     // Provide resources that pass validation but an operation that will fail
     // by creating assets with valid resource list, then calling batchPublishToWeb with bad domain
     const asset = await sdk.lifecycle.createAsset([
-      { id: 'res-pub', type: 'Image', contentType: 'image/png', hash: 'abc123', content: 'data' }
+      { id: 'res-pub', type: 'Image', contentType: 'image/png', hash: '3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7', content: 'data' }
     ]);
 
     lifecycle.on('batch:failed', (e: any) => {

--- a/packages/sdk/tests/integration/migration/peer-to-webvh.test.ts
+++ b/packages/sdk/tests/integration/migration/peer-to-webvh.test.ts
@@ -38,7 +38,7 @@ describe('Peer to WebVH Migration', () => {
         id: 'resource-1',
         type: 'Image',
         contentType: 'image/png',
-        hash: 'abc123',
+        hash: '0a3666a0710c08aa6d0de92ce72beeb5b93124cce1bf3701c9d6cdeb543cb73e',
         content: 'test-content'
       }
     ];
@@ -190,7 +190,7 @@ describe('Peer to WebVH Migration', () => {
     );
 
     const peerDid = await signedSdk.did.createDIDPeer([
-      { id: 'resource-1', type: 'Image', contentType: 'image/png', hash: 'abc123', content: 'test-content' }
+      { id: 'resource-1', type: 'Image', contentType: 'image/png', hash: '0a3666a0710c08aa6d0de92ce72beeb5b93124cce1bf3701c9d6cdeb543cb73e', content: 'test-content' }
     ]);
 
     await signedManager.migrate({ sourceDid: peerDid.id, targetLayer: 'webvh', domain: 'example.com' });

--- a/packages/sdk/tests/performance/BatchOperations.perf.test.ts
+++ b/packages/sdk/tests/performance/BatchOperations.perf.test.ts
@@ -14,6 +14,11 @@ import { FeeOracleMock } from '../../src/adapters/FeeOracleMock';
 import { OrdMockProvider } from '../../src/adapters/providers/OrdMockProvider';
 import { StorageAdapter as ConfigStorageAdapter } from '../../src/adapters/types';
 import { MockKeyStore } from '../mocks/MockKeyStore';
+import { createHash as __cryptoCreateHash } from 'crypto';
+// Real content hash — createAsset/publish now verify content against the
+// declared hash (issue #347), so fixtures must declare the true sha256.
+const contentHash = (c: string) => __cryptoCreateHash('sha256').update(c, 'utf8').digest('hex');
+
 
 function makeHash(prefix: string): string {
   const hexOnly = prefix.split('').map(c => {
@@ -83,7 +88,7 @@ describe('Batch Operations Performance', () => {
 
       for (const size of sizes) {
         const resourcesList = Array.from({ length: size }, (_, i) => [
-          { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: makeHash(`txt${i}`), content: `text${i}` }
+          { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: contentHash(`text${i}`), content: `text${i}` }
         ]);
 
         const startTime = Date.now();
@@ -127,7 +132,7 @@ describe('Batch Operations Performance', () => {
         const assets: OriginalsAsset[] = [];
         for (let i = 0; i < size; i++) {
           const asset = await sdk.lifecycle.createAsset([
-            { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: makeHash(`txt${i}`), content: `text${i}` }
+            { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: contentHash(`text${i}`), content: `text${i}` }
           ]);
           assets.push(asset);
         }
@@ -163,7 +168,7 @@ describe('Batch Operations Performance', () => {
     test('should handle large batches without memory issues', async () => {
       const size = 200;
       const resourcesList = Array.from({ length: size }, (_, i) => [
-        { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: makeHash(`txt${i}`), content: `text${i}` }
+        { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: contentHash(`text${i}`), content: `text${i}` }
       ]);
 
       // Monitor memory usage (if available)
@@ -186,7 +191,7 @@ describe('Batch Operations Performance', () => {
     test('should process very large batches with chunking', async () => {
       const size = 500;
       const resourcesList = Array.from({ length: size }, (_, i) => [
-        { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: makeHash(`txt${i}`), content: `text${i}` }
+        { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: contentHash(`text${i}`), content: `text${i}` }
       ]);
 
       const startTime = Date.now();
@@ -210,7 +215,7 @@ describe('Batch Operations Performance', () => {
       
       for (let i = 0; i < size; i++) {
         const asset = await sdk.lifecycle.createAsset([
-          { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: makeHash(`txt${i}`), content: `text${i}` }
+          { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: contentHash(`text${i}`), content: `text${i}` }
         ]);
         assets.push(asset);
       }
@@ -242,7 +247,7 @@ describe('Batch Operations Performance', () => {
         const assets: OriginalsAsset[] = [];
         for (let i = 0; i < size; i++) {
           const asset = await sdk.lifecycle.createAsset([
-            { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: makeHash(`txt${i}`), content: `text${i}` }
+            { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: contentHash(`text${i}`), content: `text${i}` }
           ]);
           assets.push(asset);
         }
@@ -288,7 +293,7 @@ describe('Batch Operations Performance', () => {
     test.skip('concurrent processing should be faster than sequential', async () => {
       const size = 20;
       const resourcesList = Array.from({ length: size }, (_, i) => [
-        { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: makeHash(`txt${i}`), content: `text${i}` }
+        { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: contentHash(`text${i}`), content: `text${i}` }
       ]);
 
       // Sequential processing
@@ -300,7 +305,7 @@ describe('Batch Operations Performance', () => {
 
       // Create new assets for concurrent test
       const resourcesList2 = Array.from({ length: size }, (_, i) => [
-        { id: `res2-${i}`, type: 'text', contentType: 'text/plain', hash: makeHash(`txt2-${i}`), content: `text${i}` }
+        { id: `res2-${i}`, type: 'text', contentType: 'text/plain', hash: contentHash(`text${i}`), content: `text${i}` }
       ]);
 
       // Concurrent processing
@@ -332,7 +337,7 @@ describe('Batch Operations Performance', () => {
       const results = [];
       for (let b = 0; b < batches; b++) {
         const resourcesList = Array.from({ length: batchSize }, (_, i) => [
-          { id: `batch${b}-res${i}`, type: 'text', contentType: 'text/plain', hash: makeHash(`b${b}txt${i}`), content: `text${i}` }
+          { id: `batch${b}-res${i}`, type: 'text', contentType: 'text/plain', hash: contentHash(`text${i}`), content: `text${i}` }
         ]);
 
         const result = await sdk.lifecycle.batchCreateAssets(resourcesList, {
@@ -355,7 +360,7 @@ describe('Batch Operations Performance', () => {
       
       // Create assets
       const resourcesList = Array.from({ length: size }, (_, i) => [
-        { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: makeHash(`txt${i}`), content: `text${i}` }
+        { id: `res${i}`, type: 'text', contentType: 'text/plain', hash: contentHash(`text${i}`), content: `text${i}` }
       ]);
       
       const startTime = Date.now();

--- a/packages/sdk/tests/security/bitcoin-penetration-tests.test.ts
+++ b/packages/sdk/tests/security/bitcoin-penetration-tests.test.ts
@@ -358,10 +358,11 @@ describe('Bitcoin Penetration Tests - Security Audit', () => {
       ];
 
       // Request amount that would leave dust change (< 546 dust limit)
-      // With 1 input, 2 outputs: ~140 vbytes, fee ~1400 sats
-      // Change = 101000 - 99500 - 1400 = 100 (< 546 dust limit)
+      // With 1 P2WPKH input (68 vB) and 2 outputs at the conservative 43 vB
+      // each (issue #344): 10 + 68 + 86 = 164 vbytes, fee 1640 sats
+      // Change = 101000 - 99260 - 1640 = 100 (< 546 dust limit)
       const result = selectResourceUtxos(utxos, {
-        requiredAmount: 99500, // Would leave ~100 sat change (< 546 dust limit)
+        requiredAmount: 99260, // Would leave ~100 sat change (< 546 dust limit)
         feeRate: 10
       });
 

--- a/packages/sdk/tests/security/multi-issue-review-regressions.test.ts
+++ b/packages/sdk/tests/security/multi-issue-review-regressions.test.ts
@@ -201,7 +201,7 @@ describe('publishToWeb rejects path-traversal in did:webvh (issue #274)', () => 
     const { MemoryStorageAdapter } = await import('../../src/storage/MemoryStorageAdapter');
     const sdk = OriginalsSDK.create({ storageAdapter: new MemoryStorageAdapter(), network: 'regtest' });
     const asset = await sdk.lifecycle.createAsset([
-      { id: 'r1', type: 'text', content: 'hello', contentType: 'text/plain', hash: 'a'.repeat(64) },
+      { id: 'r1', type: 'text', content: 'hello', contentType: 'text/plain', hash: '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824' },
     ]);
 
     // A crafted SCID-form DID with traversal segments after the domain.
@@ -214,7 +214,7 @@ describe('publishToWeb rejects path-traversal in did:webvh (issue #274)', () => 
     const { MemoryStorageAdapter } = await import('../../src/storage/MemoryStorageAdapter');
     const sdk = OriginalsSDK.create({ storageAdapter: new MemoryStorageAdapter(), network: 'regtest' });
     const asset = await sdk.lifecycle.createAsset([
-      { id: 'r1', type: 'text', content: 'hello', contentType: 'text/plain', hash: 'a'.repeat(64) },
+      { id: 'r1', type: 'text', content: 'hello', contentType: 'text/plain', hash: '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824' },
     ]);
 
     // did:webvh:{SCID}:{domain} where the domain decodes to '../../etc'.

--- a/packages/sdk/tests/security/ordinals-client-ssrf.test.ts
+++ b/packages/sdk/tests/security/ordinals-client-ssrf.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Regression tests for issue #343: OrdinalsClient fetched indexer-supplied
+ * content_url with no origin pin, redirect ban, timeout, or size cap. The
+ * #322 hardening landed in OrdinalsClientProviderAdapter/OrdHttpProvider but
+ * missed the client itself, which is reachable via SignetProvider.
+ */
+import { describe, test, expect, afterEach } from 'bun:test';
+import { OrdinalsClient } from '../../src/bitcoin/OrdinalsClient';
+
+const BASE = 'http://ord.internal:8080';
+const realFetch = (globalThis as any).fetch;
+
+function installFetch(handler: (url: string, init?: any) => Promise<any>) {
+  (globalThis as any).fetch = (url: any, init?: any) => handler(String(url), init);
+}
+
+function jsonResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    async json() { return body; }
+  };
+}
+
+function binResponse(bytes: Uint8Array, headers?: Record<string, string>) {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: (name: string) => headers?.[name.toLowerCase()] ?? null },
+    async arrayBuffer() { return bytes.buffer; }
+  };
+}
+
+afterEach(() => {
+  (globalThis as any).fetch = realFetch;
+});
+
+describe('OrdinalsClient content_url origin pinning (issue #343)', () => {
+  test('resolveInscription refuses an off-origin content_url (cloud metadata IP) and never fetches it', async () => {
+    const fetched: string[] = [];
+    installFetch(async (url) => {
+      fetched.push(url);
+      if (url.includes('/inscription/')) {
+        return jsonResponse({
+          inscription_id: 'abc', sat: 1, content_type: 'text/plain',
+          content_url: 'http://169.254.169.254/latest/meta-data/iam/'
+        });
+      }
+      return binResponse(new Uint8Array([1]));
+    });
+    const client = new OrdinalsClient(BASE, 'mainnet');
+    await expect(client.resolveInscription('abc')).rejects.toThrow(/possible SSRF/);
+    expect(fetched.some((u) => u.includes('169.254.169.254'))).toBe(false);
+  });
+
+  test('resolveInscription refuses a non-http(s) content_url scheme', async () => {
+    installFetch(async (url) => {
+      if (url.includes('/inscription/')) {
+        return jsonResponse({
+          inscription_id: 'abc', sat: 1, content_type: 'text/plain',
+          content_url: 'file:///etc/passwd'
+        });
+      }
+      return binResponse(new Uint8Array([1]));
+    });
+    const client = new OrdinalsClient(BASE, 'mainnet');
+    await expect(client.resolveInscription('abc')).rejects.toThrow(/possible SSRF|non-http/);
+  });
+
+  test('resolveInscription resolves a same-origin RELATIVE content_url against the endpoint', async () => {
+    const fetched: string[] = [];
+    installFetch(async (url) => {
+      fetched.push(url);
+      if (url.includes('/inscription/')) {
+        return jsonResponse({
+          inscription_id: 'i1', sat: 1, content_type: 'text/plain',
+          content_url: '/content/i1'
+        });
+      }
+      return binResponse(new Uint8Array([7, 7]));
+    });
+    const client = new OrdinalsClient(BASE, 'mainnet');
+    const insc = await client.resolveInscription('i1');
+    expect(insc?.content.length).toBe(2);
+    expect(fetched).toContain(`${BASE}/content/i1`);
+  });
+
+  test('getInscriptionById path is protected too (delegates to resolveInscription)', async () => {
+    installFetch(async (url) => {
+      if (url.includes('/inscription/')) {
+        return jsonResponse({
+          inscription_id: 'abc', sat: 1, content_type: 'text/plain',
+          content_url: 'http://evil.example.com/content/abc'
+        });
+      }
+      return binResponse(new Uint8Array([1]));
+    });
+    const client = new OrdinalsClient(BASE, 'signet');
+    await expect(client.getInscriptionById('abc')).rejects.toThrow(/possible SSRF/);
+  });
+
+  test('every request is made with redirect: "error" and an abort signal', async () => {
+    const inits: any[] = [];
+    installFetch(async (url, init) => {
+      inits.push(init);
+      if (url.includes('/inscription/')) {
+        return jsonResponse({ inscription_id: 'i1', sat: 1, content_type: 'text/plain' });
+      }
+      return binResponse(new Uint8Array([1]));
+    });
+    const client = new OrdinalsClient(BASE, 'mainnet');
+    await client.resolveInscription('i1');
+    expect(inits.length).toBeGreaterThanOrEqual(2); // JSON info + content
+    for (const init of inits) {
+      expect(init?.redirect).toBe('error');
+      expect(init?.signal).toBeDefined();
+    }
+  });
+});
+
+describe('OrdinalsClient response size caps (issue #343)', () => {
+  test('inscription content larger than maxContentBytes is rejected (materialized bytes)', async () => {
+    installFetch(async (url) => {
+      if (url.includes('/inscription/')) {
+        return jsonResponse({ inscription_id: 'i1', sat: 1, content_type: 'text/plain' });
+      }
+      return binResponse(new Uint8Array(64));
+    });
+    const client = new OrdinalsClient(BASE, 'mainnet', { maxContentBytes: 16 });
+    await expect(client.resolveInscription('i1')).rejects.toThrow(/exceeds 16 bytes/);
+  });
+
+  test('a declared Content-Length above the cap is rejected before reading the body', async () => {
+    let bodyRead = false;
+    installFetch(async (url) => {
+      if (url.includes('/inscription/')) {
+        return jsonResponse({ inscription_id: 'i1', sat: 1, content_type: 'text/plain' });
+      }
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: (n: string) => (n.toLowerCase() === 'content-length' ? '999999999' : null) },
+        async arrayBuffer() { bodyRead = true; return new Uint8Array(1).buffer; }
+      };
+    });
+    const client = new OrdinalsClient(BASE, 'mainnet', { maxContentBytes: 1024 });
+    await expect(client.resolveInscription('i1')).rejects.toThrow(/exceeds 1024 bytes/);
+    expect(bodyRead).toBe(false);
+  });
+
+  test('oversized JSON responses are rejected when bytes are materializable', async () => {
+    const big = new TextEncoder().encode(JSON.stringify({ inscription_ids: ['x'.repeat(4096)] }));
+    installFetch(async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      async arrayBuffer() { return big.buffer; }
+    }));
+    const client = new OrdinalsClient(BASE, 'mainnet', { maxJsonBytes: 128 });
+    await expect(client.getSatInfo('123')).rejects.toThrow(/exceeds 128 bytes/);
+  });
+});
+
+describe('OrdinalsClient per-satoshi inscription cap (issue #343)', () => {
+  test('a satoshi carrying more inscriptions than the cap fails loudly instead of downloading all content', async () => {
+    const ids = Array.from({ length: 10 }, (_, i) => `insc-${i}`);
+    const contentFetches: string[] = [];
+    installFetch(async (url) => {
+      if (url.includes('/sat/')) return jsonResponse({ inscription_ids: ids });
+      if (url.includes('/inscription/')) {
+        const id = url.split('/').pop();
+        return jsonResponse({ inscription_id: id, sat: 1, content_type: 'text/plain' });
+      }
+      contentFetches.push(url);
+      return binResponse(new Uint8Array([1]));
+    });
+    const client = new OrdinalsClient(BASE, 'mainnet', { maxInscriptionsPerSat: 3 });
+    await expect(client.getInscriptionsBySatoshi('123')).rejects.toThrow(/ORD_TOO_MANY_INSCRIPTIONS|above the configured/);
+    expect(contentFetches.length).toBe(0);
+  });
+
+  test('a satoshi within the cap still resolves every inscription', async () => {
+    const ids = ['a', 'b', 'c'];
+    installFetch(async (url) => {
+      if (url.includes('/sat/')) return jsonResponse({ inscription_ids: ids });
+      if (url.includes('/inscription/')) {
+        const id = url.split('/').pop();
+        return jsonResponse({ inscription_id: id, sat: 1, content_type: 'text/plain' });
+      }
+      return binResponse(new Uint8Array([1]));
+    });
+    const client = new OrdinalsClient(BASE, 'mainnet', { maxInscriptionsPerSat: 3 });
+    const list = await client.getInscriptionsBySatoshi('123');
+    expect(list.map((i) => i.inscriptionId)).toEqual(['a', 'b', 'c']);
+  });
+});

--- a/packages/sdk/tests/stress/batch-operations-stress.test.ts
+++ b/packages/sdk/tests/stress/batch-operations-stress.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, it, expect, beforeEach } from 'bun:test';
+import { createHash } from 'crypto';
 import { OriginalsSDK } from '../../src/core/OriginalsSDK';
 import { OrdMockProvider } from '../../src/adapters/providers/OrdMockProvider';
 import { BatchOperationExecutor } from '../../src/lifecycle/BatchOperations';
@@ -470,15 +471,20 @@ describe('Batch Operations Stress Tests', () => {
 // Helper functions
 
 function createTestResourcesList(count: number): AssetResource[][] {
-  return Array.from({ length: count }, (_, i) => [
-    {
-      id: `resource-${i}-${Date.now()}`,
-      type: 'DigitalArt',
-      contentType: 'application/json',
-      hash: Buffer.from(`hash-${i}`).toString('hex'),
-      content: JSON.stringify({ test: `data-${i}` })
-    }
-  ]);
+  return Array.from({ length: count }, (_, i) => {
+    // Real content hash — createAsset now verifies content against the
+    // declared hash (issue #347).
+    const content = JSON.stringify({ test: `data-${i}` });
+    return [
+      {
+        id: `resource-${i}-${Date.now()}`,
+        type: 'DigitalArt',
+        contentType: 'application/json',
+        hash: createHash('sha256').update(content, 'utf8').digest('hex'),
+        content
+      }
+    ];
+  });
 }
 
 interface ConcurrencyResult {

--- a/packages/sdk/tests/unit/bitcoin/fee-script-class.test.ts
+++ b/packages/sdk/tests/unit/bitcoin/fee-script-class.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Regression tests for issue #344: fee estimators charged P2WPKH sizes
+ * (68 vB in / 31 vB out) for ALL segwit inputs, but isSegwitScriptPubKey
+ * admits P2WSH and P2TR — a P2WSH-funded commit underpaid the requested rate
+ * and could stall in the mempool with the reveal key stranded in memory.
+ *
+ * The invariant under test: for every supported script class, the estimated
+ * fee must be >= (actual serialized vsize) * (requested fee rate).
+ */
+import { describe, test, expect } from 'bun:test';
+import { createCommitTransaction } from '../../../src/bitcoin/transactions/commit';
+import { PSBTBuilder } from '../../../src/bitcoin/PSBTBuilder';
+import { selectUtxos as selectUtxosSmart } from '../../../src/bitcoin/utxo';
+import {
+  classifyScriptPubKey,
+  inputVBytesForScriptPubKey,
+  outputVBytesForAddress,
+  P2TR_INPUT_VBYTES,
+  P2WPKH_INPUT_VBYTES,
+  P2WSH_INPUT_VBYTES
+} from '../../../src/bitcoin/utxo';
+import type { Utxo } from '../../../src/types/bitcoin';
+
+const P2WPKH_SPK = '0014' + 'ab'.repeat(20);
+const P2WSH_SPK = '0020' + 'cd'.repeat(32);
+const P2TR_SPK = '5120' + 'ef'.repeat(32);
+
+// Valid mainnet bech32 addresses
+const P2WPKH_ADDR = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+const P2TR_ADDR = 'bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0';
+
+/**
+ * Actual serialized vsize of a 2-of-3 P2WSH input, the common worst case:
+ * 41 vB base (outpoint 36 + scriptSig len 1 + sequence 4) plus a witness of
+ * [empty, 72-byte sig, 72-byte sig, 105-byte witness script] each with a
+ * 1-byte length prefix, plus a 1-byte stack count: 254 witness bytes / 4 =
+ * 63.5 vB → 104.5 vB total.
+ */
+const ACTUAL_P2WSH_INPUT_VSIZE = 41 + (1 + 1 + 73 + 73 + 106) / 4;
+
+const utxo = (value: number, scriptPubKey: string, i = 0): Utxo => ({
+  txid: `${'a'.repeat(62)}${i.toString().padStart(2, '0')}`,
+  vout: i,
+  value,
+  scriptPubKey
+});
+
+describe('script classification helpers', () => {
+  test('classifies P2WPKH / P2WSH / P2TR / legacy / unknown', () => {
+    expect(classifyScriptPubKey(P2WPKH_SPK)).toBe('p2wpkh');
+    expect(classifyScriptPubKey(P2WSH_SPK)).toBe('p2wsh');
+    expect(classifyScriptPubKey(P2TR_SPK)).toBe('p2tr');
+    expect(classifyScriptPubKey('76a914' + 'ab'.repeat(20) + '88ac')).toBe('legacy');
+    expect(classifyScriptPubKey(undefined)).toBe('unknown');
+  });
+
+  test('input sizing: P2WSH is charged conservatively above its true serialized size', () => {
+    expect(inputVBytesForScriptPubKey(P2WPKH_SPK)).toBe(P2WPKH_INPUT_VBYTES);
+    expect(inputVBytesForScriptPubKey(P2TR_SPK)).toBe(P2TR_INPUT_VBYTES);
+    expect(inputVBytesForScriptPubKey(P2WSH_SPK)).toBe(P2WSH_INPUT_VBYTES);
+    expect(P2WSH_INPUT_VBYTES).toBeGreaterThanOrEqual(ACTUAL_P2WSH_INPUT_VSIZE);
+  });
+
+  test('output sizing by address class: P2TR/P2WSH outputs are 43 vB, not 31', () => {
+    expect(outputVBytesForAddress(P2WPKH_ADDR)).toBe(31);
+    expect(outputVBytesForAddress(P2TR_ADDR)).toBe(43);
+    // Unknown forms err toward the largest standard output size.
+    expect(outputVBytesForAddress('someopaquestring')).toBe(43);
+  });
+});
+
+describe('createCommitTransaction with P2WSH funding (issue #344)', () => {
+  test('fee for a P2WSH input covers the actual serialized vsize at the requested rate', async () => {
+    const feeRate = 20;
+    const result = await createCommitTransaction({
+      content: Buffer.from('hello inscription'),
+      contentType: 'text/plain',
+      utxos: [utxo(200_000, P2WSH_SPK)],
+      changeAddress: P2WPKH_ADDR,
+      feeRate,
+      network: 'mainnet'
+    });
+
+    expect(result.selectedUtxos.length).toBe(1);
+    expect(result.commitPsbt.outputsLength).toBe(2); // commit + change
+
+    // What the transaction will really serialize to once the 2-of-3 P2WSH
+    // input is signed: overhead 10.5 + input 104.5 + P2TR commit output 43 +
+    // P2WPKH change output 31.
+    const actualVsize = Math.ceil(10.5 + ACTUAL_P2WSH_INPUT_VSIZE + 43 + 31);
+    expect(result.fees.commit).toBeGreaterThanOrEqual(actualVsize * feeRate);
+  });
+
+  test('P2WSH-funded commit pays more than an identical P2WPKH-funded commit', async () => {
+    const params = (spk: string) => ({
+      content: Buffer.from('hello inscription'),
+      contentType: 'text/plain',
+      utxos: [utxo(200_000, spk)],
+      changeAddress: P2WPKH_ADDR,
+      feeRate: 10,
+      network: 'mainnet' as const
+    });
+    const p2wsh = await createCommitTransaction(params(P2WSH_SPK));
+    const p2wpkh = await createCommitTransaction(params(P2WPKH_SPK));
+    expect(p2wsh.fees.commit).toBeGreaterThan(p2wpkh.fees.commit);
+  });
+
+  test('change output to a P2TR address is charged 43 vB, not 31 (PSBTBuilder)', () => {
+    // createCommitTransaction cannot be used here: validating a bech32m
+    // (P2TR) change address requires an ECC library not initialized in this
+    // test environment. PSBTBuilder sizes outputs by address class without
+    // validating them.
+    const b = new PSBTBuilder();
+    const build = (changeAddress: string) => b.build({
+      utxos: [utxo(500_000, P2WPKH_SPK)],
+      outputs: [{ address: P2WPKH_ADDR, value: 100_000 }],
+      changeAddress,
+      feeRate: 10,
+      network: 'mainnet'
+    });
+    const p2trChange = build(P2TR_ADDR);
+    const p2wpkhChange = build(P2WPKH_ADDR);
+    // 12 extra vB at 10 sat/vB = 120 sats
+    expect(p2trChange.fee).toBe(p2wpkhChange.fee + 120);
+  });
+});
+
+describe('PSBTBuilder with P2WSH funding (issue #344)', () => {
+  test('fee for a P2WSH input covers the actual serialized vsize at the requested rate', () => {
+    const feeRate = 15;
+    const b = new PSBTBuilder();
+    const res = b.build({
+      utxos: [utxo(500_000, P2WSH_SPK)],
+      outputs: [{ address: P2WPKH_ADDR, value: 100_000 }],
+      changeAddress: P2WPKH_ADDR,
+      feeRate,
+      network: 'mainnet'
+    });
+    // overhead 10 + P2WSH input 104.5 + two P2WPKH outputs 31 each
+    const actualVsize = Math.ceil(10 + ACTUAL_P2WSH_INPUT_VSIZE + 31 + 31);
+    expect(res.fee).toBeGreaterThanOrEqual(actualVsize * feeRate);
+  });
+});
+
+describe('utxo.ts selectUtxos with P2WSH funding (issue #344)', () => {
+  test('fee for a P2WSH input covers the actual serialized vsize at the requested rate', () => {
+    const feeRate = 15;
+    const res = selectUtxosSmart([utxo(500_000, P2WSH_SPK)], {
+      feeRateSatsPerVb: feeRate,
+      targetAmountSats: 100_000,
+      changeAddress: P2WPKH_ADDR
+    });
+    const actualVsize = Math.ceil(10 + ACTUAL_P2WSH_INPUT_VSIZE + 31 + 31);
+    expect(res.feeSats).toBeGreaterThanOrEqual(actualVsize * feeRate);
+  });
+
+  test('P2TR inputs are priced at 57.5 vB — cheaper than P2WPKH, never below actual', () => {
+    const feeRate = 10;
+    const p2tr = selectUtxosSmart([utxo(500_000, P2TR_SPK)], { feeRateSatsPerVb: feeRate, targetAmountSats: 100_000 });
+    const p2wpkh = selectUtxosSmart([utxo(500_000, P2WPKH_SPK)], { feeRateSatsPerVb: feeRate, targetAmountSats: 100_000 });
+    expect(p2tr.feeSats).toBeLessThan(p2wpkh.feeSats);
+    // Actual key-path P2TR input is 57.5 vB (41 base + (1 + 1 + 64)/4
+    // witness); real P2WPKH outputs are 31 vB each (the estimator's default
+    // 34 vB/output already overpays them).
+    const actualVsize = Math.ceil(10 + 57.5 + 31 + 31);
+    expect(p2tr.feeSats).toBeGreaterThanOrEqual(actualVsize * feeRate);
+  });
+});

--- a/packages/sdk/tests/unit/bitcoin/utxo-selection-new.test.ts
+++ b/packages/sdk/tests/unit/bitcoin/utxo-selection-new.test.ts
@@ -395,10 +395,14 @@ describe('selectResourceUtxos - Resource-Aware Selection', () => {
     });
 
     test('fee increases with more inputs', () => {
+      // Explicit P2WPKH scripts: inputs without a scriptPubKey are now priced
+      // at conservative legacy width (issue #344), which this small wallet
+      // could not fund.
+      const p2wpkh = '0014' + 'ab'.repeat(20);
       const utxos: ResourceUtxo[] = [
-        createResourceUtxo(5000, false),
-        createResourceUtxo(5000, false),
-        createResourceUtxo(5000, false)
+        { ...createResourceUtxo(5000, false), scriptPubKey: p2wpkh },
+        { ...createResourceUtxo(5000, false), scriptPubKey: p2wpkh },
+        { ...createResourceUtxo(5000, false), scriptPubKey: p2wpkh }
       ];
       
       const result = selectResourceUtxos(utxos, {

--- a/packages/sdk/tests/unit/lifecycle/BatchOperations.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/BatchOperations.test.ts
@@ -200,13 +200,17 @@ describe('BatchOperations', () => {
         maxConcurrent: 1
       });
 
-      expect(result.totalDuration).toBeGreaterThanOrEqual(60); // At least 60ms (3 * 20ms)
+      // 3 sequential 20ms sleeps ≈ 60ms, but setTimeout can fire fractionally
+      // early relative to Date/ISO-millisecond truncation on loaded CI
+      // runners; 55ms still proves sequential execution (concurrent ≈ 20ms)
+      // without flaking on 59.x measurements.
+      expect(result.totalDuration).toBeGreaterThanOrEqual(55);
       expect(result.startedAt).toBeDefined();
       expect(result.completedAt).toBeDefined();
-      
+
       const startTime = new Date(result.startedAt).getTime();
       const endTime = new Date(result.completedAt).getTime();
-      expect(endTime - startTime).toBeGreaterThanOrEqual(60);
+      expect(endTime - startTime).toBeGreaterThanOrEqual(55);
     });
 
     test('should track individual operation durations', async () => {

--- a/packages/sdk/tests/unit/lifecycle/LifecycleManager.atomicRollback.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/LifecycleManager.atomicRollback.test.ts
@@ -15,8 +15,8 @@ import type { AssetResource } from '../../../src/types';
 // mutations between tests.
 function makeResources(): AssetResource[] {
   return [
-    { id: 'r1', type: 'text', contentType: 'text/plain', hash: 'aa01', content: 'first resource' },
-    { id: 'r2', type: 'text', contentType: 'text/plain', hash: 'aa02', content: 'second resource' }
+    { id: 'r1', type: 'text', contentType: 'text/plain', hash: '1974d92bd968cd5723d7eafd3c5ed66642777c6119fbf81ef42e0cb6af6bc405', content: 'first resource' },
+    { id: 'r2', type: 'text', contentType: 'text/plain', hash: 'a7562edd17428eec751400f3389675e0195f7fb31cd54730cd6cafa8cc26566c', content: 'second resource' }
   ];
 }
 

--- a/packages/sdk/tests/unit/lifecycle/LifecycleManager.cleanapi.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/LifecycleManager.cleanapi.test.ts
@@ -11,7 +11,7 @@ const resources = [
     type: 'text',
     content: 'hello world',
     contentType: 'text/plain',
-    hash: 'deadbeef'
+    hash: 'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9'
   }
 ];
 
@@ -380,7 +380,8 @@ describe('LifecycleManager - Migration Validation', () => {
         type: 'text',
         content: 'x'.repeat(200),
         contentType: 'text/plain',
-        hash: 'a'.repeat(64)
+        // Real sha256 of the content — createAsset now rejects mismatches (issue #347)
+        hash: 'aa20c23e3201834050679e1d88941b9a6fed0557c9a705cb2c315e2e63fd486d'
       }));
       
       const draft = await sdk.lifecycle.createDraft(manyResources);

--- a/packages/sdk/tests/unit/lifecycle/LifecycleManager.empty-resources.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/LifecycleManager.empty-resources.test.ts
@@ -6,7 +6,7 @@ describe('LifecycleManager - empty resources guard', () => {
   test('publishToWeb with emptied resources does not produce credential with undefined resourceId', async () => {
     const sdk = OriginalsSDK.create({ storageAdapter: new MemoryStorageAdapter(), network: 'regtest' });
     const asset = await sdk.lifecycle.createAsset([
-      { id: 'res1', type: 'text', content: 'hello', contentType: 'text/plain', hash: 'abc' }
+      { id: 'res1', type: 'text', content: 'hello', contentType: 'text/plain', hash: '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824' }
     ]);
 
     // Simulate post-creation resource removal (e.g., deserialization edge case)
@@ -25,7 +25,7 @@ describe('LifecycleManager - empty resources guard', () => {
   test('publishToWeb with valid resources produces credential with defined resourceId', async () => {
     const sdk = OriginalsSDK.create({ storageAdapter: new MemoryStorageAdapter(), network: 'regtest' });
     const asset = await sdk.lifecycle.createAsset([
-      { id: 'res1', type: 'text', content: 'hello', contentType: 'text/plain', hash: 'abc123' }
+      { id: 'res1', type: 'text', content: 'hello', contentType: 'text/plain', hash: '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824' }
     ]);
     expect(asset.resources.length).toBe(1);
 
@@ -45,7 +45,7 @@ describe('LifecycleManager - empty resources guard', () => {
   test('publishToWeb with resource having empty id does not produce credential', async () => {
     const sdk = OriginalsSDK.create({ storageAdapter: new MemoryStorageAdapter(), network: 'regtest' });
     const asset = await sdk.lifecycle.createAsset([
-      { id: 'res1', type: 'text', content: 'hello', contentType: 'text/plain', hash: 'abc123' }
+      { id: 'res1', type: 'text', content: 'hello', contentType: 'text/plain', hash: '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824' }
     ]);
 
     // Force the resource id to be empty string (falsy) after creation

--- a/packages/sdk/tests/unit/lifecycle/LifecycleManager.keymanagement.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/LifecycleManager.keymanagement.test.ts
@@ -16,7 +16,7 @@ const resources = [
     type: 'text',
     content: 'hello world',
     contentType: 'text/plain',
-    hash: 'deadbeef'
+    hash: 'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9'
   }
 ];
 

--- a/packages/sdk/tests/unit/lifecycle/LifecycleManager.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/LifecycleManager.test.ts
@@ -8,7 +8,7 @@ const resources = [
     type: 'text',
     content: 'hello world',
     contentType: 'text/plain',
-    hash: 'deadbeef'
+    hash: 'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9'
   }
 ];
 
@@ -158,7 +158,7 @@ describe('LifecycleManager additional branch coverage', () => {
     const asset: any = { 
       currentLayer: 'did:peer',
       id: 'did:peer:test',
-      resources: [{ id: 'r1', type: 'data', contentType: 'text/plain', hash: 'deadbeef', content: 'test' }],
+      resources: [{ id: 'r1', type: 'data', contentType: 'text/plain', hash: '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08', content: 'test' }],
       migrate: undefined  // This should cause an error when called
     };
     await expect(lm.publishToWeb(asset, 'example.com')).rejects.toThrow();
@@ -240,7 +240,7 @@ describe('publishToWeb storage requirement (issue #244)', () => {
   test('throws STORAGE_REQUIRED when no storageAdapter is configured', async () => {
     const sdk = OriginalsSDK.create({ network: 'regtest' });
     const asset = await sdk.lifecycle.createAsset([
-      { id: 'r1', type: 'text', content: 'hello', contentType: 'text/plain', hash: 'ff00', url: undefined as any }
+      { id: 'r1', type: 'text', content: 'hello', contentType: 'text/plain', hash: '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824', url: undefined as any }
     ] as any);
     await expect(sdk.lifecycle.publishToWeb(asset, 'example.com'))
       .rejects.toThrow(/storageAdapter must be configured/);
@@ -251,7 +251,7 @@ describe('publishToWeb storage requirement (issue #244)', () => {
   test('throws STORAGE_REQUIRED when the adapter implements neither put nor putObject', async () => {
     const sdk = OriginalsSDK.create({ network: 'regtest', storageAdapter: { get: async () => null } as any });
     const asset = await sdk.lifecycle.createAsset([
-      { id: 'r1', type: 'text', content: 'hello', contentType: 'text/plain', hash: 'ff00', url: undefined as any }
+      { id: 'r1', type: 'text', content: 'hello', contentType: 'text/plain', hash: '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824', url: undefined as any }
     ] as any);
     await expect(sdk.lifecycle.publishToWeb(asset, 'example.com'))
       .rejects.toThrow(/neither put\(\) nor putObject\(\)/);

--- a/packages/sdk/tests/unit/lifecycle/lifecycle-coverage.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/lifecycle-coverage.test.ts
@@ -30,7 +30,7 @@ const baseResource: AssetResource = {
   type: 'text',
   content: 'hello world',
   contentType: 'text/plain',
-  hash: 'deadbeef',
+  hash: 'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9',
 };
 
 function makeSDK(opts?: Partial<OriginalsConfig>) {

--- a/packages/sdk/tests/unit/lifecycle/publish-domain-validation.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/publish-domain-validation.test.ts
@@ -15,7 +15,7 @@ const resources = [
     type: 'text',
     content: 'hello world',
     contentType: 'text/plain',
-    hash: 'deadbeef',
+    hash: 'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9',
   },
 ];
 

--- a/packages/sdk/tests/unit/lifecycle/resource-hash-verification.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/resource-hash-verification.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression tests for issue #347: resource content must be verified against
+ * its declared hash at create/publish/inscribe time — a signed ResourceMigrated
+ * credential (or an inscribed manifest) must never attest a hash the actual
+ * bytes do not match.
+ */
+import { describe, test, expect } from 'bun:test';
+import { createHash } from 'crypto';
+import { OriginalsSDK } from '../../../src';
+import { MemoryStorageAdapter } from '../../../src/storage/MemoryStorageAdapter';
+import { MockOrdinalsProvider } from '../../mocks/adapters';
+
+const contentHash = (c: string) => createHash('sha256').update(c, 'utf8').digest('hex');
+
+const makeSdk = (extra: Record<string, unknown> = {}) =>
+  OriginalsSDK.create({ storageAdapter: new MemoryStorageAdapter(), network: 'regtest', ...extra } as any);
+
+const goodResource = () => ({
+  id: 'res1',
+  type: 'text',
+  contentType: 'text/plain',
+  content: 'authentic bytes',
+  hash: contentHash('authentic bytes')
+});
+
+describe('issue #347: content/hash verification', () => {
+  test('createAsset rejects inline content whose hash does not match', async () => {
+    const sdk = makeSdk();
+    const mismatched = {
+      ...goodResource(),
+      // Valid hex, valid length — but the hash of DIFFERENT bytes.
+      hash: contentHash('some other bytes entirely')
+    };
+    await expect(sdk.lifecycle.createAsset([mismatched])).rejects.toThrow(/RESOURCE_HASH_MISMATCH|does not match its declared hash/);
+  });
+
+  test('createAsset accepts inline content whose hash matches (case-insensitive)', async () => {
+    const sdk = makeSdk();
+    const upper = { ...goodResource(), hash: contentHash('authentic bytes').toUpperCase() };
+    const asset = await sdk.lifecycle.createAsset([upper]);
+    expect(asset.currentLayer).toBe('did:peer');
+  });
+
+  test('createAsset still accepts hash-only resources (no inline content to check)', async () => {
+    const sdk = makeSdk();
+    const hashOnly = {
+      id: 'res1',
+      type: 'text',
+      contentType: 'text/plain',
+      hash: contentHash('content hosted elsewhere')
+    };
+    const asset = await sdk.lifecycle.createAsset([hashOnly]);
+    expect(asset.currentLayer).toBe('did:peer');
+  });
+
+  test('publishToWeb rejects content tampered with after creation, BEFORE writing or attesting', async () => {
+    const storage = new MemoryStorageAdapter();
+    const sdk = makeSdk({ storageAdapter: storage });
+    const asset = await sdk.lifecycle.createAsset([goodResource()]);
+
+    // Simulate a content swap between creation and publication (the exact
+    // gap the publish-time check closes).
+    (asset.resources[0] as { content?: string }).content = 'swapped bytes';
+
+    // MemoryStorageAdapter shares one global store across instances, so use
+    // a domain no other test publishes to.
+    const domain = 'hash-mismatch-347.test';
+    await expect(sdk.lifecycle.publishToWeb(asset, domain)).rejects.toThrow(/RESOURCE_HASH_MISMATCH|does not match its declared hash/);
+
+    // No resource content was written: the DID log (.well-known) may exist,
+    // but no content-addressed object under resources/ may have been stored.
+    const objects = await storage.listObjects(domain, '');
+    expect(objects.filter((p) => p.includes('resources/')).length).toBe(0);
+    // No publication credential was minted and no URL was attached.
+    expect(asset.credentials.length).toBe(0);
+    expect(asset.resources[0].url).toBeUndefined();
+    // The asset did not migrate.
+    expect(asset.currentLayer).toBe('did:peer');
+  });
+
+  test('publishToWeb succeeds when content matches its declared hash', async () => {
+    const sdk = makeSdk();
+    const asset = await sdk.lifecycle.createAsset([goodResource()]);
+    const published = await sdk.lifecycle.publishToWeb(asset, 'example.com');
+    expect(published.currentLayer).toBe('did:webvh');
+    expect(published.resources[0].url).toBeDefined();
+  });
+
+  test('inscribeOnBitcoin rejects tampered content before inscribing the manifest', async () => {
+    const sdk = makeSdk({ ordinalsProvider: new MockOrdinalsProvider() });
+    const asset = await sdk.lifecycle.createAsset([goodResource()]);
+    await sdk.lifecycle.publishToWeb(asset, 'example.com');
+
+    (asset.resources[0] as { content?: string }).content = 'swapped bytes';
+
+    await expect(sdk.lifecycle.inscribeOnBitcoin(asset, 5)).rejects.toThrow(/RESOURCE_HASH_MISMATCH|does not match its declared hash/);
+    expect(asset.currentLayer).toBe('did:webvh');
+  });
+});

--- a/packages/sdk/tests/unit/migration/CheckpointManager.test.ts
+++ b/packages/sdk/tests/unit/migration/CheckpointManager.test.ts
@@ -28,7 +28,7 @@ describe('CheckpointManager', () => {
 
       // Create a real peer DID
       const peerDid = await sdk.did.createDIDPeer([
-        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: 'abc123', content: 'data' }
+        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: '3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7', content: 'data' }
       ]);
 
       const migrationId = 'mig_test_001';
@@ -59,7 +59,7 @@ describe('CheckpointManager', () => {
       const { sdk, checkpointManager } = makeManagers();
       const before = Date.now();
       const peerDid = await sdk.did.createDIDPeer([
-        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: 'abc123', content: 'data' }
+        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: '3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7', content: 'data' }
       ]);
       const checkpoint = await checkpointManager.createCheckpoint('mig_ts_001', {
         sourceDid: peerDid.id,
@@ -75,7 +75,7 @@ describe('CheckpointManager', () => {
     it('should use empty object when no metadata provided', async () => {
       const { sdk, checkpointManager } = makeManagers();
       const peerDid = await sdk.did.createDIDPeer([
-        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: 'abc123', content: 'data' }
+        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: '3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7', content: 'data' }
       ]);
       const checkpoint = await checkpointManager.createCheckpoint('mig_nometa', {
         sourceDid: peerDid.id,
@@ -105,7 +105,7 @@ describe('CheckpointManager', () => {
     it('should retrieve a previously saved checkpoint', async () => {
       const { sdk, checkpointManager } = makeManagers();
       const peerDid = await sdk.did.createDIDPeer([
-        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: 'abc123', content: 'data' }
+        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: '3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7', content: 'data' }
       ]);
       const created = await checkpointManager.createCheckpoint('mig_get_001', {
         sourceDid: peerDid.id,
@@ -135,7 +135,7 @@ describe('CheckpointManager', () => {
     it('should delete a checkpoint so it is no longer retrievable', async () => {
       const { sdk, checkpointManager } = makeManagers();
       const peerDid = await sdk.did.createDIDPeer([
-        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: 'abc123', content: 'data' }
+        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: '3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7', content: 'data' }
       ]);
       const created = await checkpointManager.createCheckpoint('mig_del_001', {
         sourceDid: peerDid.id,
@@ -185,7 +185,7 @@ describe('CheckpointManager', () => {
       const cm = new CheckpointManager(config, sdk.did, sdk.credentials);
 
       const peerDid = await sdk.did.createDIDPeer([
-        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: 'abc123', content: 'data' }
+        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: '3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7', content: 'data' }
       ]);
       const checkpoint = await cm.createCheckpoint('mig_persist_001', {
         sourceDid: peerDid.id,

--- a/packages/sdk/tests/unit/migration/RollbackManager.test.ts
+++ b/packages/sdk/tests/unit/migration/RollbackManager.test.ts
@@ -28,7 +28,7 @@ describe('RollbackManager', () => {
       const { sdk, checkpointManager, rollbackManager } = makeRollbackSetup();
 
       const peerDid = await sdk.did.createDIDPeer([
-        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: 'abc123', content: 'data' }
+        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: '3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7', content: 'data' }
       ]);
 
       const migrationId = 'mig_rollback_happy';
@@ -53,7 +53,7 @@ describe('RollbackManager', () => {
       const { sdk, checkpointManager, rollbackManager } = makeRollbackSetup();
 
       const peerDid = await sdk.did.createDIDPeer([
-        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: 'abc123', content: 'data' }
+        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: '3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7', content: 'data' }
       ]);
 
       const migrationId = 'mig_chkid_in_result';
@@ -87,7 +87,7 @@ describe('RollbackManager', () => {
       const { sdk, checkpointManager, rollbackManager } = makeRollbackSetup();
 
       const peerDid = await sdk.did.createDIDPeer([
-        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: 'abc123', content: 'data' }
+        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: '3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7', content: 'data' }
       ]);
 
       // Create checkpoint for migrationA
@@ -113,7 +113,7 @@ describe('RollbackManager', () => {
       const { sdk, checkpointManager, rollbackManager } = makeRollbackSetup();
 
       const peerDid = await sdk.did.createDIDPeer([
-        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: 'abc123', content: 'data' }
+        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: '3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7', content: 'data' }
       ]);
 
       const migrationId = 'mig_peer_rollback';
@@ -141,7 +141,7 @@ describe('RollbackManager', () => {
       const { sdk, checkpointManager, rollbackManager } = makeRollbackSetup();
 
       const peerDid = await sdk.did.createDIDPeer([
-        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: 'abc123', content: 'data' }
+        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: '3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7', content: 'data' }
       ]);
 
       const migrationId = 'mig_btco_src_rollback';
@@ -173,7 +173,7 @@ describe('RollbackManager', () => {
       const { sdk, checkpointManager, rollbackManager } = makeRollbackSetup();
 
       const peerDid = await sdk.did.createDIDPeer([
-        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: 'abc123', content: 'data' }
+        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: '3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7', content: 'data' }
       ]);
 
       const migrationId = 'mig_btco_preanchor_rollback';
@@ -198,7 +198,7 @@ describe('RollbackManager', () => {
       const { sdk, config, checkpointManager, rollbackManager } = makeRollbackSetup();
 
       const peerDid = await sdk.did.createDIDPeer([
-        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: 'abc123', content: 'data' }
+        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: '3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7', content: 'data' }
       ]);
 
       const migrationId = 'mig_storage_refs';
@@ -222,7 +222,7 @@ describe('RollbackManager', () => {
       const { sdk, checkpointManager, rollbackManager } = makeRollbackSetup();
 
       const peerDid = await sdk.did.createDIDPeer([
-        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: 'abc123', content: 'data' }
+        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: '3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7', content: 'data' }
       ]);
       const migrationId = 'mig_can_rollback';
       const checkpoint = await checkpointManager.createCheckpoint(migrationId, {
@@ -243,7 +243,7 @@ describe('RollbackManager', () => {
       const { sdk, checkpointManager, rollbackManager } = makeRollbackSetup();
 
       const peerDid = await sdk.did.createDIDPeer([
-        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: 'abc123', content: 'data' }
+        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: '3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7', content: 'data' }
       ]);
       const checkpoint = await checkpointManager.createCheckpoint('mig_owner', {
         sourceDid: peerDid.id,

--- a/packages/sdk/tests/unit/migration/StateTracker.cleanup.test.ts
+++ b/packages/sdk/tests/unit/migration/StateTracker.cleanup.test.ts
@@ -115,7 +115,7 @@ describe('MIGRATION_IN_PROGRESS rejection produces no audit/event noise (item 6,
     );
 
     const peerDid = await sdk.did.createDIDPeer([
-      { id: 'res-noise', type: 'Image', contentType: 'image/png', hash: 'abc123', content: 'data' }
+      { id: 'res-noise', type: 'Image', contentType: 'image/png', hash: '3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7', content: 'data' }
     ]);
 
     const failedEvents: unknown[] = [];

--- a/packages/sdk/tests/unit/migration/checkpoint-cleanup-selfheal.test.ts
+++ b/packages/sdk/tests/unit/migration/checkpoint-cleanup-selfheal.test.ts
@@ -135,7 +135,7 @@ async function makeHarness(adapter: unknown): Promise<{
 
 async function createCheckpointFor(sdk: OriginalsSDK, manager: CheckpointManager, migrationId: string) {
   const peerDid = await sdk.did.createDIDPeer([
-    { id: 'res-1', type: 'Image', contentType: 'image/png', hash: 'abc123', content: 'data' }
+    { id: 'res-1', type: 'Image', contentType: 'image/png', hash: '3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7', content: 'data' }
   ]);
   return manager.createCheckpoint(migrationId, {
     sourceDid: peerDid.id,

--- a/packages/sdk/tests/unit/migration/checkpoint-storage-truth-sweep.test.ts
+++ b/packages/sdk/tests/unit/migration/checkpoint-storage-truth-sweep.test.ts
@@ -138,7 +138,7 @@ async function makeHarness(adapter: unknown): Promise<{
 
 async function createCheckpointFor(sdk: OriginalsSDK, manager: CheckpointManager, migrationId: string) {
   const peerDid = await sdk.did.createDIDPeer([
-    { id: 'res-1', type: 'Image', contentType: 'image/png', hash: 'abc123', content: 'data' }
+    { id: 'res-1', type: 'Image', contentType: 'image/png', hash: '3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7', content: 'data' }
   ]);
   return manager.createCheckpoint(migrationId, {
     sourceDid: peerDid.id,

--- a/packages/sdk/tests/unit/migration/migration-coverage.test.ts
+++ b/packages/sdk/tests/unit/migration/migration-coverage.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { describe, it, test, expect, beforeEach, afterEach, beforeAll } from 'bun:test';
+import { createHash } from 'crypto';
 import * as ed25519 from '@noble/ed25519';
 
 import { OriginalsSDK } from '../../../src';
@@ -40,7 +41,7 @@ const baseConfig: OriginalsConfig = {
 };
 
 const sampleResources = [
-  { id: 'res-1', type: 'Image', contentType: 'image/png', hash: 'aabbcc0011223344', content: 'data' },
+  { id: 'res-1', type: 'Image', contentType: 'image/png', hash: '3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7', content: 'data' },
 ];
 
 function makeSdk(extra: Partial<OriginalsConfig> = {}) {
@@ -105,7 +106,8 @@ describe('CORE-MIG-EVENTS-002/performance: createAsset with large resource set',
       id: `res-${i}`,
       type: 'Image',
       contentType: 'image/png',
-      hash: `aabb${i.toString(16).padStart(8, '0')}ccdd`,
+      // Real sha256 of the content — createAsset now rejects mismatches (issue #347)
+      hash: createHash('sha256').update(`data-${i}`, 'utf8').digest('hex'),
       content: `data-${i}`,
     }));
 

--- a/packages/sdk/tests/unit/migration/migration-scenarios.test.ts
+++ b/packages/sdk/tests/unit/migration/migration-scenarios.test.ts
@@ -48,7 +48,7 @@ const baseConfig: OriginalsConfig = {
 };
 
 const sampleResources = [
-  { id: 'res-1', type: 'Image', contentType: 'image/png', hash: 'aabbcc', content: 'data' },
+  { id: 'res-1', type: 'Image', contentType: 'image/png', hash: '3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7', content: 'data' },
 ];
 
 // ---------------------------------------------------------------------------
@@ -788,8 +788,8 @@ describe('CORE-MIG-EVENTS-039: Peer→WebVH migration preserves asset resources'
   test('[happy] LifecycleManager.publishToWeb preserves all asset resources after migration', async () => {
     const sdk = OriginalsSDK.create({ ...baseConfig });
     const resources = [
-      { id: 'img-1', type: 'Image', contentType: 'image/png', hash: 'aabbccdd', content: 'imgdata' },
-      { id: 'doc-1', type: 'Document', contentType: 'application/pdf', hash: 'deadbeef', content: 'docdata' },
+      { id: 'img-1', type: 'Image', contentType: 'image/png', hash: 'a5c741c7dea3a96944022b4b9a0b1480cfbeef5f4cc934850e8afacb48e18c5e', content: 'imgdata' },
+      { id: 'doc-1', type: 'Document', contentType: 'application/pdf', hash: 'aef55fef7217f696b6624c1770f9e955a4d9f90d9e9261119e301c1309e2fd99', content: 'docdata' },
     ];
 
     const asset = await sdk.lifecycle.createAsset(resources);

--- a/packages/sdk/tests/unit/vc/CredentialManager.revocation.test.ts
+++ b/packages/sdk/tests/unit/vc/CredentialManager.revocation.test.ts
@@ -246,7 +246,7 @@ describe('CredentialManager - Revocation', () => {
       const resource = {
         id: 'main.ts',
         type: 'code',
-        hash: 'abc123',
+        hash: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
         contentType: 'application/typescript',
         content: '',
       };
@@ -281,7 +281,7 @@ describe('CredentialManager - Revocation', () => {
       const resource = {
         id: 'index.html',
         type: 'text',
-        hash: 'def456',
+        hash: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
         contentType: 'text/html',
         content: '',
       };


### PR DESCRIPTION
## What

Three independent provenance/money-safety fixes:

1. **#347** — `createAsset`, `publishResources`, and `inscribeOnBitcoin` now verify inline resource content against its declared hash and reject with `RESOURCE_HASH_MISMATCH` before anything is written, attested, or inscribed.
2. **#343** — `OrdinalsClient` (reachable via `SignetProvider`) now pins indexer-supplied `content_url` to the configured endpoint's origin, refuses redirects, bounds request time, and caps response sizes; per-satoshi content downloads are batched and capped.
3. **#344** — the fee estimators in `commit.ts`, `utxo.ts`, `PSBTBuilder.ts`, and `utxo-selection.ts` size inputs by script class (P2WPKH 68 vB, P2TR 57.5 vB, P2WSH conservative 120 vB) and size change/outputs by destination address class, instead of charging P2WPKH sizes for everything.

## Why

- A caller (or upstream bug) supplying `content = A, hash = sha256(B)` produced a **signed `ResourceMigrated` credential and a resource URL attesting a hash the bytes never matched** — the publish attestation was unsound. Closes #347
- The #322 SSRF hardening landed in `OrdinalsClientProviderAdapter`/`OrdHttpProvider` but missed `OrdinalsClient` itself: a compromised ord endpoint could steer the SDK into fetching `http://169.254.169.254/…` (cloud metadata) and returning it as inscription content, and a heavily reinscribed satoshi meant unbounded `Promise.all` content downloads. Closes #343
- `isSegwitScriptPubKey` admits P2WSH and P2TR, but every estimator charged 68 vB/input and 31 vB/output (P2WPKH). A 2-of-3 P2WSH input is ~105 vB, so a P2WSH-funded commit paid ~30% below the requested fee rate and could stall in the mempool while the freshly generated reveal key sat only in memory — the strand-the-commit scenario. Closes #344

## How

- **#347**: new `assertContentMatchesDeclaredHash` helper in `LifecycleManager` using the existing `hashResource` (sha256 over UTF-8 bytes — the same semantics `OriginalsAsset.verify` and `addResourceVersion` already define). Called in the `createAsset` validation loop, in `publishResources` before any storage write / `resource.url` assignment / event / credential, and in `inscribeOnBitcoin` before building the manifest. Hash-only resources (no inline content) are unaffected.
- **#343**: ported `resolveSameOrigin` (http/https-only + origin pin, resolved-absolute return) into `OrdinalsClient`; all requests now use `redirect: 'error'` + `AbortSignal.timeout`; JSON and content responses are capped via Content-Length early-reject plus materialized-byte check (falling back to the header check for test doubles that only implement `json()`). `getInscriptionsBySatoshi` resolves in batches of 8 and fails loudly (`ORD_TOO_MANY_INSCRIPTIONS`) above a configurable `maxInscriptionsPerSat` (default 100) rather than silently truncating. New optional `OrdinalsClientOptions` constructor arg — existing 2-arg call sites unchanged.
- **#344**: new shared helpers in `bitcoin/utxo.ts` — `classifyScriptPubKey`, `inputVBytesForScriptPubKey`, `outputVBytesForAddress` — used by all four estimators. Safe direction throughout: unknown script/address classes are charged at the largest plausible width (P2WSH 120 vB covers the common 2-of-3 worst case of ~105 vB; unknown outputs charged 43 vB), so estimates may overpay slightly but never underpay. `commit.ts` now estimates from the actually selected UTXOs and sizes the change output by the change address class.
- Test fixtures across the suite declared placeholder hashes alongside inline content; they now declare the real sha256 of their content (required by the #347 check). Two tests that modeled segwit wallets without `scriptPubKey` now set explicit P2WPKH scripts.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test addition or improvement

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] I have updated JSDoc comments for any changed public APIs
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Testing

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing (describe steps)

New regression tests:
- `tests/unit/lifecycle/resource-hash-verification.test.ts` — mismatched content rejected at create, at publish (nothing written/attested, asset not migrated), and at inscribe; matching and hash-only resources still work.
- `tests/security/ordinals-client-ssrf.test.ts` — off-origin/cloud-metadata and non-http(s) `content_url` rejected without being fetched; relative same-origin URLs resolved; `redirect: 'error'` + abort signal on every request; Content-Length and materialized-byte caps; per-satoshi inscription cap.
- `tests/unit/bitcoin/fee-script-class.test.ts` — for a 2-of-3 P2WSH input, the estimated fee is ≥ the actual serialized vsize × the requested rate across `createCommitTransaction`, `PSBTBuilder`, and `selectUtxos`; P2TR change output charged 43 vB; classification helpers.

Full suite: 3677 tests across 202 files, 0 failures. `bun run lint`: 0 errors (and two fewer warnings than main). `bun run build`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSmZKvQaB4VbNbignffQ7T

---
_Generated by [Claude Code](https://claude.ai/code/session_01RSmZKvQaB4VbNbignffQ7T)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Verify resource content hashes at publish, harden OrdinalsClient against SSRF, and fix fee sizing by script class
> - `LifecycleManager` now computes SHA-256 over each resource's inline content and rejects with `RESOURCE_HASH_MISMATCH` if it doesn't match the declared hash; this check runs in `createAsset`, `publishToWeb`, and `inscribeOnBitcoin` before any writes or inscriptions occur.
> - `OrdinalsClient` is hardened against SSRF: content URLs are restricted to same-origin http(s), all fetches refuse redirects and carry an `AbortSignal` timeout, and response sizes are capped via `Content-Length` and post-download byte checks.
> - Fee estimation in [`utxo.ts`](https://github.com/onionoriginals/sdk/pull/357/files#diff-4ac8c0d190cbfd9eba50a89348b4b43efb13879540826beee53e4f368a9cbc4b), [`PSBTBuilder.ts`](https://github.com/onionoriginals/sdk/pull/357/files#diff-cdf69252a60d2d5b37724bb465e346881e8b6181bf16a54e271ffbfd3c659cf1), [`commit.ts`](https://github.com/onionoriginals/sdk/pull/357/files#diff-b6174e7b8349705e25b5d4b9b99b1ebc9986a41e30826d89895deda0fec46da0), and [`utxo-selection.ts`](https://github.com/onionoriginals/sdk/pull/357/files#diff-52ae4a428c746036f8e428fbac0838540a527ad9d9ccde6379dabfc1c6671970) now sizes each input by script class (P2WPKH 68 vB, P2TR 57.5 vB, P2WSH 120 vB) and each output by address type instead of using a flat 31 vB assumption.
> - All existing tests are updated to provide real SHA-256 hashes matching resource content to satisfy the new hash verification.
> - Risk: the hash verification and fee-sizing changes are breaking for callers that supply placeholder hashes or fund transactions with P2WSH UTXOs — both will now fail or require larger fees than before.
>
> #### 🖇️ Linked Issues
> Fixes issues #347 (resource hash verification), #343 (OrdinalsClient SSRF hardening), and #344 (script-class-aware fee sizing), as referenced in the PR title and changeset.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a2ee873.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->