### PR TITLE
fix: batch of 12 verification, event, logging, and Bitcoin-provider fixes — #340, #345, #301, #309, #346, #349, #350, #351, #352, #311, #312, #313

### DIFF
--- a/.changeset/security-and-events-issue-batch.md
+++ b/.changeset/security-and-events-issue-batch.md
@@ -1,0 +1,17 @@
+---
+"@originals/sdk": patch
+"@originals/auth": patch
+---
+
+Batch of verification, event, and provider hardening fixes:
+
+- `Verifier.verifyCredentialMultiSig` now enforces the credential validity window and fails closed on (or resolver-checks) a declared `BitstringStatusListEntry`, so expired/revoked multi-sig credentials no longer verify (#340).
+- `CredentialManager.verifyCredentialWithStatus` returns `verified: false` for revoked/suspended credentials; `checkRevocationStatus`/`isRevoked` reject a status list whose `id` doesn't match the credential's reference and document that they trust the caller-supplied list (#345).
+- Status-list trust validation (id match, proof verification, issuer equality) is now a single shared implementation used by both Verifier and CredentialManager (#301).
+- Fail-closed signing refusals key on typed `StructuredError` codes (`ISSUER_BINDING_MISMATCH`, `VM_RETIRED`) instead of error-message wording (#309).
+- `asset:migrated`/`asset:transferred` are mirrored onto the LifecycleManager emitter so `sdk.lifecycle.on(...)` subscriptions and built-in EventLogger metrics fire; `verification:completed` and `batch:progress` are now actually emitted (#346, #352).
+- `Logger.sanitize` is cycle-safe and cannot crash the calling operation; `FileLogOutput` retains batches on failed writes and flushes on process exit (#349, #352).
+- `SignetProvider.estimateFee` fails loudly instead of fabricating an inverted fallback rate; regtest commit change outputs accept testnet-format addresses like the transfer path; cost quotes apply the `MAX_REASONABLE_FEE_RATE` cap (#351).
+- QuickNodeProvider: optional `expectedNetwork` chain check, explicit `contentEncoding` option, txid/inscriptionId/sat shape validation before provenance, content-unavailable distinguished from nonexistent, endpoint token redacted from errors (#350).
+- Prerelease versions no longer pass the pichu/cleffa release gates; Multikey decode validates key lengths; 33-byte "prefixed Ed25519" keys are rejected instead of guessed at; JWT verification pins HS256 and requires a ≥32-char secret (#352).
+- Cross-network `did:btco` guard runs before the DID cache read; LRU eviction no longer deletes entries from persistent cache storage; `addResourceVersion` types `newContent` as `string` (#312, #313, #311).

--- a/packages/auth/src/server/jwt.ts
+++ b/packages/auth/src/server/jwt.ts
@@ -9,6 +9,10 @@ import type { TokenPayload, AuthCookieConfig } from '../types.js';
 // 7 days in seconds
 const DEFAULT_JWT_EXPIRES_IN = 7 * 24 * 60 * 60;
 
+// HS256 keys shorter than the hash output (32 bytes) weaken the MAC and are
+// trivially brute-forceable; RFC 7518 §3.2 requires >= 256 bits.
+const MIN_JWT_SECRET_LENGTH = 32;
+
 /**
  * Get JWT secret from config or environment
  */
@@ -16,6 +20,9 @@ function getJwtSecret(configSecret?: string): string {
   const secret = configSecret ?? process.env.JWT_SECRET;
   if (!secret) {
     throw new Error('JWT_SECRET environment variable is required');
+  }
+  if (secret.length < MIN_JWT_SECRET_LENGTH) {
+    throw new Error(`JWT secret must be at least ${MIN_JWT_SECRET_LENGTH} characters`);
   }
   return secret;
 }
@@ -84,6 +91,11 @@ export function verifyToken(
     const payload = jwt.verify(token, secret, {
       issuer: options?.issuer ?? 'originals-auth',
       audience: options?.audience ?? 'originals-api',
+      // Pin the algorithm family: signing uses HS256 (jsonwebtoken's default
+      // for string secrets), and leaving verify unpinned invites algorithm
+      // confusion/downgrade if the library or key handling ever changes
+      // (issue #352).
+      algorithms: ['HS256'],
     }) as TokenPayload;
 
     if (!payload.sub) {

--- a/packages/auth/src/server/turnkey-signer.ts
+++ b/packages/auth/src/server/turnkey-signer.ts
@@ -133,15 +133,16 @@ export class TurnkeyWebVHSigner implements ExternalSigner, ExternalVerifier {
     publicKey: Uint8Array
   ): Promise<boolean> {
     try {
-      // Ed25519 public keys must be exactly 32 bytes
-      let ed25519PublicKey = publicKey;
-      if (publicKey.length === 33) {
-        ed25519PublicKey = publicKey.slice(1);
-      } else if (publicKey.length !== 32) {
+      // Ed25519 public keys must be exactly 32 bytes. A 33-byte input is NOT
+      // a "prefixed Ed25519 key": Ed25519 multicodec prefixes are 2 bytes
+      // (0xed 0x01 → 34 bytes), while 33 bytes is the shape of a compressed
+      // secp256k1 key. Stripping one byte verified against garbage — reject
+      // instead of guessing (issue #352).
+      if (publicKey.length !== 32) {
         return false;
       }
 
-      return await ed25519.verifyAsync(signature, message, ed25519PublicKey);
+      return await ed25519.verifyAsync(signature, message, publicKey);
     } catch (error) {
       console.error('Error verifying signature:', error);
       return false;

--- a/packages/auth/tests/auth-coverage.test.ts
+++ b/packages/auth/tests/auth-coverage.test.ts
@@ -169,7 +169,7 @@ describe('[AUTH-009] TurnkeyWebVHSigner – happy paths', () => {
     expect(resultWrong).toBe(false);
   });
 
-  test('verify → handles 33-byte prefixed public key (strips first byte, succeeds)', async () => {
+  test('verify → rejects a 33-byte public key instead of guessing at a prefix (issue #352)', async () => {
     const ed25519 = await import('@noble/ed25519');
 
     const privKey = new Uint8Array(32).fill(5);
@@ -191,9 +191,11 @@ describe('[AUTH-009] TurnkeyWebVHSigner – happy paths', () => {
       'did:key:z6MkTest#z6MkTest'
     );
 
-    // Signer strips the prefix byte → verification should succeed
+    // 33 bytes is the shape of a compressed secp256k1 key, not a "prefixed
+    // Ed25519 key" (Ed25519 multicodec prefixes are 2 bytes → 34 bytes).
+    // Stripping one byte verified against garbage — it must reject instead.
     const result = await signer.verify(signature, message, pubKey33);
-    expect(result).toBe(true);
+    expect(result).toBe(false);
   });
 });
 

--- a/packages/auth/tests/jwt.test.ts
+++ b/packages/auth/tests/jwt.test.ts
@@ -114,7 +114,7 @@ describe('jwt', () => {
       const token = signToken('sub_org_123', 'user@example.com', undefined, {
         secret: TEST_SECRET,
       });
-      expect(() => verifyToken(token, { secret: 'wrong-secret' })).toThrow('Invalid token');
+      expect(() => verifyToken(token, { secret: 'wrong-secret-that-is-long-enough-for-hs256' })).toThrow('Invalid token');
     });
 
     test('throws for token with wrong issuer', () => {

--- a/packages/sdk/src/adapters/providers/OrdHttpProvider.ts
+++ b/packages/sdk/src/adapters/providers/OrdHttpProvider.ts
@@ -198,13 +198,21 @@ export class OrdHttpProvider implements OrdinalsProvider {
   }
 }
 
-export async function createOrdinalsProviderFromEnv(): Promise<OrdinalsProvider> {
+export async function createOrdinalsProviderFromEnv(
+  options?: { network?: 'mainnet' | 'testnet' | 'signet' | 'regtest' }
+): Promise<OrdinalsProvider> {
   // A configured QuickNode endpoint takes precedence: it is the only
   // env-selectable provider with real broadcast/status/fee support.
   const quickNodeEndpoint = ((globalThis as any).process?.env?.QUICKNODE_ENDPOINT) || '';
   if (quickNodeEndpoint) {
     const mod = await import('./QuickNodeProvider.js');
-    return new mod.QuickNodeProvider({ endpoint: quickNodeEndpoint });
+    // Pass the SDK's network through so the provider verifies the endpoint's
+    // chain on first RPC use (issue #350). Falls back to BITCOIN_NETWORK; when
+    // neither is set, no chain check is performed (unchanged behavior).
+    const envNetworkRaw = String(((globalThis as any).process?.env?.BITCOIN_NETWORK) || '');
+    const envNetwork = (['mainnet', 'testnet', 'signet', 'regtest'] as const).find((n) => n === envNetworkRaw);
+    const expectedNetwork = options?.network ?? envNetwork;
+    return new mod.QuickNodeProvider({ endpoint: quickNodeEndpoint, expectedNetwork });
   }
   const useLive = String(((globalThis as any).process?.env?.USE_LIVE_ORD_PROVIDER) || '').toLowerCase() === 'true';
   if (useLive) {

--- a/packages/sdk/src/adapters/providers/QuickNodeProvider.ts
+++ b/packages/sdk/src/adapters/providers/QuickNodeProvider.ts
@@ -149,7 +149,11 @@ export class QuickNodeProvider implements OrdinalsProvider {
           );
         }
       })().catch((err) => {
-        this.networkCheck = null;
+        // Only reset for transient errors so a permanent QUICKNODE_NETWORK_MISMATCH
+        // doesn't cause a redundant getblockchaininfo call on every subsequent retry.
+        if (!(err instanceof StructuredError) || err.code !== 'QUICKNODE_NETWORK_MISMATCH') {
+          this.networkCheck = null;
+        }
         throw err;
       });
     }

--- a/packages/sdk/src/adapters/providers/QuickNodeProvider.ts
+++ b/packages/sdk/src/adapters/providers/QuickNodeProvider.ts
@@ -18,7 +18,37 @@ export interface QuickNodeProviderOptions {
   maxJsonBytes?: number;
   /** Max bytes accepted for decoded inscription content (default 5 MiB). */
   maxContentBytes?: number;
+  /**
+   * Bitcoin network this endpoint is expected to serve. When set, the
+   * provider verifies `getblockchaininfo.chain` against it on first RPC use
+   * and fails loudly on a mismatch — a mainnet-configured SDK pointed at a
+   * testnet endpoint would otherwise silently answer mainnet DID
+   * existence/transfer questions with testnet data (issue #350).
+   */
+  expectedNetwork?: 'mainnet' | 'testnet' | 'signet' | 'regtest';
+  /**
+   * How `ord_getContent` results are encoded (issue #350):
+   * - 'base64' (recommended): always base64-decode; malformed base64 fails loudly.
+   * - 'utf8': treat the result as literal UTF-8 text.
+   * - 'auto' (default, for backwards compatibility): heuristic — base64-shaped
+   *   content is decoded, anything else is treated as literal UTF-8. Ambiguous
+   *   short text inscriptions can be misdecoded; pin an explicit encoding for
+   *   deployments where content hashes matter.
+   */
+  contentEncoding?: 'base64' | 'utf8' | 'auto';
 }
+
+/** getblockchaininfo.chain values mapped to SDK network names. */
+const CHAIN_TO_NETWORK: Record<string, 'mainnet' | 'testnet' | 'signet' | 'regtest'> = {
+  main: 'mainnet',
+  test: 'testnet',
+  signet: 'signet',
+  regtest: 'regtest',
+};
+
+/** Shape gate for inscription ids: 64-hex txid + 'i' + numeric index. */
+const INSCRIPTION_ID_RE = /^[0-9a-f]{64}i\d+$/i;
+const TXID_RE = /^[0-9a-f]{64}$/i;
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_MAX_JSON_BYTES = 1 * 1024 * 1024;
@@ -71,6 +101,9 @@ export class QuickNodeProvider implements OrdinalsProvider {
   private readonly timeout: number;
   private readonly maxJsonBytes: number;
   private readonly maxContentBytes: number;
+  private readonly expectedNetwork?: 'mainnet' | 'testnet' | 'signet' | 'regtest';
+  private readonly contentEncoding: 'base64' | 'utf8' | 'auto';
+  private networkCheck: Promise<void> | null = null;
 
   constructor(options: QuickNodeProviderOptions) {
     if (!options?.endpoint) {
@@ -80,7 +113,10 @@ export class QuickNodeProvider implements OrdinalsProvider {
     try {
       parsed = new URL(options.endpoint);
     } catch {
-      throw new StructuredError('QUICKNODE_ENDPOINT_INVALID', `QuickNodeProvider endpoint is not a valid URL: ${options.endpoint}`);
+      // Never echo the endpoint string back: the QuickNode auth token is
+      // embedded in the URL path and error text lands in logs/telemetry
+      // (issue #350).
+      throw new StructuredError('QUICKNODE_ENDPOINT_INVALID', 'QuickNodeProvider endpoint is not a valid URL');
     }
     if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
       throw new StructuredError('QUICKNODE_ENDPOINT_INVALID', `QuickNodeProvider endpoint must be http(s), got ${parsed.protocol}`);
@@ -89,6 +125,35 @@ export class QuickNodeProvider implements OrdinalsProvider {
     this.timeout = options.timeout ?? DEFAULT_TIMEOUT_MS;
     this.maxJsonBytes = options.maxJsonBytes ?? DEFAULT_MAX_JSON_BYTES;
     this.maxContentBytes = options.maxContentBytes ?? DEFAULT_MAX_CONTENT_BYTES;
+    this.expectedNetwork = options.expectedNetwork;
+    this.contentEncoding = options.contentEncoding ?? 'auto';
+  }
+
+  /**
+   * Verify the endpoint's chain matches the expected network (issue #350).
+   * Runs once before the first real RPC call; the memoized promise is reset
+   * on failure so a transient RPC error does not poison the provider forever.
+   */
+  private ensureExpectedNetwork(): Promise<void> {
+    if (!this.expectedNetwork) return Promise.resolve();
+    if (!this.networkCheck) {
+      this.networkCheck = (async () => {
+        const info = await this.rpcCall<{ chain?: string } | null>('getblockchaininfo', []);
+        const chain = info?.chain;
+        const actual = typeof chain === 'string' ? CHAIN_TO_NETWORK[chain] : undefined;
+        if (actual !== this.expectedNetwork) {
+          throw new StructuredError(
+            'QUICKNODE_NETWORK_MISMATCH',
+            `QuickNodeProvider: endpoint serves chain '${String(chain)}' (${String(actual)}) but the SDK is configured for ${this.expectedNetwork}. ` +
+            'Point QUICKNODE_ENDPOINT at an endpoint on the configured network.'
+          );
+        }
+      })().catch((err) => {
+        this.networkCheck = null;
+        throw err;
+      });
+    }
+    return this.networkCheck;
   }
 
   /**
@@ -194,7 +259,20 @@ export class QuickNodeProvider implements OrdinalsProvider {
     }
     let buf: Buffer | undefined;
     const compact = raw.replace(/\s+/g, '');
-    if (compact.length > 0 && /^[A-Za-z0-9+/]+={0,2}$/.test(compact) && compact.length % 4 === 0) {
+    const isBase64Shaped = compact.length > 0 && /^[A-Za-z0-9+/]+={0,2}$/.test(compact) && compact.length % 4 === 0;
+    if (this.contentEncoding === 'base64') {
+      // Explicit encoding: no guessing. Content that is not valid base64 is a
+      // server contract violation, not literal text (issue #350).
+      if (!isBase64Shaped) {
+        throw new StructuredError(
+          'QUICKNODE_CONTENT_UNEXPECTED_SHAPE',
+          "QuickNodeProvider: ord_getContent result is not base64 (provider configured with contentEncoding: 'base64')"
+        );
+      }
+      buf = Buffer.from(compact, 'base64');
+    } else if (this.contentEncoding === 'utf8') {
+      buf = Buffer.from(raw, 'utf8');
+    } else if (isBase64Shaped) {
       const decoded = Buffer.from(compact, 'base64');
       if (!QuickNodeProvider.isTextContentType(contentType) || QuickNodeProvider.isValidUtf8(decoded)) {
         buf = decoded;
@@ -232,6 +310,7 @@ export class QuickNodeProvider implements OrdinalsProvider {
 
   async getInscriptionById(id: string) {
     if (!id) return null;
+    await this.ensureExpectedNetwork();
     let info: QuickNodeInscription | null;
     try {
       info = await this.rpcCall<QuickNodeInscription | null>('ord_getInscription', [id]);
@@ -241,15 +320,43 @@ export class QuickNodeProvider implements OrdinalsProvider {
     }
     if (!info) return null;
 
+    // Validate server-supplied fields BEFORE they flow into provenance
+    // records (issue #350): a compromised endpoint must not be able to inject
+    // arbitrary strings as txid/inscriptionId/satoshi. Malformed data is a
+    // contract violation and throws — it is not "not found".
+    const inscriptionId = info.id || info.inscription_id || id;
+    if (!INSCRIPTION_ID_RE.test(inscriptionId)) {
+      throw new StructuredError(
+        'QUICKNODE_UNEXPECTED_SHAPE',
+        `QuickNodeProvider: ord_getInscription returned a malformed inscription id (${inscriptionId})`
+      );
+    }
+
     // Current location comes from the satpoint ('txid:vout:offset'); fall
-    // back to the owning output ('txid:vout') if satpoint is absent.
-    let txid = 'unknown';
-    let vout = 0;
+    // back to the owning output ('txid:vout') if satpoint is absent. A
+    // missing or malformed location throws rather than fabricating the
+    // literal 'unknown' as a txid.
     const location = info.satpoint || info.output;
-    if (typeof location === 'string' && location.includes(':')) {
-      const [tid, v] = location.split(':');
-      txid = tid;
-      vout = Number(v) || 0;
+    const [tid, v] = typeof location === 'string' ? location.split(':') : [];
+    if (!tid || !TXID_RE.test(tid)) {
+      throw new StructuredError(
+        'QUICKNODE_UNEXPECTED_SHAPE',
+        'QuickNodeProvider: ord_getInscription returned no valid satpoint/output location'
+      );
+    }
+    const txid = tid;
+    const vout = Number(v) || 0;
+
+    const satRaw = info.sat;
+    let satoshi: string | undefined;
+    if (satRaw !== null && satRaw !== undefined) {
+      satoshi = String(satRaw);
+      if (!validateSatoshiNumber(satoshi).valid) {
+        throw new StructuredError(
+          'QUICKNODE_UNEXPECTED_SHAPE',
+          `QuickNodeProvider: ord_getInscription returned an invalid sat number (${satoshi})`
+        );
+      }
     }
 
     // Content bytes are a separate call: ord_getInscription returns metadata
@@ -261,18 +368,27 @@ export class QuickNodeProvider implements OrdinalsProvider {
       const contentResult = await this.rpcCall<unknown>('ord_getContent', [id], contentJsonCap);
       content = this.decodeContent(contentResult, info.content_type || info.effective_content_type);
     } catch (err) {
-      if (QuickNodeProvider.isNotFound(err)) return null;
+      // The inscription's metadata EXISTS (ord_getInscription succeeded), so
+      // a content-lookup miss (e.g. indexer lag) is "content unavailable",
+      // not "inscription does not exist". Returning null here made
+      // verifyBitcoinWitnessProof report a hard false negative for a real
+      // on-chain anchor (issue #350).
+      if (QuickNodeProvider.isNotFound(err)) {
+        throw new StructuredError(
+          'QUICKNODE_CONTENT_UNAVAILABLE',
+          `QuickNodeProvider: inscription ${id} exists but its content is not yet available from the endpoint (possible indexer lag); retry later`,
+          { inscriptionId: id }
+        );
+      }
       throw err;
     }
 
-    const satRaw = info.sat;
-    const satoshi = satRaw === null || satRaw === undefined ? undefined : String(satRaw);
     const blockHeight = typeof info.height === 'number'
       ? info.height
       : (typeof info.genesis_height === 'number' ? info.genesis_height : undefined);
 
     return {
-      inscriptionId: info.id || info.inscription_id || id,
+      inscriptionId,
       content,
       contentType: info.content_type || info.effective_content_type || 'application/octet-stream',
       txid,
@@ -287,6 +403,7 @@ export class QuickNodeProvider implements OrdinalsProvider {
     if (!validation.valid) {
       throw new StructuredError('QUICKNODE_INVALID_SATOSHI', `QuickNodeProvider: ${validation.error}`);
     }
+    await this.ensureExpectedNetwork();
     // Sat ordinals max out at 2,099,999,997,689,999 (< 2^53), so Number is
     // exact here; ord_getSat expects a JSON number, not a string.
     let info: { inscriptions?: string[]; inscription_ids?: string[] } | null;
@@ -302,8 +419,10 @@ export class QuickNodeProvider implements OrdinalsProvider {
     const ids = Array.isArray(info?.inscriptions)
       ? info.inscriptions
       : (Array.isArray(info?.inscription_ids) ? info.inscription_ids : []);
+    // Shape-gate server-supplied ids before they flow into DID resolution /
+    // provenance (issue #350).
     return ids
-      .filter((x): x is string => typeof x === 'string' && x.length > 0)
+      .filter((x): x is string => typeof x === 'string' && INSCRIPTION_ID_RE.test(x))
       .map((inscriptionId) => ({ inscriptionId }));
   }
 
@@ -317,6 +436,7 @@ export class QuickNodeProvider implements OrdinalsProvider {
         'QuickNodeProvider.broadcastTransaction requires a raw transaction hex string (even-length hexadecimal)'
       );
     }
+    await this.ensureExpectedNetwork();
     const result = await this.rpcCall<unknown>('sendrawtransaction', [txHexOrObj]);
     // A malformed or empty result must not become a "successful" txid that
     // downstream code records as provenance — require a real 64-char hex txid.
@@ -336,6 +456,7 @@ export class QuickNodeProvider implements OrdinalsProvider {
         'QuickNodeProvider.getTransactionStatus requires a 64-character hex txid'
       );
     }
+    await this.ensureExpectedNetwork();
     let tx: { confirmations?: number; blockhash?: string } | null;
     try {
       tx = await this.rpcCall<{ confirmations?: number; blockhash?: string } | null>(
@@ -369,6 +490,7 @@ export class QuickNodeProvider implements OrdinalsProvider {
   }
 
   async estimateFee(blocks: number = 1): Promise<number> {
+    await this.ensureExpectedNetwork();
     const target = Math.max(1, Math.floor(blocks));
     const result = await this.rpcCall<{ feerate?: number; errors?: string[] } | null>(
       'estimatesmartfee',

--- a/packages/sdk/src/bitcoin/BitcoinManager.ts
+++ b/packages/sdk/src/bitcoin/BitcoinManager.ts
@@ -11,9 +11,11 @@ import { validateSatoshiNumber } from '../utils/satoshi-validation.js';
 /**
  * Upper bound on any fee rate the SDK will use, whether caller-provided or
  * returned by a fee oracle / ordinals provider. Guards against a misbehaving or
- * compromised estimator draining funds via an absurd sat/vB value.
+ * compromised estimator draining funds via an absurd sat/vB value. Exported so
+ * quote-only paths (LifecycleManager.estimateCost) apply the same cap
+ * (issue #351).
  */
-const MAX_REASONABLE_FEE_RATE = 10_000; // sat/vB
+export const MAX_REASONABLE_FEE_RATE = 10_000; // sat/vB
 
 export class BitcoinManager {
   private readonly feeOracle?: FeeOracleAdapter;

--- a/packages/sdk/src/bitcoin/providers/SignetProvider.ts
+++ b/packages/sdk/src/bitcoin/providers/SignetProvider.ts
@@ -140,30 +140,38 @@ export class SignetProvider implements OrdinalsProvider {
   }
 
   async estimateFee(blocks: number = 1): Promise<number> {
-    if (this.bitcoinRpcUrl) {
-      try {
-        const res = await fetch(this.bitcoinRpcUrl, {
-          method: 'POST',
-          headers: this.rpcHeaders(),
-          body: JSON.stringify({
-            jsonrpc: '2.0',
-            id: 1,
-            method: 'estimatesmartfee',
-            params: [blocks],
-          }),
-          signal: AbortSignal.timeout(this.timeout),
-        });
-        const data = await res.json() as { result?: { feerate?: number } };
-        if (data.result?.feerate) {
-          // Convert BTC/kB to sat/vB
-          return Math.ceil(data.result.feerate * 1e5);
-        }
-      } catch {
-        // Fall through to default
-      }
+    // Fail loudly instead of fabricating a rate: the old fallback returned
+    // `Math.max(1, blocks) * 2`, an invented value that *increased* with the
+    // confirmation target (real fee curves go the other way) and silently
+    // swallowed RPC errors — contradicting the fail-loud fee policy of the
+    // other providers (OrdinalsClient/OrdHttpProvider/QuickNodeProvider).
+    // Issue #351.
+    if (!this.bitcoinRpcUrl) {
+      throw new Error(
+        'SignetProvider.estimateFee requires bitcoinRpcUrl to be configured. ' +
+        'Configure a bitcoinRpcUrl (or a FeeOracleAdapter) instead of relying on a fabricated rate.'
+      );
     }
-    // Signet has low fees; return a sensible default
-    return Math.max(1, blocks) * 2;
+    const res = await fetch(this.bitcoinRpcUrl, {
+      method: 'POST',
+      headers: this.rpcHeaders(),
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'estimatesmartfee',
+        params: [blocks],
+      }),
+      signal: AbortSignal.timeout(this.timeout),
+    });
+    const data = await res.json() as { result?: { feerate?: number } };
+    if (typeof data.result?.feerate !== 'number' || !(data.result.feerate > 0)) {
+      throw new Error(
+        'SignetProvider: estimatesmartfee returned no feerate. ' +
+        'Configure a FeeOracleAdapter or retry with a higher block target.'
+      );
+    }
+    // Convert BTC/kB to sat/vB
+    return Math.ceil(data.result.feerate * 1e5);
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await

--- a/packages/sdk/src/bitcoin/transactions/commit.ts
+++ b/packages/sdk/src/bitcoin/transactions/commit.ts
@@ -15,6 +15,7 @@ import { calculateFee } from '../fee-calculation.js';
 import { selectUtxos, SimpleUtxoSelectionOptions } from '../utxo-selection.js';
 import { isSegwitScriptPubKey, inputVBytesForScriptPubKey, outputVBytesForAddress } from '../utxo.js';
 import { validateBitcoinAddress } from '../../utils/bitcoin-address.js';
+import { scriptPubKeyForAddress } from '../transfer.js';
 
 // Define minimum dust limit (satoshis)
 const MIN_DUST_LIMIT = 546;
@@ -566,13 +567,19 @@ export async function createCommitTransaction(
     scureNetwork
   );
 
-  // Step 10: Add change output if above dust limit
+  // Step 10: Add change output if above dust limit. The change script is
+  // derived via scriptPubKeyForAddress rather than tx.addOutputAddress:
+  // validateBitcoinAddress deliberately accepts testnet-format (`tb1…`)
+  // change addresses on regtest, but addOutputAddress decodes strictly
+  // against `bcrt` and would throw a cryptic @scure error here — after all
+  // the keygen/selection/fee work the early validation exists to protect
+  // (issue #351). scriptPubKeyForAddress carries the same regtest→testnet
+  // decode fallback transfer.ts already uses.
   if (finalChange >= MIN_DUST_LIMIT) {
-    tx.addOutputAddress(
-      changeAddress,
-      BigInt(finalChange),
-      scureNetwork
-    );
+    tx.addOutput({
+      script: Buffer.from(scriptPubKeyForAddress(changeAddress, network), 'hex'),
+      amount: BigInt(finalChange)
+    });
   } else if (finalChange > 0) {
     // If change is below dust limit, it's effectively added to the fee
     console.log(

--- a/packages/sdk/src/core/OriginalsSDK.ts
+++ b/packages/sdk/src/core/OriginalsSDK.ts
@@ -329,20 +329,20 @@ export class OriginalsSDK {
   ): Promise<boolean> {
     // Dynamically import @noble/ed25519 to avoid module resolution issues
     const ed25519Mod = await import('@noble/ed25519');
-    
-    // Ed25519 public keys must be exactly 32 bytes
-    // Some keys may have a version byte prefix, so remove it if present
-    let ed25519PublicKey = publicKey;
-    if (publicKey.length === 33) {
-      ed25519PublicKey = publicKey.slice(1);
-    } else if (publicKey.length !== 32) {
+
+    // Ed25519 public keys must be exactly 32 bytes. A 33-byte input is NOT a
+    // "prefixed Ed25519 key": Ed25519 multicodec prefixes are 2 bytes
+    // (0xed 0x01 → 34 bytes), while 33 bytes is the shape of a compressed
+    // secp256k1 key. Stripping one byte and verifying against the remainder
+    // verified against garbage — reject instead of guessing (issue #352).
+    if (publicKey.length !== 32) {
       throw new Error(`Invalid Ed25519 public key length: ${publicKey.length} (expected 32 bytes)`);
     }
-    
+
     // Verify using @noble/ed25519 with Uint8Array (browser-compatible)
     // ed25519.verifyAsync accepts Uint8Array directly
     try {
-      return await ed25519Mod.verifyAsync(signature, message, ed25519PublicKey);
+      return await ed25519Mod.verifyAsync(signature, message, publicKey);
     } catch (_error) {
       // Verification failed or error occurred
       return false;

--- a/packages/sdk/src/crypto/Multikey.ts
+++ b/packages/sdk/src/crypto/Multikey.ts
@@ -19,6 +19,27 @@ export const LEGACY_SECP256K1_PRIV_HEADER = new Uint8Array([0x13, 0x01]);
 
 export type MultikeyType = 'Ed25519' | 'Secp256k1' | 'Bls12381G2' | 'P256';
 
+// Expected raw key lengths per type. Decode paths enforce these so a
+// wrong-length body cannot decode "successfully" and be re-encoded into a
+// well-formed-looking but wrong multikey (e.g. during migrateToDIDBTCO key
+// carry-over) — issue #352. Shared with validateMultikeyFormat.
+const EXPECTED_KEY_LENGTHS: Record<MultikeyType, { private: number; public: number }> = {
+  Ed25519: { private: 32, public: 32 },
+  Secp256k1: { private: 32, public: 33 },
+  P256: { private: 32, public: 33 },
+  Bls12381G2: { private: 32, public: 96 }
+};
+
+function assertKeyLength(key: Uint8Array, type: MultikeyType, isPrivate: boolean): void {
+  const expected = isPrivate ? EXPECTED_KEY_LENGTHS[type].private : EXPECTED_KEY_LENGTHS[type].public;
+  if (key.length !== expected) {
+    throw new Error(
+      `Invalid multibase key format. Expected ${type} ${isPrivate ? 'private' : 'public'} key to be ` +
+      `${expected} bytes, but found ${key.length} bytes.`
+    );
+  }
+}
+
 function concatBytes(a: Uint8Array, b: Uint8Array): Uint8Array {
   const out = new Uint8Array(a.length + b.length);
   out.set(a, 0);
@@ -95,26 +116,8 @@ export function validateMultikeyFormat(
       );
     }
 
-    // Validate key length (basic sanity check)
-    const keyBytes = mc.slice(2);
-    const expectedLengths: Record<MultikeyType, { private: number; public: number }> = {
-      Ed25519: { private: 32, public: 32 },
-      Secp256k1: { private: 32, public: 33 },
-      P256: { private: 32, public: 33 },
-      Bls12381G2: { private: 32, public: 96 }
-    };
-
-    const expectedLength = isPrivate
-      ? expectedLengths[expectedType].private
-      : expectedLengths[expectedType].public;
-
-    if (keyBytes.length !== expectedLength) {
-      throw new Error(
-        `Invalid multibase key format. Expected ${expectedType} ${
-          isPrivate ? 'private' : 'public'
-        } key to be ${expectedLength} bytes, but found ${keyBytes.length} bytes.`
-      );
-    }
+    // Validate key length (basic sanity check; same table the decode paths enforce)
+    assertKeyLength(mc.slice(2), expectedType, isPrivate);
   } catch (error) {
     // Re-throw our own errors as-is
     if (error instanceof Error && error.message.startsWith('Invalid multibase key format')) {
@@ -194,17 +197,21 @@ export const multikey = {
     const mc = base58.decode(publicKeyMultibase.slice(1));
     const header = mc.slice(0, 2);
     const key = mc.slice(2);
+    const decoded = (type: MultikeyType): { key: Uint8Array; type: MultikeyType } => {
+      assertKeyLength(key, type, false);
+      return { key, type };
+    };
     if (header[0] === MULTICODEC_ED25519_PUB_HEADER[0] && header[1] === MULTICODEC_ED25519_PUB_HEADER[1]) {
-      return { key, type: 'Ed25519' };
+      return decoded('Ed25519');
     }
     if (header[0] === MULTICODEC_SECP256K1_PUB_HEADER[0] && header[1] === MULTICODEC_SECP256K1_PUB_HEADER[1]) {
-      return { key, type: 'Secp256k1' };
+      return decoded('Secp256k1');
     }
     if (header[0] === MULTICODEC_BLS12381_G2_PUB_HEADER[0] && header[1] === MULTICODEC_BLS12381_G2_PUB_HEADER[1]) {
-      return { key, type: 'Bls12381G2' };
+      return decoded('Bls12381G2');
     }
     if (header[0] === MULTICODEC_P256_PUB_HEADER[0] && header[1] === MULTICODEC_P256_PUB_HEADER[1]) {
-      return { key, type: 'P256' };
+      return decoded('P256');
     }
     throw new Error('Unsupported key type');
   },
@@ -216,20 +223,24 @@ export const multikey = {
     const mc = base58.decode(privateKeyMultibase.slice(1));
     const header = mc.slice(0, 2);
     const key = mc.slice(2);
+    const decoded = (type: MultikeyType): { key: Uint8Array; type: MultikeyType } => {
+      assertKeyLength(key, type, true);
+      return { key, type };
+    };
     if (header[0] === MULTICODEC_ED25519_PRIV_HEADER[0] && header[1] === MULTICODEC_ED25519_PRIV_HEADER[1]) {
-      return { key, type: 'Ed25519' };
+      return decoded('Ed25519');
     }
     if (header[0] === MULTICODEC_SECP256K1_PRIV_HEADER[0] && header[1] === MULTICODEC_SECP256K1_PRIV_HEADER[1]) {
-      return { key, type: 'Secp256k1' };
+      return decoded('Secp256k1');
     }
     if (header[0] === LEGACY_SECP256K1_PRIV_HEADER[0] && header[1] === LEGACY_SECP256K1_PRIV_HEADER[1]) {
-      return { key, type: 'Secp256k1' };
+      return decoded('Secp256k1');
     }
     if (header[0] === MULTICODEC_BLS12381_G2_PRIV_HEADER[0] && header[1] === MULTICODEC_BLS12381_G2_PRIV_HEADER[1]) {
-      return { key, type: 'Bls12381G2' };
+      return decoded('Bls12381G2');
     }
     if (header[0] === MULTICODEC_P256_PRIV_HEADER[0] && header[1] === MULTICODEC_P256_PRIV_HEADER[1]) {
-      return { key, type: 'P256' };
+      return decoded('P256');
     }
     throw new Error('Unsupported key type');
   }

--- a/packages/sdk/src/did/DIDCache.ts
+++ b/packages/sdk/src/did/DIDCache.ts
@@ -100,7 +100,7 @@ export class DIDCache {
       entry = await this.storage.get(did);
       if (entry) {
         if (!this.cache.has(did) && this.cache.size >= this.maxEntries) {
-          await this.evictLRU();
+          this.evictLRU();
         }
         this.cache.set(did, entry);
       }
@@ -143,7 +143,7 @@ export class DIDCache {
 
     // Check if we need to evict before adding
     if (!this.cache.has(did) && this.cache.size >= this.maxEntries) {
-      await this.evictLRU();
+      this.evictLRU();
     }
 
     this.cache.set(did, entry);
@@ -171,7 +171,7 @@ export class DIDCache {
     };
 
     if (!this.cache.has(did) && this.cache.size >= this.maxEntries) {
-      await this.evictLRU();
+      this.evictLRU();
     }
 
     this.cache.set(did, entry);
@@ -272,15 +272,21 @@ export class DIDCache {
   }
 
   /**
-   * Evict the least recently used unpinned entry.
+   * Evict the least recently used unpinned entry from MEMORY ONLY.
+   *
+   * LRU eviction bounds the in-memory map; it must not delete from the
+   * persistent store. Deleting there meant every hydrating get() on a store
+   * larger than maxEntries permanently removed some other entry, so reads
+   * shrank the persistent cache and it could never usefully hold more than
+   * maxEntries (issue #313). Storage deletion is reserved for explicit
+   * invalidation paths (delete/clear) and TTL expiry.
    */
-  private async evictLRU(): Promise<void> {
+  private evictLRU(): void {
     for (const did of this.accessOrder) {
       const entry = this.cache.get(did);
       if (entry && !entry.pinned) {
         this.cache.delete(did);
         this.removeFromAccessOrder(did);
-        if (this.storage) await this.storage.delete(did);
         return;
       }
     }

--- a/packages/sdk/src/did/DIDManager.ts
+++ b/packages/sdk/src/did/DIDManager.ts
@@ -389,8 +389,49 @@ export class DIDManager {
     }); // end track did.migrateToDIDBTCO
   }
 
+  /**
+   * Cross-network did:btco guard (issue #267). The configured ordinalsProvider
+   * is pinned to one Bitcoin network, so a DID whose encoded network differs
+   * must be rejected — otherwise an attacker can inscribe "did:btco:reg:N"
+   * content on mainnet sat N and have it resolve as the regtest DID. This runs
+   * BEFORE the cache lookup: DIDCache supports a pluggable persistent storage
+   * adapter that may be shared between SDK instances on different networks (or
+   * populated via the bitcoinRpcUrl branch, which deliberately resolves any
+   * network), so a cached cross-network document must not bypass the guard
+   * (issue #312). It is a prefix parse of the DID string — no provider query.
+   */
+  private assertBtcoNetworkMatchesProvider(did: string): void {
+    if (!did.startsWith('did:btco:') || !this.config.ordinalsProvider) return;
+    const btcoNetworkPrefix = did.match(/^did:btco:(reg|sig|test):/)?.[1];
+    // 'test' (testnet) has no OrdinalsClient/config counterpart; preserve
+    // existing pass-through behavior for it.
+    //
+    // Only reject when the SDK's network is actually known. If neither
+    // `network` nor `webvhNetwork` is configured, the provider's chain is
+    // genuinely unknown, so defaulting to mainnet and rejecting a reg/sig DID
+    // would be a false positive — fall through and let the provider answer
+    // (its own resolution still validates the DID).
+    const providerNetwork = this.getConfiguredBitcoinNetwork();
+    if (btcoNetworkPrefix === 'test' || !providerNetwork) return;
+    const didNetwork: 'mainnet' | 'regtest' | 'signet' =
+      btcoNetworkPrefix === 'reg' ? 'regtest'
+      : btcoNetworkPrefix === 'sig' ? 'signet'
+      : 'mainnet';
+    if (didNetwork !== providerNetwork) {
+      throw new StructuredError(
+        'BTCO_NETWORK_MISMATCH',
+        `Cannot resolve ${did}: the DID targets the ${didNetwork} network but the configured ` +
+        `ordinalsProvider serves ${providerNetwork}. Configure an SDK instance for ${didNetwork} ` +
+        'to resolve this DID.'
+      );
+    }
+  }
+
   async resolveDID(did: string, options?: { skipCache?: boolean }): Promise<DIDDocument | null> {
     return this.track('did.resolveDID', async () => {
+      // Network guard must precede the cache read (issue #312).
+      this.assertBtcoNetworkMatchesProvider(did);
+
       // Check cache first (unless skipCache is set). The read is best-effort:
       // a throwing storage adapter must not crash resolution — treat it as a miss.
       if (!options?.skipCache) {
@@ -423,35 +464,9 @@ export class DIDManager {
           }
         } else if (did.startsWith('did:btco:')) {
           if (this.config.ordinalsProvider) {
-            // The configured ordinalsProvider is pinned to one Bitcoin
-            // network, so a DID whose encoded network differs must be
-            // rejected before querying (issue #267): otherwise an attacker
-            // can inscribe "did:btco:reg:N" content on mainnet sat N and have
-            // it resolve — and be cached — as the regtest DID.
-            const btcoNetworkPrefix = did.match(/^did:btco:(reg|sig|test):/)?.[1];
-            // 'test' (testnet) has no OrdinalsClient/config counterpart;
-            // preserve existing pass-through behavior for it.
+            // Cross-network guard already enforced pre-cache by
+            // assertBtcoNetworkMatchesProvider (issues #267/#312).
             //
-            // Only reject when the SDK's network is actually known. If neither
-            // `network` nor `webvhNetwork` is configured, the provider's chain
-            // is genuinely unknown, so defaulting to mainnet and rejecting a
-            // reg/sig DID would be a false positive — fall through and let the
-            // provider answer (its own resolution still validates the DID).
-            const providerNetwork = this.getConfiguredBitcoinNetwork();
-            if (btcoNetworkPrefix !== 'test' && providerNetwork) {
-              const didNetwork: 'mainnet' | 'regtest' | 'signet' =
-                btcoNetworkPrefix === 'reg' ? 'regtest'
-                : btcoNetworkPrefix === 'sig' ? 'signet'
-                : 'mainnet';
-              if (didNetwork !== providerNetwork) {
-                throw new StructuredError(
-                  'BTCO_NETWORK_MISMATCH',
-                  `Cannot resolve ${did}: the DID targets the ${didNetwork} network but the configured ` +
-                  `ordinalsProvider serves ${providerNetwork}. Configure an SDK instance for ${didNetwork} ` +
-                  'to resolve this DID.'
-                );
-              }
-            }
             // The configured ordinalsProvider is the source of truth for
             // Bitcoin state (it performed the inscriptions), so resolution
             // must go through it — not through a freshly constructed HTTP

--- a/packages/sdk/src/did/Ed25519Verifier.ts
+++ b/packages/sdk/src/did/Ed25519Verifier.ts
@@ -24,18 +24,18 @@ export class Ed25519Verifier implements ExternalVerifier {
    */
   async verify(signature: Uint8Array, message: Uint8Array, publicKey: Uint8Array): Promise<boolean> {
     try {
-      // Ed25519 public keys must be exactly 32 bytes
-      // Some keys may have a version byte prefix, so remove it if present
-      let ed25519PublicKey = publicKey;
-      if (publicKey.length === 33) {
-        ed25519PublicKey = publicKey.slice(1);
-      } else if (publicKey.length !== 32) {
+      // Ed25519 public keys must be exactly 32 bytes. A 33-byte input is NOT
+      // a "prefixed Ed25519 key": Ed25519 multicodec prefixes are 2 bytes
+      // (0xed 0x01 → 34 bytes), while 33 bytes is the shape of a compressed
+      // secp256k1 key. Stripping one byte verified against garbage — reject
+      // instead of guessing (issue #352).
+      if (publicKey.length !== 32) {
         console.error(`[Ed25519Verifier] Invalid public key length: ${publicKey.length} (expected 32 bytes)`);
         return false;
       }
-      
+
       // Correct parameter order: verifyAsync(signature, message, publicKey)
-      return await verifyAsync(signature, message, ed25519PublicKey);
+      return await verifyAsync(signature, message, publicKey);
     } catch (error) {
       console.error('[Ed25519Verifier] Verification error:', error);
       return false;
@@ -64,9 +64,12 @@ export class Ed25519Verifier implements ExternalVerifier {
     if (!this.publicKey) {
       return undefined;
     }
-    // A 33-byte key carries a version-byte prefix (see verify()).
-    const key = this.publicKey.length === 33 ? this.publicKey.slice(1) : this.publicKey;
-    return multikey.encodePublicKey(key, 'Ed25519');
+    // Silently slicing a "prefix" off a wrong-length key would mint a
+    // well-formed-looking but wrong multikey (see verify(), issue #352).
+    if (this.publicKey.length !== 32) {
+      throw new Error(`Invalid Ed25519 public key length: ${this.publicKey.length} (expected 32 bytes)`);
+    }
+    return multikey.encodePublicKey(this.publicKey, 'Ed25519');
   }
 }
 

--- a/packages/sdk/src/lifecycle/BatchLifecycleOperations.ts
+++ b/packages/sdk/src/lifecycle/BatchLifecycleOperations.ts
@@ -16,6 +16,7 @@ import {
   type BatchResult,
   type BatchOperationOptions,
   type BatchInscriptionOptions,
+  type BatchProgressSnapshot,
 } from './BatchOperations.js';
 
 /**
@@ -47,6 +48,26 @@ export class BatchLifecycleOperations {
   ) {
     this.batchExecutor = new BatchOperationExecutor();
     this.batchValidator = new BatchValidator();
+  }
+
+  /**
+   * Per-settled-item 'batch:progress' emitter. Declared in the public
+   * EventTypeMap and subscribed by EventLogger but previously never emitted
+   * anywhere (issue #352).
+   */
+  private emitBatchProgress(batchId: string, operation: string) {
+    return async ({ completed, failed, total }: BatchProgressSnapshot): Promise<void> => {
+      await this.eventEmitter.emit({
+        type: 'batch:progress',
+        timestamp: new Date().toISOString(),
+        batchId,
+        operation,
+        progress: total > 0 ? Math.round(((completed + failed) / total) * 100) : 100,
+        completed,
+        failed,
+        total
+      });
+    };
   }
 
   /**
@@ -86,7 +107,8 @@ export class BatchLifecycleOperations {
           return asset;
         },
         options,
-        batchId // Pass the pre-generated batchId for event correlation
+        batchId, // Pass the pre-generated batchId for event correlation
+        this.emitBatchProgress(batchId, 'create')
       );
 
       // Emit batch:completed event
@@ -147,7 +169,8 @@ export class BatchLifecycleOperations {
           return await this.core.publishToWeb(asset, domain);
         },
         options,
-        batchId // Pass the pre-generated batchId for event correlation
+        batchId, // Pass the pre-generated batchId for event correlation
+        this.emitBatchProgress(batchId, 'publish')
       );
 
       // Emit batch:completed event
@@ -241,7 +264,8 @@ export class BatchLifecycleOperations {
           return await this.core.inscribeOnBitcoin(asset, options?.feeRate);
         },
         options,
-        batchId // Pass the pre-generated batchId for event correlation
+        batchId, // Pass the pre-generated batchId for event correlation
+        this.emitBatchProgress(batchId, 'inscribe')
       );
 
       // Emit batch:completed event
@@ -318,7 +342,8 @@ export class BatchLifecycleOperations {
           return await this.core.transferOwnership(transfer.asset, transfer.to);
         },
         options,
-        batchId // Pass the pre-generated batchId for event correlation
+        batchId, // Pass the pre-generated batchId for event correlation
+        this.emitBatchProgress(batchId, 'transfer')
       );
 
       // Emit batch:completed event

--- a/packages/sdk/src/lifecycle/BatchOperations.ts
+++ b/packages/sdk/src/lifecycle/BatchOperations.ts
@@ -60,6 +60,16 @@ export interface BatchOperationOptions {
 }
 
 /**
+ * Progress snapshot reported after each batch item settles (succeeds or
+ * exhausts its retries). Used to emit 'batch:progress' events (issue #352).
+ */
+export interface BatchProgressSnapshot {
+  completed: number;
+  failed: number;
+  total: number;
+}
+
+/**
  * Options for batch inscription operations with Bitcoin-specific settings
  */
 export interface BatchInscriptionOptions extends BatchOperationOptions {
@@ -135,7 +145,8 @@ export class BatchOperationExecutor {
     items: T[],
     operation: (item: T, index: number) => Promise<R>,
     options?: BatchOperationOptions,
-    predeterminedBatchId?: string
+    predeterminedBatchId?: string,
+    onItemSettled?: (progress: BatchProgressSnapshot) => void | Promise<void>
   ): Promise<BatchResult<R>> {
     const opts = { ...this.defaultOptions, ...options };
     const {
@@ -152,6 +163,17 @@ export class BatchOperationExecutor {
     
     const successful: BatchResult<R>['successful'] = [];
     const failed: BatchResult<R>['failed'] = [];
+
+    // Report progress after each settled item; a throwing progress callback
+    // must never fail the batch itself.
+    const reportProgress = async (): Promise<void> => {
+      if (!onItemSettled) return;
+      try {
+        await onItemSettled({ completed: successful.length, failed: failed.length, total: items.length });
+      } catch {
+        // progress reporting is best-effort
+      }
+    };
 
     // Fail-fast abort flag: set as soon as any item exhausts its attempts in
     // fail-fast mode. Sibling operations already in flight cannot be
@@ -181,6 +203,7 @@ export class BatchOperationExecutor {
 
           const duration = Date.now() - itemStartTime;
           successful.push({ index, result, duration });
+          await reportProgress();
           return;
         } catch (error) {
           lastError = error instanceof Error ? error : new Error(String(error));
@@ -229,6 +252,7 @@ export class BatchOperationExecutor {
         duration,
         retryAttempts: attempts - 1
       });
+      await reportProgress();
 
       // If fail-fast mode, abort the batch and throw error
       if (!continueOnError) {

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -7,7 +7,7 @@ import {
   VerifiableCredential,
   LayerType
 } from '../types/index.js';
-import { BitcoinManager } from '../bitcoin/BitcoinManager.js';
+import { BitcoinManager, MAX_REASONABLE_FEE_RATE } from '../bitcoin/BitcoinManager.js';
 import { DIDManager } from '../did/DIDManager.js';
 import { CredentialManager } from '../vc/CredentialManager.js';
 import { OriginalsAsset } from './OriginalsAsset.js';
@@ -527,22 +527,22 @@ export class LifecycleManager {
     if (!effectiveFeeRate) {
       if (this.config.feeOracle) {
         try {
-          effectiveFeeRate = await this.config.feeOracle.estimateFeeRate(1);
+          effectiveFeeRate = this.capEstimatedFeeRate(await this.config.feeOracle.estimateFeeRate(1));
           confidence = 'high';
         } catch {
           // Fallback to default
         }
       }
-      
+
       if (!effectiveFeeRate && this.config.ordinalsProvider) {
         try {
-          effectiveFeeRate = await this.config.ordinalsProvider.estimateFee(1);
+          effectiveFeeRate = this.capEstimatedFeeRate(await this.config.ordinalsProvider.estimateFee(1));
           confidence = 'medium';
         } catch {
           // Fallback to default
         }
       }
-      
+
       if (!effectiveFeeRate) {
         effectiveFeeRate = 10;
         confidence = 'low';
@@ -621,6 +621,15 @@ export class LifecycleManager {
         // Migrate asset to did:webvh layer
         await asset.migrate('did:webvh');
         asset.bindings = { ...(asset.bindings || {}), 'did:peer': originalPeerDid, 'did:webvh': publisherDid };
+
+        // Mirror onto the manager emitter: asset.migrate emits only on the
+        // asset's private emitter, so sdk.lifecycle.on('asset:migrated', ...)
+        // subscriptions (and the built-in EventLogger) never fired (issue #346).
+        await this.eventEmitter.emit({
+          type: 'asset:migrated',
+          timestamp: new Date().toISOString(),
+          asset: { id: asset.id, fromLayer: 'did:peer', toLayer: 'did:webvh' }
+        });
       } catch (publishError) {
         if (atomicRollback) {
           await this.rollbackPartialPublish(asset, urlSnapshots, writtenObjects);
@@ -1181,13 +1190,24 @@ export class LifecycleManager {
     // Capture the layer before migration for accurate metrics
     const fromLayer = asset.currentLayer;
 
-    await asset.migrate('did:btco', {
+    const migrationDetails = {
       transactionId: revealTxId,
       inscriptionId: inscription.inscriptionId,
       satoshi: inscription.satoshi,
       commitTxId,
       revealTxId,
       feeRate: usedFeeRate
+    };
+    await asset.migrate('did:btco', migrationDetails);
+
+    // Mirror onto the manager emitter: asset.migrate emits only on the
+    // asset's private emitter, so sdk.lifecycle.on('asset:migrated', ...)
+    // subscriptions (and the built-in EventLogger) never fired (issue #346).
+    await this.eventEmitter.emit({
+      type: 'asset:migrated',
+      timestamp: new Date().toISOString(),
+      asset: { id: asset.id, fromLayer, toLayer: 'did:btco' },
+      details: migrationDetails
     });
 
     // The binding must be network-prefixed: a regtest/signet satoshi recorded
@@ -1320,7 +1340,19 @@ export class LifecycleManager {
       ? priorTransfers[priorTransfers.length - 1].to
       : asset.id;
     await asset.recordTransfer(currentOwner, newOwner, tx.txid);
-    
+
+    // Mirror onto the manager emitter: asset.recordTransfer emits only on the
+    // asset's private emitter, so sdk.lifecycle.on('asset:transferred', ...)
+    // subscriptions (and the built-in EventLogger) never fired (issue #346).
+    await this.eventEmitter.emit({
+      type: 'asset:transferred',
+      timestamp: new Date().toISOString(),
+      asset: { id: asset.id, layer: asset.currentLayer },
+      from: currentOwner,
+      to: newOwner,
+      transactionId: tx.txid
+    });
+
     stopTimer();
     this.logger.info('Asset ownership transferred successfully', { 
       assetId: asset.id, 
@@ -1719,6 +1751,27 @@ export class LifecycleManager {
   // ===== Cost Estimation =====
 
   /**
+   * Reject absurd estimator output on quote-only paths, mirroring
+   * BitcoinManager's MAX_REASONABLE_FEE_RATE cap on spend paths: a compromised
+   * fee oracle/provider must not be able to show users an arbitrary quote
+   * (issue #351). Returning undefined lets the caller fall through to the
+   * next fee source, matching BitcoinManager.resolveFeeRate's skip semantics.
+   */
+  private capEstimatedFeeRate(estimated: number): number | undefined {
+    if (typeof estimated !== 'number' || !Number.isFinite(estimated) || estimated <= 0) {
+      return undefined;
+    }
+    if (estimated > MAX_REASONABLE_FEE_RATE) {
+      this.logger.warn('Ignoring absurd estimated fee rate for cost quote', {
+        estimated,
+        max: MAX_REASONABLE_FEE_RATE
+      });
+      return undefined;
+    }
+    return estimated;
+  }
+
+  /**
    * Estimate the cost of migrating an asset to a target layer
    * 
    * Returns a detailed breakdown of expected costs for Bitcoin operations.
@@ -1779,17 +1832,17 @@ export class LifecycleManager {
         // Try to get from fee oracle
         if (this.config.feeOracle) {
           try {
-            effectiveFeeRate = await this.config.feeOracle.estimateFeeRate(1);
+            effectiveFeeRate = this.capEstimatedFeeRate(await this.config.feeOracle.estimateFeeRate(1));
             confidence = 'high';
           } catch {
             // Fallback to default
           }
         }
-        
+
         // Try ordinals provider
         if (!effectiveFeeRate && this.config.ordinalsProvider) {
           try {
-            effectiveFeeRate = await this.config.ordinalsProvider.estimateFee(1);
+            effectiveFeeRate = this.capEstimatedFeeRate(await this.config.ordinalsProvider.estimateFee(1));
             confidence = 'medium';
           } catch {
             // Fallback to default

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -628,7 +628,22 @@ export class LifecycleManager {
         await this.eventEmitter.emit({
           type: 'asset:migrated',
           timestamp: new Date().toISOString(),
+        // Capture the layer before migration (always 'did:peer' here due to
+        // the guard above, but captured dynamically for correctness).
+        const priorLayer = asset.currentLayer;
+
+        // Migrate asset to did:webvh layer
+        await asset.migrate('did:webvh');
+        asset.bindings = { ...(asset.bindings || {}), 'did:peer': originalPeerDid, 'did:webvh': publisherDid };
+
+        // Mirror onto the manager emitter: asset.migrate emits only on the
+        // asset's private emitter, so sdk.lifecycle.on('asset:migrated', ...)
+        // subscriptions (and the built-in EventLogger) never fired (issue #346).
+        await this.eventEmitter.emit({
+          type: 'asset:migrated',
+          timestamp: new Date().toISOString(),
           asset: { id: asset.id, fromLayer: priorLayer, toLayer: 'did:webvh' }
+        });
         });
       } catch (publishError) {
         if (atomicRollback) {

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -618,16 +618,6 @@ export class LifecycleManager {
         // Store the original did:peer ID before migration
         const originalPeerDid = asset.id;
 
-        // Migrate asset to did:webvh layer
-        await asset.migrate('did:webvh');
-        asset.bindings = { ...(asset.bindings || {}), 'did:peer': originalPeerDid, 'did:webvh': publisherDid };
-
-        // Mirror onto the manager emitter: asset.migrate emits only on the
-        // asset's private emitter, so sdk.lifecycle.on('asset:migrated', ...)
-        // subscriptions (and the built-in EventLogger) never fired (issue #346).
-        await this.eventEmitter.emit({
-          type: 'asset:migrated',
-          timestamp: new Date().toISOString(),
         // Capture the layer before migration (always 'did:peer' here due to
         // the guard above, but captured dynamically for correctness).
         const priorLayer = asset.currentLayer;
@@ -643,7 +633,6 @@ export class LifecycleManager {
           type: 'asset:migrated',
           timestamp: new Date().toISOString(),
           asset: { id: asset.id, fromLayer: priorLayer, toLayer: 'did:webvh' }
-        });
         });
       } catch (publishError) {
         if (atomicRollback) {

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -628,7 +628,7 @@ export class LifecycleManager {
         await this.eventEmitter.emit({
           type: 'asset:migrated',
           timestamp: new Date().toISOString(),
-          asset: { id: asset.id, fromLayer: 'did:peer', toLayer: 'did:webvh' }
+          asset: { id: asset.id, fromLayer: priorLayer, toLayer: 'did:webvh' }
         });
       } catch (publishError) {
         if (atomicRollback) {

--- a/packages/sdk/src/lifecycle/OriginalsAsset.ts
+++ b/packages/sdk/src/lifecycle/OriginalsAsset.ts
@@ -265,6 +265,23 @@ export class OriginalsAsset {
     credentialManager?: CredentialManager;
     fetch?: (url: string) => Promise<{ arrayBuffer: () => Promise<ArrayBuffer> }>;
   }): Promise<boolean> {
+    const result = await this.runVerificationChecks(deps);
+    // 'verification:completed' is part of the public EventTypeMap and is
+    // subscribed by EventLogger; it was declared but never emitted (issue #352).
+    await this.eventEmitter.emit({
+      type: 'verification:completed',
+      timestamp: new Date().toISOString(),
+      asset: { id: this.id },
+      result
+    });
+    return result;
+  }
+
+  private async runVerificationChecks(deps?: {
+    didManager?: DIDManager;
+    credentialManager?: CredentialManager;
+    fetch?: (url: string) => Promise<{ arrayBuffer: () => Promise<ArrayBuffer> }>;
+  }): Promise<boolean> {
     try {
       // 1) DID Document validation (structure + supported method via validateDID)
       if (!validateDIDDocument(this.did)) {
@@ -402,14 +419,15 @@ export class OriginalsAsset {
    */
   addResourceVersion(
     resourceId: string,
-    newContent: string | Buffer,
+    newContent: string,
     contentType: string,
     changes?: string
   ): AssetResource {
     // AssetResource.content is a string; a Buffer used to be silently dropped
     // (only its hash was stored), unrecoverably losing the binary content
-    // while the caller believed it was versioned (issue #276). Fail loudly
-    // instead.
+    // while the caller believed it was versioned (issue #276). The parameter
+    // is now declared `string` so TypeScript callers get a compile-time error
+    // (issue #311); the runtime guard stays for JS callers.
     if (typeof newContent !== 'string') {
       throw new StructuredError(
         'BINARY_CONTENT_UNSUPPORTED',

--- a/packages/sdk/src/types/network.ts
+++ b/packages/sdk/src/types/network.ts
@@ -97,13 +97,21 @@ export function getNetworkContextUrl(network: WebVHNetworkName): string {
 export function validateVersionForNetwork(version: string, network: WebVHNetworkName): boolean {
   const config = getNetworkConfig(network);
 
-  // Parse semver (basic parsing, assumes format X.Y.Z)
-  const match = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-.*)?$/);
+  // Parse semver (basic parsing, assumes format X.Y.Z with optional prerelease)
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)(-.*)?$/);
   if (!match) {
     throw new Error(`Invalid version format: ${version}. Expected semver format (e.g., 1.2.3)`);
   }
 
-  const [, , minor, patch] = match;
+  const [, , minor, patch, prerelease] = match;
+
+  // A prerelease (e.g. 2.0.0-rc.1) is NOT a release: it must not pass the
+  // pichu "major releases only" or cleffa "minor releases" gates just because
+  // its numeric part matches (issue #352). Only magby (all versions) accepts
+  // prereleases.
+  if (prerelease && config.stability !== 'patch') {
+    return false;
+  }
 
   switch (config.stability) {
     case 'major':

--- a/packages/sdk/src/utils/Logger.ts
+++ b/packages/sdk/src/utils/Logger.ts
@@ -91,6 +91,30 @@ function loadAppendFile(): Promise<AppendFileFn> {
 }
 
 /**
+ * All live FileLogOutput instances, flushed by ONE shared pair of process
+ * exit hooks. Per-instance listeners would accumulate on `process` (listener
+ * leak + MaxListenersExceeded warnings) for apps or test suites that create
+ * many file outputs.
+ */
+const fileOutputRegistry = new Set<FileLogOutput>();
+let exitHooksInstalled = false;
+function registerFileOutputForExitFlush(output: FileLogOutput): void {
+  fileOutputRegistry.add(output);
+  if (exitHooksInstalled) return;
+  const proc = (globalThis as { process?: { on?: (event: string, listener: () => void) => unknown } }).process;
+  if (!proc || typeof proc.on !== 'function') return;
+  exitHooksInstalled = true;
+  // beforeExit can run async work; 'exit' cannot, so it uses the sync fs
+  // module (loaded on first flush) as a last resort for hard exits.
+  proc.on('beforeExit', () => {
+    for (const out of fileOutputRegistry) void out.flushForExit();
+  });
+  proc.on('exit', () => {
+    for (const out of fileOutputRegistry) out.flushSyncForExit();
+  });
+}
+
+/**
  * File log output implementation (async)
  *
  * Node/Bun only: lazily loads `node:fs/promises` on first flush.
@@ -99,7 +123,6 @@ export class FileLogOutput implements LogOutput {
   private buffer: string[] = [];
   private flushTimeout: ReturnType<typeof setTimeout> | null = null;
   private readonly flushInterval = 1000; // Flush every 1 second
-  private exitHooksInstalled = false;
   // Bound on lines retained across failed writes so an unwritable file
   // cannot grow the buffer without limit.
   private static readonly MAX_BUFFERED_LINES = 10_000;
@@ -110,7 +133,11 @@ export class FileLogOutput implements LogOutput {
     // Format as JSON line
     const line = JSON.stringify(entry) + '\n';
     this.buffer.push(line);
-    this.installExitHooks();
+    // Flush trailing buffered lines at process exit: without this, up to
+    // flushInterval worth of the most recent (often most important) log
+    // lines was always lost on shutdown (issue #352). Browser/edge runtimes
+    // have no `process`, so this is a no-op there.
+    registerFileOutputForExitFlush(this);
 
     // Schedule flush
     if (!this.flushTimeout) {
@@ -120,24 +147,13 @@ export class FileLogOutput implements LogOutput {
     }
   }
 
-  /**
-   * Flush trailing buffered lines at process exit: without this, up to
-   * flushInterval worth of the most recent (often most important) log lines
-   * was always lost on shutdown (issue #352). Browser/edge runtimes have no
-   * `process`, so this is a no-op there.
-   */
-  private installExitHooks(): void {
-    if (this.exitHooksInstalled) return;
-    const proc = (globalThis as { process?: { on?: (event: string, listener: () => void) => unknown } }).process;
-    if (!proc || typeof proc.on !== 'function') return;
-    this.exitHooksInstalled = true;
-    // beforeExit can run async work; 'exit' cannot, so it uses the sync fs
-    // module (loaded on first flush) as a last resort for hard exits.
-    proc.on('beforeExit', () => { void this.flush(); });
-    proc.on('exit', () => { this.flushSync(); });
+  /** @internal Called by the shared 'beforeExit' hook. */
+  flushForExit(): Promise<void> {
+    return this.flush();
   }
 
-  private flushSync(): void {
+  /** @internal Called by the shared 'exit' hook, which cannot await. */
+  flushSyncForExit(): void {
     if (this.buffer.length === 0 || !fsSyncModule) return;
     try {
       fsSyncModule.appendFileSync(this.filePath, this.buffer.join(''), 'utf8');

--- a/packages/sdk/src/utils/Logger.ts
+++ b/packages/sdk/src/utils/Logger.ts
@@ -79,9 +79,13 @@ export class ConsoleLogOutput implements LogOutput {
  */
 type AppendFileFn = (typeof import('node:fs/promises'))['appendFile'];
 let appendFilePromise: Promise<AppendFileFn> | null = null;
+// Sync fs module, loaded together with the async one so the process 'exit'
+// hook (which cannot await) can flush any trailing buffered lines.
+let fsSyncModule: typeof import('node:fs') | null = null;
 function loadAppendFile(): Promise<AppendFileFn> {
   if (!appendFilePromise) {
     appendFilePromise = import('node:fs/promises').then((fs) => fs.appendFile);
+    void import('node:fs').then((fs) => { fsSyncModule = fs; }).catch(() => { /* sync exit flush unavailable */ });
   }
   return appendFilePromise;
 }
@@ -95,6 +99,10 @@ export class FileLogOutput implements LogOutput {
   private buffer: string[] = [];
   private flushTimeout: ReturnType<typeof setTimeout> | null = null;
   private readonly flushInterval = 1000; // Flush every 1 second
+  private exitHooksInstalled = false;
+  // Bound on lines retained across failed writes so an unwritable file
+  // cannot grow the buffer without limit.
+  private static readonly MAX_BUFFERED_LINES = 10_000;
 
   constructor(private filePath: string) {}
 
@@ -102,6 +110,7 @@ export class FileLogOutput implements LogOutput {
     // Format as JSON line
     const line = JSON.stringify(entry) + '\n';
     this.buffer.push(line);
+    this.installExitHooks();
 
     // Schedule flush
     if (!this.flushTimeout) {
@@ -110,24 +119,56 @@ export class FileLogOutput implements LogOutput {
       }, this.flushInterval);
     }
   }
-  
+
+  /**
+   * Flush trailing buffered lines at process exit: without this, up to
+   * flushInterval worth of the most recent (often most important) log lines
+   * was always lost on shutdown (issue #352). Browser/edge runtimes have no
+   * `process`, so this is a no-op there.
+   */
+  private installExitHooks(): void {
+    if (this.exitHooksInstalled) return;
+    const proc = (globalThis as { process?: { on?: (event: string, listener: () => void) => unknown } }).process;
+    if (!proc || typeof proc.on !== 'function') return;
+    this.exitHooksInstalled = true;
+    // beforeExit can run async work; 'exit' cannot, so it uses the sync fs
+    // module (loaded on first flush) as a last resort for hard exits.
+    proc.on('beforeExit', () => { void this.flush(); });
+    proc.on('exit', () => { this.flushSync(); });
+  }
+
+  private flushSync(): void {
+    if (this.buffer.length === 0 || !fsSyncModule) return;
+    try {
+      fsSyncModule.appendFileSync(this.filePath, this.buffer.join(''), 'utf8');
+      this.buffer = [];
+    } catch {
+      // best effort — the process is exiting
+    }
+  }
+
   private async flush(): Promise<void> {
     if (this.buffer.length === 0) {
       return;
     }
-    
-    const lines = this.buffer.join('');
+
+    // Snapshot and clear; on write failure the snapshot is restored so the
+    // batch is retried on the next flush instead of silently dropped
+    // (issue #352). Writes that arrive while the append is in flight land in
+    // the fresh buffer and schedule their own flush.
+    const lines = this.buffer;
     this.buffer = [];
     this.flushTimeout = null;
-    
+
     try {
       // Append via node:fs/promises so file logging works under both Node and Bun.
       // appendFile creates the file if it does not exist and avoids the
       // read-whole-file-then-rewrite pattern. The module is imported lazily
       // (memoized) so non-Node bundles never evaluate it.
       const appendFile = await loadAppendFile();
-      await appendFile(this.filePath, lines, 'utf8');
+      await appendFile(this.filePath, lines.join(''), 'utf8');
     } catch (err) {
+      this.buffer = lines.concat(this.buffer).slice(-FileLogOutput.MAX_BUFFERED_LINES);
       // Fallback to console on file write error
       console.error('Failed to write log file:', err);
     }
@@ -257,8 +298,20 @@ export class Logger {
       return;
     }
     
-    // Sanitize data if needed
-    const sanitizedData = this.sanitizeLogs ? this.sanitize(data) : data;
+    // Sanitize data if needed. Sanitization must never crash the calling SDK
+    // operation: a pathological payload (e.g. exotic exotic proxies/getters)
+    // degrades to a placeholder instead of throwing out of the log call
+    // (issue #349).
+    let sanitizedData: unknown;
+    if (this.sanitizeLogs) {
+      try {
+        sanitizedData = this.sanitize(data, new WeakSet());
+      } catch {
+        sanitizedData = '[unsanitizable]';
+      }
+    } else {
+      sanitizedData = data;
+    }
     
     // Create log entry
     const entry: LogEntry = {
@@ -293,46 +346,72 @@ export class Logger {
   }
   
   /**
-   * Sanitize sensitive data from logs
+   * Sanitize sensitive data from logs.
+   *
+   * Cycle-safe: circular references (common in HTTP client errors carrying
+   * request/response cycles) are replaced with '[Circular]' instead of
+   * recursing until the stack overflows (issue #349).
    */
-  private sanitize(data: unknown): unknown {
+  private sanitize(data: unknown, seen: WeakSet<object>): unknown {
     if (!data) {
       return data;
     }
 
-    // Handle arrays
-    if (Array.isArray(data)) {
-      return data.map(item => this.sanitize(item));
+    // Cycle guard for anything object-shaped (arrays included). `seen` tracks
+    // the CURRENT traversal path (entries are removed on the way back up), so
+    // only true cycles — not shared references — collapse to '[Circular]'.
+    if (typeof data === 'object') {
+      if (seen.has(data)) {
+        return '[Circular]';
+      }
+      seen.add(data);
     }
 
-    // Handle objects
-    if (typeof data === 'object') {
-      const sanitized: Record<string, unknown> = {};
-      
-      for (const [key, value] of Object.entries(data)) {
-        const lowerKey = key.toLowerCase();
-        
-        // Sanitize sensitive keys
-        if (
-          lowerKey.includes('private') ||
-          lowerKey.includes('key') ||
-          lowerKey.includes('secret') ||
-          lowerKey.includes('password') ||
-          lowerKey.includes('token') ||
-          lowerKey.includes('credential')
-        ) {
-          sanitized[key] = '[REDACTED]';
-        } else {
-          // Recursively sanitize nested objects
-          sanitized[key] = this.sanitize(value);
-        }
+    try {
+      // Handle arrays
+      if (Array.isArray(data)) {
+        return data.map(item => this.sanitize(item, seen));
       }
-      
-      return sanitized;
+
+      // Handle objects
+      if (typeof data === 'object') {
+        // Dates and byte arrays carry no key names to redact; flattening them
+        // through Object.entries would reduce them to '{}' / index maps.
+        if (data instanceof Date || data instanceof Uint8Array) {
+          return data;
+        }
+
+        const sanitized: Record<string, unknown> = {};
+
+        for (const [key, value] of Object.entries(data)) {
+          const lowerKey = key.toLowerCase();
+
+          // Sanitize sensitive keys
+          if (
+            lowerKey.includes('private') ||
+            lowerKey.includes('key') ||
+            lowerKey.includes('secret') ||
+            lowerKey.includes('password') ||
+            lowerKey.includes('token') ||
+            lowerKey.includes('credential')
+          ) {
+            sanitized[key] = '[REDACTED]';
+          } else {
+            // Recursively sanitize nested objects
+            sanitized[key] = this.sanitize(value, seen);
+          }
+        }
+
+        return sanitized;
+      }
+
+      // Return primitive values as-is
+      return data;
+    } finally {
+      if (typeof data === 'object' && data !== null) {
+        seen.delete(data);
+      }
     }
-    
-    // Return primitive values as-is
-    return data;
   }
 }
 

--- a/packages/sdk/src/vc/CredentialManager.ts
+++ b/packages/sdk/src/vc/CredentialManager.ts
@@ -21,9 +21,10 @@ import { bytesToHex } from '@noble/hashes/utils.js';
 import { signerForKeyType } from '../crypto/Signer.js';
 import { multikey } from '../crypto/Multikey.js';
 import { DIDManager } from '../did/DIDManager.js';
-import { Issuer, VerificationMethodLike } from './Issuer.js';
+import { Issuer, VerificationMethodLike, isSecuritySigningRefusal } from './Issuer.js';
 import { createDocumentLoader } from './documentLoader.js';
 import { Verifier, checkCredentialValidityPeriod } from './Verifier.js';
+import { validateStatusListCredentialTrust } from './statusListTrust.js';
 import { MultiSigManager } from './MultiSigManager.js';
 import type { MetricsCollector } from '../utils/MetricsCollector.js';
 
@@ -242,18 +243,17 @@ export class CredentialManager {
         // SECURITY refusals must fail closed — never fall through to the
         // legacy local signer, which would sign the credential the Data
         // Integrity path just refused. Two conditions are security refusals:
-        //   1. issuer-binding mismatch — a key for did:me minting a
-        //      credential that claims issuer did:victim;
-        //   2. a retired (revoked/compromised) verification method.
-        // Every OTHER error (the loader can't resolve this VM, the key is not
-        // Ed25519, the VM doc is incomplete) is a legitimate reason to fall
-        // back to the legacy signer, which supports ES256K/ES256 did:key
-        // signing that eddsa-rdfc-2022 cannot.
-        const msg = e instanceof Error ? e.message : String(e);
-        const isSecurityRefusal =
-          msg.includes('does not match the verification method controller') ||
-          /retired|revoked|compromised/i.test(msg);
-        if (isSecurityRefusal) {
+        //   1. issuer-binding mismatch (ISSUER_BINDING_MISMATCH) — a key for
+        //      did:me minting a credential that claims issuer did:victim;
+        //   2. a retired (revoked/compromised) verification method (VM_RETIRED).
+        // Both are matched by typed StructuredError code (with the legacy
+        // message patterns as fallback), so rewording an error message cannot
+        // silently reopen the fall-through (issue #309). Every OTHER error
+        // (the loader can't resolve this VM, the key is not Ed25519, the VM
+        // doc is incomplete) is a legitimate reason to fall back to the
+        // legacy signer, which supports ES256K/ES256 did:key signing that
+        // eddsa-rdfc-2022 cannot.
+        if (isSecuritySigningRefusal(e)) {
           throw e;
         }
         // fall through to legacy signing
@@ -401,6 +401,10 @@ export class CredentialManager {
    * If the credential has a `credentialStatus` of type `BitstringStatusListEntry`,
    * the status is checked against the provided status list credential.
    *
+   * A revoked or suspended credential is NOT verified: `verified` is false
+   * whenever `revoked` or `suspended` is true (issue #345), so callers gating
+   * on `verified` alone cannot accept a revoked credential.
+   *
    * @param credential - The credential to verify
    * @param statusListCredential - The resolved status list credential (required if credential has credentialStatus)
    * @returns Result with signature validity and revocation status
@@ -444,34 +448,33 @@ export class CredentialManager {
         errors.push('Credential has a BitstringStatusListEntry but no status list credential was provided');
       } else {
         try {
-          // Trust checks (issue #238): the supplied status list credential
-          // must be the referenced one, must carry a valid proof, and must be
-          // issued by the checked credential's issuer — otherwise a holder
-          // can hand the verifier a fabricated all-zeros list and bypass
-          // revocation.
-          if (!statusListCredential.id || statusListCredential.id !== status.statusListCredential) {
-            throw new Error(
-              `Status list credential id (${String(statusListCredential.id)}) does not match the ` +
-              `credential's statusListCredential reference (${status.statusListCredential})`
-            );
-          }
-          const listProofValid = await this.verifyCredential(statusListCredential);
-          if (!listProofValid) {
-            throw new Error('Status list credential proof verification failed');
-          }
-          const issuerOf = (c: VerifiableCredential): string | undefined =>
-            typeof c.issuer === 'string' ? c.issuer : (c.issuer as { id?: string } | undefined)?.id;
-          const credentialIssuer = issuerOf(credential);
-          const listIssuer = issuerOf(statusListCredential);
-          if (!credentialIssuer || !listIssuer || credentialIssuer !== listIssuer) {
-            throw new Error(
-              `Status list credential issuer (${String(listIssuer)}) does not match the ` +
-              `checked credential's issuer (${String(credentialIssuer)})`
-            );
+          // Trust checks (issue #238, shared with Verifier via
+          // validateStatusListCredentialTrust — issue #301): the supplied
+          // status list credential must be the referenced one, must carry a
+          // valid proof, and must be issued by the checked credential's
+          // issuer — otherwise a holder can hand the verifier a fabricated
+          // all-zeros list and bypass revocation.
+          const trust = await validateStatusListCredentialTrust(
+            credential,
+            status,
+            statusListCredential,
+            async (listVC) => {
+              const ok = await this.verifyCredential(listVC);
+              return { verified: ok, errors: [] };
+            }
+          );
+          if (!trust.verified) {
+            throw new Error(trust.errors.join('; '));
           }
 
           const result = this.statusList.checkStatus(status, statusListCredential);
           if (result.isSet) {
+            // A determinate revoked/suspended state must fail verification:
+            // a caller gating on `verified` alone would otherwise accept a
+            // revoked credential (issue #345). This aligns with
+            // Verifier.checkCredentialStatus, which returns verified: false
+            // for the same state.
+            verified = false;
             if (result.statusPurpose === 'revocation') {
               revoked = true;
               errors.push('Credential has been revoked');
@@ -483,8 +486,7 @@ export class CredentialManager {
         } catch (err) {
           // Fail closed: a status entry that cannot be evaluated (purpose
           // mismatch, out-of-range index, corrupt encodedList) must not be
-          // treated as "not revoked". Determinable states (revoked/suspended)
-          // are reported via their own flags and leave `verified` untouched.
+          // treated as "not revoked".
           verified = false;
           errors.push(`Status check error: ${err instanceof Error ? err.message : String(err)}`);
         }
@@ -1327,6 +1329,17 @@ export class CredentialManager {
   /**
    * Check the revocation or suspension status of a credential.
    *
+   * SECURITY: this is a LOW-LEVEL bitstring lookup that TRUSTS THE CALLER to
+   * have established the supplied status list credential is authentic — it
+   * does NOT verify the list's proof or its issuer (issue #345). The only
+   * trust check performed here is that the list's `id` matches the
+   * credential's `statusListCredential` reference (a mismatched list is
+   * always a caller bug or a substitution attack, so it throws). An attacker
+   * who can substitute a fabricated same-id list can still fake "not
+   * revoked" through this method: for untrusted inputs use
+   * `verifyCredentialWithStatus`, which verifies the list's proof and
+   * issuer before consulting its bits.
+   *
    * @param credential - The credential to check (must have credentialStatus)
    * @param statusListCredential - The resolved status list credential
    * @returns Status check result with isSet, statusPurpose, and statusListIndex
@@ -1336,6 +1349,12 @@ export class CredentialManager {
     statusListCredential: VerifiableCredential
   ): StatusCheckResult {
     const entry = this.extractStatusEntry(credential);
+    if (!statusListCredential.id || statusListCredential.id !== entry.statusListCredential) {
+      throw new Error(
+        `Status list credential id (${String(statusListCredential.id)}) does not match the ` +
+        `credential's statusListCredential reference (${entry.statusListCredential})`
+      );
+    }
     const manager = new StatusListManager();
     return manager.checkStatus(entry, statusListCredential);
   }
@@ -1345,6 +1364,10 @@ export class CredentialManager {
    *
    * Convenience method that returns a simple boolean. The credential must have
    * a credentialStatus with statusPurpose 'revocation'.
+   *
+   * SECURITY: like `checkRevocationStatus`, this trusts the caller-supplied
+   * status list (no proof/issuer verification beyond the id match). Use
+   * `verifyCredentialWithStatus` for untrusted inputs.
    *
    * @param credential - The credential to check
    * @param statusListCredential - The resolved status list credential

--- a/packages/sdk/src/vc/Issuer.ts
+++ b/packages/sdk/src/vc/Issuer.ts
@@ -3,6 +3,31 @@ import { multikey, MultikeyType } from '../crypto/Multikey.js';
 import { DIDManager } from '../did/DIDManager.js';
 import { createDocumentLoader } from './documentLoader.js';
 import { DataIntegrityProofManager } from './proofs/data-integrity.js';
+import { StructuredError } from '../utils/telemetry.js';
+
+/**
+ * True when the error is a SECURITY refusal that must fail closed (never fall
+ * back to a more permissive signing path): an issuer-binding mismatch or a
+ * retired (revoked/compromised) verification method. Matched by typed
+ * StructuredError code, with the legacy message patterns kept as a
+ * defense-in-depth fallback for errors raised outside this SDK (issue #309).
+ */
+export function isSecuritySigningRefusal(e: unknown): boolean {
+  if (e instanceof StructuredError && (e.code === 'ISSUER_BINDING_MISMATCH' || e.code === 'VM_RETIRED')) {
+    return true;
+  }
+  const msg = e instanceof Error ? e.message : String(e);
+  return (
+    msg.includes('does not match the verification method controller') ||
+    /retired|revoked|compromised/i.test(msg)
+  );
+}
+
+/** True when the error marks a retired (revoked/compromised) verification method. */
+function isRetiredVmError(e: unknown): boolean {
+  if (e instanceof StructuredError && e.code === 'VM_RETIRED') return true;
+  return e instanceof Error && /retired/i.test(e.message);
+}
 
 export interface IssueOptions {
   proofPurpose: 'assertionMethod' | 'authentication';
@@ -70,7 +95,7 @@ export class Issuer {
     try {
       await documentLoader(this.verificationMethod.id);
     } catch (e) {
-      if (e instanceof Error && /retired/i.test(e.message)) throw e;
+      if (isRetiredVmError(e)) throw e;
       // otherwise proceed with the self-provided verification method
     }
 
@@ -81,7 +106,10 @@ export class Issuer {
     // Fail closed: refuse to sign when the stated issuer doesn't own the key.
     const keyController = this.verificationMethod.controller || this.verificationMethod.id.split('#')[0];
     if (issuerId && issuerId !== keyController) {
-      throw new Error(
+      // Typed ISSUER_BINDING_MISMATCH code: CredentialManager.signCredential
+      // fails closed on this error by CODE, not by message wording (issue #309).
+      throw new StructuredError(
+        'ISSUER_BINDING_MISMATCH',
         `Issuer DID (${issuerId}) does not match the verification method controller (${keyController})`
       );
     }
@@ -122,7 +150,7 @@ export class Issuer {
     try {
       await documentLoader(this.verificationMethod.id);
     } catch (e) {
-      if (e instanceof Error && /retired/i.test(e.message)) throw e;
+      if (isRetiredVmError(e)) throw e;
       // otherwise proceed with the self-provided verification method
     }
 

--- a/packages/sdk/src/vc/Verifier.ts
+++ b/packages/sdk/src/vc/Verifier.ts
@@ -5,6 +5,7 @@ import { createDocumentLoader } from './documentLoader.js';
 import { DataIntegrityProofManager } from './proofs/data-integrity.js';
 import type { DataIntegrityProof } from './cryptosuites/eddsa.js';
 import { StatusListManager } from './StatusListManager.js';
+import { validateStatusListCredentialTrust } from './statusListTrust.js';
 
 export type VerificationResult = { verified: boolean; errors: string[] };
 
@@ -308,56 +309,20 @@ export class Verifier {
   }
 
   /**
-   * Trust checks for a resolved status list credential (issue #238):
-   * 1. its `id` must equal the entry's `statusListCredential` URL (any list
-   *    with a matching statusPurpose would otherwise be accepted),
-   * 2. its own proof must verify (an entirely unsigned list must not decide
-   *    revocation),
-   * 3. its issuer must equal the issuer of the credential being checked —
-   *    revocation authority lies with the credential's issuer.
+   * Trust checks for a resolved status list credential (issue #238), shared
+   * with CredentialManager.verifyCredentialWithStatus via
+   * validateStatusListCredentialTrust (issue #301). The list's own proof is
+   * verified with checkStatus: false because the list's own status (if any)
+   * is out of scope here and would recurse.
    */
   private async validateStatusListCredential(
     vc: VerifiableCredential,
     entry: BitstringStatusListEntry,
     statusListVC: VerifiableCredential
   ): Promise<VerificationResult> {
-    if (!statusListVC.id || statusListVC.id !== entry.statusListCredential) {
-      return {
-        verified: false,
-        errors: [
-          `Status list credential id (${String(statusListVC.id)}) does not match the credential's ` +
-          `statusListCredential reference (${entry.statusListCredential})`
-        ]
-      };
-    }
-
-    const issuerOf = (c: VerifiableCredential): string | undefined =>
-      typeof c.issuer === 'string' ? c.issuer : (c.issuer as { id?: string } | undefined)?.id;
-
-    // Verify the status list credential's own proof. Status lists must carry
-    // a Data Integrity (eddsa-rdfc-2022) proof — the only proof format this
-    // SDK supports. checkStatus: false because the list's own status (if any)
-    // is out of scope here and would recurse.
-    const proofResult = await this.verifyCredential(statusListVC, { checkStatus: false });
-    if (!proofResult.verified) {
-      return {
-        verified: false,
-        errors: ['Status list credential proof verification failed', ...proofResult.errors]
-      };
-    }
-    const credentialIssuer = issuerOf(vc);
-    const listIssuer = issuerOf(statusListVC);
-    if (!credentialIssuer || !listIssuer || credentialIssuer !== listIssuer) {
-      return {
-        verified: false,
-        errors: [
-          `Status list credential issuer (${String(listIssuer)}) does not match the ` +
-          `checked credential's issuer (${String(credentialIssuer)})`
-        ]
-      };
-    }
-
-    return { verified: true, errors: [] };
+    return validateStatusListCredentialTrust(vc, entry, statusListVC, (listVC) =>
+      this.verifyCredential(listVC, { checkStatus: false })
+    );
   }
 
   /**
@@ -463,6 +428,38 @@ export class Verifier {
         result.errors.push(
           `Threshold not met: ${result.validSignatures}/${policy.required} valid signatures`
         );
+      }
+
+      // Enforce the credential's validity window. A valid m-of-n proof set
+      // over an expired (or not-yet-valid) credential must not verify — the
+      // single-sig path and MultiSigManager.verifyMultiSig both enforce this
+      // window; skipping it here let multi-sig credentials verified through
+      // the Verifier bypass expiration entirely (issue #340).
+      const validity = checkCredentialValidityPeriod(vc);
+      if (!validity.verified) {
+        result.verified = false;
+        result.errors.push(...validity.errors);
+      }
+
+      // Enforce revocation. When this verifier has a status list resolver,
+      // check the declared status like the single-sig path does; without one,
+      // fail closed on a declared BitstringStatusListEntry rather than
+      // silently accepting a possibly-revoked credential (issue #340).
+      const statusType = (vc.credentialStatus as BitstringStatusListEntry | undefined)?.type;
+      if (statusType === 'BitstringStatusListEntry') {
+        if (this.statusListResolver) {
+          const statusResult = await this.checkCredentialStatus(vc);
+          if (!statusResult.verified) {
+            result.verified = false;
+            result.errors.push(...statusResult.errors);
+          }
+        } else {
+          result.verified = false;
+          result.errors.push(
+            'Credential declares credentialStatus but no statusListResolver is configured. ' +
+            'Provide a statusListResolver to check revocation for multi-sig credentials.'
+          );
+        }
       }
 
       // Check timelock

--- a/packages/sdk/src/vc/documentLoader.ts
+++ b/packages/sdk/src/vc/documentLoader.ts
@@ -1,6 +1,7 @@
 import { DIDManager } from '../did/DIDManager.js';
 import { PRELOADED_CONTEXTS } from '../utils/serialization.js';
 import { multikey } from '../crypto/Multikey.js';
+import { StructuredError } from '../utils/telemetry.js';
 
 type LoadedDocument = { document: unknown; documentUrl: string; contextUrl: string | null };
 
@@ -52,7 +53,9 @@ export class DocumentLoader {
         const cached = verificationMethodRegistry.get(didUrl);
         if (cached && ((cached as { revoked?: string; compromised?: string }).revoked ||
                        (cached as { revoked?: string; compromised?: string }).compromised)) {
-          throw new Error(`Verification method is retired (revoked or compromised): ${didUrl}`);
+          // Typed VM_RETIRED code: signing paths fail closed on this error by
+          // CODE, not by message wording (issue #309).
+          throw new StructuredError('VM_RETIRED', `Verification method is retired (revoked or compromised): ${didUrl}`);
         }
       }
       if (fragment && did.startsWith('did:key:')) {
@@ -104,7 +107,9 @@ export class DocumentLoader {
     // the DID document precisely so verifiers can recognise it as retired.
     const assertNotRetired = (vm: { revoked?: string; compromised?: string }): void => {
       if (vm.revoked || vm.compromised) {
-        throw new Error(`Verification method is retired (revoked or compromised): ${didUrl}`);
+        // Typed VM_RETIRED code: signing paths fail closed on this error by
+        // CODE, not by message wording (issue #309).
+        throw new StructuredError('VM_RETIRED', `Verification method is retired (revoked or compromised): ${didUrl}`);
       }
     };
 

--- a/packages/sdk/src/vc/statusListTrust.ts
+++ b/packages/sdk/src/vc/statusListTrust.ts
@@ -1,0 +1,63 @@
+import type { VerifiableCredential, BitstringStatusListEntry } from '../types/index.js';
+
+/** Extract the issuer DID from a credential's string-or-object issuer field. */
+export function issuerOf(c: VerifiableCredential): string | undefined {
+  return typeof c.issuer === 'string' ? c.issuer : (c.issuer as { id?: string } | undefined)?.id;
+}
+
+export type StatusListTrustResult = { verified: boolean; errors: string[] };
+
+/**
+ * Trust checks for a resolved status list credential (issue #238), shared by
+ * every status-checking path (Verifier.checkCredentialStatus and
+ * CredentialManager.verifyCredentialWithStatus) so the checks cannot drift
+ * between entry points (issue #301):
+ *
+ * 1. the list's `id` must equal the entry's `statusListCredential` URL (any
+ *    list with a matching statusPurpose would otherwise be accepted),
+ * 2. the list's own proof must verify (an entirely unsigned list must not
+ *    decide revocation) — proof verification is delegated to the caller via
+ *    `verifyListProof` since each entry point verifies with its own machinery,
+ * 3. the list's issuer must equal the issuer of the credential being checked —
+ *    revocation authority lies with the credential's issuer. (Deliberately
+ *    stricter than the W3C Bitstring Status List spec, which permits delegated
+ *    status services.)
+ */
+export async function validateStatusListCredentialTrust(
+  vc: VerifiableCredential,
+  entry: BitstringStatusListEntry,
+  statusListVC: VerifiableCredential,
+  verifyListProof: (listVC: VerifiableCredential) => Promise<StatusListTrustResult>
+): Promise<StatusListTrustResult> {
+  if (!statusListVC.id || statusListVC.id !== entry.statusListCredential) {
+    return {
+      verified: false,
+      errors: [
+        `Status list credential id (${String(statusListVC.id)}) does not match the credential's ` +
+        `statusListCredential reference (${entry.statusListCredential})`
+      ]
+    };
+  }
+
+  const proofResult = await verifyListProof(statusListVC);
+  if (!proofResult.verified) {
+    return {
+      verified: false,
+      errors: ['Status list credential proof verification failed', ...proofResult.errors]
+    };
+  }
+
+  const credentialIssuer = issuerOf(vc);
+  const listIssuer = issuerOf(statusListVC);
+  if (!credentialIssuer || !listIssuer || credentialIssuer !== listIssuer) {
+    return {
+      verified: false,
+      errors: [
+        `Status list credential issuer (${String(listIssuer)}) does not match the ` +
+        `checked credential's issuer (${String(credentialIssuer)})`
+      ]
+    };
+  }
+
+  return { verified: true, errors: [] };
+}

--- a/packages/sdk/tests/integration/bitcoin-signet.integration.test.ts
+++ b/packages/sdk/tests/integration/bitcoin-signet.integration.test.ts
@@ -229,17 +229,11 @@ describeSignet('SignetProvider against signet', () => {
     expect(Array.isArray(results)).toBe(true);
   });
 
-  test('estimateFee returns a positive number', async () => {
-    const fee = await provider.estimateFee(1);
-    expect(typeof fee).toBe('number');
-    expect(fee).toBeGreaterThan(0);
-  });
-
-  test('estimateFee uses Bitcoin Core RPC when configured', async () => {
+  test('estimateFee uses Bitcoin Core RPC when configured, throws without it (#351)', async () => {
     if (!BITCOIN_SIGNET_RPC_URL) {
-      // Without RPC, falls back to default
-      const fee = await provider.estimateFee(6);
-      expect(fee).toBeGreaterThan(0);
+      // Without RPC there is no real fee source; fabricating a rate is
+      // forbidden (issue #351), so the provider must fail loudly.
+      await expect(provider.estimateFee(6)).rejects.toThrow(/bitcoinRpcUrl/);
       return;
     }
     // With RPC, should get a real fee estimate

--- a/packages/sdk/tests/security/issue-batch-340-345-309-312-regressions.test.ts
+++ b/packages/sdk/tests/security/issue-batch-340-345-309-312-regressions.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Security regressions for the 2026-07 issue batch:
+ *
+ * - #340: Verifier.verifyCredentialMultiSig bypassed validity-period and
+ *   revocation checks — expired/revoked multi-sig credentials verified valid.
+ * - #345: CredentialManager.checkRevocationStatus/isRevoked consulted an
+ *   attacker-suppliable status list with no id binding at all.
+ * - #309: signCredential's fail-closed refusal depended on error-message
+ *   string matching; it now keys on typed StructuredError codes.
+ * - #312: the BTCO_NETWORK_MISMATCH guard ran after the cache lookup, so a
+ *   shared persistent DID cache could serve cross-network documents.
+ * - #351: quote-only fee estimation bypassed the MAX_REASONABLE_FEE_RATE cap,
+ *   letting a compromised estimator show users absurd quotes.
+ */
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+import * as ed25519 from '@noble/ed25519';
+import { Verifier } from '../../src/vc/Verifier';
+import { Issuer, isSecuritySigningRefusal } from '../../src/vc/Issuer';
+import { multikey } from '../../src/crypto/Multikey';
+import { registerVerificationMethod } from '../../src/vc/documentLoader';
+import { DIDManager } from '../../src/did/DIDManager';
+import { OriginalsSDK } from '../../src';
+import { StructuredError } from '../../src/utils/telemetry';
+import { MockOrdinalsProvider } from '../mocks/adapters';
+import { MemoryStorageAdapter } from '../../src/storage/MemoryStorageAdapter';
+import type { MultiSigPolicy, VerifiableCredential } from '../../src/types';
+
+const did = 'did:peer:batch-issuer';
+const sk = new Uint8Array(32).map((_, i) => (i + 11) & 0xff);
+const pk = ed25519.getPublicKey(sk);
+const vm = {
+  id: `${did}#keys-1`,
+  controller: did,
+  type: 'Multikey',
+  publicKeyMultibase: multikey.encodePublicKey(pk, 'Ed25519'),
+  secretKeyMultibase: multikey.encodePrivateKey(sk, 'Ed25519')
+};
+
+const didManager = new DIDManager({} as never);
+
+beforeEach(() => {
+  registerVerificationMethod(vm);
+});
+
+async function issueSigned(extra: Record<string, unknown> = {}): Promise<VerifiableCredential> {
+  const issuer = new Issuer(didManager, vm);
+  return issuer.issueCredential(
+    {
+      type: ['VerifiableCredential', 'Test'],
+      issuer: did,
+      issuanceDate: new Date().toISOString(),
+      credentialSubject: { id: 'did:peer:subject1' },
+      ...extra
+    } as never,
+    { proofPurpose: 'assertionMethod' }
+  );
+}
+
+function policyFor(vc: VerifiableCredential): MultiSigPolicy {
+  const proof = Array.isArray(vc.proof) ? vc.proof[0] : vc.proof;
+  return {
+    required: 1,
+    total: 1,
+    signerVerificationMethods: [(proof as { verificationMethod: string }).verificationMethod]
+  } as MultiSigPolicy;
+}
+
+describe('#340 — Verifier.verifyCredentialMultiSig enforces validity and revocation', () => {
+  test('an expired credential with a valid m-of-n proof set does NOT verify', async () => {
+    const vc = await issueSigned({ expirationDate: new Date(Date.now() - 60_000).toISOString() });
+    const verifier = new Verifier(didManager);
+    const result = await verifier.verifyCredentialMultiSig(vc, policyFor(vc));
+    expect(result.validSignatures).toBe(1); // the signature itself is genuine
+    expect(result.verified).toBe(false);
+    expect(result.errors.some(e => /expired/i.test(e))).toBe(true);
+  });
+
+  test('a not-yet-valid credential does NOT verify', async () => {
+    const vc = await issueSigned({ validFrom: new Date(Date.now() + 3_600_000).toISOString() });
+    const verifier = new Verifier(didManager);
+    const result = await verifier.verifyCredentialMultiSig(vc, policyFor(vc));
+    expect(result.verified).toBe(false);
+    expect(result.errors.some(e => /not yet valid/i.test(e))).toBe(true);
+  });
+
+  test('a declared BitstringStatusListEntry fails closed without a statusListResolver', async () => {
+    const vc = await issueSigned({
+      credentialStatus: {
+        id: 'https://example.com/status/1#0',
+        type: 'BitstringStatusListEntry',
+        statusPurpose: 'revocation',
+        statusListIndex: '0',
+        statusListCredential: 'https://example.com/status/1'
+      }
+    });
+    const verifier = new Verifier(didManager);
+    const result = await verifier.verifyCredentialMultiSig(vc, policyFor(vc));
+    expect(result.verified).toBe(false);
+    expect(result.errors.some(e => /statusListResolver/.test(e))).toBe(true);
+  });
+
+  test('baseline: a currently-valid credential without status still verifies', async () => {
+    const vc = await issueSigned();
+    const verifier = new Verifier(didManager);
+    const result = await verifier.verifyCredentialMultiSig(vc, policyFor(vc));
+    expect(result.verified).toBe(true);
+  });
+});
+
+describe('#345 — low-level revocation helpers bind the supplied list', () => {
+  test('checkRevocationStatus rejects a status list whose id differs from the credential reference', () => {
+    const sdk = OriginalsSDK.create({ defaultKeyType: 'Ed25519' });
+    const entry = sdk.statusList.allocateStatusEntry('https://issuer.example/status/1', 3, 'revocation');
+    const credential = {
+      '@context': ['https://www.w3.org/ns/credentials/v2'],
+      type: ['VerifiableCredential'],
+      issuer: did,
+      issuanceDate: new Date().toISOString(),
+      credentialSubject: { id: 'did:peer:subject1' },
+      credentialStatus: entry
+    } as unknown as VerifiableCredential;
+
+    // Attacker-supplied all-zeros list published under a DIFFERENT id.
+    const fabricated = sdk.statusList.createStatusListCredential({
+      id: 'https://attacker.example/status/other',
+      issuer: did,
+      statusPurpose: 'revocation'
+    });
+
+    expect(() => sdk.credentials.checkRevocationStatus(credential, fabricated))
+      .toThrow(/does not match the credential's statusListCredential reference/);
+    expect(() => sdk.credentials.isRevoked(credential, fabricated))
+      .toThrow(/does not match the credential's statusListCredential reference/);
+  });
+});
+
+describe('#309 — fail-closed signing refusal keys on typed error codes', () => {
+  test('typed codes are security refusals regardless of message wording', () => {
+    expect(isSecuritySigningRefusal(new StructuredError('ISSUER_BINDING_MISMATCH', 'nope'))).toBe(true);
+    expect(isSecuritySigningRefusal(new StructuredError('VM_RETIRED', 'nope'))).toBe(true);
+    // Non-security errors still fall through to the legacy signer path.
+    expect(isSecuritySigningRefusal(new Error('DID not resolved: did:peer:x'))).toBe(false);
+    expect(isSecuritySigningRefusal(new StructuredError('SOME_OTHER_CODE', 'nope'))).toBe(false);
+  });
+
+  test('legacy message patterns still refuse (defense in depth)', () => {
+    expect(isSecuritySigningRefusal(new Error('Issuer DID (a) does not match the verification method controller (b)'))).toBe(true);
+    expect(isSecuritySigningRefusal(new Error('Verification method is retired (revoked or compromised): x'))).toBe(true);
+  });
+
+  test('Issuer throws the typed ISSUER_BINDING_MISMATCH code on impersonation', async () => {
+    const issuer = new Issuer(didManager, vm);
+    const err = await issuer.issueCredential(
+      {
+        type: ['VerifiableCredential'],
+        issuer: 'did:peer:victim',
+        issuanceDate: new Date().toISOString(),
+        credentialSubject: { id: 'did:peer:subject1' }
+      } as never,
+      { proofPurpose: 'assertionMethod' }
+    ).then(() => null, (e) => e as StructuredError);
+    expect(err).not.toBeNull();
+    expect(err!.code).toBe('ISSUER_BINDING_MISMATCH');
+  });
+});
+
+describe('#312 — cross-network did:btco documents cannot be served from cache', () => {
+  test('a cached regtest DID still trips BTCO_NETWORK_MISMATCH on a mainnet-configured SDK', async () => {
+    const dm = new DIDManager({
+      network: 'mainnet',
+      defaultKeyType: 'Ed25519',
+      ordinalsProvider: new MockOrdinalsProvider()
+    } as never);
+
+    // Simulate a shared persistent cache already holding the cross-network
+    // document (e.g. populated by a regtest-configured sibling instance).
+    const crossNetworkDid = 'did:btco:reg:123';
+    await (dm as unknown as { cache: { set: (d: string, doc: unknown) => Promise<void> } }).cache.set(
+      crossNetworkDid,
+      { '@context': ['https://www.w3.org/ns/did/v1'], id: crossNetworkDid }
+    );
+
+    const err = await dm.resolveDID(crossNetworkDid).then(() => null, (e) => e as StructuredError);
+    expect(err).not.toBeNull();
+    expect(err!.code).toBe('BTCO_NETWORK_MISMATCH');
+  });
+});
+
+describe('#351 — cost quotes apply the MAX_REASONABLE_FEE_RATE cap', () => {
+  test('an absurd fee-oracle estimate is ignored for estimateCost quotes', async () => {
+    const sdk = OriginalsSDK.create({
+      network: 'regtest',
+      storageAdapter: new MemoryStorageAdapter(),
+      ordinalsProvider: new MockOrdinalsProvider(),
+      feeOracle: { estimateFeeRate: async () => 5_000_000 } // compromised estimator
+    } as never);
+    const asset = await sdk.lifecycle.createAsset([
+      {
+        id: 'res1',
+        type: 'text',
+        content: 'hello world',
+        contentType: 'text/plain',
+        hash: 'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9'
+      }
+    ]);
+
+    const estimate = await sdk.lifecycle.estimateCost(asset, 'did:btco');
+    // The absurd oracle rate is skipped; the quote falls through to the next
+    // source (mock provider) or the conservative default — never 5M sat/vB.
+    expect(estimate.feeRate).toBeLessThanOrEqual(10_000);
+  });
+});

--- a/packages/sdk/tests/unit/adapters/QuickNodeProvider.test.ts
+++ b/packages/sdk/tests/unit/adapters/QuickNodeProvider.test.ts
@@ -198,10 +198,13 @@ describe('getInscriptionById', () => {
 describe('getInscriptionsBySatoshi', () => {
   const provider = () => new QuickNodeProvider({ endpoint: ENDPOINT });
 
-  test('sends the sat as a JSON number and maps the inscriptions array', async () => {
+  test('sends the sat as a JSON number and maps the inscriptions array, dropping malformed ids (issue #350)', async () => {
+    // 'otherI0id' is not a valid inscription id (64-hex txid + 'i' + index);
+    // server-substitutable strings must not flow into DID resolution or
+    // provenance, so the shape gate drops it.
     mockRpc('ord_getSat', { number: 125866034480298, rarity: 'common', inscriptions: [INSCRIPTION_ID, 'otherI0id'] });
     const result = await provider().getInscriptionsBySatoshi('125866034480298');
-    expect(result).toEqual([{ inscriptionId: INSCRIPTION_ID }, { inscriptionId: 'otherI0id' }]);
+    expect(result).toEqual([{ inscriptionId: INSCRIPTION_ID }]);
     expect(requests[0]).toMatchObject({ method: 'ord_getSat', params: [125866034480298] });
   });
 
@@ -383,5 +386,100 @@ describe('response hardening', () => {
     ) as any;
     const provider = new QuickNodeProvider({ endpoint: ENDPOINT });
     await expect(provider.broadcastTransaction('0200aabb')).rejects.toThrow(/txn-mempool-conflict/);
+  });
+});
+
+describe('QuickNodeProvider hardening (issue #350)', () => {
+  test('constructor does not echo the endpoint (embedded token) into error text', () => {
+    try {
+      new QuickNodeProvider({ endpoint: 'not-a-url/super-secret-token' });
+      throw new Error('expected constructor to throw');
+    } catch (err) {
+      expect((err as Error).message).not.toContain('super-secret-token');
+    }
+  });
+
+  describe('expectedNetwork chain check', () => {
+    test('fails loudly when the endpoint serves a different chain', async () => {
+      mockRpc('getblockchaininfo', { chain: 'test' });
+      const provider = new QuickNodeProvider({ endpoint: ENDPOINT, expectedNetwork: 'mainnet' });
+      await expect(provider.getInscriptionsBySatoshi('123')).rejects.toThrow(/configured for mainnet/);
+      // The check runs BEFORE the real RPC: no ord_getSat request was made.
+      expect(requests.filter((r) => r.method === 'ord_getSat').length).toBe(0);
+    });
+
+    test('passes on a matching chain and only checks once', async () => {
+      mockRpc('getblockchaininfo', { chain: 'main' });
+      mockRpc('ord_getSat', { inscriptions: [] });
+      const provider = new QuickNodeProvider({ endpoint: ENDPOINT, expectedNetwork: 'mainnet' });
+      await provider.getInscriptionsBySatoshi('123');
+      await provider.getInscriptionsBySatoshi('456');
+      expect(requests.filter((r) => r.method === 'getblockchaininfo').length).toBe(1);
+    });
+
+    test('performs no chain check when expectedNetwork is not set', async () => {
+      mockRpc('ord_getSat', { inscriptions: [] });
+      await new QuickNodeProvider({ endpoint: ENDPOINT }).getInscriptionsBySatoshi('123');
+      expect(requests.filter((r) => r.method === 'getblockchaininfo').length).toBe(0);
+    });
+  });
+
+  describe('explicit contentEncoding', () => {
+    test("'base64' rejects non-base64 content instead of silently keeping it literal", async () => {
+      mockRpc('ord_getInscription', { id: INSCRIPTION_ID, sat: 1, satpoint: `${TXID}:0:0`, content_type: 'text/plain' });
+      mockRpc('ord_getContent', '{"p":"x"}');
+      const provider = new QuickNodeProvider({ endpoint: ENDPOINT, contentEncoding: 'base64' });
+      await expect(provider.getInscriptionById(INSCRIPTION_ID)).rejects.toThrow(/not base64/);
+    });
+
+    test("'utf8' keeps base64-shaped literal content literal (no heuristic)", async () => {
+      mockRpc('ord_getInscription', { id: INSCRIPTION_ID, sat: 1, satpoint: `${TXID}:0:0`, content_type: 'text/plain' });
+      // 'aGVsbG8h' is base64 for 'hello!' — the auto heuristic would decode it,
+      // but an explicit utf8 pin must return the literal characters.
+      mockRpc('ord_getContent', 'aGVsbG8h');
+      const provider = new QuickNodeProvider({ endpoint: ENDPOINT, contentEncoding: 'utf8' });
+      const result = await provider.getInscriptionById(INSCRIPTION_ID);
+      expect(result!.content.toString('utf8')).toBe('aGVsbG8h');
+    });
+  });
+
+  describe('server-data validation before provenance', () => {
+    test('content-lookup not-found on an EXISTING inscription throws (not "nonexistent")', async () => {
+      mockRpc('ord_getInscription', { id: INSCRIPTION_ID, sat: 1, satpoint: `${TXID}:0:0`, content_type: 'text/plain' });
+      mockRpcError('ord_getContent', { code: -32000, message: 'content not found' });
+      const err = await new QuickNodeProvider({ endpoint: ENDPOINT })
+        .getInscriptionById(INSCRIPTION_ID)
+        .then(() => null, (e) => e as StructuredError);
+      expect(err).not.toBeNull();
+      expect(err!.code).toBe('QUICKNODE_CONTENT_UNAVAILABLE');
+    });
+
+    test('throws instead of fabricating txid "unknown" when the location is missing', async () => {
+      mockRpc('ord_getInscription', { id: INSCRIPTION_ID, sat: 1, content_type: 'text/plain' });
+      mockRpc('ord_getContent', Buffer.from('x').toString('base64'));
+      await expect(new QuickNodeProvider({ endpoint: ENDPOINT }).getInscriptionById(INSCRIPTION_ID))
+        .rejects.toThrow(/satpoint\/output/);
+    });
+
+    test('rejects a malformed (non-64-hex) location txid', async () => {
+      mockRpc('ord_getInscription', { id: INSCRIPTION_ID, sat: 1, satpoint: 'evil-txid:0:0', content_type: 'text/plain' });
+      mockRpc('ord_getContent', Buffer.from('x').toString('base64'));
+      await expect(new QuickNodeProvider({ endpoint: ENDPOINT }).getInscriptionById(INSCRIPTION_ID))
+        .rejects.toThrow(/satpoint\/output/);
+    });
+
+    test('rejects a server-substituted malformed inscription id', async () => {
+      mockRpc('ord_getInscription', { id: 'evil-id', sat: 1, satpoint: `${TXID}:0:0`, content_type: 'text/plain' });
+      mockRpc('ord_getContent', Buffer.from('x').toString('base64'));
+      await expect(new QuickNodeProvider({ endpoint: ENDPOINT }).getInscriptionById(INSCRIPTION_ID))
+        .rejects.toThrow(/malformed inscription id/);
+    });
+
+    test('rejects an out-of-range sat number from the server', async () => {
+      mockRpc('ord_getInscription', { id: INSCRIPTION_ID, sat: '2100000000000000', satpoint: `${TXID}:0:0`, content_type: 'text/plain' });
+      mockRpc('ord_getContent', Buffer.from('x').toString('base64'));
+      await expect(new QuickNodeProvider({ endpoint: ENDPOINT }).getInscriptionById(INSCRIPTION_ID))
+        .rejects.toThrow(/invalid sat number/);
+    });
   });
 });

--- a/packages/sdk/tests/unit/bitcoin/SignetProvider.broadcast.test.ts
+++ b/packages/sdk/tests/unit/bitcoin/SignetProvider.broadcast.test.ts
@@ -68,3 +68,34 @@ describe('SignetProvider.broadcastTransaction (issue #272)', () => {
     expect(seenAuth).toBe('Basic ' + Buffer.from('user:pass').toString('base64'));
   });
 });
+
+describe('SignetProvider.estimateFee fail-loud policy (issue #351)', () => {
+  test('throws without bitcoinRpcUrl instead of fabricating a rate', async () => {
+    const provider = new SignetProvider({ ordUrl: 'http://ord' });
+    await expect(provider.estimateFee(6)).rejects.toThrow(/bitcoinRpcUrl/);
+  });
+
+  test('throws when the RPC returns no feerate instead of inventing one', async () => {
+    globalThis.fetch = (async () => new Response(
+      JSON.stringify({ result: { errors: ['Insufficient data or no feerate found'] } }),
+      { status: 200 }
+    )) as typeof fetch;
+    const provider = new SignetProvider({ ordUrl: 'http://ord', bitcoinRpcUrl: 'http://rpc' });
+    await expect(provider.estimateFee(1)).rejects.toThrow(/no feerate/i);
+  });
+
+  test('propagates RPC transport failures instead of swallowing them', async () => {
+    globalThis.fetch = (async () => { throw new Error('connection refused'); }) as typeof fetch;
+    const provider = new SignetProvider({ ordUrl: 'http://ord', bitcoinRpcUrl: 'http://rpc' });
+    await expect(provider.estimateFee(1)).rejects.toThrow(/connection refused/);
+  });
+
+  test('converts a real BTC/kB feerate to sat/vB', async () => {
+    globalThis.fetch = (async () => new Response(
+      JSON.stringify({ result: { feerate: 0.00012 } }),
+      { status: 200 }
+    )) as typeof fetch;
+    const provider = new SignetProvider({ ordUrl: 'http://ord', bitcoinRpcUrl: 'http://rpc' });
+    await expect(provider.estimateFee(1)).resolves.toBe(12);
+  });
+});

--- a/packages/sdk/tests/unit/bitcoin/bitcoin-scenarios.test.ts
+++ b/packages/sdk/tests/unit/bitcoin/bitcoin-scenarios.test.ts
@@ -448,11 +448,11 @@ describe('BITCOIN-023: SignetProvider write ops without bitcoinRpcUrl', () => {
     ).rejects.toThrow(/bitcoinRpcUrl/i);
   });
 
-  test('estimateFee without bitcoinRpcUrl falls back to default (no throw)', async () => {
+  test('estimateFee without bitcoinRpcUrl throws instead of fabricating a rate (issue #351)', async () => {
     const provider = new SignetProvider({ ordUrl: 'http://localhost:80' });
-    // Should not throw; returns a default fee
-    const fee = await provider.estimateFee(1);
-    expect(fee).toBeGreaterThan(0);
+    // The old fallback invented a rate that INCREASED with the confirmation
+    // target; fee estimation must fail loudly like the other providers.
+    await expect(provider.estimateFee(1)).rejects.toThrow(/bitcoinRpcUrl/);
   });
 });
 

--- a/packages/sdk/tests/unit/bitcoin/transactions/commit.test.ts
+++ b/packages/sdk/tests/unit/bitcoin/transactions/commit.test.ts
@@ -353,6 +353,25 @@ describe('createCommitTransaction', () => {
       expect(result.commitAddress).toMatch(/^bcrt1p/);
       expect(result.commitPsbtBase64).toBeDefined();
     });
+
+    test('regtest commit accepts a testnet-format (tb1) change address (issue #351)', async () => {
+      // validateBitcoinAddress deliberately accepts testnet-format addresses
+      // on regtest (regtest tooling commonly emits them), so the change output
+      // encoding must accept them too — previously tx.addOutputAddress decoded
+      // strictly against 'bcrt' and threw a cryptic @scure error AFTER
+      // keygen/selection/fee work, defeating the early fail-fast validation.
+      const params = createCommitParams({
+        network: 'regtest',
+        changeAddress: 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx',
+        utxos: [createUtxo(50000, 0, 'regtest')]
+      });
+      const result = await createCommitTransaction(params);
+
+      expect(result.commitAddress).toMatch(/^bcrt1p/);
+      // With 50k sats in and a small commit output, change is above dust —
+      // the tx must carry the change output derived from the tb1 address.
+      expect(result.commitPsbt.outputsLength).toBe(2);
+    });
   });
 
   describe('Error Handling', () => {

--- a/packages/sdk/tests/unit/core/OriginalsSDK.test.ts
+++ b/packages/sdk/tests/unit/core/OriginalsSDK.test.ts
@@ -186,10 +186,13 @@ describe('OriginalsSDK', () => {
       expect(result).toBe(true);
     });
 
-    test('verifies valid signature with 33-byte public key (slices off version byte)', async () => {
+    test('rejects a 33-byte public key instead of guessing at a prefix (issue #352)', async () => {
+      // 33 bytes is the shape of a compressed secp256k1 key, not a "prefixed
+      // Ed25519 key" (Ed25519 multicodec prefixes are 2 bytes → 34 bytes).
+      // Stripping one byte verified against garbage; it must throw instead.
       const signature = await signAsync(message, privateKey);
-      const result = await OriginalsSDK.verifyDIDSignature(signature, message, publicKey33);
-      expect(result).toBe(true);
+      await expect(OriginalsSDK.verifyDIDSignature(signature, message, publicKey33))
+        .rejects.toThrow('Invalid Ed25519 public key length: 33');
     });
 
     test('returns false for invalid signature', async () => {

--- a/packages/sdk/tests/unit/crypto/Multikey.test.ts
+++ b/packages/sdk/tests/unit/crypto/Multikey.test.ts
@@ -267,3 +267,28 @@ describe('Multicodec private-key headers match the multicodec registry', () => {
     }
   });
 });
+
+describe('decode length validation (issue #352)', () => {
+  test('decodePublicKey rejects wrong-length key bodies', () => {
+    const short = 'z' + base58.encode(concatBytes(MULTICODEC_ED25519_PUB_HEADER, new Uint8Array(16).fill(1)));
+    expect(() => multikey.decodePublicKey(short)).toThrow(/32 bytes/);
+
+    const long = 'z' + base58.encode(concatBytes(MULTICODEC_SECP256K1_PUB_HEADER, new Uint8Array(64).fill(1)));
+    expect(() => multikey.decodePublicKey(long)).toThrow(/33 bytes/);
+  });
+
+  test('decodePrivateKey rejects wrong-length key bodies', () => {
+    const short = 'z' + base58.encode(concatBytes(MULTICODEC_ED25519_PRIV_HEADER, new Uint8Array(31).fill(2)));
+    expect(() => multikey.decodePrivateKey(short)).toThrow(/32 bytes/);
+
+    const legacyLong = 'z' + base58.encode(concatBytes(new Uint8Array([0x13, 0x01]), new Uint8Array(40).fill(3)));
+    expect(() => multikey.decodePrivateKey(legacyLong)).toThrow(/32 bytes/);
+  });
+
+  test('correct-length keys still decode for every type', () => {
+    expect(multikey.decodePublicKey(multikey.encodePublicKey(new Uint8Array(32).fill(1), 'Ed25519')).type).toBe('Ed25519');
+    expect(multikey.decodePublicKey(multikey.encodePublicKey(new Uint8Array(33).fill(1), 'Secp256k1')).type).toBe('Secp256k1');
+    expect(multikey.decodePublicKey(multikey.encodePublicKey(new Uint8Array(33).fill(1), 'P256')).type).toBe('P256');
+    expect(multikey.decodePublicKey(multikey.encodePublicKey(new Uint8Array(96).fill(1), 'Bls12381G2')).type).toBe('Bls12381G2');
+  });
+});

--- a/packages/sdk/tests/unit/did/DIDCache.test.ts
+++ b/packages/sdk/tests/unit/did/DIDCache.test.ts
@@ -522,3 +522,63 @@ describe('DIDCache', () => {
     });
   });
 });
+
+describe('LRU eviction is memory-only (issue #313)', () => {
+  test('hydrating reads beyond maxEntries do not delete entries from persistent storage', async () => {
+    const storageMap = new Map<string, DIDCacheEntry>();
+    const storage: DIDCacheStorage = {
+      get: async (key: string) => storageMap.get(key) ?? null,
+      set: async (key: string, entry: DIDCacheEntry) => { storageMap.set(key, entry); },
+      delete: async (key: string) => { storageMap.delete(key); },
+      keys: async () => Array.from(storageMap.keys()),
+      clear: async () => { storageMap.clear(); },
+    };
+
+    // Persistent store holds more entries than the memory cap.
+    const dids = ['did:peer:a', 'did:peer:b', 'did:peer:c', 'did:peer:d'];
+    for (const did of dids) {
+      storageMap.set(did, {
+        did,
+        document: makeDIDDoc(did),
+        resolvedAt: Date.now(),
+        ttlMs: 60_000,
+        pinned: false,
+      });
+    }
+
+    const cache = new DIDCache({ storage, maxEntries: 2 });
+    // Each get() hydrates from storage; beyond maxEntries this triggers LRU
+    // eviction, which previously ALSO deleted the evicted entry from the
+    // persistent store — reads shrank the persistent cache.
+    for (const did of dids) {
+      expect(await cache.get(did)).not.toBeNull();
+    }
+
+    // Every entry is still in persistent storage and still resolvable.
+    expect(storageMap.size).toBe(4);
+    for (const did of dids) {
+      expect(await cache.get(did)).not.toBeNull();
+    }
+  });
+
+  test('set() eviction keeps the evicted entry in persistent storage', async () => {
+    const storageMap = new Map<string, DIDCacheEntry>();
+    const storage: DIDCacheStorage = {
+      get: async (key: string) => storageMap.get(key) ?? null,
+      set: async (key: string, entry: DIDCacheEntry) => { storageMap.set(key, entry); },
+      delete: async (key: string) => { storageMap.delete(key); },
+      keys: async () => Array.from(storageMap.keys()),
+      clear: async () => { storageMap.clear(); },
+    };
+
+    const cache = new DIDCache({ storage, maxEntries: 2 });
+    await cache.set('did:peer:a', makeDIDDoc('did:peer:a'));
+    await cache.set('did:peer:b', makeDIDDoc('did:peer:b'));
+    await cache.set('did:peer:c', makeDIDDoc('did:peer:c')); // evicts 'a' from memory
+
+    expect(storageMap.has('did:peer:a')).toBe(true);
+    // Explicit invalidation still deletes from storage.
+    await cache.delete('did:peer:a');
+    expect(storageMap.has('did:peer:a')).toBe(false);
+  });
+});

--- a/packages/sdk/tests/unit/did/Ed25519Verifier.test.ts
+++ b/packages/sdk/tests/unit/did/Ed25519Verifier.test.ts
@@ -59,12 +59,13 @@ describe('Ed25519Verifier', () => {
       expect(result).toBe(true);
     });
 
-    test('verifies valid signature with 33-byte public key (slices off version byte)', async () => {
+    test('rejects a 33-byte public key instead of guessing at a prefix (issue #352)', async () => {
+      // 33 bytes is the shape of a compressed secp256k1 key, not a "prefixed
+      // Ed25519 key" (Ed25519 multicodec prefixes are 2 bytes → 34 bytes).
       const verifier = new Ed25519Verifier();
       const signature = await signAsync(message, privateKey);
-      // Pass the 33-byte key - verifier should slice off first byte
       const result = await verifier.verify(signature, message, publicKey33Bytes);
-      expect(result).toBe(true);
+      expect(result).toBe(false);
     });
 
     test('rejects invalid signature', async () => {
@@ -155,6 +156,11 @@ describe('Ed25519Verifier', () => {
     test('returns undefined when only verificationMethodId is set', () => {
       const verifier = new Ed25519Verifier(verificationMethodId);
       expect(verifier.getPublicKeyMultibase()).toBeUndefined();
+    });
+
+    test('throws for a wrong-length key instead of minting a wrong multikey (issue #352)', () => {
+      const verifier = new Ed25519Verifier(verificationMethodId, publicKey33Bytes);
+      expect(() => verifier.getPublicKeyMultibase()).toThrow(/expected 32 bytes/);
     });
   });
 });

--- a/packages/sdk/tests/unit/did/KeyManager.test.ts
+++ b/packages/sdk/tests/unit/did/KeyManager.test.ts
@@ -22,7 +22,9 @@ describe('KeyManager', () => {
   });
 
   test('encode/decode multibase roundtrip', () => {
-    const pub = Buffer.from('hello');
+    // A compressed secp256k1 public key is 33 bytes; decode validates length
+    // since issue #352, so the roundtrip fixture must be a plausible key.
+    const pub = Buffer.alloc(33, 7);
     const encoded = km.encodePublicKeyMultibase(pub, 'ES256K' as KeyType);
     const decoded = km.decodePublicKeyMultibase(encoded);
     expect(Buffer.from(decoded.key)).toEqual(Buffer.from(pub));
@@ -30,11 +32,19 @@ describe('KeyManager', () => {
   });
 
   test('decodePublicKeyMultibase handles Ed25519 multikey values', () => {
-    const pub = Buffer.from([0, 255, 1, 2, 3, 4, 5]);
+    // Ed25519 public keys are exactly 32 bytes (length-checked on decode).
+    const pub = Buffer.alloc(32, 9);
     const encoded = km.encodePublicKeyMultibase(pub, 'Ed25519' as KeyType);
     const decoded = km.decodePublicKeyMultibase(encoded);
     expect(Buffer.from(decoded.key)).toEqual(Buffer.from(pub));
     expect(decoded.type).toBe('Ed25519');
+  });
+
+  test('decodePublicKeyMultibase rejects wrong-length key bodies (issue #352)', () => {
+    // KeyManager wraps multikey decode errors in 'Invalid multibase string';
+    // the underlying length check comes from multikey.decodePublicKey.
+    const encodedShort = km.encodePublicKeyMultibase(Buffer.from('hello'), 'Ed25519' as KeyType);
+    expect(() => km.decodePublicKeyMultibase(encodedShort)).toThrow('Invalid multibase string');
   });
 
   test('rotateKeys updates DID document keys', async () => {

--- a/packages/sdk/tests/unit/events/ManagerEventMirroring.test.ts
+++ b/packages/sdk/tests/unit/events/ManagerEventMirroring.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Regression tests for issues #346 and #352:
+ *
+ * - #346: asset:migrated / asset:transferred were emitted only on the asset's
+ *   private emitter, so documented `sdk.lifecycle.on(...)` subscriptions (and
+ *   the built-in EventLogger metrics) never fired for migrations/transfers.
+ * - #352: 'verification:completed' and 'batch:progress' were declared in the
+ *   public EventTypeMap and subscribed by EventLogger but never emitted.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { OriginalsSDK } from '../../../src';
+import { MockOrdinalsProvider } from '../../mocks/adapters';
+import { MemoryStorageAdapter } from '../../../src/storage/MemoryStorageAdapter';
+import type { AssetMigratedEvent, AssetTransferredEvent, BatchProgressEvent, VerificationCompletedEvent } from '../../../src/events/types';
+
+// Fresh objects per call: createAsset keeps resource objects by reference, so
+// a test that corrupts its asset must not poison the shared fixture.
+const makeResources = () => [
+  {
+    id: 'res1',
+    type: 'text',
+    content: 'hello world',
+    contentType: 'text/plain',
+    hash: 'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9'
+  }
+];
+
+const makeSdk = () => OriginalsSDK.create({
+  storageAdapter: new MemoryStorageAdapter(),
+  network: 'regtest',
+  ordinalsProvider: new MockOrdinalsProvider()
+} as never);
+
+describe('manager-level asset:migrated / asset:transferred (issue #346)', () => {
+  test('publishToWeb emits asset:migrated on the LifecycleManager emitter', async () => {
+    const sdk = makeSdk();
+    const events: AssetMigratedEvent[] = [];
+    sdk.lifecycle.on('asset:migrated', (e) => { events.push(e); });
+
+    const asset = await sdk.lifecycle.createAsset(makeResources());
+    await sdk.lifecycle.publishToWeb(asset, 'example.com');
+
+    expect(events.length).toBe(1);
+    expect(events[0].asset.fromLayer).toBe('did:peer');
+    expect(events[0].asset.toLayer).toBe('did:webvh');
+    expect(events[0].asset.id).toBe(asset.id);
+  });
+
+  test('inscribeOnBitcoin emits asset:migrated with Bitcoin details on the manager emitter', async () => {
+    const sdk = makeSdk();
+    const events: AssetMigratedEvent[] = [];
+    sdk.lifecycle.on('asset:migrated', (e) => { events.push(e); });
+
+    const asset = await sdk.lifecycle.createAsset(makeResources());
+    await sdk.lifecycle.publishToWeb(asset, 'example.com');
+    await sdk.lifecycle.inscribeOnBitcoin(asset, 7);
+
+    const btcoEvent = events.find((e) => e.asset.toLayer === 'did:btco');
+    expect(btcoEvent).toBeDefined();
+    expect(btcoEvent!.details?.inscriptionId).toBe('insc-mock');
+    expect(btcoEvent!.details?.satoshi).toBe('123');
+    expect(btcoEvent!.details?.feeRate).toBe(7);
+  });
+
+  test('transferOwnership emits asset:transferred on the manager emitter', async () => {
+    const sdk = makeSdk();
+    const events: AssetTransferredEvent[] = [];
+    sdk.lifecycle.on('asset:transferred', (e) => { events.push(e); });
+
+    const asset = await sdk.lifecycle.createAsset(makeResources());
+    await sdk.lifecycle.publishToWeb(asset, 'example.com');
+    await sdk.lifecycle.inscribeOnBitcoin(asset, 7);
+    const tx = await sdk.lifecycle.transferOwnership(asset, 'bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080');
+
+    expect(events.length).toBe(1);
+    expect(events[0].to).toBe('bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080');
+    expect(events[0].transactionId).toBe(tx.txid);
+    expect(events[0].asset.layer).toBe('did:btco');
+  });
+
+  test('asset-level subscriptions still fire (dual emit)', async () => {
+    const sdk = makeSdk();
+    const asset = await sdk.lifecycle.createAsset(makeResources());
+    const assetEvents: AssetMigratedEvent[] = [];
+    asset.on('asset:migrated', (e) => { assetEvents.push(e); });
+
+    await sdk.lifecycle.publishToWeb(asset, 'example.com');
+    expect(assetEvents.length).toBe(1);
+  });
+});
+
+describe("'verification:completed' is emitted by OriginalsAsset.verify (issue #352)", () => {
+  test('emits with the verification result', async () => {
+    const sdk = makeSdk();
+    const asset = await sdk.lifecycle.createAsset(makeResources());
+    const events: VerificationCompletedEvent[] = [];
+    asset.on('verification:completed', (e) => { events.push(e); });
+
+    const ok = await asset.verify();
+    expect(events.length).toBe(1);
+    expect(events[0].result).toBe(ok);
+    expect(events[0].asset.id).toBe(asset.id);
+  });
+
+  test('emits result=false for a corrupted asset', async () => {
+    const sdk = makeSdk();
+    const asset = await sdk.lifecycle.createAsset(makeResources());
+    (asset.resources[0] as { hash: string }).hash = 'not-a-real-hash';
+    const events: VerificationCompletedEvent[] = [];
+    asset.on('verification:completed', (e) => { events.push(e); });
+
+    const ok = await asset.verify();
+    expect(ok).toBe(false);
+    expect(events.length).toBe(1);
+    expect(events[0].result).toBe(false);
+  });
+});
+
+describe("'batch:progress' is emitted per settled batch item (issue #352)", () => {
+  test('batchCreateAssets reports incremental progress on the manager emitter', async () => {
+    const sdk = makeSdk();
+    const events: BatchProgressEvent[] = [];
+    sdk.lifecycle.on('batch:progress', (e) => { events.push(e); });
+
+    const result = await sdk.lifecycle.batchCreateAssets([makeResources(), makeResources(), makeResources()]);
+    expect(result.successful.length).toBe(3);
+
+    expect(events.length).toBe(3);
+    expect(events[0].operation).toBe('create');
+    expect(events[0].total).toBe(3);
+    expect(events.map((e) => e.completed)).toEqual([1, 2, 3]);
+    expect(events[events.length - 1].progress).toBe(100);
+    // Correlated with the batch lifecycle events
+    expect(events.every((e) => e.batchId === events[0].batchId)).toBe(true);
+  });
+});

--- a/packages/sdk/tests/unit/lifecycle/ResourceVersioning.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/ResourceVersioning.test.ts
@@ -392,7 +392,9 @@ describe('OriginalsAsset - Resource Versioning', () => {
     const buffer2 = Buffer.from('binary content 2', 'utf-8');
     // Buffer content used to be accepted but only its hash was stored — the
     // bytes were unrecoverably lost. It now throws so the loss is impossible.
-    expect(() => asset.addResourceVersion('res1', buffer2, 'application/octet-stream'))
+    // The parameter is declared `string` since issue #311, so JS callers
+    // (modelled with the cast) still hit the runtime guard.
+    expect(() => asset.addResourceVersion('res1', buffer2 as unknown as string, 'application/octet-stream'))
       .toThrow(/binary \(Buffer\) content/);
   });
 

--- a/packages/sdk/tests/unit/types/network.test.ts
+++ b/packages/sdk/tests/unit/types/network.test.ts
@@ -142,11 +142,13 @@ describe('Network Configuration', () => {
     });
 
     it('should handle pre-release versions', () => {
-      // Pre-release should still follow the same rules for the base version
-      expect(validateVersionForNetwork('1.0.0-beta.1', 'pichu')).toBe(true);
+      // A prerelease is NOT a release (issue #352): only magby (all versions)
+      // accepts prerelease builds, regardless of the numeric part.
+      expect(validateVersionForNetwork('1.0.0-beta.1', 'pichu')).toBe(false);
       expect(validateVersionForNetwork('1.1.0-alpha', 'pichu')).toBe(false);
-      expect(validateVersionForNetwork('1.1.0-beta.1', 'cleffa')).toBe(true);
+      expect(validateVersionForNetwork('1.1.0-beta.1', 'cleffa')).toBe(false);
       expect(validateVersionForNetwork('1.1.1-rc.1', 'cleffa')).toBe(false);
+      expect(validateVersionForNetwork('1.0.0-beta.1', 'magby')).toBe(true);
     });
 
     it('should throw error for invalid version format', () => {
@@ -176,8 +178,10 @@ describe('Network Configuration', () => {
     });
 
     it('should handle pre-release versions correctly', () => {
-      expect(getRecommendedNetworkForVersion('1.0.0-beta')).toBe('pichu');
-      expect(getRecommendedNetworkForVersion('1.1.0-alpha')).toBe('cleffa');
+      // Prereleases only pass the magby gate (issue #352), so magby is the
+      // most restrictive network that accepts any prerelease build.
+      expect(getRecommendedNetworkForVersion('1.0.0-beta')).toBe('magby');
+      expect(getRecommendedNetworkForVersion('1.1.0-alpha')).toBe('magby');
       expect(getRecommendedNetworkForVersion('1.1.1-rc.1')).toBe('magby');
     });
   });
@@ -251,5 +255,21 @@ describe('Network Configuration', () => {
         expect(getBitcoinNetworkForWebVH('pichu')).toBe('mainnet');
       });
     });
+  });
+});
+
+describe('prerelease versions and network gates (issue #352)', () => {
+  it('rejects prereleases on pichu even when the numeric part is a major release', () => {
+    expect(validateVersionForNetwork('2.0.0-rc.1', 'pichu')).toBe(false);
+    expect(validateVersionForNetwork('1.0.0-beta', 'pichu')).toBe(false);
+  });
+
+  it('rejects prereleases on cleffa', () => {
+    expect(validateVersionForNetwork('1.1.0-rc.2', 'cleffa')).toBe(false);
+  });
+
+  it('accepts prereleases on magby (all versions)', () => {
+    expect(validateVersionForNetwork('2.0.0-rc.1', 'magby')).toBe(true);
+    expect(validateVersionForNetwork('1.2.3-alpha.4', 'magby')).toBe(true);
   });
 });

--- a/packages/sdk/tests/unit/utils/Logger.test.ts
+++ b/packages/sdk/tests/unit/utils/Logger.test.ts
@@ -553,3 +553,92 @@ describe('Logger', () => {
   });
 });
 
+
+describe('Logger.sanitize cycle safety (issue #349)', () => {
+  const makeConfig = (): OriginalsConfig => ({
+    network: 'mainnet',
+    defaultKeyType: 'ES256K',
+    logging: { level: 'info', sanitizeLogs: true }
+  });
+
+  test('logging a circular object does not throw and marks the cycle', () => {
+    const output = mock(() => {});
+    const config = makeConfig();
+    config.logging!.outputs = [{ write: output }];
+    const logger = new Logger('Test', config);
+
+    // Shape of a typical HTTP client error: request/response reference each other
+    const request: Record<string, unknown> = { url: 'https://x' };
+    const response: Record<string, unknown> = { status: 500, request };
+    request.response = response;
+
+    expect(() => logger.error('boom', undefined, { request })).not.toThrow();
+    const entry = output.mock.calls[0][0] as LogEntry;
+    const data = entry.data as { request: { response: { request: unknown } } };
+    expect(data.request.response.request).toBe('[Circular]');
+  });
+
+  test('shared (non-circular) references are sanitized normally, not marked circular', () => {
+    const output = mock(() => {});
+    const config = makeConfig();
+    config.logging!.outputs = [{ write: output }];
+    const logger = new Logger('Test', config);
+
+    const shared = { privateKey: 'z6Mk...', name: 'k' };
+    logger.info('msg', { a: shared, b: shared });
+
+    const entry = output.mock.calls[0][0] as LogEntry;
+    const data = entry.data as { a: Record<string, unknown>; b: Record<string, unknown> };
+    expect(data.a.privateKey).toBe('[REDACTED]');
+    expect(data.b.privateKey).toBe('[REDACTED]');
+  });
+
+  test('Date and Uint8Array values pass through instead of flattening to {}', () => {
+    const output = mock(() => {});
+    const config = makeConfig();
+    config.logging!.outputs = [{ write: output }];
+    const logger = new Logger('Test', config);
+
+    const when = new Date('2026-01-01T00:00:00Z');
+    const bytes = new Uint8Array([1, 2, 3]);
+    logger.info('msg', { when, bytes });
+
+    const entry = output.mock.calls[0][0] as LogEntry;
+    const data = entry.data as { when: unknown; bytes: unknown };
+    expect(data.when).toBe(when);
+    expect(data.bytes).toBe(bytes);
+  });
+});
+
+describe('FileLogOutput write-failure retention (issue #352)', () => {
+  test('a failed write retains the batch for the next flush instead of dropping it', async () => {
+    const entry: LogEntry = {
+      timestamp: '2026-01-01T00:00:00.000Z',
+      level: 'info',
+      context: 'RetentionTest',
+      message: 'keep-me'
+    };
+    // A path whose parent directory does not exist makes appendFile fail.
+    const badPath = join(tmpdir(), 'originals-logger-nonexistent-dir', 'deep', 'app.log');
+    const fileOutput = new FileLogOutput(badPath);
+    const internals = fileOutput as unknown as { buffer: string[]; flush(): Promise<void>; filePath: string };
+
+    fileOutput.write(entry);
+    await internals.flush();
+    // The batch survived the failed write...
+    expect(internals.buffer.length).toBe(1);
+    expect(internals.buffer[0]).toContain('keep-me');
+
+    // ...and lands in the file once the destination becomes writable.
+    const dir = await mkdtemp(join(tmpdir(), 'originals-logger-retry-'));
+    try {
+      internals.filePath = join(dir, 'app.log');
+      await internals.flush();
+      const content = await readFile(join(dir, 'app.log'), 'utf8');
+      expect(JSON.parse(content.trim()).message).toBe('keep-me');
+      expect(internals.buffer.length).toBe(0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/sdk/tests/unit/vc/StatusListManager.test.ts
+++ b/packages/sdk/tests/unit/vc/StatusListManager.test.ts
@@ -855,12 +855,13 @@ describe('StatusListManager', () => {
       expect(mismatch.verified).toBe(false);
       expect(mismatch.errors.some(e => e.includes('Status check error'))).toBe(true);
 
-      // Determinable revocation still leaves the signature valid: `revoked`
-      // carries the status, `verified` stays true (the signature is genuine).
+      // Determinable revocation fails verification (issue #345): a caller
+      // gating on `verified` alone must not accept a revoked credential, so
+      // `revoked` carries the status AND `verified` flips to false.
       const revokedList = sdk.statusList.setStatus(statusListVC, 7, true);
       const revoked = await sdk.credentials.verifyCredentialWithStatus(signed, revokedList);
       expect(revoked.revoked).toBe(true);
-      expect(revoked.verified).toBe(true);
+      expect(revoked.verified).toBe(false);
     });
 
     test('SDK exposes statusList on top-level instance', async () => {


### PR DESCRIPTION
## What

Fixes 12 open issues in one coherent batch: credential-verification security gaps, dead/missing lifecycle events, logger crash safety, Bitcoin fee/provider hardening, DID cache correctness, and a set of small validation footguns.

Closes #340, closes #345, closes #301, closes #309, closes #346, closes #349, closes #350, closes #351, closes #352, closes #311, closes #312, closes #313.

## Why

All 12 are open findings from the 2026-07-06/07 post-merge reviews. Each was re-verified against the current code before fixing (none had been fixed on main in the meantime). Grouped because they are independent, well-scoped, low-to-medium-risk corrections; none needs a design or interop decision.

**Deliberately excluded:** #341/#342/#348 (already covered by open PR #356), #310/#306 (require an `ExternalSigner` capability/API design decision), #300 (VCDM 1.1 removal needs an interop call), #279/#283/#302/#303 (migration-subsystem architectural rework), #304/#305 (perf follow-ups, kept out to hold this batch's scope), #314 (docs/edge-case roundup), #328–#333 (features/landing/deploy), #329 (third-party-adapter race, tracked with its own options).

## How

**VC verification (security)**

- **#340**: `Verifier.verifyCredentialMultiSig` now runs `checkCredentialValidityPeriod` after the threshold check and handles `credentialStatus`: with a configured `statusListResolver` it performs the same status check as single-sig verification; without one it fails closed on a declared `BitstringStatusListEntry` (mirroring `MultiSigManager.verifyMultiSig`). Expired/revoked multi-sig credentials no longer verify.
- **#345**: `verifyCredentialWithStatus` sets `verified: false` when `revoked || suspended` — a caller gating on `verified` can no longer accept a revoked credential. The low-level `checkRevocationStatus`/`isRevoked` now reject a supplied list whose `id` doesn't match the credential's `statusListCredential` reference, and their JSDoc states loudly that they perform no proof/issuer trust validation (use `verifyCredentialWithStatus` for untrusted input).
- **#301**: the issue-#238 status-list trust checks (id match, list-proof verification, issuer equality) are extracted into one shared `validateStatusListCredentialTrust` (`src/vc/statusListTrust.ts`, with `issuerOf`) used by both `Verifier` and `CredentialManager`, so the two paths can no longer drift.
- **#309**: `Issuer` throws typed `StructuredError('ISSUER_BINDING_MISMATCH')` and the document loader throws `StructuredError('VM_RETIRED')`; `CredentialManager.signCredential`'s fail-closed gate keys on those codes via a shared `isSecuritySigningRefusal` helper (legacy message patterns retained as defense-in-depth). Rewording an error message can no longer silently reopen the legacy-signer fall-through.

**Events**

- **#346**: `publishToWeb`, `inscribeOnBitcoin`, and `transferOwnership` mirror `asset:migrated`/`asset:transferred` onto the LifecycleManager emitter (same dual-emit pattern as `resource:published`), so documented `sdk.lifecycle.on(...)` subscriptions and the built-in EventLogger logging/metrics now fire.
- **#352.1**: `OriginalsAsset.verify` emits `verification:completed`; `BatchOperationExecutor` gained an `onItemSettled` hook and all four batch operations emit `batch:progress` per settled item.

**Logging**

- **#349**: `Logger.sanitize` tracks the traversal path with a `WeakSet` (true cycles become `'[Circular]'`; shared references still sanitize normally), passes `Date`/`Uint8Array` through instead of flattening them to `{}`, and the sanitize call is wrapped so a pathological payload can never crash the SDK operation that logged it.
- **#352.6**: `FileLogOutput.flush` restores the batch (bounded to 10k lines) when the write fails instead of dropping it, and registers `beforeExit`/`exit` hooks so trailing buffered lines are flushed on shutdown (sync fs used on hard `exit`; no-op in browser runtimes).

**Bitcoin**

- **#351**: `SignetProvider.estimateFee` throws without `bitcoinRpcUrl` or on RPC failure instead of fabricating a rate that *increased* with the confirmation target. `commit.ts` derives the change-output script via `scriptPubKeyForAddress` (with transfer.ts's regtest→testnet decode fallback), so a `tb1…` change address accepted by early validation no longer explodes late in `addOutputAddress`. `LifecycleManager.estimateCost` applies the exported `MAX_REASONABLE_FEE_RATE` cap to oracle/provider quotes (absurd estimates are skipped, falling through to the next source).
- **#350** (QuickNodeProvider): optional `expectedNetwork` verifies `getblockchaininfo.chain` on first RPC use (memoized, reset on transient failure; wired through `createOrdinalsProviderFromEnv` via `options.network`/`BITCOIN_NETWORK`); optional `contentEncoding: 'base64' | 'utf8' | 'auto'` replaces per-call guessing (default `'auto'` preserves behavior); txid/vout/inscriptionId/sat are shape-validated before flowing into provenance (no more literal `'unknown'` txids); a content-lookup miss on an existing inscription throws `QUICKNODE_CONTENT_UNAVAILABLE` instead of reporting the inscription nonexistent; the endpoint URL (which embeds the auth token) is no longer interpolated into error text.

**DID / misc**

- **#312**: the `BTCO_NETWORK_MISMATCH` guard (extracted to `assertBtcoNetworkMatchesProvider`) runs before the cache read, so a shared persistent DID cache can no longer serve cross-network documents. Semantics otherwise unchanged (testnet pass-through, unknown-network fall-through, `bitcoinRpcUrl` branch untouched).
- **#313**: `DIDCache.evictLRU` is memory-only — hydrating reads and set() eviction no longer delete entries from the persistent store; explicit `delete`/`clear` and TTL expiry still do.
- **#311**: `addResourceVersion` types `newContent` as `string` (runtime Buffer guard retained for JS callers).
- **#352.2**: prerelease versions (e.g. `2.0.0-rc.1`) no longer pass the pichu/cleffa release gates; only magby accepts prereleases. `getRecommendedNetworkForVersion` consequently recommends magby for prereleases.
- **#352.3**: `multikey.decodePublicKey`/`decodePrivateKey` enforce per-type key lengths (shared table with `validateMultikeyFormat`), closing the wrong-length-body re-encoding hole in `migrateToDIDBTCO` key carry-over.
- **#352.4**: 33-byte keys are rejected instead of "stripping a version byte" in `OriginalsSDK.verifyDIDSignature`, auth's `TurnkeyWebVHSigner.verify`, **and** `Ed25519Verifier` (a sibling site with the same heuristic found during self-review; its `getPublicKeyMultibase` also now refuses to mint a multikey from a wrong-length key).
- **#352.5**: `verifyToken` pins `algorithms: ['HS256']` and JWT secrets must be ≥ 32 chars.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test addition or improvement

**⚠️ Breaking/observable behavior changes** (each is the deliberate point of its fix; every in-repo caller/test was updated in the same change):

1. `verifyCredentialWithStatus` returns `verified: false` for revoked/suspended credentials (was `true` with only the flag set) — #345.
2. `Verifier.verifyCredentialMultiSig` rejects expired credentials and fails closed on declared status without a resolver — #340.
3. `checkRevocationStatus`/`isRevoked` throw on a status list whose `id` mismatches the credential's reference — #345.
4. `SignetProvider.estimateFee` throws instead of returning a fabricated default — #351.
5. `validateVersionForNetwork` rejects prereleases on pichu/cleffa; `getRecommendedNetworkForVersion('X.Y.Z-pre')` now returns `'magby'` — #352.
6. `multikey.decodePublicKey`/`decodePrivateKey` throw on wrong-length key bodies — #352.
7. 33-byte public keys are rejected by `verifyDIDSignature` (throws), `Ed25519Verifier.verify` (returns false), and `TurnkeyWebVHSigner.verify` (returns false) — #352.
8. `verifyToken` requires HS256 tokens and ≥32-char secrets — #352.
9. `addResourceVersion(newContent)` narrows from `string | Buffer` to `string` (compile-time only; runtime already threw) — #311.
10. QuickNodeProvider throws `QUICKNODE_UNEXPECTED_SHAPE`/`QUICKNODE_CONTENT_UNAVAILABLE` where it previously fabricated `'unknown'` txids or returned `null`; malformed inscription ids are dropped from `getInscriptionsBySatoshi` — #350.
11. LRU eviction no longer deletes from persistent `DIDCache` storage (stores can now exceed `maxEntries`) — #313.

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] I have updated JSDoc comments for any changed public APIs
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Testing

- [x] Unit tests — regression tests added for every fix, each verified to FAIL against the unfixed source (33 failures + 1 error with src stashed, 0 with the fixes): `tests/security/issue-batch-340-345-309-312-regressions.test.ts` (10 tests), `tests/unit/events/ManagerEventMirroring.test.ts` (7), plus targeted additions to the QuickNodeProvider, SignetProvider, commit-transaction, DIDCache, Logger, Multikey, KeyManager, network, Ed25519Verifier, and auth test suites. Tests that pinned the old buggy behaviors (revoked-but-verified, prerelease-passes-gate, 33-byte slice, fabricated signet fee, unfiltered inscription ids) were updated to assert the corrected behavior.
- [ ] Integration tests — live signet/QuickNode integration suites remain env-gated (skipped without `ORD_SIGNET_URL`/`QUICKNODE_ENDPOINT`); the signet fee test was updated for the new fail-loud contract.
- [x] Manual testing — full quality gate below.

## Screenshots / Output (if applicable)

```
bun run typecheck:  clean (exit 0)
bun run build:      clean (exit 0)
bun run lint:       exit 0 — sdk 92 warnings / 0 errors, auth 23 warnings / 0 errors (identical to base; 0 added)
bun test (root):    3873 pass / 73 skip / 0 fail  (3946 tests, 217 files)
```

Base-branch note: a fresh checkout of `main` shows 23 failing tests / 4 errors when run before `bun run build` (auth + CEL-CLI suites resolve `@originals/sdk` from `dist/`); after building, base is fully green. The counts above are with the SDK built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPLN9uJU51xcwFtTV5sKuB

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPLN9uJU51xcwFtTV5sKuB)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix verification, event emission, logging, and Bitcoin provider correctness across the SDK
> - **VC verification**: `verifyCredentialWithStatus` and `Verifier.verifyCredential` (multi-sig path) now set `verified=false` for revoked/suspended credentials and enforce validity periods; trust checks are centralized in a new `validateStatusListCredentialTrust` utility.
> - **QuickNodeProvider hardening**: adds `ensureExpectedNetwork()` before all RPCs (throws `QUICKNODE_NETWORK_MISMATCH` on chain mismatch), validates inscription id/location/sat fields, throws `QUICKNODE_CONTENT_UNAVAILABLE` instead of returning null, and adds configurable `contentEncoding`; endpoint URL is no longer echoed in error messages.
> - **Ed25519 key length**: `Ed25519Verifier`, `TurnkeyWebVHSigner.verify`, `OriginalsSDK.verifyDIDSignature`, and `Multikey` decode helpers now strictly require 32-byte keys and throw/return false for 33-byte inputs instead of silently slicing.
> - **Batch & lifecycle events**: `LifecycleManager` emits `asset:migrated` and `asset:transferred`; `OriginalsAsset.verify` emits `verification:completed`; batch operations emit `batch:progress` per settled item.
> - **Logger fixes**: `sanitize` is now cycle-safe (via `WeakSet`), preserves `Date`/`Uint8Array`, and replaces unsanitizable data with `[unsanitizable]` instead of throwing; `FileLogOutput` flushes on process exit and caps buffered lines at 10,000.
> - **Fee/provider fixes**: `SignetProvider.estimateFee` throws instead of returning a fabricated fallback; `LifecycleManager.capEstimatedFeeRate` discards non-finite or above-cap fee estimates; `commit.createCommitTransaction` accepts `tb1` change addresses on regtest.
> - **JWT hardening**: `getJwtSecret` rejects secrets shorter than 32 chars; `verifyToken` pins algorithm to `HS256`.
> - Risk: `verifyCredentialWithStatus` now returns `verified=false` for revoked credentials (previously could return `verified=true` with `revoked=true`), and `SignetProvider.estimateFee` now throws when `bitcoinRpcUrl` is absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b399d93.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->