### PR TITLE
fix(adapters): fail fast on placeholder ord base URL + correct stale signet fee test (#328 cleanup)

### DIFF
--- a/.changeset/ord-provider-env-fail-fast.md
+++ b/.changeset/ord-provider-env-fail-fast.md
@@ -1,0 +1,12 @@
+---
+"@originals/sdk": patch
+---
+
+`createOrdinalsProviderFromEnv` now fails fast when `USE_LIVE_ORD_PROVIDER=true`
+but `ORD_PROVIDER_BASE_URL` is unset, blank, or left at the documentation
+placeholder `https://ord.example.com/api`, throwing
+`StructuredError('ORD_PROVIDER_BASE_URL_REQUIRED')` instead of silently building
+a live provider aimed at a nonexistent host. Also corrects a stale signet
+integration test to assert `OrdinalsClient.estimateFee` throws (its hardened
+behavior) rather than returning a fabricated positive fee rate. Related cleanup
+from #328.

--- a/packages/sdk/src/adapters/providers/OrdHttpProvider.ts
+++ b/packages/sdk/src/adapters/providers/OrdHttpProvider.ts
@@ -13,6 +13,12 @@ interface HttpProviderOptions {
 const DEFAULT_MAX_JSON_BYTES = 1 * 1024 * 1024;
 const DEFAULT_MAX_CONTENT_BYTES = 5 * 1024 * 1024;
 
+/**
+ * Documentation placeholder — never a reachable host. createOrdinalsProviderFromEnv
+ * refuses to build a live provider pointed at it (issue #328).
+ */
+const PLACEHOLDER_ORD_BASE_URL = 'https://ord.example.com/api';
+
 function buildUrl(baseUrl: string, path: string): string {
   const base = baseUrl.replace(/\/$/, '');
   return `${base}${path.startsWith('/') ? '' : '/'}${path}`;
@@ -216,7 +222,20 @@ export async function createOrdinalsProviderFromEnv(
   }
   const useLive = String(((globalThis as any).process?.env?.USE_LIVE_ORD_PROVIDER) || '').toLowerCase() === 'true';
   if (useLive) {
-    const baseUrl = ((globalThis as any).process?.env?.ORD_PROVIDER_BASE_URL) || 'https://ord.example.com/api';
+    // USE_LIVE_ORD_PROVIDER opts into real network I/O, so the base URL must
+    // point at a real ord server. Previously this silently defaulted to the
+    // placeholder https://ord.example.com/api when ORD_PROVIDER_BASE_URL was
+    // unset — quietly aiming every read at a nonexistent host and risking
+    // failures/garbage being written into provenance. Fail fast instead so
+    // misconfiguration surfaces at startup rather than mid-lifecycle (#328).
+    const baseUrl = String(((globalThis as any).process?.env?.ORD_PROVIDER_BASE_URL) || '').trim();
+    if (!baseUrl || baseUrl === PLACEHOLDER_ORD_BASE_URL) {
+      throw new StructuredError(
+        'ORD_PROVIDER_BASE_URL_REQUIRED',
+        'USE_LIVE_ORD_PROVIDER=true requires ORD_PROVIDER_BASE_URL to be set to a real ord ' +
+        `server URL; refusing to fall back to the placeholder ${PLACEHOLDER_ORD_BASE_URL}.`
+      );
+    }
     return new OrdHttpProvider({ baseUrl });
   }
   const mod = await import('./OrdMockProvider.js');

--- a/packages/sdk/src/adapters/providers/OrdHttpProvider.ts
+++ b/packages/sdk/src/adapters/providers/OrdHttpProvider.ts
@@ -230,10 +230,13 @@ export async function createOrdinalsProviderFromEnv(
     // misconfiguration surfaces at startup rather than mid-lifecycle (#328).
     const baseUrl = String(((globalThis as any).process?.env?.ORD_PROVIDER_BASE_URL) || '').trim();
     if (!baseUrl || baseUrl === PLACEHOLDER_ORD_BASE_URL) {
+      const reason = !baseUrl
+        ? 'it is not set or is blank'
+        : `it is left at the documentation placeholder ${PLACEHOLDER_ORD_BASE_URL}`;
       throw new StructuredError(
         'ORD_PROVIDER_BASE_URL_REQUIRED',
         'USE_LIVE_ORD_PROVIDER=true requires ORD_PROVIDER_BASE_URL to be set to a real ord ' +
-        `server URL; refusing to fall back to the placeholder ${PLACEHOLDER_ORD_BASE_URL}.`
+        `server URL, but ${reason}.`
       );
     }
     return new OrdHttpProvider({ baseUrl });

--- a/packages/sdk/tests/integration/bitcoin-signet.integration.test.ts
+++ b/packages/sdk/tests/integration/bitcoin-signet.integration.test.ts
@@ -95,10 +95,11 @@ describeSignet('OrdinalsClient against signet', () => {
     client = new OrdinalsClient(ORD_SIGNET_URL!, 'signet');
   });
 
-  test('estimateFee returns a positive number', async () => {
-    const fee = await client.estimateFee(1);
-    expect(typeof fee).toBe('number');
-    expect(fee).toBeGreaterThan(0);
+  test('estimateFee throws NOT_IMPLEMENTED instead of returning a hardcoded rate (#318/#328)', async () => {
+    // OrdinalsClient.estimateFee was hardened in #248/#318 to refuse to return
+    // a fabricated fee rate. Until real fee estimation lands (#328) this must
+    // assert the fail-loud behavior, not a positive number.
+    await expect(client.estimateFee(1)).rejects.toThrow(/not implemented/i);
   });
 
   test('getSatInfo returns inscription_ids array for unknown sat', async () => {

--- a/packages/sdk/tests/unit/adapters/OrdHttpProvider.not-implemented.test.ts
+++ b/packages/sdk/tests/unit/adapters/OrdHttpProvider.not-implemented.test.ts
@@ -103,12 +103,21 @@ describe('OrdHttpProvider write-path methods fail loudly instead of fabricating 
 describe('createOrdinalsProviderFromEnv with USE_LIVE_ORD_PROVIDER=true (#318)', () => {
   const savedUseLive = process.env.USE_LIVE_ORD_PROVIDER;
   const savedBaseUrl = process.env.ORD_PROVIDER_BASE_URL;
+  const savedQuickNode = process.env.QUICKNODE_ENDPOINT;
+
+  beforeEach(() => {
+    // QuickNode takes precedence over the live HTTP provider; clear it so these
+    // tests exercise the USE_LIVE_ORD_PROVIDER branch deterministically.
+    delete process.env.QUICKNODE_ENDPOINT;
+  });
 
   afterEach(() => {
     if (savedUseLive === undefined) delete process.env.USE_LIVE_ORD_PROVIDER;
     else process.env.USE_LIVE_ORD_PROVIDER = savedUseLive;
     if (savedBaseUrl === undefined) delete process.env.ORD_PROVIDER_BASE_URL;
     else process.env.ORD_PROVIDER_BASE_URL = savedBaseUrl;
+    if (savedQuickNode === undefined) delete process.env.QUICKNODE_ENDPOINT;
+    else process.env.QUICKNODE_ENDPOINT = savedQuickNode;
   });
 
   test('live provider broadcast throws rather than returning a fake txid', async () => {
@@ -146,5 +155,51 @@ describe('createOrdinalsProviderFromEnv with USE_LIVE_ORD_PROVIDER=true (#318)',
     // The mock is allowed to simulate inscriptions — that is its entire job.
     const created = await provider.createInscription({ data: Buffer.from('x'), contentType: 'text/plain' });
     expect(created.inscriptionId).toBeTruthy();
+  });
+
+  // Regression for #328: enabling the live provider without a real base URL used
+  // to silently fall back to the placeholder https://ord.example.com/api, aiming
+  // every read at a nonexistent host. It must now fail fast at construction.
+  test('throws when ORD_PROVIDER_BASE_URL is unset', async () => {
+    process.env.USE_LIVE_ORD_PROVIDER = 'true';
+    delete process.env.ORD_PROVIDER_BASE_URL;
+
+    let caught: unknown;
+    try {
+      await createOrdinalsProviderFromEnv();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(StructuredError);
+    expect((caught as StructuredError).code).toBe('ORD_PROVIDER_BASE_URL_REQUIRED');
+  });
+
+  test('throws when ORD_PROVIDER_BASE_URL is blank/whitespace', async () => {
+    process.env.USE_LIVE_ORD_PROVIDER = 'true';
+    process.env.ORD_PROVIDER_BASE_URL = '   ';
+
+    await expect(createOrdinalsProviderFromEnv()).rejects.toThrow(/ORD_PROVIDER_BASE_URL/);
+  });
+
+  test('throws when ORD_PROVIDER_BASE_URL is left at the documentation placeholder', async () => {
+    process.env.USE_LIVE_ORD_PROVIDER = 'true';
+    process.env.ORD_PROVIDER_BASE_URL = 'https://ord.example.com/api';
+
+    let caught: unknown;
+    try {
+      await createOrdinalsProviderFromEnv();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(StructuredError);
+    expect((caught as StructuredError).code).toBe('ORD_PROVIDER_BASE_URL_REQUIRED');
+  });
+
+  test('builds an OrdHttpProvider when a real base URL is supplied', async () => {
+    process.env.USE_LIVE_ORD_PROVIDER = 'true';
+    process.env.ORD_PROVIDER_BASE_URL = 'https://ord.live.example';
+
+    const provider = await createOrdinalsProviderFromEnv();
+    expect(provider).toBeInstanceOf(OrdHttpProvider);
   });
 });


### PR DESCRIPTION
## What

Hardens `createOrdinalsProviderFromEnv()` so that opting into the live Ordinals provider (`USE_LIVE_ORD_PROVIDER=true`) without a real `ORD_PROVIDER_BASE_URL` fails fast instead of silently pointing every read at the documentation placeholder `https://ord.example.com/api`. Also corrects a stale signet integration test whose assertion no longer matches the hardened `estimateFee` behavior.

These are the two **"Related cleanup"** acceptance items of #328. The broader real-provider implementation (the bulk of #328) is intentionally out of scope here — see *Scope & why this batch is small* below.

## Why

**`createOrdinalsProviderFromEnv` footgun (#328 cleanup):** the factory defaulted `ORD_PROVIDER_BASE_URL` to `https://ord.example.com/api` when unset. With `USE_LIVE_ORD_PROVIDER=true` this handed back an `OrdHttpProvider` aimed at a nonexistent host, so the misconfiguration only surfaced deep in a lifecycle operation (or as failures/garbage flowing toward provenance) rather than at construction. #328 explicitly asks this to *"fail fast if missing"*.

**Stale signet test (#328 cleanup):** `bitcoin-signet.integration.test.ts` still asserted `OrdinalsClient.estimateFee` *"returns a positive number"*, but that method was hardened in #248/#318 to **throw** rather than fabricate a fee rate. The test was wrong (and would fail against a real signet node). #328 lists updating it as a cleanup item.

## How

- Introduced a `PLACEHOLDER_ORD_BASE_URL` constant and made the `useLive` branch of `createOrdinalsProviderFromEnv` throw a `StructuredError('ORD_PROVIDER_BASE_URL_REQUIRED', …)` when the env var is unset, blank/whitespace, or left at the placeholder. A real base URL still constructs the provider unchanged. QuickNode configuration still takes precedence (that branch returns before this check).
- Updated the stale signet test to assert `estimateFee` rejects with `/not implemented/i`, mirroring the existing `OrdHttpProvider` fail-loud test and honestly reflecting current behavior until real fee estimation lands.
- Added 4 unit regressions in `OrdHttpProvider.not-implemented.test.ts` covering unset / blank / placeholder (throws) and real-URL (constructs) cases, plus a `beforeEach` that clears `QUICKNODE_ENDPOINT` so the live-provider branch is exercised deterministically.

## Scope & why this batch is small

The other open issues were reviewed against current code and deliberately excluded:

- **#341, #342, #348** — already covered by open PR #356.
- **#300** — requires an explicit interop confirmation before dropping VCDM 1.1 acceptance (called out in the issue).
- **#279, #303** — architectural (wire/de-export the migration subsystem; introduce a shared cross-manager lock); need a design decision.
- **#283** — the `StorageValidator` half is already fixed on this branch; the remaining `CredentialValidator` half needs the migration subsystem to source real credentials by DID, which is blocked on #279.
- **#328 (main)** — real provider implementations need a live ord/QuickNode backend and env-gated integration tests.
- **#330, #332, #333** — landing-page work blocked on external decisions/prerequisites (host choice, spending real sats, a network index endpoint that doesn't exist yet).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Breaking change (behavior change: a misconfigured live provider now throws at construction instead of returning a broken provider aimed at a nonexistent host)
- [x] Test addition or improvement

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`)
- [x] Linting passes (no new errors/warnings vs base)
- [x] I have updated JSDoc comments for any changed public APIs
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have read CONTRIBUTING.md

## Testing

- [x] **Unit tests** — 4 new regressions in `OrdHttpProvider.not-implemented.test.ts`; verified they fail without the src fix (3 fail on revert) and pass with it.
- [x] **Integration tests** — corrected the signet `estimateFee` assertion (env-gated; runs only with `ORD_SIGNET_URL`).
- [x] **Full suite** — `bun test` (after `bun run build`): **3609 pass / 68 skip / 0 fail**. Typecheck clean. Lint: **35 errors / 487 warnings**, unchanged errors and −2 warnings vs base (35/489); no new problems introduced.

## Output

```
typecheck: 0 errors
lint:      35 errors / 487 warnings (base 35 / 489 — 0 added, 2 fewer)
bun test:  3609 pass, 68 skip, 0 fail (197 files)
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01HTqs7DJvux5NtRCeHN1DXg)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fail fast in `createOrdinalsProviderFromEnv` when `ORD_PROVIDER_BASE_URL` is missing or placeholder
> - `createOrdinalsProviderFromEnv` now throws a `StructuredError('ORD_PROVIDER_BASE_URL_REQUIRED')` when `USE_LIVE_ORD_PROVIDER=true` but `ORD_PROVIDER_BASE_URL` is unset, blank, or set to the placeholder `https://ord.example.com/api`, instead of silently constructing a provider pointed at a non-existent host.
> - Introduces `OrdHttpProvider.PLACEHOLDER_ORD_BASE_URL` as a named constant for the placeholder value used in validation.
> - Corrects a stale signet integration test to assert that `OrdinalsClient.estimateFee` rejects with a not-implemented error rather than returning a number.
> - Adds unit tests covering the three invalid `ORD_PROVIDER_BASE_URL` cases and the valid-URL happy path, with deterministic `QUICKNODE_ENDPOINT` isolation.
> - Behavioral Change: callers with `USE_LIVE_ORD_PROVIDER=true` and a missing or placeholder URL will now get an immediate thrown error at startup instead of a runtime network failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f4dd704.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->