### PR TITLE
fix: batch VC/CEL/migration/storage hardening — #302 #304 #305 #306 #310 #314 #329

### DIFF
--- a/.changeset/batch-vc-cel-migration-storage-hardening.md
+++ b/.changeset/batch-vc-cel-migration-storage-hardening.md
@@ -1,0 +1,13 @@
+---
+"@originals/sdk": minor
+---
+
+Batch of independent review fixes (#302, #304, #305, #306, #310, #314, #329):
+
+- **#310 (breaking for multi-sig external signers):** multi-sig external-signer contributions were unverifiable — the signer canonicalized itself (JCS) while verification hashes RDFC-2022. The SDK now canonicalizes+hashes and the signer signs those exact bytes via a new optional `ExternalSigner.signBytes(data)`; a signer implementing only the document-level `sign()` is refused up front. did:webvh signing and all other `sign()` usage are unaffected.
+- **#306:** multi-sig signing rejects non-Ed25519 signer keys with a clear upfront error, and verification reports a distinguishing "unsupported/legacy proof format" message instead of a generic "Invalid signature".
+- **#305:** multi-sig proofs are verified concurrently over one shared document loader (deterministic post-collection dedupe; results unchanged).
+- **#304:** the status list credential's proof verification is memoized on the full resolved document (positives-only, TTL-bounded), avoiding N re-verifications of one shared list.
+- **#302:** rollback reports `PARTIALLY_ROLLED_BACK` whenever the failure error carries on-chain artifacts, regardless of the tracked pre-anchoring state.
+- **#314:** added the exported `witnessSigningBytes(digest)` helper and documented the CEL witness signing-byte contract.
+- **#329:** `listObjects(domain, prefix)` is now an optional, documented member of the public `StorageAdapter` interface (additive).

--- a/packages/sdk/src/cel/canonicalize.ts
+++ b/packages/sdk/src/cel/canonicalize.ts
@@ -38,6 +38,35 @@ export function canonicalizeEvent(data: unknown): Uint8Array {
 }
 
 /**
+ * Returns the exact bytes a witness must sign when attesting to a CEL event
+ * (issue #314). `witnessEvent` hands `witness.witness(digestMultibase)` only
+ * the Multibase digest *string* (from `computeDigestMultibase`), and
+ * verification (`verifyEventLog` → `dispatchVerify`) checks the witness
+ * signature against `canonicalizeEvent(digestMultibase)` — i.e. the UTF-8
+ * bytes of the JSON-*quoted* digest (`"uEiD…"`, surrounding quotes INCLUDED),
+ * not the raw digest bytes.
+ *
+ * This convention is easy to get subtly wrong: a third-party witness that
+ * signs the decoded digest bytes, or the unquoted string, produces a proof
+ * that fails verification with no hint why. Expose the contract as a helper so
+ * external witness implementations can sign the correct preimage:
+ *
+ * @example
+ * ```typescript
+ * const message = witnessSigningBytes(digestMultibase); // bytes to sign
+ * const proofValue = multibaseEncode(await ed25519.sign(message, privateKey));
+ * ```
+ *
+ * @param digestMultibase - The Multibase-encoded event digest to attest to
+ *   (exactly the value passed to `WitnessService.witness`).
+ * @returns UTF-8 bytes of the canonical (JSON-quoted) digest — the witness
+ *   signature preimage.
+ */
+export function witnessSigningBytes(digestMultibase: string): Uint8Array {
+  return canonicalizeEvent(digestMultibase);
+}
+
+/**
  * Extracts the *committed* fields of a log entry — exactly the message the
  * signer signs (`{ type, data, previousEvent? }`) — and canonicalizes them for
  * use as the hash-chain preimage.

--- a/packages/sdk/src/cel/witnesses/WitnessService.ts
+++ b/packages/sdk/src/cel/witnesses/WitnessService.ts
@@ -37,12 +37,23 @@ import type { WitnessProof } from '../types.js';
 export interface WitnessService {
   /**
    * Witnesses a digest and returns a proof of attestation.
-   * 
+   *
    * The witness should:
    * 1. Record the digest at the current point in time
    * 2. Generate a cryptographic proof of the attestation
    * 3. Include a witnessedAt timestamp in the proof
-   * 
+   *
+   * ## Signing-byte contract (issue #314)
+   *
+   * For signature-based witness proofs, the signature MUST be computed over
+   * `witnessSigningBytes(digestMultibase)` — the UTF-8 bytes of the
+   * JSON-*quoted* digest string (`"uEiD…"`, surrounding quotes included), NOT
+   * the raw/decoded digest bytes. `verifyEventLog` reconstructs the preimage
+   * as `canonicalizeEvent(digestMultibase)`, so a witness that signs the
+   * decoded bytes (or the unquoted string) produces a proof that fails
+   * verification with no hint why. Use the exported `witnessSigningBytes`
+   * helper to obtain the exact preimage.
+   *
    * @param digestMultibase - The Multibase-encoded digest to witness (from computeDigestMultibase)
    * @returns A WitnessProof containing the attestation and witnessedAt timestamp
    * @throws Error if the witness service is unavailable or fails

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -211,6 +211,7 @@ export {
   decodeDigestMultibase,
   digestMultibaseEquals,
 } from './cel/hash.js';
+export { witnessSigningBytes } from './cel/canonicalize.js';
 export {
   createExternalReference,
   verifyExternalReference,

--- a/packages/sdk/src/migration/rollback/RollbackManager.ts
+++ b/packages/sdk/src/migration/rollback/RollbackManager.ts
@@ -115,8 +115,24 @@ export class RollbackManager implements IRollbackManager {
       ]);
       const failedBeforeAnchoring =
         context?.stateAtFailure !== undefined && preAnchoringStates.has(context.stateAtFailure);
-      if (checkpoint.targetLayer === 'btco' && !failedBeforeAnchoring) {
-        const artifactDetails = this.extractBitcoinArtifacts(context);
+
+      // Positive broadcast signal (issue #302). The `preAnchoringStates`
+      // inference above is a NEGATIVE, choreography-coupled heuristic: it
+      // trusts that broadcast only ever happens after the ANCHORING
+      // transition. A future operation (or a refactor) that broadcasts while
+      // the tracked state is still IN_PROGRESS — or that adds its ANCHORING
+      // transition AFTER inscribeData — would make that inference report a
+      // clean ROLLED_BACK for a migration that actually spent fees, and the
+      // caller would retry and pay for a second inscription (the #237 bug this
+      // logic prevents). So when the failing error carries on-chain artifacts
+      // (txids/inscriptionId from BitcoinManager.inscribeData), that is direct
+      // evidence a broadcast happened: force partial rollback regardless of
+      // the tracked state. This override can only make the report MORE
+      // conservative, never less.
+      const broadcastArtifacts = this.extractBitcoinArtifacts(context);
+      const broadcastConfirmed = broadcastArtifacts !== undefined;
+      if (checkpoint.targetLayer === 'btco' && (!failedBeforeAnchoring || broadcastConfirmed)) {
+        const artifactDetails = broadcastArtifacts;
         return {
           success: false,
           migrationId,

--- a/packages/sdk/src/storage/StorageAdapter.ts
+++ b/packages/sdk/src/storage/StorageAdapter.ts
@@ -16,6 +16,23 @@ export interface StorageAdapter {
 
   // Checks whether a path exists
   exists(domain: string, path: string): Promise<boolean>;
+
+  /**
+   * OPTIONAL prefix enumeration hook (issue #329). Returns every stored path
+   * under `domain` whose key starts with `prefix` (paths are the same bare key
+   * strings passed to putObject/getObject).
+   *
+   * This is additive and non-breaking: adapters that omit it keep working.
+   * The migration audit log (AuditLogger) prefers this native enumeration and
+   * only falls back to a shared, single-process-safe `index.json` for opaque
+   * custom adapters that implement neither `listObjects` nor a legacy `list`.
+   * Implement it on custom adapters to make audit/checkpoint discovery
+   * race-free across processes — each record already lives at a unique
+   * immutable key, so enumeration needs no shared read-modify-write object.
+   *
+   * The shipped MemoryStorageAdapter and LocalStorageAdapter implement this.
+   */
+  listObjects?(domain: string, prefix: string): Promise<string[]>;
 }
 
 export interface LocalStorageAdapterOptions {

--- a/packages/sdk/src/types/common.ts
+++ b/packages/sdk/src/types/common.ts
@@ -70,7 +70,24 @@ export interface ExternalSigner {
    * @returns The proof value (typically multibase-encoded signature)
    */
   sign(input: { document: Record<string, unknown>; proof: Record<string, unknown> }): Promise<{ proofValue: string }>;
-  
+
+  /**
+   * OPTIONAL: sign pre-canonicalized, pre-hashed bytes (issue #310).
+   *
+   * Required for multi-sig `eddsa-rdfc-2022` contributions
+   * (`MultiSigManager.signWithExternalSigner`), where the SDK — not the signer
+   * — canonicalizes and hashes with RDFC-2022, and the signer must sign
+   * exactly those bytes. The document-level {@link ExternalSigner.sign} above
+   * lets the signer choose its own canonicalization (didwebvh-ts signers use
+   * JCS), which does NOT match multi-sig verification; a `sign()`-only signer's
+   * multi-sig contribution can never verify. Signers that back multi-sig must
+   * implement this and return the raw signature bytes.
+   *
+   * @param data - The exact bytes to sign (already canonicalized + hashed).
+   * @returns The raw signature bytes.
+   */
+  signBytes?(data: Uint8Array): Promise<{ signature: Uint8Array }>;
+
   /**
    * Get the verification method ID for this signer
    * @returns The verification method ID (e.g., "did:key:z6Mk...")

--- a/packages/sdk/src/vc/MultiSigManager.ts
+++ b/packages/sdk/src/vc/MultiSigManager.ts
@@ -686,10 +686,15 @@ export class MultiSigManager {
 
     const signResult = await signer.signBytes(hashData);
     const signature = signResult?.signature;
-    if (!(signature instanceof Uint8Array) || signature.length === 0) {
+    // eddsa-rdfc-2022 is Ed25519-only, so a valid signature is exactly 64
+    // bytes. Reject a wrong-length return here (mirrors the sign() guard in
+    // EdDSACryptosuiteManager) instead of base58-encoding it into a
+    // syntactically valid but never-verifiable proofValue.
+    if (!(signature instanceof Uint8Array) || signature.length !== 64) {
       throw new Error(
         `External signer for ${verificationMethod} returned an invalid signBytes result ` +
-        `(expected { signature: Uint8Array }).`
+        `(expected { signature: Uint8Array } of 64 bytes for Ed25519, got ` +
+        `${signature instanceof Uint8Array ? `${signature.length} bytes` : typeof signature}).`
       );
     }
 

--- a/packages/sdk/src/vc/MultiSigManager.ts
+++ b/packages/sdk/src/vc/MultiSigManager.ts
@@ -16,7 +16,9 @@ import { checkCredentialValidityPeriod } from './Verifier.js';
 import { withSecuringContext } from './Issuer.js';
 import { DataIntegrityProofManager } from './proofs/data-integrity.js';
 import { createDocumentLoader } from './documentLoader.js';
-import type { DataIntegrityProof } from './cryptosuites/eddsa.js';
+import { EdDSACryptosuiteManager, type DataIntegrityProof } from './cryptosuites/eddsa.js';
+import { multikey } from '../crypto/Multikey.js';
+import { describeMultiSigProofFailure } from './multiSigProofFormat.js';
 
 /**
  * MultiSigManager handles m-of-n multi-signature operations for verifiable credentials.
@@ -229,17 +231,29 @@ export class MultiSigManager {
       return result;
     }
 
-    // Verify each proof individually, tracking unique signers
-    const seenSigners = new Set<string>();
-    for (const proof of proofs) {
+    // Verify the proofs concurrently (issue #305). The independent per-proof
+    // verifications — each an RDF canonicalization plus a possibly-networked
+    // signer DID resolution — no longer run in sequence (wall-clock was the
+    // SUM of the resolutions instead of the MAX). The document loader is built
+    // ONCE and shared, and the signer-dedupe/threshold accounting runs in a
+    // deterministic post-collection pass below, so results stay identical and
+    // order-independent (only authorized proofs incur the expensive verify,
+    // exactly as the sequential path did).
+    const loader = this.didManager ? createDocumentLoader(this.didManager) : undefined;
+    const evaluations = await Promise.all(proofs.map(async (proof) => {
       const vm = proof.verificationMethod;
-      if (!policy.signerVerificationMethods.includes(vm)) {
+      const authorized = policy.signerVerificationMethods.includes(vm);
+      const valid = authorized ? await this.verifyProof(credential, proof, loader) : false;
+      return { proof, vm, authorized, valid };
+    }));
+
+    const seenSigners = new Set<string>();
+    for (const { proof, vm, authorized, valid } of evaluations) {
+      if (!authorized) {
         result.invalidSigners.push(vm);
         result.errors.push(`Signer ${vm} is not authorized by the policy`);
         continue;
       }
-
-      const valid = await this.verifyProof(credential, proof);
       if (valid) {
         // Reject duplicate proofs from the same signer. Dedupe only after
         // successful verification so an invalid proof cannot consume the
@@ -253,7 +267,10 @@ export class MultiSigManager {
         result.validSigners.push(vm);
       } else {
         result.invalidSigners.push(vm);
-        result.errors.push(`Invalid signature from ${vm}`);
+        // Distinguish a legacy/unsupported proof format from a bad signature
+        // so callers holding pre-Data-Integrity proofs get actionable guidance
+        // (issue #306) instead of a misleading "Invalid signature".
+        result.errors.push(describeMultiSigProofFailure(proof, vm));
       }
     }
 
@@ -567,6 +584,30 @@ export class MultiSigManager {
 
   // === Private helpers ===
 
+  /**
+   * Throw a clear, actionable error when a multi-sig signer key is not
+   * Ed25519 (issue #306). eddsa-rdfc-2022 is the only Data Integrity
+   * cryptosuite implemented and it is Ed25519-only; a secp256k1 (ES256K, the
+   * SDK's default) or ES256 key would otherwise fail with the opaque
+   * `Invalid key type for EdDSA` thrown from inside the cryptosuite.
+   */
+  private assertEd25519SignerKey(privateKeyMultibase: string, verificationMethod: string): void {
+    let keyType: string;
+    try {
+      keyType = multikey.decodePrivateKey(privateKeyMultibase).type;
+    } catch (e) {
+      throw new Error(
+        `Multi-sig signer key for ${verificationMethod} is not a valid Multikey private key: ${(e as Error).message}`
+      );
+    }
+    if (keyType !== 'Ed25519') {
+      throw new Error(
+        `Multi-sig signing requires an Ed25519 signer key; the key for ${verificationMethod} is ${keyType}. ` +
+        `eddsa-rdfc-2022 is the only Data Integrity cryptosuite implemented (no ECDSA suite yet — see issue #306).`
+      );
+    }
+  }
+
   private async signWithPrivateKey(
     credential: VerifiableCredential,
     privateKeyMultibase: string,
@@ -581,6 +622,14 @@ export class MultiSigManager {
         'MultiSigManager requires a DIDManager to create Data Integrity proofs; pass one to the constructor'
       );
     }
+    // Multi-sig proofs are eddsa-rdfc-2022 — the only Data Integrity
+    // cryptosuite implemented — which is Ed25519-only. Reject a non-Ed25519
+    // signer key here with a clear, actionable message instead of letting it
+    // fall through to the low-level `Invalid key type for EdDSA` thrown deep
+    // inside EdDSACryptosuiteManager (issue #306). An ECDSA cryptosuite
+    // (ecdsa-rdfc-2019) would be required to sign multi-sig with ES256K/ES256
+    // keys; until it exists, this is a hard, well-labelled limitation.
+    this.assertEd25519SignerKey(privateKeyMultibase, verificationMethod);
     const documentLoader = createDocumentLoader(this.didManager);
     const unsigned: Record<string, unknown> = { ...credential };
     delete unsigned.proof;
@@ -601,23 +650,58 @@ export class MultiSigManager {
     signer: ExternalSigner,
     verificationMethod: string
   ): Promise<Proof> {
-    const proofBase = {
-      type: 'DataIntegrityProof',
-      cryptosuite: 'eddsa-rdfc-2022',
-      created: new Date().toISOString(),
-      verificationMethod,
-      proofPurpose: 'assertionMethod',
-    };
+    if (!this.didManager) {
+      throw new Error(
+        'MultiSigManager requires a DIDManager to create Data Integrity proofs; pass one to the constructor'
+      );
+    }
+    // The SDK canonicalizes and hashes (RDFC-2022); the external signer signs
+    // ONLY those bytes (issue #310). Handing the raw {document, proof} to the
+    // document-level sign() delegated canonicalization to the signer — and
+    // shipped signers (e.g. Turnkey via didwebvh-ts) canonicalize with JCS,
+    // so the signature was over JCS bytes while multi-sig verification hashes
+    // RDFC bytes. Every such contribution failed verification and could never
+    // count toward the threshold. Require the byte-level signBytes capability
+    // and fail loudly for signers that only implement document-level sign().
+    if (typeof signer.signBytes !== 'function') {
+      throw new Error(
+        `External signer for ${verificationMethod} must implement signBytes(data) to contribute an ` +
+        `eddsa-rdfc-2022 multi-sig proof. The SDK canonicalizes and hashes (RDFC-2022) and the signer ` +
+        `signs those bytes; a signer implementing only the document-level sign() canonicalizes ` +
+        `differently (e.g. JCS) and its contribution can never verify (issue #310).`
+      );
+    }
 
+    const documentLoader = createDocumentLoader(this.didManager);
     const unsignedCredential: Record<string, unknown> = { ...credential };
     delete unsignedCredential.proof;
 
-    const { proofValue } = await signer.sign({
-      document: unsignedCredential,
-      proof: proofBase,
+    const { hashData, proofConfig } = await EdDSACryptosuiteManager.computeSigningInput(unsignedCredential, {
+      type: 'DataIntegrityProof',
+      cryptosuite: 'eddsa-rdfc-2022',
+      verificationMethod,
+      proofPurpose: 'assertionMethod',
+      documentLoader,
     });
 
-    return { ...proofBase, proofValue };
+    const signResult = await signer.signBytes(hashData);
+    const signature = signResult?.signature;
+    if (!(signature instanceof Uint8Array) || signature.length === 0) {
+      throw new Error(
+        `External signer for ${verificationMethod} returned an invalid signBytes result ` +
+        `(expected { signature: Uint8Array }).`
+      );
+    }
+
+    const proof: Record<string, unknown> = {
+      ...proofConfig,
+      proofValue: EdDSACryptosuiteManager.encodeProofValue(signature),
+    };
+    // computeSigningInput's proofConfig carries the @context used for hashing;
+    // it must not appear on the emitted proof (verify re-attaches the
+    // credential's @context, exactly as createProof does).
+    delete proof['@context'];
+    return proof as unknown as Proof;
   }
 
   /**
@@ -629,7 +713,8 @@ export class MultiSigManager {
    */
   private async verifyProof(
     credential: VerifiableCredential,
-    proof: Proof
+    proof: Proof,
+    sharedLoader?: (iri: string) => Promise<unknown>
   ): Promise<boolean> {
     try {
       const { proofValue, verificationMethod } = proof;
@@ -645,7 +730,9 @@ export class MultiSigManager {
       if ((proof as { proofPurpose?: unknown }).proofPurpose !== 'assertionMethod') {
         return false;
       }
-      const loader = createDocumentLoader(this.didManager);
+      // Reuse the caller's loader when verifying a batch of proofs (issue
+      // #305) so N proofs share one loader instead of constructing one each.
+      const loader = sharedLoader ?? createDocumentLoader(this.didManager);
       const result = await DataIntegrityProofManager.verifyProof(
         credential,
         proof as unknown as DataIntegrityProof,

--- a/packages/sdk/src/vc/Verifier.ts
+++ b/packages/sdk/src/vc/Verifier.ts
@@ -1,5 +1,6 @@
 import { VerifiableCredential, VerifiablePresentation, BitstringStatusListEntry, MultiSigPolicy } from '../types/index.js';
 import type { MultiSigVerificationResult } from '../types/index.js';
+import { describeMultiSigProofFailure } from './multiSigProofFormat.js';
 import { DIDManager } from '../did/DIDManager.js';
 import { createDocumentLoader } from './documentLoader.js';
 import { DataIntegrityProofManager } from './proofs/data-integrity.js';
@@ -61,6 +62,19 @@ export type StatusListResolver = (url: string) => Promise<VerifiableCredential |
 
 export class Verifier {
   private statusListResolver?: StatusListResolver;
+
+  /**
+   * Memoizes the expensive proof verification of resolved status list
+   * credentials (issue #304). Keyed by the list's `id` + its `proofValue`(s):
+   * a status list credential is immutable for a given proofValue, so this key
+   * is exact and carries no staleness risk. Verifying N credentials that share
+   * one status list (the normal deployment — one list covers up to 131,072
+   * credentials) otherwise re-runs RDF canonicalization + issuer DID
+   * resolution + signature verification of the same (often tens-of-KB)
+   * document N times. The stored promise also collapses concurrent checks.
+   */
+  private statusListProofCache = new Map<string, Promise<VerificationResult>>();
+  private static readonly STATUS_LIST_PROOF_CACHE_MAX = 256;
 
   constructor(private didManager: DIDManager, options?: { statusListResolver?: StatusListResolver }) {
     this.statusListResolver = options?.statusListResolver;
@@ -321,8 +335,58 @@ export class Verifier {
     statusListVC: VerifiableCredential
   ): Promise<VerificationResult> {
     return validateStatusListCredentialTrust(vc, entry, statusListVC, (listVC) =>
-      this.verifyCredential(listVC, { checkStatus: false })
+      this.verifyStatusListProofCached(listVC)
     );
+  }
+
+  /**
+   * Verify a status list credential's own proof, memoized per (id, proofValue)
+   * so repeated status checks against the same immutable list don't re-run the
+   * expensive canonicalization + signature verification (issue #304). Only the
+   * list-only proof verification is cached; the id-match and issuer-equality
+   * trust checks (which depend on the credential being checked) still run every
+   * call in validateStatusListCredentialTrust.
+   */
+  private verifyStatusListProofCached(listVC: VerifiableCredential): Promise<VerificationResult> {
+    const key = this.statusListCacheKey(listVC);
+    if (key === null) {
+      // No stable (id + proofValue) identity to key on — verify without
+      // caching. An unsigned or id-less list also fails the surrounding trust
+      // checks, so this path is not a bypass.
+      return this.verifyCredential(listVC, { checkStatus: false });
+    }
+    let pending = this.statusListProofCache.get(key);
+    if (!pending) {
+      pending = this.verifyCredential(listVC, { checkStatus: false });
+      // Bound the cache: evict oldest insertion when over the cap.
+      if (this.statusListProofCache.size >= Verifier.STATUS_LIST_PROOF_CACHE_MAX) {
+        const oldest = this.statusListProofCache.keys().next().value;
+        if (oldest !== undefined) this.statusListProofCache.delete(oldest);
+      }
+      this.statusListProofCache.set(key, pending);
+      // verifyCredential resolves (never rejects) with a VerificationResult,
+      // but guard against an unexpected rejection poisoning the cache.
+      pending.catch(() => this.statusListProofCache.delete(key));
+    }
+    return pending;
+  }
+
+  /**
+   * Cache key for a resolved status list credential: its `id` joined with its
+   * `proofValue`(s). Returns null when either is missing so such lists are not
+   * cached (they also fail the trust checks). The list is immutable for a given
+   * proofValue, so this key is exact.
+   */
+  private statusListCacheKey(listVC: VerifiableCredential): string | null {
+    const id = (listVC as { id?: unknown }).id;
+    if (typeof id !== 'string' || id.length === 0) return null;
+    const rawProof = (listVC as { proof?: unknown }).proof;
+    const proofs = Array.isArray(rawProof) ? rawProof : rawProof ? [rawProof] : [];
+    const proofValues = proofs
+      .map(p => (p as { proofValue?: unknown })?.proofValue)
+      .filter((v): v is string => typeof v === 'string' && v.length > 0);
+    if (proofValues.length === 0) return null;
+    return `${id} ${proofValues.join(' ')}`;
   }
 
   /**
@@ -368,17 +432,21 @@ export class Verifier {
         : [String(vcContext)];
       for (const c of ctxs) await loader(c);
 
-      // Verify each proof, counting each authorized signer at most once so a
-      // replicated proof cannot satisfy the threshold on its own.
-      const seenSigners = new Set<string>();
-      for (const proof of proofs) {
+      // Verify the proofs concurrently, then account for them in a
+      // deterministic post-collection pass (issue #305). The independent
+      // per-proof verifications — RDF canonicalization + a possibly-networked
+      // signer DID resolution — previously ran strictly in sequence, so
+      // wall-clock latency was the SUM of the signer resolutions instead of
+      // the MAX. The shared `loader` (built once above) is reused across all
+      // proofs, and the seen-signer dedupe / threshold accounting runs below
+      // over results in original order, so the outcome is identical and
+      // order-independent. Only authorized, correct-purpose proofs incur the
+      // expensive verification, exactly as the sequential path did.
+      const evaluations = await Promise.all(proofs.map(async (proof) => {
         const vm = proof.verificationMethod;
         if (!policy.signerVerificationMethods.includes(vm)) {
-          result.invalidSigners.push(vm);
-          result.errors.push(`Signer ${vm} is not authorized by the policy`);
-          continue;
+          return { kind: 'unauthorized' as const, vm };
         }
-
         // A multi-sig member proof is an ASSERTION (issuance assent). Without
         // this check, a signature an authorized signer produced for another
         // purpose (e.g. `authentication`) would count toward the assertion
@@ -386,11 +454,8 @@ export class Verifier {
         // into the signed proof-config hash, so it cannot be flipped after
         // signing; rejecting the wrong purpose here refuses the reuse.
         if ((proof as { proofPurpose?: unknown }).proofPurpose !== 'assertionMethod') {
-          result.invalidSigners.push(vm);
-          result.errors.push(`Proof from ${vm} has proofPurpose ${String((proof as { proofPurpose?: unknown }).proofPurpose)}, expected assertionMethod`);
-          continue;
+          return { kind: 'wrong-purpose' as const, vm, proof };
         }
-
         try {
           // Every proof this SDK emits is a Data Integrity eddsa-rdfc-2022
           // proof; there is no legacy proof format. Anything else fails
@@ -400,25 +465,40 @@ export class Verifier {
             proof as unknown as DataIntegrityProof,
             { documentLoader: loader }
           );
-          const proofVerified = proofResult.verified === true;
-          if (proofVerified) {
-            // Dedupe only after successful verification: an invalid proof
-            // must not consume the signer's slot and suppress a later valid
-            // proof from the same signer.
-            if (seenSigners.has(vm)) {
-              result.errors.push(`Duplicate proof from ${vm} (ignored)`);
-              continue;
-            }
-            seenSigners.add(vm);
-            result.validSignatures++;
-            result.validSigners.push(vm);
-          } else {
-            result.invalidSigners.push(vm);
-            result.errors.push(`Invalid signature from ${vm}`);
-          }
+          return { kind: proofResult.verified === true ? ('verified' as const) : ('invalid' as const), vm, proof };
         } catch (e) {
+          return { kind: 'error' as const, vm, error: (e as Error).message };
+        }
+      }));
+
+      const seenSigners = new Set<string>();
+      for (const ev of evaluations) {
+        const vm = ev.vm;
+        if (ev.kind === 'unauthorized') {
           result.invalidSigners.push(vm);
-          result.errors.push(`Verification error for ${vm}: ${(e as Error).message}`);
+          result.errors.push(`Signer ${vm} is not authorized by the policy`);
+        } else if (ev.kind === 'wrong-purpose') {
+          result.invalidSigners.push(vm);
+          result.errors.push(`Proof from ${vm} has proofPurpose ${String((ev.proof as { proofPurpose?: unknown }).proofPurpose)}, expected assertionMethod`);
+        } else if (ev.kind === 'verified') {
+          // Dedupe only after successful verification: an invalid proof must
+          // not consume the signer's slot and suppress a later valid proof
+          // from the same signer.
+          if (seenSigners.has(vm)) {
+            result.errors.push(`Duplicate proof from ${vm} (ignored)`);
+            continue;
+          }
+          seenSigners.add(vm);
+          result.validSignatures++;
+          result.validSigners.push(vm);
+        } else if (ev.kind === 'invalid') {
+          result.invalidSigners.push(vm);
+          // Distinguish a legacy/unsupported proof format from a genuine bad
+          // signature (issue #306).
+          result.errors.push(describeMultiSigProofFailure(ev.proof, vm));
+        } else {
+          result.invalidSigners.push(vm);
+          result.errors.push(`Verification error for ${vm}: ${ev.error}`);
         }
       }
 

--- a/packages/sdk/src/vc/Verifier.ts
+++ b/packages/sdk/src/vc/Verifier.ts
@@ -65,16 +65,29 @@ export class Verifier {
 
   /**
    * Memoizes the expensive proof verification of resolved status list
-   * credentials (issue #304). Keyed by the list's `id` + its `proofValue`(s):
-   * a status list credential is immutable for a given proofValue, so this key
-   * is exact and carries no staleness risk. Verifying N credentials that share
-   * one status list (the normal deployment — one list covers up to 131,072
-   * credentials) otherwise re-runs RDF canonicalization + issuer DID
-   * resolution + signature verification of the same (often tens-of-KB)
-   * document N times. The stored promise also collapses concurrent checks.
+   * credentials (issue #304). Verifying N credentials that share one status
+   * list (the normal deployment — one list covers up to 131,072 credentials)
+   * otherwise re-runs RDF canonicalization + issuer DID resolution + signature
+   * verification of the same (often tens-of-KB) document N times.
+   *
+   * Security-critical keying (see the #304 self-review): the cache MUST key on
+   * the FULL resolved document, not on `id + proofValue`. The stored verdict is
+   * a property of the entire (body + proof) credential; the caller reads the
+   * revocation bits from the PRESENTED document. Keying on `id + proofValue`
+   * let a poisoned resolver / holder swap a forged all-zeros body under a
+   * legitimate `id + proofValue` (both are public) and reuse a cached
+   * "verified" verdict without the proof ever being checked against that body —
+   * a revocation bypass (#238). A full-document key collides only on
+   * byte-identical content, so reusing the verdict is sound.
+   *
+   * Only VERIFIED (`true`) verdicts are cached: a `false` result may be a
+   * transient issuer-DID-resolution failure, and caching it would fail-closed a
+   * legitimate list until eviction. A short TTL bounds staleness (e.g. a signer
+   * key revoked after a positive verdict was cached).
    */
-  private statusListProofCache = new Map<string, Promise<VerificationResult>>();
+  private statusListProofCache = new Map<string, { at: number; result: VerificationResult }>();
   private static readonly STATUS_LIST_PROOF_CACHE_MAX = 256;
+  private static readonly STATUS_LIST_PROOF_CACHE_TTL_MS = 5 * 60 * 1000;
 
   constructor(private didManager: DIDManager, options?: { statusListResolver?: StatusListResolver }) {
     this.statusListResolver = options?.statusListResolver;
@@ -340,53 +353,52 @@ export class Verifier {
   }
 
   /**
-   * Verify a status list credential's own proof, memoized per (id, proofValue)
-   * so repeated status checks against the same immutable list don't re-run the
-   * expensive canonicalization + signature verification (issue #304). Only the
-   * list-only proof verification is cached; the id-match and issuer-equality
-   * trust checks (which depend on the credential being checked) still run every
-   * call in validateStatusListCredentialTrust.
+   * Verify a status list credential's own proof, memoized on the FULL resolved
+   * document so repeated status checks against the same immutable list don't
+   * re-run the expensive canonicalization + signature verification (issue
+   * #304). Only the list-only proof verification is cached; the id-match and
+   * issuer-equality trust checks (which depend on the credential being checked)
+   * still run every call in validateStatusListCredentialTrust.
    */
-  private verifyStatusListProofCached(listVC: VerifiableCredential): Promise<VerificationResult> {
+  private async verifyStatusListProofCached(listVC: VerifiableCredential): Promise<VerificationResult> {
     const key = this.statusListCacheKey(listVC);
-    if (key === null) {
-      // No stable (id + proofValue) identity to key on — verify without
-      // caching. An unsigned or id-less list also fails the surrounding trust
-      // checks, so this path is not a bypass.
-      return this.verifyCredential(listVC, { checkStatus: false });
+    if (key !== null) {
+      const cached = this.statusListProofCache.get(key);
+      if (cached) {
+        if (Date.now() - cached.at < Verifier.STATUS_LIST_PROOF_CACHE_TTL_MS) {
+          return cached.result;
+        }
+        this.statusListProofCache.delete(key); // expired
+      }
     }
-    let pending = this.statusListProofCache.get(key);
-    if (!pending) {
-      pending = this.verifyCredential(listVC, { checkStatus: false });
-      // Bound the cache: evict oldest insertion when over the cap.
+    const result = await this.verifyCredential(listVC, { checkStatus: false });
+    // Cache ONLY verified lists (see the field docstring): a false verdict may
+    // be a transient issuer-resolution failure, and the document key already
+    // guarantees a cached true corresponds to this exact body.
+    if (key !== null && result.verified) {
       if (this.statusListProofCache.size >= Verifier.STATUS_LIST_PROOF_CACHE_MAX) {
         const oldest = this.statusListProofCache.keys().next().value;
         if (oldest !== undefined) this.statusListProofCache.delete(oldest);
       }
-      this.statusListProofCache.set(key, pending);
-      // verifyCredential resolves (never rejects) with a VerificationResult,
-      // but guard against an unexpected rejection poisoning the cache.
-      pending.catch(() => this.statusListProofCache.delete(key));
+      this.statusListProofCache.set(key, { at: Date.now(), result });
     }
-    return pending;
+    return result;
   }
 
   /**
-   * Cache key for a resolved status list credential: its `id` joined with its
-   * `proofValue`(s). Returns null when either is missing so such lists are not
-   * cached (they also fail the trust checks). The list is immutable for a given
-   * proofValue, so this key is exact.
+   * Cache key for a resolved status list credential: a serialization of the
+   * ENTIRE document. Two documents collide only when byte-identical, so a
+   * cached verdict is only ever reused for the exact body it was computed over
+   * -- a forged body (even with a matching id/proofValue) serializes
+   * differently and is re-verified. Returns null if the credential is not
+   * serializable (then it is never cached).
    */
   private statusListCacheKey(listVC: VerifiableCredential): string | null {
-    const id = (listVC as { id?: unknown }).id;
-    if (typeof id !== 'string' || id.length === 0) return null;
-    const rawProof = (listVC as { proof?: unknown }).proof;
-    const proofs = Array.isArray(rawProof) ? rawProof : rawProof ? [rawProof] : [];
-    const proofValues = proofs
-      .map(p => (p as { proofValue?: unknown })?.proofValue)
-      .filter((v): v is string => typeof v === 'string' && v.length > 0);
-    if (proofValues.length === 0) return null;
-    return `${id} ${proofValues.join(' ')}`;
+    try {
+      return JSON.stringify(listVC);
+    } catch {
+      return null;
+    }
   }
 
   /**

--- a/packages/sdk/src/vc/Verifier.ts
+++ b/packages/sdk/src/vc/Verifier.ts
@@ -7,6 +7,8 @@ import { DataIntegrityProofManager } from './proofs/data-integrity.js';
 import type { DataIntegrityProof } from './cryptosuites/eddsa.js';
 import { StatusListManager } from './StatusListManager.js';
 import { validateStatusListCredentialTrust } from './statusListTrust.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex } from '@noble/hashes/utils.js';
 
 export type VerificationResult = { verified: boolean; errors: string[] };
 
@@ -366,7 +368,9 @@ export class Verifier {
       const cached = this.statusListProofCache.get(key);
       if (cached) {
         if (Date.now() - cached.at < Verifier.STATUS_LIST_PROOF_CACHE_TTL_MS) {
-          return cached.result;
+          // Return a fresh copy so a caller mutating `errors` cannot corrupt the
+          // cached entry (and vice-versa).
+          return { verified: cached.result.verified, errors: [...cached.result.errors] };
         }
         this.statusListProofCache.delete(key); // expired
       }
@@ -380,25 +384,31 @@ export class Verifier {
         const oldest = this.statusListProofCache.keys().next().value;
         if (oldest !== undefined) this.statusListProofCache.delete(oldest);
       }
-      this.statusListProofCache.set(key, { at: Date.now(), result });
+      // Store a snapshot, not the returned reference, so post-return mutation of
+      // `result.errors` cannot pollute the cache.
+      this.statusListProofCache.set(key, { at: Date.now(), result: { verified: result.verified, errors: [...result.errors] } });
     }
     return result;
   }
 
   /**
-   * Cache key for a resolved status list credential: a serialization of the
-   * ENTIRE document. Two documents collide only when byte-identical, so a
-   * cached verdict is only ever reused for the exact body it was computed over
-   * -- a forged body (even with a matching id/proofValue) serializes
-   * differently and is re-verified. Returns null if the credential is not
-   * serializable (then it is never cached).
+   * Cache key for a resolved status list credential: a SHA-256 hash of the
+   * serialization of the ENTIRE document. Two documents collide only on a
+   * SHA-256 collision (i.e. never in practice), so a cached verdict is only
+   * ever reused for the exact body it was computed over -- a forged body (even
+   * with a matching id/proofValue) hashes differently and is re-verified. The
+   * fixed-length hash keeps the cache small regardless of the list's
+   * `encodedList` size. Returns null if the credential is not serializable
+   * (then it is never cached).
    */
   private statusListCacheKey(listVC: VerifiableCredential): string | null {
+    let serialized: string;
     try {
-      return JSON.stringify(listVC);
+      serialized = JSON.stringify(listVC);
     } catch {
       return null;
     }
+    return bytesToHex(sha256(new TextEncoder().encode(serialized)));
   }
 
   /**

--- a/packages/sdk/src/vc/cryptosuites/eddsa.ts
+++ b/packages/sdk/src/vc/cryptosuites/eddsa.ts
@@ -16,9 +16,7 @@ export interface VerificationResult {
 export class EdDSACryptosuiteManager {
 
   static async createProof(document: any, options: any): Promise<DataIntegrityProof> {
-    const proofConfig = await this.createProofConfiguration(options, document?.['@context']);
-    const transformedData = await this.transform(document, options);
-    const hashData = await this.hash(transformedData, proofConfig, options);
+    const { hashData, proofConfig } = await this.computeSigningInput(document, options);
     let privateKey: Uint8Array;
     if (typeof options.privateKey === 'string') {
       const dec = multikey.decodePrivateKey(options.privateKey);
@@ -32,7 +30,29 @@ export class EdDSACryptosuiteManager {
     const proofValueBytes = await this.sign({ data: hashData, privateKey });
     delete (proofConfig)['@context'];
     // proofValue is multibase base58btc per the Data Integrity spec
-    return { ...proofConfig, proofValue: `z${base58.encode(proofValueBytes)}` } as DataIntegrityProof;
+    return { ...proofConfig, proofValue: this.encodeProofValue(proofValueBytes) } as DataIntegrityProof;
+  }
+
+  /**
+   * Compute the eddsa-rdfc-2022 signing input so an EXTERNAL signer can sign
+   * pre-canonicalized, pre-hashed bytes (issue #310). The SDK canonicalizes
+   * (RDFC-2022) and hashes; the signer only signs the returned `hashData`. The
+   * returned `proofConfig` (minus its `@context`) must be emitted verbatim as
+   * the proof so verification reconstructs and hashes identical bytes.
+   *
+   * This is the SAME construction `createProof` uses, factored out so the
+   * local-key and external-signer paths cannot drift.
+   */
+  static async computeSigningInput(document: any, options: any): Promise<{ hashData: Uint8Array; proofConfig: Record<string, unknown> }> {
+    const proofConfig = await this.createProofConfiguration(options, document?.['@context']);
+    const transformedData = await this.transform(document, options);
+    const hashData = await this.hash(transformedData, proofConfig, options);
+    return { hashData, proofConfig: proofConfig as Record<string, unknown> };
+  }
+
+  /** Encode a raw Ed25519 signature as a multibase base58btc (`z…`) proofValue. */
+  static encodeProofValue(signatureBytes: Uint8Array): string {
+    return `z${base58.encode(signatureBytes)}`;
   }
 
   static async verifyProof(document: any, proof: DataIntegrityProof, options: any): Promise<VerificationResult> {

--- a/packages/sdk/src/vc/multiSigProofFormat.ts
+++ b/packages/sdk/src/vc/multiSigProofFormat.ts
@@ -1,0 +1,38 @@
+import type { Proof } from '../types/index.js';
+
+/**
+ * The only Data Integrity cryptosuite this SDK signs and verifies.
+ * Multi-sig member proofs must declare it; anything else is either a legacy
+ * proof from an older SDK release or an unsupported format.
+ */
+export const MULTISIG_CRYPTOSUITE = 'eddsa-rdfc-2022';
+
+/**
+ * Produce a caller-facing error message for a multi-sig member proof that
+ * failed verification, distinguishing an UNSUPPORTED/legacy proof format from
+ * a genuine bad signature (issue #306).
+ *
+ * A proof whose `cryptosuite` is missing or not {@link MULTISIG_CRYPTOSUITE}
+ * (e.g. a legacy cryptosuite-less proof from a pre-Data-Integrity SDK release,
+ * or a did:btco-inscribed provenance proof in an old format) can never verify
+ * against the current path. Reporting the generic `Invalid signature from …`
+ * for it is misleading — it suggests a tampered/forged signature rather than a
+ * format that is simply no longer supported and must be re-signed.
+ */
+export function describeMultiSigProofFailure(proof: Proof, verificationMethod: string): string {
+  const cryptosuite = (proof as { cryptosuite?: unknown }).cryptosuite;
+  if (cryptosuite !== MULTISIG_CRYPTOSUITE) {
+    const shown =
+      cryptosuite === undefined
+        ? 'undefined'
+        : typeof cryptosuite === 'string'
+          ? cryptosuite
+          : JSON.stringify(cryptosuite);
+    return (
+      `Unsupported multi-sig proof format from ${verificationMethod}: ` +
+      `cryptosuite ${shown} is not supported ` +
+      `(only ${MULTISIG_CRYPTOSUITE}). Legacy-format proofs from older SDK releases must be re-signed — see issue #306.`
+    );
+  }
+  return `Invalid signature from ${verificationMethod}`;
+}

--- a/packages/sdk/tests/security/issue-batch-302-310-314-regressions.test.ts
+++ b/packages/sdk/tests/security/issue-batch-302-310-314-regressions.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Security regressions for the 2026-07 review batch:
+ *
+ * - #310: multi-sig external-signer contributions were signed over JCS bytes
+ *   while verification hashes RDFC bytes, so an externally-signed contribution
+ *   could never verify — and, framed from the attacker side, a contributor who
+ *   controls canonicalization must not be able to smuggle a mismatched-preimage
+ *   signature toward the threshold. The SDK now canonicalizes+hashes and the
+ *   signer signs those exact bytes (via signBytes); a wrong-preimage signature
+ *   is rejected and cannot count.
+ * - #314: CEL witness proofs must be signed over the JSON-quoted digest bytes
+ *   the verifier reconstructs; a witness signing the raw decoded digest bytes
+ *   must be reported unverified, not silently accepted.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import * as ed25519 from '@noble/ed25519';
+import { MultiSigManager } from '../../src/vc/MultiSigManager';
+import { KeyManager } from '../../src/did/KeyManager';
+import { DIDManager } from '../../src/did/DIDManager';
+import { multikey } from '../../src/crypto/Multikey';
+import { verifyEventLog } from '../../src/cel/algorithms/verifyEventLog';
+import {
+  canonicalizeEntryForChain,
+  witnessSigningBytes,
+} from '../../src/cel/canonicalize';
+import { computeDigestMultibase, decodeDigestMultibase } from '../../src/cel/hash';
+import type { EventLog } from '../../src/cel/types';
+import type { ExternalSigner, MultiSigPolicy, VerifiableCredential } from '../../src/types';
+
+const config = { network: 'regtest' as const, defaultKeyType: 'Ed25519' as const };
+
+async function ed25519Signer(privateKeyMultibase: string, vm: string, mode: 'correct' | 'wrong'): Promise<ExternalSigner> {
+  return {
+    getVerificationMethodId: () => vm,
+    sign: async () => { throw new Error('document-level sign() must not be used for multi-sig'); },
+    signBytes: async (data: Uint8Array) => {
+      const dec = multikey.decodePrivateKey(privateKeyMultibase);
+      const key = dec.key.length === 64 ? dec.key.slice(0, 32) : dec.key;
+      // 'wrong' models a signer that canonicalizes differently (e.g. JCS) and
+      // therefore signs a different preimage than the SDK's RDFC hash.
+      const bytes = mode === 'correct' ? data : new TextEncoder().encode('attacker JCS preimage');
+      const signature = await (ed25519 as any).signAsync(bytes, key);
+      return { signature: new Uint8Array(signature) };
+    },
+  };
+}
+
+describe('#310 — external multi-sig contributions must sign the SDK-canonicalized bytes', () => {
+  const km = new KeyManager();
+
+  const baseVC: VerifiableCredential = {
+    '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
+    type: ['VerifiableCredential', 'ResourceCreated'],
+    issuer: 'did:peer:issuer',
+    issuanceDate: '2026-01-01T00:00:00Z',
+    credentialSubject: {
+      id: 'did:peer:subject',
+      resourceId: 'res1',
+      resourceType: 'text',
+      creator: 'did:peer:issuer',
+      createdAt: '2026-01-01T00:00:00Z',
+    },
+  } as VerifiableCredential;
+
+  test('a wrong-preimage (JCS-style) contribution cannot count toward the threshold', async () => {
+    const manager = new MultiSigManager(config, new DIDManager(config));
+    const key = await km.generateKeyPair('Ed25519');
+    const vm = `did:key:${key.publicKey}#${key.publicKey}`;
+    const policy: MultiSigPolicy = { required: 1, total: 1, signerVerificationMethods: [vm] };
+
+    const signed = await manager.signCredentialMultiSig(baseVC, {
+      policy,
+      externalSigners: new Map([[vm, await ed25519Signer(key.privateKey, vm, 'wrong')]]),
+    });
+    const result = await manager.verifyMultiSig(signed, policy);
+    expect(result.verified).toBe(false);
+    expect(result.validSignatures).toBe(0);
+  });
+
+  test('a correctly (signBytes) signed contribution verifies and meets the threshold', async () => {
+    const manager = new MultiSigManager(config, new DIDManager(config));
+    const key = await km.generateKeyPair('Ed25519');
+    const vm = `did:key:${key.publicKey}#${key.publicKey}`;
+    const policy: MultiSigPolicy = { required: 1, total: 1, signerVerificationMethods: [vm] };
+
+    const signed = await manager.signCredentialMultiSig(baseVC, {
+      policy,
+      externalSigners: new Map([[vm, await ed25519Signer(key.privateKey, vm, 'correct')]]),
+    });
+    const result = await manager.verifyMultiSig(signed, policy);
+    expect(result.verified).toBe(true);
+    expect(result.validSignatures).toBe(1);
+  });
+});
+
+describe('#314 — witness proofs must sign the digest preimage the verifier reconstructs', () => {
+  async function buildLog(witnessSign: (digest: string, key: Uint8Array) => Promise<Uint8Array>) {
+    const controllerSk = ed25519.utils.randomSecretKey();
+    const controllerPk = new Uint8Array(await (ed25519 as any).getPublicKeyAsync(controllerSk));
+    const controllerPub = multikey.encodePublicKey(controllerPk, 'Ed25519');
+    const controllerVm = `did:key:${controllerPub}#${controllerPub}`;
+
+    const eventData = { name: 'Attested Asset' };
+    // Reproduce the controller-proof signing convention used by the SDK.
+    const { canonicalizeEvent } = await import('../../src/cel/canonicalize');
+    const controllerSig = await (ed25519 as any).signAsync(
+      canonicalizeEvent({ type: 'create', data: eventData }),
+      controllerSk,
+    );
+
+    const witnessSk = ed25519.utils.randomSecretKey();
+    const witnessPk = new Uint8Array(await (ed25519 as any).getPublicKeyAsync(witnessSk));
+    const witnessVm = 'did:webvh:witness.example.com#key-ed25519';
+
+    const digest = computeDigestMultibase(canonicalizeEntryForChain({ type: 'create', data: eventData, proof: [] } as any));
+    const witnessSig = await witnessSign(digest, witnessSk);
+
+    const log: EventLog = {
+      events: [{
+        type: 'create',
+        data: eventData,
+        proof: [
+          {
+            type: 'DataIntegrityProof',
+            cryptosuite: 'eddsa-jcs-2022',
+            created: '2026-01-20T12:00:00Z',
+            verificationMethod: controllerVm,
+            proofPurpose: 'assertionMethod',
+            proofValue: multikey.encodeMultibase(new Uint8Array(controllerSig)),
+          },
+          {
+            type: 'DataIntegrityProof',
+            cryptosuite: 'eddsa-jcs-2022',
+            created: '2026-01-20T12:00:00Z',
+            verificationMethod: witnessVm,
+            proofPurpose: 'assertionMethod',
+            proofValue: multikey.encodeMultibase(new Uint8Array(witnessSig)),
+            witnessedAt: '2026-01-20T12:00:00Z',
+          } as any,
+        ],
+      }],
+    };
+    const resolveKey = async (method: string): Promise<Uint8Array | null> =>
+      method === witnessVm ? witnessPk : null;
+    return { log, resolveKey };
+  }
+
+  test('a witness signing the JSON-quoted digest (witnessSigningBytes) is accepted', async () => {
+    const { log, resolveKey } = await buildLog(async (digest, key) =>
+      new Uint8Array(await (ed25519 as any).signAsync(witnessSigningBytes(digest), key)),
+    );
+    const result = await verifyEventLog(log, { resolveKey });
+    expect(result.events[0].witnessProofs![0].verified).toBe(true);
+  });
+
+  test('a witness signing the raw decoded digest bytes is reported unverified', async () => {
+    const { log, resolveKey } = await buildLog(async (digest, key) =>
+      new Uint8Array(await (ed25519 as any).signAsync(decodeDigestMultibase(digest), key)),
+    );
+    const result = await verifyEventLog(log, { resolveKey });
+    expect(result.events[0].witnessProofs![0].verified).toBe(false);
+  });
+});

--- a/packages/sdk/tests/unit/cel/verifyEventLog.test.ts
+++ b/packages/sdk/tests/unit/cel/verifyEventLog.test.ts
@@ -10,8 +10,8 @@ import type {
   VerifyOptions,
 } from '../../../src/cel/types';
 import { multikey } from '../../../src/crypto/Multikey';
-import { canonicalizeEvent, canonicalizeEntryForChain } from '../../../src/cel/canonicalize';
-import { computeDigestMultibase } from '../../../src/cel/hash';
+import { canonicalizeEvent, canonicalizeEntryForChain, witnessSigningBytes } from '../../../src/cel/canonicalize';
+import { computeDigestMultibase, decodeDigestMultibase } from '../../../src/cel/hash';
 
 /**
  * Mock signer that creates a structurally valid DataIntegrityProof.
@@ -926,6 +926,103 @@ describe('verifyEventLog', () => {
       expect(result.events[0].witnessProofs).toHaveLength(1);
       expect(result.events[0].witnessProofs![0].verificationMethod).toBe(witnessVm);
       expect(result.events[0].witnessProofs![0].verified).toBe(true);
+    });
+
+    test('witnessSigningBytes(digest) produces the exact preimage verifyEventLog accepts (#314)', async () => {
+      const { signer } = await makeRealSigner();
+      const eventData = { name: 'Helper-Signed Asset' };
+      const controllerProof = await signer({ type: 'create', data: eventData });
+
+      const ed25519 = await import('@noble/ed25519');
+      const witnessPrivateKey = ed25519.utils.randomSecretKey();
+      const witnessPublicKey = new Uint8Array(
+        await (ed25519 as any).getPublicKeyAsync(witnessPrivateKey),
+      );
+      const witnessVm = 'did:webvh:witness.example.com#key-ed25519';
+
+      const digest = computeDigestMultibase(canonicalizeEntryForChain({
+        type: 'create',
+        data: eventData,
+        proof: [],
+      } as any));
+
+      // Sign the bytes the public helper hands out — no knowledge of the
+      // internal canonicalizeEvent(<string>) quoting convention required.
+      const message = witnessSigningBytes(digest);
+      // The helper must return exactly what the verifier reconstructs.
+      expect(Array.from(message)).toEqual(Array.from(canonicalizeEvent(digest)));
+      const witnessSig = await (ed25519 as any).signAsync(message, witnessPrivateKey);
+
+      const log: EventLog = {
+        events: [{
+          type: 'create',
+          data: eventData,
+          proof: [controllerProof, {
+            type: 'DataIntegrityProof' as const,
+            cryptosuite: 'eddsa-jcs-2022',
+            created: new Date().toISOString(),
+            verificationMethod: witnessVm,
+            proofPurpose: 'assertionMethod',
+            proofValue: multikey.encodeMultibase(new Uint8Array(witnessSig)),
+            witnessedAt: '2026-01-20T12:00:00Z',
+          }],
+        }],
+      };
+
+      const resolveKey = async (method: string): Promise<Uint8Array | null> =>
+        method === witnessVm ? witnessPublicKey : null;
+
+      const result = await verifyEventLog(log, { resolveKey });
+      expect(result.events[0].witnessProofs![0].verified).toBe(true);
+    });
+
+    test('signing the RAW decoded digest bytes (the wrong preimage) fails witness verification (#314)', async () => {
+      const { signer } = await makeRealSigner();
+      const eventData = { name: 'Wrong-Preimage Asset' };
+      const controllerProof = await signer({ type: 'create', data: eventData });
+
+      const ed25519 = await import('@noble/ed25519');
+      const witnessPrivateKey = ed25519.utils.randomSecretKey();
+      const witnessPublicKey = new Uint8Array(
+        await (ed25519 as any).getPublicKeyAsync(witnessPrivateKey),
+      );
+      const witnessVm = 'did:webvh:witness.example.com#key-ed25519';
+
+      const digest = computeDigestMultibase(canonicalizeEntryForChain({
+        type: 'create',
+        data: eventData,
+        proof: [],
+      } as any));
+
+      // The classic third-party mistake: sign the raw hash bytes rather than
+      // the JSON-quoted digest string the SDK actually verifies against.
+      const wrongMessage = decodeDigestMultibase(digest);
+      expect(Array.from(wrongMessage)).not.toEqual(Array.from(witnessSigningBytes(digest)));
+      const witnessSig = await (ed25519 as any).signAsync(wrongMessage, witnessPrivateKey);
+
+      const log: EventLog = {
+        events: [{
+          type: 'create',
+          data: eventData,
+          proof: [controllerProof, {
+            type: 'DataIntegrityProof' as const,
+            cryptosuite: 'eddsa-jcs-2022',
+            created: new Date().toISOString(),
+            verificationMethod: witnessVm,
+            proofPurpose: 'assertionMethod',
+            proofValue: multikey.encodeMultibase(new Uint8Array(witnessSig)),
+            witnessedAt: '2026-01-20T12:00:00Z',
+          }],
+        }],
+      };
+
+      const resolveKey = async (method: string): Promise<Uint8Array | null> =>
+        method === witnessVm ? witnessPublicKey : null;
+
+      const result = await verifyEventLog(log, { resolveKey });
+      // Witness proofs are non-gating, so the event still verifies overall,
+      // but the witness proof itself must be reported unverified.
+      expect(result.events[0].witnessProofs![0].verified).toBe(false);
     });
 
     test('event with ONLY a witness proof (no controller proof) → verified: false', async () => {

--- a/packages/sdk/tests/unit/migration/RollbackManager.test.ts
+++ b/packages/sdk/tests/unit/migration/RollbackManager.test.ts
@@ -192,6 +192,43 @@ describe('RollbackManager', () => {
       expect(result.irreversibleArtifacts).toBeUndefined();
     });
 
+    // Issue #302 — the positive broadcast signal must win over the negative
+    // pre-anchoring state inference. A migration whose tracked state at
+    // failure is IN_PROGRESS (a "pre-anchoring" state that the choreography
+    // heuristic alone would treat as never-broadcast) but whose error carries
+    // on-chain artifacts (a txid) provably DID broadcast — rollback must
+    // report PARTIALLY_ROLLED_BACK, not a clean success that invites a
+    // fee-paying retry (regression against a broadcast-before-ANCHORING op).
+    it('btco migration with broadcast artifacts reports PARTIALLY_ROLLED_BACK even when stateAtFailure looks pre-anchoring', async () => {
+      const { sdk, checkpointManager, rollbackManager } = makeRollbackSetup();
+
+      const peerDid = await sdk.did.createDIDPeer([
+        { id: 'res-1', type: 'Image', contentType: 'image/png', hash: '3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7', content: 'data' }
+      ]);
+
+      const migrationId = 'mig_btco_broadcast_in_progress';
+      const checkpoint = await checkpointManager.createCheckpoint(migrationId, {
+        sourceDid: peerDid.id,
+        targetLayer: 'btco',
+      });
+
+      const failureError = Object.assign(new Error('reveal broadcast then indexer timeout'), {
+        details: { txid: 'broadcasted-txid', revealTxId: 'reveal-abc' }
+      });
+      const result = await rollbackManager.rollback(migrationId, checkpoint.checkpointId!, {
+        error: failureError,
+        stateAtFailure: MigrationStateEnum.IN_PROGRESS
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.restoredState).toBe(MigrationStateEnum.PARTIALLY_ROLLED_BACK);
+      expect(result.irreversibleArtifacts).toBeDefined();
+      expect(result.irreversibleArtifacts![0].details).toMatchObject({
+        txid: 'broadcasted-txid',
+        revealTxId: 'reveal-abc'
+      });
+    });
+
 
     // CORE-MIG-EVENTS-024/happy — rollback restores storage references (checkpoint contains them)
     it('rollback captures storageReferences from checkpoint', async () => {

--- a/packages/sdk/tests/unit/storage/listObjects.test.ts
+++ b/packages/sdk/tests/unit/storage/listObjects.test.ts
@@ -1,11 +1,13 @@
 /**
  * Native prefix enumeration on the shipped concrete adapters.
  *
- * `listObjects(domain, prefix)` is an extra capability on the concrete
- * classes (NOT part of the public StorageAdapter interface): both shipped
- * backends are fully enumerable, and exposing that lets MigrationStorage
- * discover persisted keys natively instead of maintaining a shared mutable
- * index object (the source of the cross-process audit-index race).
+ * `listObjects(domain, prefix)` is now an OPTIONAL member of the public
+ * StorageAdapter interface (issue #329): both shipped backends are fully
+ * enumerable, and exposing that lets MigrationStorage discover persisted keys
+ * natively instead of maintaining a shared mutable index object (the source of
+ * the cross-process audit-index race). Making it a documented, optional
+ * interface member — rather than a hidden concrete-only capability — lets
+ * third-party adapter authors discover and implement the race-free hook.
  */
 import { describe, test, expect, beforeEach } from 'bun:test';
 import * as fs from 'fs';
@@ -13,6 +15,26 @@ import * as os from 'os';
 import * as path from 'path';
 import { MemoryStorageAdapter } from '../../../src/storage/MemoryStorageAdapter';
 import { LocalStorageAdapter } from '../../../src/storage/LocalStorageAdapter';
+import type { StorageAdapter } from '../../../src/storage/StorageAdapter';
+
+describe('StorageAdapter.listObjects (optional interface member, #329)', () => {
+  beforeEach(() => {
+    MemoryStorageAdapter.clear();
+  });
+
+  test('is reachable through the StorageAdapter interface type', async () => {
+    // Typing the adapter as the public interface (not the concrete class)
+    // and calling listObjects through it is the regression guard: before
+    // #329, listObjects was not on the interface, so this reference would
+    // not typecheck. A third-party adapter author following the interface
+    // can now discover and implement the enumeration hook.
+    const adapter: StorageAdapter = new MemoryStorageAdapter();
+    await adapter.putObject('iface-mem.example', 'audit/migrations/m1/a.json', '1');
+    expect(typeof adapter.listObjects).toBe('function');
+    const listed = await adapter.listObjects!('iface-mem.example', 'audit/migrations/');
+    expect(listed).toEqual(['audit/migrations/m1/a.json']);
+  });
+});
 
 describe('MemoryStorageAdapter.listObjects', () => {
   beforeEach(() => {

--- a/packages/sdk/tests/unit/vc/MultiSigManager.test.ts
+++ b/packages/sdk/tests/unit/vc/MultiSigManager.test.ts
@@ -10,7 +10,28 @@ import type {
   EscrowPolicy,
   CorporatePolicy,
   OriginalsConfig,
+  ExternalSigner,
 } from '../../../src/types';
+import * as ed25519 from '@noble/ed25519';
+import { multikey } from '../../../src/crypto/Multikey';
+
+/**
+ * Build a signBytes-capable external signer backed by a real Ed25519 key
+ * (issue #310). It signs exactly the bytes the SDK hands it — the document
+ * level sign() throws to prove multi-sig never routes through it.
+ */
+function ed25519ExternalSigner(privateKeyMultibase: string, vm: string): ExternalSigner {
+  return {
+    getVerificationMethodId: () => vm,
+    sign: async () => { throw new Error('document-level sign() must not be used for multi-sig'); },
+    signBytes: async (data: Uint8Array) => {
+      const dec = multikey.decodePrivateKey(privateKeyMultibase);
+      const key = dec.key.length === 64 ? dec.key.slice(0, 32) : dec.key;
+      const signature = await (ed25519 as any).signAsync(data, key);
+      return { signature: new Uint8Array(signature) };
+    },
+  };
+}
 
 describe('MultiSigManager', () => {
   const config: OriginalsConfig = {
@@ -302,25 +323,16 @@ describe('MultiSigManager', () => {
       expect((signed.proof as any[]).length).toBe(2);
     });
 
-    test('signs with external signers', async () => {
+    test('signs with external signers (signBytes) and the contributions verify (#310)', async () => {
       const policy: MultiSigPolicy = {
         required: 2,
         total: 3,
         signerVerificationMethods: [vms[0], vms[1], vms[2]],
       };
 
-      const mockSigner1 = {
-        sign: async () => ({ proofValue: 'u' + Buffer.from('sig1').toString('base64') }),
-        getVerificationMethodId: () => vms[0],
-      };
-      const mockSigner2 = {
-        sign: async () => ({ proofValue: 'u' + Buffer.from('sig2').toString('base64') }),
-        getVerificationMethodId: () => vms[1],
-      };
-
-      const externalSigners = new Map([
-        [vms[0], mockSigner1],
-        [vms[1], mockSigner2],
+      const externalSigners = new Map<string, ExternalSigner>([
+        [vms[0], ed25519ExternalSigner(keys[0].privateKey, vms[0])],
+        [vms[1], ed25519ExternalSigner(keys[1].privateKey, vms[1])],
       ]);
 
       const signed = await manager.signCredentialMultiSig(baseVC, {
@@ -330,6 +342,114 @@ describe('MultiSigManager', () => {
 
       expect(Array.isArray(signed.proof)).toBe(true);
       expect((signed.proof as any[]).length).toBe(2);
+
+      // The whole point of #310: an externally-signed contribution must
+      // actually verify (previously the signer's JCS bytes never matched the
+      // RDFC verification hash, so the threshold could never be met).
+      const result = await manager.verifyMultiSig(signed, policy);
+      expect(result.verified).toBe(true);
+      expect(result.validSignatures).toBe(2);
+      expect([...result.validSigners].sort()).toEqual([vms[0], vms[1]].sort());
+    });
+
+    test('#310 external signer without signBytes is rejected with a clear error', async () => {
+      const policy: MultiSigPolicy = {
+        required: 1,
+        total: 1,
+        signerVerificationMethods: [vms[0]],
+      };
+      // A document-level-only signer (the didwebvh-ts/Turnkey shape): its JCS
+      // signature can never verify against the RDFC multi-sig hash, so it must
+      // be refused up front rather than producing an unverifiable proof.
+      const legacySigner: ExternalSigner = {
+        getVerificationMethodId: () => vms[0],
+        sign: async () => ({ proofValue: 'u' + Buffer.from('sig').toString('base64') }),
+      };
+      const externalSigners = new Map([[vms[0], legacySigner]]);
+
+      await expect(
+        manager.signCredentialMultiSig(baseVC, { policy, externalSigners })
+      ).rejects.toThrow(/must implement signBytes/);
+      await expect(
+        manager.signCredentialMultiSig(baseVC, { policy, externalSigners })
+      ).rejects.toThrow(/issue #310/);
+    });
+
+    test('#310 a contribution signed over the WRONG bytes (JCS-style) fails verification', async () => {
+      const policy: MultiSigPolicy = {
+        required: 1,
+        total: 1,
+        signerVerificationMethods: [vms[0]],
+      };
+      // Simulate a signer that signs a different canonicalization than the
+      // SDK's RDFC hash — exactly the failure #310 fixes. signBytes exists (so
+      // signing succeeds) but signs the wrong preimage, so verification fails.
+      const wrongSigner: ExternalSigner = {
+        getVerificationMethodId: () => vms[0],
+        sign: async () => { throw new Error('unused'); },
+        signBytes: async () => {
+          const dec = multikey.decodePrivateKey(keys[0].privateKey);
+          const key = dec.key.length === 64 ? dec.key.slice(0, 32) : dec.key;
+          const wrong = new TextEncoder().encode('not the sdk rdfc hash');
+          const signature = await (ed25519 as any).signAsync(wrong, key);
+          return { signature: new Uint8Array(signature) };
+        },
+      };
+      const externalSigners = new Map([[vms[0], wrongSigner]]);
+
+      const signed = await manager.signCredentialMultiSig(baseVC, { policy, externalSigners });
+      const result = await manager.verifyMultiSig(signed, policy);
+      expect(result.verified).toBe(false);
+      expect(result.validSignatures).toBe(0);
+    });
+  });
+
+  // ===== #306: clear key-type / legacy-proof errors =====
+
+  describe('#306 key-type and legacy-proof errors', () => {
+    test('signing with a non-Ed25519 (ES256K) key throws a clear upfront error', async () => {
+      const es256k = await keyManager.generateKeyPair('ES256K');
+      const vm = `did:key:${es256k.publicKey}#${es256k.publicKey}`;
+      const policy: MultiSigPolicy = {
+        required: 1,
+        total: 1,
+        signerVerificationMethods: [vm],
+      };
+      const privateKeys = new Map([[vm, es256k.privateKey]]);
+
+      // Must be the actionable message, NOT the deep cryptosuite-internal
+      // 'Invalid key type for EdDSA'.
+      await expect(
+        manager.signCredentialMultiSig(baseVC, { policy, privateKeys })
+      ).rejects.toThrow(/requires an Ed25519 signer key/);
+      await expect(
+        manager.signCredentialMultiSig(baseVC, { policy, privateKeys })
+      ).rejects.toThrow(/issue #306/);
+    });
+
+    test('verifying a legacy (cryptosuite-less) proof reports a distinguishing error, not "Invalid signature"', async () => {
+      const policy: MultiSigPolicy = {
+        required: 2,
+        total: 3,
+        signerVerificationMethods: [vms[0], vms[1], vms[2]],
+      };
+      const signed = await manager.signCredentialMultiSig(baseVC, {
+        policy,
+        privateKeys: new Map([
+          [vms[0], keys[0].privateKey],
+          [vms[1], keys[1].privateKey],
+        ]),
+      });
+
+      // Simulate a legacy proof from an older SDK release: strip cryptosuite.
+      const proofs = signed.proof as Array<Record<string, unknown>>;
+      delete proofs[0].cryptosuite;
+
+      const result = await manager.verifyMultiSig(signed, policy);
+      expect(result.errors.some(e => /Unsupported multi-sig proof format/.test(e))).toBe(true);
+      expect(result.errors.some(e => /must be re-signed|issue #306/.test(e))).toBe(true);
+      // The stripped proof must NOT be reported with the generic message.
+      expect(result.errors.some(e => e === `Invalid signature from ${vms[0]}`)).toBe(false);
     });
   });
 
@@ -355,6 +475,35 @@ describe('MultiSigManager', () => {
       expect(result.verified).toBe(true);
       expect(result.validSignatures).toBe(2);
       expect(result.validSigners).toEqual([vms[0], vms[1]]);
+      expect(result.errors.length).toBe(0);
+    });
+
+    test('#305 verifies proofs concurrently but reports validSigners in deterministic proof order', async () => {
+      // Proofs are verified concurrently now; the seen-signer accounting must
+      // still be a deterministic post-collection pass, so validSigners follows
+      // the PROOF order regardless of which verification resolves first. A
+      // naive push-on-resolve parallelization would make this order flaky.
+      const policy: MultiSigPolicy = {
+        required: 4,
+        total: 5,
+        signerVerificationMethods: [vms[0], vms[1], vms[2], vms[3], vms[4]],
+      };
+      const signed = await manager.signCredentialMultiSig(baseVC, {
+        policy,
+        privateKeys: new Map([
+          [vms[0], keys[0].privateKey],
+          [vms[1], keys[1].privateKey],
+          [vms[2], keys[2].privateKey],
+          [vms[3], keys[3].privateKey],
+        ]),
+      });
+
+      // Reverse the proof order; validSigners must mirror the new order exactly.
+      const reordered = { ...signed, proof: [...(signed.proof as any[])].reverse() } as VerifiableCredential;
+      const result = await manager.verifyMultiSig(reordered, policy);
+      expect(result.verified).toBe(true);
+      expect(result.validSignatures).toBe(4);
+      expect(result.validSigners).toEqual([vms[3], vms[2], vms[1], vms[0]]);
       expect(result.errors.length).toBe(0);
     });
 

--- a/packages/sdk/tests/unit/vc/MultiSigManager.test.ts
+++ b/packages/sdk/tests/unit/vc/MultiSigManager.test.ts
@@ -375,6 +375,26 @@ describe('MultiSigManager', () => {
       ).rejects.toThrow(/issue #310/);
     });
 
+    test('#310 external signer returning a wrong-length (non-64-byte) signature is rejected at sign time', async () => {
+      const policy: MultiSigPolicy = {
+        required: 1,
+        total: 1,
+        signerVerificationMethods: [vms[0]],
+      };
+      const badLengthSigner: ExternalSigner = {
+        getVerificationMethodId: () => vms[0],
+        sign: async () => { throw new Error('unused'); },
+        // 32 bytes — a plausible mistake (e.g. returning a hash/seed) that would
+        // otherwise base58-encode into a syntactically valid, never-verifiable proof.
+        signBytes: async () => ({ signature: new Uint8Array(32) }),
+      };
+      const externalSigners = new Map([[vms[0], badLengthSigner]]);
+
+      await expect(
+        manager.signCredentialMultiSig(baseVC, { policy, externalSigners })
+      ).rejects.toThrow(/64 bytes/);
+    });
+
     test('#310 a contribution signed over the WRONG bytes (JCS-style) fails verification', async () => {
       const policy: MultiSigPolicy = {
         required: 1,

--- a/packages/sdk/tests/unit/vc/Verifier.test.ts
+++ b/packages/sdk/tests/unit/vc/Verifier.test.ts
@@ -295,10 +295,10 @@ describe('diwings Verifier', () => {
 
   test('#304 caches the status list proof verification across credentials sharing the list', async () => {
     const listId = 'https://issuer.example/status/304/1';
-    // A resolved, all-zeros status list with a (stable) proofValue so the
-    // cache can key on (id + proofValue). The proof's actual cryptographic
-    // validity is exercised elsewhere; here we assert the EXPENSIVE proof
-    // verification is invoked once and reused.
+    // A resolved status list; the SAME immutable document is returned every
+    // call, so the content-keyed cache verifies its proof once and reuses it.
+    // The proof's actual cryptographic validity is exercised elsewhere; here we
+    // assert the EXPENSIVE proof verification is invoked once and reused.
     const statusListVC = new StatusListManager().createStatusListCredential({
       id: listId,
       issuer: did,
@@ -350,39 +350,60 @@ describe('diwings Verifier', () => {
     expect(resolverCalls).toBe(3);
   });
 
-  test('#304 does not cache when the status list has no (id + proofValue) identity', async () => {
-    // A list without a proofValue cannot be safely keyed (and also fails the
-    // trust checks), so it must be re-verified each time — never a silent
-    // bypass that reuses a stale result.
-    const listId = 'https://issuer.example/status/304/unsigned';
-    const statusListVC = new StatusListManager().createStatusListCredential({
-      id: listId,
-      issuer: did,
-      statusPurpose: 'revocation',
-    });
-    const verifier = new Verifier(didManager, {
-      statusListResolver: async () => statusListVC as any,
-    });
-    let listVerifyCount = 0;
+  test('#304 does NOT reuse a cached verdict for a different list body with the same id+proofValue (revocation-bypass guard, #238)', async () => {
+    // The self-review caught a revocation bypass in a naive (id + proofValue)
+    // cache: an attacker/poisoned resolver could swap a forged all-zeros body
+    // under a legitimate id+proofValue (both public) and reuse the cached
+    // "verified" verdict without the proof ever being checked against the
+    // forged body. The cache MUST key on the full document, so a swapped body
+    // is re-verified (and, having a proof that does not sign it, rejected).
+    const slm = new StatusListManager();
+    const listId = 'https://issuer.example/status/304/bypass';
+    const base = slm.createStatusListCredential({ id: listId, issuer: did, statusPurpose: 'revocation' });
+    // legit: bit 5 SET (revoked). forged: bit 5 CLEAR (all zeros). Only the
+    // encodedList differs — same id, same public proofValue, same issuanceDate.
+    const legit = slm.setStatus(base, 5, true) as any;
+    const forged = slm.setStatus(base, 5, false) as any;
+    for (const l of [legit, forged]) {
+      l.issuanceDate = '2026-01-01T00:00:00Z';
+      l.proof = { type: 'DataIntegrityProof', cryptosuite: 'eddsa-rdfc-2022', proofValue: 'zSharedPublicProof' };
+    }
+
+    // Only the legit body's proof "verifies" (the forged body was never signed).
+    const legitEncoded = legit.credentialSubject.encodedList;
+    const verifyCalls: any[] = [];
+    const queue = [legit, forged, legit];
+    let i = 0;
+    const verifier = new Verifier(didManager, { statusListResolver: async () => queue[i++] });
     (verifier as any).verifyCredential = async (c: any) => {
-      if (c === statusListVC) listVerifyCount++;
-      return { verified: true, errors: [] };
+      verifyCalls.push(c);
+      return { verified: c.credentialSubject.encodedList === legitEncoded, errors: [] };
     };
-    const mkCred = (index: number) => ({
+
+    const mkCred = () => ({
       '@context': ['https://www.w3.org/ns/credentials/v2'],
       type: ['VerifiableCredential'],
       issuer: did,
-      credentialSubject: { id: 'did:peer:subject-304u' },
+      credentialSubject: { id: 'did:peer:subject-304b' },
       credentialStatus: {
         type: 'BitstringStatusListEntry',
         statusPurpose: 'revocation',
-        statusListIndex: String(index),
+        statusListIndex: '5',
         statusListCredential: listId,
       },
     } as any);
-    await verifier.checkCredentialStatus(mkCred(1));
-    await verifier.checkCredentialStatus(mkCred(2));
-    expect(listVerifyCount).toBe(2);
+
+    const rLegit = await verifier.checkCredentialStatus(mkCred());   // legit → bit5 set → revoked
+    const rForged = await verifier.checkCredentialStatus(mkCred());  // forged → MUST re-verify, proof fails
+    await verifier.checkCredentialStatus(mkCred());                  // legit again → cache hit
+
+    // The forged body was verified independently (NOT served from legit's
+    // cache entry) and, failing its proof check, could not clear the revocation.
+    expect(verifyCalls.length).toBe(2);
+    expect(verifyCalls[0]).toBe(legit);
+    expect(verifyCalls[1]).toBe(forged);
+    expect(rLegit.verified).toBe(false);   // legit list: credential is revoked
+    expect(rForged.verified).toBe(false);  // forged list: rejected (proof does not sign it) — no bypass
   });
 
   test('verifyPresentation validates expectedChallenge and expectedDomain', async () => {

--- a/packages/sdk/tests/unit/vc/Verifier.test.ts
+++ b/packages/sdk/tests/unit/vc/Verifier.test.ts
@@ -5,6 +5,7 @@ import * as ed25519 from '@noble/ed25519';
 import { multikey } from '../../../src/crypto/Multikey';
 import { registerVerificationMethod, verificationMethodRegistry } from '../../../src/vc/documentLoader';
 import { DIDManager } from '../../../src/did/DIDManager';
+import { StatusListManager } from '../../../src/vc/StatusListManager';
 
 describe('diwings Verifier', () => {
   const didManager = new DIDManager({} as any);
@@ -290,6 +291,98 @@ describe('diwings Verifier', () => {
     // Explicit opt-out still verifies
     const skipped = await verifier.verifyCredential(vc, { checkStatus: false });
     expect(skipped.verified).toBe(true);
+  });
+
+  test('#304 caches the status list proof verification across credentials sharing the list', async () => {
+    const listId = 'https://issuer.example/status/304/1';
+    // A resolved, all-zeros status list with a (stable) proofValue so the
+    // cache can key on (id + proofValue). The proof's actual cryptographic
+    // validity is exercised elsewhere; here we assert the EXPENSIVE proof
+    // verification is invoked once and reused.
+    const statusListVC = new StatusListManager().createStatusListCredential({
+      id: listId,
+      issuer: did,
+      statusPurpose: 'revocation',
+    });
+    (statusListVC as any).proof = {
+      type: 'DataIntegrityProof',
+      cryptosuite: 'eddsa-rdfc-2022',
+      proofValue: 'zStableStatusListProofValue',
+    };
+
+    let resolverCalls = 0;
+    const verifier = new Verifier(didManager, {
+      statusListResolver: async () => { resolverCalls++; return statusListVC as any; },
+    });
+
+    // Stand in for the expensive verifyCredential(list) call and count it. The
+    // cache must collapse three status checks into a single list verification.
+    let listVerifyCount = 0;
+    (verifier as any).verifyCredential = async (c: any) => {
+      if (c === statusListVC) listVerifyCount++;
+      return { verified: true, errors: [] };
+    };
+
+    const mkCred = (index: number) => ({
+      '@context': ['https://www.w3.org/ns/credentials/v2'],
+      type: ['VerifiableCredential'],
+      issuer: did,
+      credentialSubject: { id: 'did:peer:subject-304' },
+      credentialStatus: {
+        type: 'BitstringStatusListEntry',
+        statusPurpose: 'revocation',
+        statusListIndex: String(index),
+        statusListCredential: listId,
+      },
+    } as any);
+
+    const r1 = await verifier.checkCredentialStatus(mkCred(1));
+    const r2 = await verifier.checkCredentialStatus(mkCred(2));
+    const r3 = await verifier.checkCredentialStatus(mkCred(3));
+
+    expect(r1.verified).toBe(true);
+    expect(r2.verified).toBe(true);
+    expect(r3.verified).toBe(true);
+    // With the cache, the immutable list's proof is verified exactly once for
+    // all three checks (issue #304) instead of three times.
+    expect(listVerifyCount).toBe(1);
+    // The resolver fetch itself is intentionally still per-call.
+    expect(resolverCalls).toBe(3);
+  });
+
+  test('#304 does not cache when the status list has no (id + proofValue) identity', async () => {
+    // A list without a proofValue cannot be safely keyed (and also fails the
+    // trust checks), so it must be re-verified each time — never a silent
+    // bypass that reuses a stale result.
+    const listId = 'https://issuer.example/status/304/unsigned';
+    const statusListVC = new StatusListManager().createStatusListCredential({
+      id: listId,
+      issuer: did,
+      statusPurpose: 'revocation',
+    });
+    const verifier = new Verifier(didManager, {
+      statusListResolver: async () => statusListVC as any,
+    });
+    let listVerifyCount = 0;
+    (verifier as any).verifyCredential = async (c: any) => {
+      if (c === statusListVC) listVerifyCount++;
+      return { verified: true, errors: [] };
+    };
+    const mkCred = (index: number) => ({
+      '@context': ['https://www.w3.org/ns/credentials/v2'],
+      type: ['VerifiableCredential'],
+      issuer: did,
+      credentialSubject: { id: 'did:peer:subject-304u' },
+      credentialStatus: {
+        type: 'BitstringStatusListEntry',
+        statusPurpose: 'revocation',
+        statusListIndex: String(index),
+        statusListCredential: listId,
+      },
+    } as any);
+    await verifier.checkCredentialStatus(mkCred(1));
+    await verifier.checkCredentialStatus(mkCred(2));
+    expect(listVerifyCount).toBe(2);
   });
 
   test('verifyPresentation validates expectedChallenge and expectedDomain', async () => {


### PR DESCRIPTION
## What

A batch of independent, low-to-medium-risk fixes from the 2026-07 review, shipped
together. Each issue was verified against the current code before fixing, and each
fix has a regression test that fails without it.

- **#310** (bug/vc): multi-sig external-signer contributions were unverifiable — the
  signer canonicalized itself (JCS) while verification hashes RDFC-2022 bytes.
- **#306** (vc/interop): non-Ed25519 multi-sig signing and legacy-format proofs gave
  misleading low-level errors.
- **#305** (vc/perf): multi-sig proofs verified strictly sequentially.
- **#304** (vc/perf): the status list credential was re-verified on every status check.
- **#302** (migration): rollback inferred "nothing broadcast" purely from tracked state.
- **#314** (interop): the CEL witness signing-byte contract was undocumented.
- **#329** (storage): `listObjects` was a hidden concrete-only capability, not discoverable.

## Why

Closes #310, closes #306, closes #305, closes #304, closes #302, closes #314, closes #329.

## How

**#310 — SDK canonicalizes+hashes; the signer signs bytes.** `MultiSigManager.signWithExternalSigner`
no longer hands the raw `{document, proof}` to the signer. It computes the exact
`eddsa-rdfc-2022` hash via the new `EdDSACryptosuiteManager.computeSigningInput`
(factored out of `createProof`, so create/verify/external-sign share one construction)
and passes those bytes to a new **optional** `ExternalSigner.signBytes(data)` capability.
A signer implementing only the document-level `sign()` is refused up front with a clear
error rather than producing a proof that can never verify. Round-trip and
wrong-preimage regression tests added (unit + security).

**#306 — clear errors.** `signCredentialMultiSig` rejects non-Ed25519 signer keys with an
actionable message (was the opaque `Invalid key type for EdDSA` from inside the
cryptosuite). Verify now reports a distinguishing "unsupported/legacy proof format"
message for cryptosuite-less proofs instead of "Invalid signature". Full ECDSA Data
Integrity cryptosuite remains out of scope (tracked in #306).

**#305 — concurrent verification.** Both `MultiSigManager.verifyMultiSig` and
`Verifier.verifyCredentialMultiSig` verify proofs with `Promise.all` over one shared
document loader; signer-dedupe and threshold accounting run in a deterministic
post-collection pass, so results (and the order of `validSigners`/errors) are unchanged.

**#304 — status list cache.** The Verifier memoizes the status list credential's proof
verification keyed by the **full resolved document**, caching only positive verdicts,
bounded to 256 entries with a 5-minute TTL. The per-call id-match and issuer-equality
trust checks are untouched. (An earlier `(id + proofValue)` key was caught by the
self-review as a revocation bypass — see below.)

**#302 — positive broadcast signal.** `RollbackManager` now reports
`PARTIALLY_ROLLED_BACK` whenever the failure error carries on-chain artifacts
(txids/inscriptionId), regardless of the tracked pre-anchoring state — decoupling
irreversibility from the operations' state-transition choreography. The override can
only make the report more conservative.

**#314 — witness contract.** Added and exported `witnessSigningBytes(digest)` and
documented in `WitnessService` that witnesses must sign the JSON-quoted digest bytes
the verifier reconstructs. Positive + negative (raw-bytes) regression tests added.

**#329 — enumeration hook.** `listObjects(domain, prefix)` is now an optional, documented
member of the public `StorageAdapter` interface (additive/non-breaking) so custom
adapters can discover the race-free enumeration hook.

### Deliberately excluded (not in this batch)

- **#341 / #342 / #348** (Turnkey auth) — already covered by open PR #356.
- **#283** — `StorageValidator` already hardened on `main`; the residual (unwired
  credential validation) is part of the #279 migration-wiring design decision.
- **#303** (shared inscription lock), **#279** (wire/de-export migration subsystem),
  **#300** (VCDM 2.0-only, needs interop confirmation), **#306 full ECDSA cryptosuite**,
  **#328** (real Ordinals providers) — architectural / need a design or interop call.
- **#330 / #332 / #333** — landing-page infra / require a hosting or network decision.
- **#314 item 3** (`parseWebVHDid` single-label hostnames) — the shorthand
  `did:webvh:{domain}:user` form collides structurally with the spec form
  `did:webvh:{SCID}:{domain}`, and supporting single-label domains requires widening
  `validateAndNormalizeDomain` (a domain-format policy decision). Item 2 (issuer-equality
  policy) was already documented on `main`. Item 1 is fixed here.

## Self-review

After the first commit I adversarially reviewed the whole diff along several angles
(line-by-line correctness, removed/weakened behavior, cross-file caller impact,
sync→async races). It surfaced **one real defect, in this PR's own #304 fix**:

- **#304 revocation bypass (fixed in the follow-up commit).** The initial cache keyed on
  `(id + proofValue)`. But the cached verdict is a property of the whole
  `(body + proof)` document, while the caller reads the revocation bits from the
  *presented* document. Since `id` and `proofValue` are public, a poisoned resolver /
  holder could swap a forged all-zeros body under a legitimate `id + proofValue` and
  reuse a cached "verified" verdict without the proof ever being checked against that
  body — reopening #238. Fixed by keying on the **full document** (a collision means
  byte-identical content), caching **only positive** verdicts (a `false` may be a
  transient issuer-resolution failure that must not fail-close a legit list), and adding
  a **TTL**. A regression test asserts a swapped body is re-verified and rejected.

Everything else reviewed clean: #310 hash symmetry (emit vs. verify bytes) and the
`createProof` refactor are byte-identical; #305's parallelization preserves ordering,
dedupe, and the "unauthorized proofs skip verification" behavior, and the shared document
loader is safe under concurrency; #302 never flips a genuine no-broadcast failure to
partial (every error carrying txid/inscription details is thrown post-broadcast); #314's
helper reproduces the exact verification preimage; #329 is additive and breaks no adapter.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Test addition or improvement

### Breaking change

**#310:** multi-sig external signers must now implement `ExternalSigner.signBytes`.
The document-level `sign()`-only path for multi-sig contributions is refused (it never
produced verifiable proofs). `ExternalSigner.signBytes` is optional on the interface, so
did:webvh signing and all other `sign()` usage are unaffected.

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] I have updated JSDoc comments for any changed public APIs
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Testing

- [x] Unit tests — new regression tests for every fix (`MultiSigManager`, `Verifier`,
  `verifyEventLog`, `RollbackManager`, `listObjects`) plus a security-directory
  regression (`issue-batch-302-310-314-regressions.test.ts`) exercising the attacker/caller
  side of #310 and #314.
- [x] Integration tests — full suite run.
- [x] Manual testing — see output below.

## Screenshots / Output

```
typecheck:  clean (0 errors)
lint:       0 errors, 92 warnings  (identical to base — no warnings added)
tests:      unit + security + integration: 3586 pass / 0 fail / 68 skip
            stress:                          18 pass / 0 fail
```

No pre-existing failures were observed on this branch; the full suite is green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmWNaMwRthkaWYyGh1iZq7)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden multi-sig VC signing, CEL witness bytes, btco rollback, and status list proof caching
> - `MultiSigManager` now enforces Ed25519-only keys for multi-sig, requires external signers to implement `signBytes()`, and rejects wrong-length signatures at sign time; concurrent proof verification is added to both `MultiSigManager` and `Verifier`
> - Adds `witnessSigningBytes(digestMultibase)` to the public SDK API, clarifying that witnesses must sign JSON-quoted digest bytes (not raw decoded bytes)
> - `Verifier` memoizes status list credential proof verification using a SHA-256 content key with TTL, avoiding repeated expensive proof checks for the same document
> - `RollbackManager.rollback()` now returns `PARTIALLY_ROLLED_BACK` with `irreversibleArtifacts` for btco migrations when on-chain broadcast artifacts are present, regardless of tracked pre-anchoring state
> - `StorageAdapter` gains an optional `listObjects?(domain, prefix)` method and `ExternalSigner` gains an optional `signBytes?(data)` method, both backward-compatible
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e12e8a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->