### PR TITLE
fix(vc,migration): standardize on VCDM 2.0; mark migration subsystem experimental (#300, #279)

### DIFF
--- a/.changeset/vcdm2-only-and-experimental-migration.md
+++ b/.changeset/vcdm2-only-and-experimental-migration.md
@@ -1,0 +1,26 @@
+---
+"@originals/sdk": patch
+---
+
+Standardize on W3C VCDM 2.0 and mark the migration subsystem experimental.
+
+**BREAKING (#300 — VCDM 2.0 only):** `validateCredential` now requires the
+`https://www.w3.org/ns/credentials/v2` context and rejects credentials that
+present only the VCDM 1.1 (`https://www.w3.org/2018/credentials/v1`) context
+(reversing the 1.1 acceptance added in #264). All SDK-emitted credentials now use
+the 2.0 context and the `validFrom` timestamp instead of `issuanceDate`:
+resource credentials, chained credentials, presentations, Bitstring status-list
+credentials, and key-recovery credentials. The 1.1 JSON-LD context remains
+preloaded so previously-issued 1.1 credentials can still be read/verified
+cryptographically, but it is no longer accepted at the structural gate. The
+`VerifiableCredential` type gains optional `validFrom`/`validUntil` and marks
+`issuanceDate`/`expirationDate` as deprecated legacy fields. Fixes a latent
+signing bug where `StatusListManager` emitted a v2 context with `issuanceDate`,
+a term the v2 context does not define (safe-mode canonicalization would fail).
+
+**BREAKING (#279 — migration subsystem experimental):** `MigrationManager` is no
+longer re-exported from the package entry point. It is experimental and unused in
+production — `OriginalsSDK`/`LifecycleManager` run their own migration flow and
+never use it — so its checkpoint/rollback/audit machinery protected no production
+path. It remains importable from its module path for experimentation. Only the
+`MigrationError` type stays exported (the public event API references it).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,9 @@ Pluggable storage via StorageAdapter interface:
 - `LocalStorageAdapter` - Browser localStorage
 - Custom adapters can be implemented for databases, IPFS, etc.
 
-### Migration System (src/migration/)
+### Migration System (src/migration/) — EXPERIMENTAL, not the production path
+
+> **Note:** This subsystem is **experimental and unused in production.** `OriginalsSDK`/`LifecycleManager` run their own migrate/publish/inscribe flow with independent validation and never instantiate `MigrationManager`, so the checkpoint/rollback/audit/state-machine machinery below protects no production code path (issue #279). `MigrationManager` is intentionally **not** exported from the package entry point. Do not treat it as the supported migration API; use `LifecycleManager` (`sdk.lifecycle`) for real migrations.
 
 State machine-driven asset migration with validation:
 - **StateMachine (migration/state/StateMachine.ts)** - Enforces lifecycle rules

--- a/packages/sdk/src/did/KeyManager.ts
+++ b/packages/sdk/src/did/KeyManager.ts
@@ -144,7 +144,7 @@ export class KeyManager {
 		// Ensure required contexts
 		const multikeyContext = 'https://w3id.org/security/multikey/v1';
 		const securityContext = 'https://w3id.org/security/v1';
-		const credentialsContext = 'https://www.w3.org/2018/credentials/v1';
+		const credentialsContext = 'https://www.w3.org/ns/credentials/v2';
 		
 		const updatedContext = [...didDoc['@context']];
 		if (!updatedContext.includes(multikeyContext)) {
@@ -205,7 +205,7 @@ export class KeyManager {
 			'@context': [credentialsContext, securityContext],
 			type: ['VerifiableCredential', 'KeyRecoveryCredential'],
 			issuer: didDoc.id,
-			issuanceDate: compromisedTimestamp,
+			validFrom: compromisedTimestamp,
 			credentialSubject: {
 				id: didDoc.id,
 				recoveredAt: compromisedTimestamp,

--- a/packages/sdk/src/did/WebVHManager.ts
+++ b/packages/sdk/src/did/WebVHManager.ts
@@ -281,12 +281,12 @@ export interface RecoverWebVHOptions {
   outputDir?: string;
 }
 
-/** Minimal W3C VC documenting a key-compromise recovery. */
+/** Minimal W3C VCDM 2.0 VC documenting a key-compromise recovery. */
 export interface KeyRecoveryCredential {
   '@context': string[];
   type: string[];
   issuer: string;
-  issuanceDate: string;
+  validFrom: string;
   credentialSubject: {
     id: string;
     recoveredAt: string;
@@ -871,12 +871,12 @@ export class WebVHManager {
     const now = new Date().toISOString();
     const recoveryCredential: KeyRecoveryCredential = {
       '@context': [
-        'https://www.w3.org/2018/credentials/v1',
+        'https://www.w3.org/ns/credentials/v2',
         'https://w3id.org/security/multikey/v1'
       ],
       type: ['VerifiableCredential', 'KeyRecoveryCredential'],
       issuer: did,
-      issuanceDate: now,
+      validFrom: now,
       credentialSubject: {
         id: did,
         recoveredAt: now,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -92,9 +92,18 @@ export type { MultikeyType } from './crypto/Multikey.js';
 // Event system exports
 export * from './events/index.js';
 
-// Migration system exports
-export { MigrationManager } from './migration/index.js';
-export * from './migration/types.js';
+// Migration system (EXPERIMENTAL — intentionally NOT part of the public API).
+//
+// The `MigrationManager` subsystem (validation pipeline, checkpoints, rollback,
+// audit log, state machine) is experimental and is NOT the migration path used
+// in production: `OriginalsSDK`/`LifecycleManager` run their own
+// migrate/publish/inscribe flow and never instantiate `MigrationManager`
+// (issue #279). Re-exporting it from the package entry point advertised unused
+// machinery as a supported API, so it is deliberately not exported here. It
+// remains importable from its module path for experimentation, at the caller's
+// own risk. Only `MigrationError` is surfaced, because the public event API
+// (`MigrationFailedEvent.error`) references it.
+export type { MigrationError } from './migration/types.js';
 
 // Batch operations exports
 export {

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -1981,7 +1981,8 @@ export class LifecycleManager {
     if (asset.credentials.length > 0) {
       let credentialsValid = true;
       for (const cred of asset.credentials) {
-        if (!cred.type || !cred.issuer || !cred.issuanceDate) {
+        // VCDM 2.0 credentials carry validFrom; accept legacy issuanceDate too (#300).
+        if (!cred.type || !cred.issuer || !(cred.validFrom || cred.issuanceDate)) {
           credentialsValid = false;
           warnings.push('Asset has credentials with missing fields');
         }

--- a/packages/sdk/src/migration/MigrationManager.ts
+++ b/packages/sdk/src/migration/MigrationManager.ts
@@ -29,6 +29,15 @@ import { PeerToBtcoMigration } from './operations/PeerToBtcoMigration.js';
 import { EventEmitter } from '../events/EventEmitter.js';
 import type { EventHandler, EventTypeMap } from '../events/types.js';
 
+/**
+ * @experimental Not the production migration path. `OriginalsSDK` and
+ * `LifecycleManager` do NOT use `MigrationManager`; they implement their own
+ * migrate/publish/inscribe flow with independent validation. This subsystem's
+ * checkpoint / rollback / audit / state-machine machinery therefore protects no
+ * production code path, and its validators can diverge from LifecycleManager's
+ * (issue #279). It is intentionally excluded from the package's public exports.
+ * Treat the API as unstable — it may change or be removed without a major bump.
+ */
 export class MigrationManager {
   private static instance: MigrationManager | null = null;
 

--- a/packages/sdk/src/types/credentials.ts
+++ b/packages/sdk/src/types/credentials.ts
@@ -6,7 +6,17 @@ export interface VerifiableCredential {
   type: string[];
   id?: string;
   issuer: string | Issuer;
-  issuanceDate: string;
+  /**
+   * VCDM 2.0 issuance timestamp. The SDK standardizes on VCDM 2.0 and emits
+   * `validFrom` (issue #300). `issuanceDate` is retained (optional) only so
+   * previously-issued VCDM 1.1 credentials can still be read/verified.
+   */
+  validFrom?: string;
+  /** VCDM 2.0 expiry timestamp (replaces the 1.1 `expirationDate`). */
+  validUntil?: string;
+  /** @deprecated VCDM 1.1 issuance timestamp — read-only legacy field; emit `validFrom`. */
+  issuanceDate?: string;
+  /** @deprecated VCDM 1.1 expiry timestamp — read-only legacy field; emit `validUntil`. */
   expirationDate?: string;
   credentialSubject: CredentialSubject;
   credentialStatus?: CredentialStatus;

--- a/packages/sdk/src/utils/validation.ts
+++ b/packages/sdk/src/utils/validation.ts
@@ -31,12 +31,12 @@ export function validateCredential(vc: VerifiableCredential): boolean {
     return false;
   }
 
-  // Require the VC v1 or v2 credentials context. The SDK itself issues
-  // v2-context credentials (Issuer, StatusListManager), so v2 must validate.
+  // Require the W3C VCDM 2.0 credentials context. The SDK standardizes on
+  // VCDM 2.0 and no longer accepts the 1.1 (`2018/credentials/v1`) context
+  // (issue #300). A credential presenting only the 1.1 context is rejected.
   const contextValues = vc['@context'];
-  const hasVcV1 = contextValues.includes('https://www.w3.org/2018/credentials/v1');
   const hasVcV2 = contextValues.includes('https://www.w3.org/ns/credentials/v2');
-  if (!hasVcV1 && !hasVcV2) {
+  if (!hasVcV2) {
     return false;
   }
 
@@ -48,10 +48,10 @@ export function validateCredential(vc: VerifiableCredential): boolean {
     return false;
   }
 
-  // v1 mandates issuanceDate; VC 2.0 replaced it with validFrom, so under the
-  // v2 context accept either property as the issuance timestamp.
+  // VC 2.0 uses validFrom; still accept a legacy issuanceDate when reading
+  // previously-issued credentials.
   const issuanceTimestamp =
-    vc.issuanceDate ?? (hasVcV2 ? (vc as { validFrom?: unknown }).validFrom : undefined);
+    (vc as { validFrom?: unknown }).validFrom ?? vc.issuanceDate;
   if (!vc.issuer || issuanceTimestamp === undefined) {
     return false;
   }

--- a/packages/sdk/src/vc/CredentialManager.ts
+++ b/packages/sdk/src/vc/CredentialManager.ts
@@ -184,13 +184,13 @@ export class CredentialManager {
   ): VerifiableCredential {
     return {
       '@context': [
-        'https://www.w3.org/2018/credentials/v1',
+        'https://www.w3.org/ns/credentials/v2',
         'https://w3id.org/security/data-integrity/v2',
         'https://originals.build/context'
       ],
       type: ['VerifiableCredential', type],
       issuer,
-      issuanceDate: new Date().toISOString(),
+      validFrom: new Date().toISOString(),
       credentialSubject: subject
     };
   }
@@ -501,7 +501,7 @@ export class CredentialManager {
     holder: string
   ): VerifiablePresentation {
     return {
-      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      '@context': ['https://www.w3.org/ns/credentials/v2'],
       type: ['VerifiablePresentation'],
       holder,
       verifiableCredential: credentials
@@ -926,20 +926,20 @@ export class CredentialManager {
   ): VerifiableCredential {
     const credential: VerifiableCredential = {
       '@context': [
-        'https://www.w3.org/2018/credentials/v1',
+        'https://www.w3.org/ns/credentials/v2',
         'https://w3id.org/security/data-integrity/v2',
         'https://originals.build/context'
       ],
       type: ['VerifiableCredential', type],
       id: this.generateCredentialId(),
       issuer,
-      issuanceDate: new Date().toISOString(),
+      validFrom: new Date().toISOString(),
       credentialSubject: subject
     };
 
-    // Add expiration if specified
+    // Add expiration if specified (VCDM 2.0 validUntil)
     if (chainOptions?.expirationDate) {
-      credential.expirationDate = chainOptions.expirationDate;
+      credential.validUntil = chainOptions.expirationDate;
     }
 
     // Add credential status if specified

--- a/packages/sdk/src/vc/StatusListManager.ts
+++ b/packages/sdk/src/vc/StatusListManager.ts
@@ -52,6 +52,35 @@ function toV2Context(context: unknown): string[] {
   return withoutV1.includes(VCDM_V2_CONTEXT) ? withoutV1 : [VCDM_V2_CONTEXT, ...withoutV1];
 }
 
+/**
+ * Re-issue a status-list credential after mutating its bitstring (#300). The
+ * result is always a valid VCDM 2.0 document regardless of the input's vintage:
+ * the @context is normalized to 2.0, a fresh `validFrom` is written, and the
+ * deprecated 1.1 date fields are removed so a genuinely legacy input (created
+ * with `issuanceDate`/`expirationDate`) cannot leave those terms on a v2
+ * document — the v2 context does not define them, which breaks safe-mode JSON-LD
+ * canonicalization. `expirationDate` is migrated to `validUntil` to preserve any
+ * expiry. The now-stale proof is stripped so the caller must re-sign.
+ */
+function reissueStatusList(
+  base: VerifiableCredential,
+  newSubject: BitstringStatusListSubject
+): VerifiableCredential {
+  const result = {
+    ...base,
+    '@context': toV2Context(base['@context']),
+    credentialSubject: newSubject,
+    validFrom: new Date().toISOString(),
+  } as VerifiableCredential & Record<string, unknown>;
+  if (result.expirationDate && !result.validUntil) {
+    result.validUntil = result.expirationDate;
+  }
+  delete result.issuanceDate;
+  delete result.expirationDate;
+  delete result.proof;
+  return result;
+}
+
 // Upper bound for decompressed encodedList payloads. A legitimate status list
 // is a few MiB at most (the spec minimum is 16 KiB); 16 MiB covers 134M
 // entries while keeping a hostile gzip bomb from exhausting memory.
@@ -220,14 +249,7 @@ export class StatusListManager {
     // the stale proof intact would let a publisher host an unverifiable list
     // (every credential in it then fails a proof-checking verifier). Forcing a
     // re-sign is the only safe contract.
-    const result = {
-      ...statusListCredential,
-      '@context': toV2Context(statusListCredential['@context']),
-      credentialSubject: newSubject,
-      validFrom: new Date().toISOString(),
-    } as VerifiableCredential & { proof?: unknown };
-    delete result.proof;
-    return result;
+    return reissueStatusList(statusListCredential, newSubject);
   }
 
   /**
@@ -317,14 +339,7 @@ export class StatusListManager {
 
     // Strip any existing proof — see setStatus: the mutated bitstring
     // invalidates the prior signature, so the caller must re-sign.
-    const result = {
-      ...statusListCredential,
-      '@context': toV2Context(statusListCredential['@context']),
-      credentialSubject: newSubject,
-      validFrom: new Date().toISOString(),
-    } as VerifiableCredential & { proof?: unknown };
-    delete result.proof;
-    return result;
+    return reissueStatusList(statusListCredential, newSubject);
   }
 
   /**

--- a/packages/sdk/src/vc/StatusListManager.ts
+++ b/packages/sdk/src/vc/StatusListManager.ts
@@ -118,7 +118,7 @@ export class StatusListManager {
       type: ['VerifiableCredential', 'BitstringStatusListCredential'],
       id: options.id,
       issuer: options.issuer,
-      issuanceDate: new Date().toISOString(),
+      validFrom: new Date().toISOString(),
       credentialSubject: {
         type: 'BitstringStatusList',
         statusPurpose: options.statusPurpose,
@@ -198,7 +198,7 @@ export class StatusListManager {
       encodedList: StatusListManager.encodeBitstring(updated),
     };
 
-    // Strip any existing proof: the bitstring (and issuanceDate) just changed,
+    // Strip any existing proof: the bitstring (and validFrom) just changed,
     // so the prior signature no longer covers this document. Returning it with
     // the stale proof intact would let a publisher host an unverifiable list
     // (every credential in it then fails a proof-checking verifier). Forcing a
@@ -206,7 +206,7 @@ export class StatusListManager {
     const result = {
       ...statusListCredential,
       credentialSubject: newSubject,
-      issuanceDate: new Date().toISOString(),
+      validFrom: new Date().toISOString(),
     } as VerifiableCredential & { proof?: unknown };
     delete result.proof;
     return result;
@@ -302,7 +302,7 @@ export class StatusListManager {
     const result = {
       ...statusListCredential,
       credentialSubject: newSubject,
-      issuanceDate: new Date().toISOString(),
+      validFrom: new Date().toISOString(),
     } as VerifiableCredential & { proof?: unknown };
     delete result.proof;
     return result;

--- a/packages/sdk/src/vc/StatusListManager.ts
+++ b/packages/sdk/src/vc/StatusListManager.ts
@@ -35,6 +35,23 @@ export interface StatusCheckResult {
 // Minimum bitstring length per W3C spec
 const MINIMUM_BITSTRING_LENGTH = 131072;
 
+const VCDM_V1_CONTEXT = 'https://www.w3.org/2018/credentials/v1';
+const VCDM_V2_CONTEXT = 'https://www.w3.org/ns/credentials/v2';
+
+/**
+ * Normalize a status-list credential's @context to VCDM 2.0 when re-issuing it
+ * (issue #300). setStatus/batchSetStatus rewrite `validFrom` and re-sign, so a
+ * legacy credential carrying the dropped 1.1 context must be upgraded to v2 —
+ * otherwise the returned document would be re-signable but rejected by the SDK's
+ * own validateCredential gate. The 1.1 context is stripped; any other contexts
+ * (e.g. status-list extensions) are preserved.
+ */
+function toV2Context(context: unknown): string[] {
+  const list: string[] = Array.isArray(context) ? context.filter((c): c is string => typeof c === 'string') : [];
+  const withoutV1 = list.filter((c) => c !== VCDM_V1_CONTEXT);
+  return withoutV1.includes(VCDM_V2_CONTEXT) ? withoutV1 : [VCDM_V2_CONTEXT, ...withoutV1];
+}
+
 // Upper bound for decompressed encodedList payloads. A legitimate status list
 // is a few MiB at most (the spec minimum is 16 KiB); 16 MiB covers 134M
 // entries while keeping a hostile gzip bomb from exhausting memory.
@@ -205,6 +222,7 @@ export class StatusListManager {
     // re-sign is the only safe contract.
     const result = {
       ...statusListCredential,
+      '@context': toV2Context(statusListCredential['@context']),
       credentialSubject: newSubject,
       validFrom: new Date().toISOString(),
     } as VerifiableCredential & { proof?: unknown };
@@ -301,6 +319,7 @@ export class StatusListManager {
     // invalidates the prior signature, so the caller must re-sign.
     const result = {
       ...statusListCredential,
+      '@context': toV2Context(statusListCredential['@context']),
       credentialSubject: newSubject,
       validFrom: new Date().toISOString(),
     } as VerifiableCredential & { proof?: unknown };

--- a/packages/sdk/tests/index.test.ts
+++ b/packages/sdk/tests/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import * as SDK from '../src';
+import { MigrationManager } from '../src/migration';
 
 describe('package exports', () => {
   test('exports core classes and utils', () => {
@@ -15,6 +16,16 @@ describe('package exports', () => {
     expect(SDK.ES256KSigner).toBeDefined();
     expect(SDK.Ed25519Signer).toBeDefined();
     expect(SDK.ES256Signer).toBeDefined();
+  });
+
+  // Issue #279: the experimental MigrationManager subsystem is intentionally NOT
+  // part of the public API (it is unused in production and its safety machinery
+  // protects no real path). It must not be re-exported from the package entry
+  // point, but must remain importable from its module path for experimentation.
+  test('does not re-export the experimental MigrationManager from the package root', () => {
+    expect((SDK as Record<string, unknown>).MigrationManager).toBeUndefined();
+    // Still available at its module path (subsystem itself is intact).
+    expect(MigrationManager).toBeDefined();
   });
 });
 

--- a/packages/sdk/tests/security/critical-high-fix-regressions.test.ts
+++ b/packages/sdk/tests/security/critical-high-fix-regressions.test.ts
@@ -181,7 +181,7 @@ describe('multi-sig proofs must be assertions (review follow-up)', () => {
   });
 });
 
-describe('multi-sig signs plain VCDM 1.1 credentials (review follow-up)', () => {
+describe('multi-sig adds a securing context when one is missing (review follow-up)', () => {
   test('a credential without a data-integrity context signs and verifies (securing context added)', async () => {
     const { MultiSigManager } = await import('../../src/vc/MultiSigManager');
     const { DIDManager } = await import('../../src/did/DIDManager');
@@ -194,12 +194,15 @@ describe('multi-sig signs plain VCDM 1.1 credentials (review follow-up)', () => 
     const mgr = new MultiSigManager(config, new DIDManager(config));
     const policy = { required: 1, total: 1, signerVerificationMethods: [vm] };
 
-    // Plain VCDM 1.1 context only — previously threw 'Safe mode validation error'
+    // A credential whose @context defines no securing (data-integrity) context —
+    // previously threw 'Safe mode validation error' until withSecuringContext
+    // appended data-integrity/v2. (The SDK is VCDM 2.0-only per #300; this uses a
+    // non-securing, resolvable context to still exercise the append path.)
     const credential = {
-      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      '@context': ['https://originals.build/context'],
       type: ['VerifiableCredential'],
       issuer: 'did:peer:issuer',
-      issuanceDate: new Date().toISOString(),
+      validFrom: new Date().toISOString(),
       credentialSubject: { id: 'did:peer:subject' },
     };
     const signed = await mgr.signCredentialMultiSig(credential as never, {

--- a/packages/sdk/tests/security/vcdm2-only-context.test.ts
+++ b/packages/sdk/tests/security/vcdm2-only-context.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect } from 'bun:test';
+import { validateCredential } from '../../src/utils/validation';
+import { deserializeCredential } from '../../src/utils/serialization';
+import type { VerifiableCredential } from '../../src/types';
+
+/**
+ * Issue #300: the SDK standardizes on W3C VCDM 2.0 and no longer accepts the
+ * VCDM 1.1 (`https://www.w3.org/2018/credentials/v1`) context. This reverses the
+ * 1.1 acceptance added in #264. These tests approach it from the caller/attacker
+ * side: a credential presenting only the 1.1 context must be rejected at every
+ * structural acceptance boundary (validateCredential, deserializeCredential, and
+ * OriginalsAsset.addCredential, which both call validateCredential).
+ */
+describe('VCDM 2.0-only context enforcement (issue #300)', () => {
+  const wellFormedExceptContext = {
+    type: ['VerifiableCredential'],
+    issuer: 'did:peer:issuer',
+    credentialSubject: { id: 'did:peer:subject' },
+  };
+
+  test('validateCredential rejects a VCDM 1.1-only credential', () => {
+    const v1Cred = {
+      ...wellFormedExceptContext,
+      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      issuanceDate: new Date().toISOString(),
+    } as unknown as VerifiableCredential;
+    expect(validateCredential(v1Cred)).toBe(false);
+  });
+
+  test('validateCredential accepts the equivalent VCDM 2.0 credential', () => {
+    const v2Cred = {
+      ...wellFormedExceptContext,
+      '@context': ['https://www.w3.org/ns/credentials/v2'],
+      validFrom: new Date().toISOString(),
+    } as unknown as VerifiableCredential;
+    expect(validateCredential(v2Cred)).toBe(true);
+  });
+
+  test('deserializeCredential refuses a VCDM 1.1-only credential', () => {
+    const json = JSON.stringify({
+      ...wellFormedExceptContext,
+      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      issuanceDate: '2024-01-01T00:00:00Z',
+    });
+    expect(() => deserializeCredential(json)).toThrow('Invalid Verifiable Credential JSON');
+  });
+
+  test('a 1.1 context mixed only with non-credentials contexts is still rejected', () => {
+    const mixed = {
+      ...wellFormedExceptContext,
+      '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
+      issuanceDate: new Date().toISOString(),
+    } as unknown as VerifiableCredential;
+    expect(validateCredential(mixed)).toBe(false);
+  });
+});

--- a/packages/sdk/tests/unit/did/DIDManager.rotation.test.ts
+++ b/packages/sdk/tests/unit/did/DIDManager.rotation.test.ts
@@ -237,9 +237,9 @@ describe('DIDManager - Key Recovery', () => {
       });
 
       const cred = recoveryResult.recoveryCredential;
-      expect(cred['@context']).toContain('https://www.w3.org/2018/credentials/v1');
+      expect(cred['@context']).toContain('https://www.w3.org/ns/credentials/v2');
       expect(cred.issuer).toBeDefined();
-      expect(cred.issuanceDate).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(cred.validFrom).toMatch(/^\d{4}-\d{2}-\d{2}T/);
       expect(cred.credentialSubject.previousVerificationMethods).toBeDefined();
       expect(Array.isArray(cred.credentialSubject.previousVerificationMethods)).toBe(true);
       expect(cred.credentialSubject.newVerificationMethod).toBeDefined();

--- a/packages/sdk/tests/unit/did/KeyManager.test.ts
+++ b/packages/sdk/tests/unit/did/KeyManager.test.ts
@@ -258,12 +258,12 @@ describe('KeyManager', () => {
     const credential = result.recoveryCredential;
 
     // Verify credential structure
-    expect(credential['@context']).toContain('https://www.w3.org/2018/credentials/v1');
+    expect(credential['@context']).toContain('https://www.w3.org/ns/credentials/v2');
     expect(credential['@context']).toContain('https://w3id.org/security/v1');
     expect(credential.type).toContain('VerifiableCredential');
     expect(credential.type).toContain('KeyRecoveryCredential');
     expect(credential.issuer).toBe('did:peer:recovery-test');
-    expect(credential.issuanceDate).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(credential.validFrom).toMatch(/^\d{4}-\d{2}-\d{2}T/);
 
     // Verify credential subject
     expect(credential.credentialSubject.id).toBe('did:peer:recovery-test');

--- a/packages/sdk/tests/unit/did/WebVHManager.rotation.test.ts
+++ b/packages/sdk/tests/unit/did/WebVHManager.rotation.test.ts
@@ -319,7 +319,7 @@ describe('WebVHManager - Key Recovery', () => {
       expect(cred.credentialSubject.id).toBeDefined();
       expect(cred.credentialSubject.previousVerificationMethods.length).toBeGreaterThan(0);
       expect(cred.credentialSubject.newVerificationMethod).toBeDefined();
-      expect(cred.issuanceDate).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(cred.validFrom).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     }, 15000);
 
     test('can rotate keys after recovery', async () => {

--- a/packages/sdk/tests/unit/did/did-layer-scenarios.test.ts
+++ b/packages/sdk/tests/unit/did/did-layer-scenarios.test.ts
@@ -429,7 +429,7 @@ describe('DID-009 — recovery credential is tamper-evident (W3C VC)', () => {
     const cred = result.recoveryCredential;
 
     // Verify the credential has the expected W3C VC shape
-    expect(cred['@context']).toContain('https://www.w3.org/2018/credentials/v1');
+    expect(cred['@context']).toContain('https://www.w3.org/ns/credentials/v2');
     expect(cred.type).toContain('VerifiableCredential');
     expect(cred.type).toContain('KeyRecoveryCredential');
     expect(cred.issuer).toBe('did:peer:test-recovery-tamper');
@@ -462,7 +462,7 @@ describe('DID-009 — recovery credential is tamper-evident (W3C VC)', () => {
     expect(tamperResult).toBe(false);
   });
 
-  test('mutating issuanceDate of recovery credential invalidates signature', async () => {
+  test('mutating validFrom of recovery credential invalidates signature', async () => {
     const km = new KeyManager();
     const kp = await km.generateKeyPair('Ed25519');
 
@@ -483,8 +483,8 @@ describe('DID-009 — recovery credential is tamper-evident (W3C VC)', () => {
     const originalBytes = Buffer.from(JSON.stringify(cred), 'utf8');
     const sig: Buffer = await signer.sign(originalBytes, signerKP.privateKey);
 
-    // Tamper: change issuanceDate
-    const tampered = { ...cred, issuanceDate: '1970-01-01T00:00:00Z' };
+    // Tamper: change validFrom
+    const tampered = { ...cred, validFrom: '1970-01-01T00:00:00Z' };
     const tamperedBytes = Buffer.from(JSON.stringify(tampered), 'utf8');
 
     expect(await signer.verify(tamperedBytes, sig, signerKP.publicKey)).toBe(false);
@@ -711,8 +711,8 @@ describe('DID-013 — recovery marks compromised key with ISO-8601 timestamp', (
 
     // recoveredAt on the credential subject must be ISO-8601
     expect(cred.credentialSubject.recoveredAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
-    // issuanceDate must also be ISO-8601
-    expect(cred.issuanceDate).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    // validFrom must also be ISO-8601
+    expect(cred.validFrom).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 });
 

--- a/packages/sdk/tests/unit/lifecycle/OriginalsAsset.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/OriginalsAsset.test.ts
@@ -93,10 +93,10 @@ describe('OriginalsAsset', () => {
 
   test('verify with credentialManager performs cryptographic verification', async () => {
     const goodVc: any = {
-      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      '@context': ['https://www.w3.org/ns/credentials/v2'],
       type: ['VerifiableCredential'],
       issuer: 'did:peer:issuer',
-      issuanceDate: new Date().toISOString(),
+      validFrom: new Date().toISOString(),
       credentialSubject: { id: 'did:peer:xyz' },
       proof: { type: 'DataIntegrityProof', created: new Date().toISOString(), verificationMethod: 'did:peer:issuer#key', proofPurpose: 'assertionMethod', proofValue: 'zabc' }
     };
@@ -112,10 +112,10 @@ describe('OriginalsAsset', () => {
 
   test('verify returns false when credentialManager verification fails', async () => {
     const goodVc: any = {
-      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      '@context': ['https://www.w3.org/ns/credentials/v2'],
       type: ['VerifiableCredential'],
       issuer: 'did:peer:issuer',
-      issuanceDate: new Date().toISOString(),
+      validFrom: new Date().toISOString(),
       credentialSubject: { id: 'did:peer:xyz' },
       proof: { type: 'DataIntegrityProof', created: new Date().toISOString(), verificationMethod: 'did:peer:issuer#key', proofPurpose: 'assertionMethod', proofValue: 'zabc' }
     };

--- a/packages/sdk/tests/unit/utils/serialization.test.ts
+++ b/packages/sdk/tests/unit/utils/serialization.test.ts
@@ -10,7 +10,7 @@ describe('serialization utils', () => {
   });
 
   test('serialize/deserialize VC roundtrip', () => {
-    const vc: any = { '@context': ['https://www.w3.org/2018/credentials/v1'], type: ['VerifiableCredential'], issuer: 'did:peer:abc', issuanceDate: new Date().toISOString(), credentialSubject: { id: 'did:peer:abc' } };
+    const vc: any = { '@context': ['https://www.w3.org/ns/credentials/v2'], type: ['VerifiableCredential'], issuer: 'did:peer:abc', validFrom: new Date().toISOString(), credentialSubject: { id: 'did:peer:abc' } };
     const ser = serializeCredential(vc);
     const round = deserializeCredential(ser);
     expect(round).toEqual(vc);

--- a/packages/sdk/tests/unit/utils/validation.test.ts
+++ b/packages/sdk/tests/unit/utils/validation.test.ts
@@ -18,7 +18,7 @@ describe('validation utils', () => {
 
   test('validateCredential basic VC shape', () => {
     const vc: any = {
-      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      '@context': ['https://www.w3.org/ns/credentials/v2'],
       type: ['VerifiableCredential', 'Test'],
       issuer: 'did:peer:abc',
       issuanceDate: new Date().toISOString(),
@@ -29,7 +29,7 @@ describe('validation utils', () => {
 
   test('validateCredential accepts issuer object with DID id', () => {
     const vc: any = {
-      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      '@context': ['https://www.w3.org/ns/credentials/v2'],
       type: ['VerifiableCredential'],
       issuer: { id: 'did:webvh:example.com:abc' },
       issuanceDate: new Date().toISOString(),
@@ -40,7 +40,7 @@ describe('validation utils', () => {
 
   test('validateCredential returns false when issuer object has no id', () => {
     const vc: any = {
-      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      '@context': ['https://www.w3.org/ns/credentials/v2'],
       type: ['VerifiableCredential'],
       issuer: { name: 'Test Issuer' },
       issuanceDate: new Date().toISOString(),
@@ -52,21 +52,21 @@ describe('validation utils', () => {
   test('validateCredential negative cases', () => {
     expect(validateCredential({} as any)).toBe(false);
     // Fails on missing type array
-    expect(validateCredential({ '@context': ['https://www.w3.org/2018/credentials/v1'], type: undefined, issuer: 'did:peer:x', issuanceDate: new Date().toISOString(), credentialSubject: {} } as any)).toBe(false);
+    expect(validateCredential({ '@context': ['https://www.w3.org/ns/credentials/v2'], type: undefined, issuer: 'did:peer:x', issuanceDate: new Date().toISOString(), credentialSubject: {} } as any)).toBe(false);
     // Fails on missing VerifiableCredential type
-    expect(validateCredential({ '@context': ['https://www.w3.org/2018/credentials/v1'], type: ['Other'], issuer: 'did:peer:x', issuanceDate: new Date().toISOString(), credentialSubject: {} } as any)).toBe(false);
+    expect(validateCredential({ '@context': ['https://www.w3.org/ns/credentials/v2'], type: ['Other'], issuer: 'did:peer:x', issuanceDate: new Date().toISOString(), credentialSubject: {} } as any)).toBe(false);
     // Fails on missing issuanceDate
-    expect(validateCredential({ '@context': ['https://www.w3.org/2018/credentials/v1'], type: ['VerifiableCredential'], issuer: 'did:peer:x', credentialSubject: {} } as any)).toBe(false);
+    expect(validateCredential({ '@context': ['https://www.w3.org/ns/credentials/v2'], type: ['VerifiableCredential'], issuer: 'did:peer:x', credentialSubject: {} } as any)).toBe(false);
     // Fails on missing credentialSubject
-    expect(validateCredential({ '@context': ['https://www.w3.org/2018/credentials/v1'], type: ['VerifiableCredential'], issuer: 'did:peer:x', issuanceDate: new Date().toISOString() } as any)).toBe(false);
-    // Fails when VC v1 context missing
+    expect(validateCredential({ '@context': ['https://www.w3.org/ns/credentials/v2'], type: ['VerifiableCredential'], issuer: 'did:peer:x', issuanceDate: new Date().toISOString() } as any)).toBe(false);
+    // Fails when the VCDM 2.0 credentials context is missing
     expect(validateCredential({ '@context': ['https://example.com/ctx'], type: ['VerifiableCredential'], issuer: 'did:peer:x', issuanceDate: new Date().toISOString(), credentialSubject: {} } as any)).toBe(false);
     // Fails when issuer is not DID
-    expect(validateCredential({ '@context': ['https://www.w3.org/2018/credentials/v1'], type: ['VerifiableCredential'], issuer: 'https://example.com', issuanceDate: new Date().toISOString(), credentialSubject: {} } as any)).toBe(false);
+    expect(validateCredential({ '@context': ['https://www.w3.org/ns/credentials/v2'], type: ['VerifiableCredential'], issuer: 'https://example.com', issuanceDate: new Date().toISOString(), credentialSubject: {} } as any)).toBe(false);
     // Fails when issuer object has non-DID id
-    expect(validateCredential({ '@context': ['https://www.w3.org/2018/credentials/v1'], type: ['VerifiableCredential'], issuer: { id: 'example.com' }, issuanceDate: new Date().toISOString(), credentialSubject: {} } as any)).toBe(false);
+    expect(validateCredential({ '@context': ['https://www.w3.org/ns/credentials/v2'], type: ['VerifiableCredential'], issuer: { id: 'example.com' }, issuanceDate: new Date().toISOString(), credentialSubject: {} } as any)).toBe(false);
     // Fails when issuanceDate is not valid ISO
-    expect(validateCredential({ '@context': ['https://www.w3.org/2018/credentials/v1'], type: ['VerifiableCredential'], issuer: 'did:peer:x', issuanceDate: 'not-a-date', credentialSubject: {} } as any)).toBe(false);
+    expect(validateCredential({ '@context': ['https://www.w3.org/ns/credentials/v2'], type: ['VerifiableCredential'], issuer: 'did:peer:x', issuanceDate: 'not-a-date', credentialSubject: {} } as any)).toBe(false);
   });
 
   test('validateDIDDocument shape', () => {

--- a/packages/sdk/tests/unit/vc/CredentialManager.helpers.test.ts
+++ b/packages/sdk/tests/unit/vc/CredentialManager.helpers.test.ts
@@ -38,7 +38,7 @@ describe('CredentialManager - Factory Methods', () => {
       expect(credential.type).toContain('VerifiableCredential');
       expect(credential.type).toContain('ResourceCreated');
       expect(credential.issuer).toBe('did:peer:creator');
-      expect(credential.issuanceDate).toBeDefined();
+      expect(credential.validFrom).toBeDefined();
       expect(credential.id).toBeDefined();
       expect(credential.id?.startsWith('urn:uuid:')).toBe(true);
       

--- a/packages/sdk/tests/unit/vc/StatusList.test.ts
+++ b/packages/sdk/tests/unit/vc/StatusList.test.ts
@@ -35,7 +35,7 @@ describe('StatusListManager', () => {
       expect(vc.type).toContain('BitstringStatusListCredential');
       expect(vc.id).toBe(listId);
       expect(vc.issuer).toBe(issuer);
-      expect(vc.issuanceDate).toBeDefined();
+      expect(vc.validFrom).toBeDefined();
       expect(vc.credentialSubject.type).toBe('BitstringStatusList');
       expect(vc.credentialSubject.statusPurpose).toBe('revocation');
       expect(vc.credentialSubject.encodedList).toBeDefined();

--- a/packages/sdk/tests/unit/vc/StatusListManager.test.ts
+++ b/packages/sdk/tests/unit/vc/StatusListManager.test.ts
@@ -219,6 +219,33 @@ describe('StatusListManager', () => {
       expect(typeof updated.validFrom).toBe('string');
     });
 
+    // Regression (#300 review): updating a legacy VCDM 1.1 status list must
+    // upgrade its @context to 2.0, not silently produce a 1.1 credential that
+    // the SDK's own validateCredential gate rejects.
+    test('upgrades a legacy v1-context status list to VCDM 2.0 on update', async () => {
+      const { validateCredential } = await import('../../../src/utils/validation');
+      const v2 = manager.createStatusListCredential({
+        id: 'https://example.com/status/legacy',
+        issuer: 'did:peer:issuer',
+        statusPurpose: 'revocation',
+      });
+      // Simulate a status list minted before the 2.0 standardization.
+      const legacyV1 = {
+        ...v2,
+        '@context': ['https://www.w3.org/2018/credentials/v1'],
+      } as typeof v2;
+
+      const setUpdated = manager.setStatus(legacyV1, 0, true);
+      expect(setUpdated['@context']).toContain('https://www.w3.org/ns/credentials/v2');
+      expect(setUpdated['@context']).not.toContain('https://www.w3.org/2018/credentials/v1');
+      expect(validateCredential(setUpdated)).toBe(true);
+
+      const batchUpdated = manager.batchSetStatus(legacyV1, [[1, true]]);
+      expect(batchUpdated['@context']).toContain('https://www.w3.org/ns/credentials/v2');
+      expect(batchUpdated['@context']).not.toContain('https://www.w3.org/2018/credentials/v1');
+      expect(validateCredential(batchUpdated)).toBe(true);
+    });
+
     test('returns a new credential (immutable)', () => {
       const vc = manager.createStatusListCredential({
         id: 'https://example.com/status/1',

--- a/packages/sdk/tests/unit/vc/StatusListManager.test.ts
+++ b/packages/sdk/tests/unit/vc/StatusListManager.test.ts
@@ -32,7 +32,7 @@ describe('StatusListManager', () => {
       expect(vc.type).toContain('BitstringStatusListCredential');
       expect(vc.id).toBe('https://example.com/status/1');
       expect(vc.issuer).toBe('did:example:issuer');
-      expect(vc.issuanceDate).toBeDefined();
+      expect(vc.validFrom).toBeDefined();
 
       const subject = vc.credentialSubject as BitstringStatusListSubject;
       expect(subject.type).toBe('BitstringStatusList');
@@ -207,7 +207,7 @@ describe('StatusListManager', () => {
       expect(manager.checkStatus(entry43, updated).isSet).toBe(false);
     });
 
-    test('sets issuanceDate on update', () => {
+    test('sets validFrom on update', () => {
       const vc = manager.createStatusListCredential({
         id: 'https://example.com/status/1',
         issuer: 'did:example:issuer',
@@ -215,8 +215,8 @@ describe('StatusListManager', () => {
       });
 
       const updated = manager.setStatus(vc, 0, true);
-      expect(updated.issuanceDate).toBeDefined();
-      expect(typeof updated.issuanceDate).toBe('string');
+      expect(updated.validFrom).toBeDefined();
+      expect(typeof updated.validFrom).toBe('string');
     });
 
     test('returns a new credential (immutable)', () => {

--- a/packages/sdk/tests/unit/vc/StatusListManager.test.ts
+++ b/packages/sdk/tests/unit/vc/StatusListManager.test.ts
@@ -219,31 +219,44 @@ describe('StatusListManager', () => {
       expect(typeof updated.validFrom).toBe('string');
     });
 
-    // Regression (#300 review): updating a legacy VCDM 1.1 status list must
-    // upgrade its @context to 2.0, not silently produce a 1.1 credential that
-    // the SDK's own validateCredential gate rejects.
-    test('upgrades a legacy v1-context status list to VCDM 2.0 on update', async () => {
+    // Regression (#300 review): updating a genuinely legacy VCDM 1.1 status
+    // list (1.1 context + issuanceDate, no validFrom) must yield a valid 2.0
+    // credential — upgrade @context to 2.0 AND strip the deprecated 1.1 date
+    // fields, which the v2 context does not define (leaving them would break
+    // safe-mode canonicalization and the validateCredential gate).
+    test('upgrades a legacy v1/issuanceDate status list to VCDM 2.0 on update', async () => {
       const { validateCredential } = await import('../../../src/utils/validation');
       const v2 = manager.createStatusListCredential({
         id: 'https://example.com/status/legacy',
         issuer: 'did:peer:issuer',
         statusPurpose: 'revocation',
       });
-      // Simulate a status list minted before the 2.0 standardization.
-      const legacyV1 = {
+      // Simulate a status list minted before the 2.0 standardization: 1.1
+      // context, issuanceDate present, validFrom absent, and a legacy
+      // expirationDate to prove expiry semantics are preserved.
+      const legacy = {
         ...v2,
         '@context': ['https://www.w3.org/2018/credentials/v1'],
-      } as typeof v2;
+        issuanceDate: '2020-01-01T00:00:00Z',
+        expirationDate: '2999-01-01T00:00:00Z',
+      } as Record<string, unknown>;
+      delete legacy.validFrom;
 
-      const setUpdated = manager.setStatus(legacyV1, 0, true);
-      expect(setUpdated['@context']).toContain('https://www.w3.org/ns/credentials/v2');
-      expect(setUpdated['@context']).not.toContain('https://www.w3.org/2018/credentials/v1');
-      expect(validateCredential(setUpdated)).toBe(true);
-
-      const batchUpdated = manager.batchSetStatus(legacyV1, [[1, true]]);
-      expect(batchUpdated['@context']).toContain('https://www.w3.org/ns/credentials/v2');
-      expect(batchUpdated['@context']).not.toContain('https://www.w3.org/2018/credentials/v1');
-      expect(validateCredential(batchUpdated)).toBe(true);
+      for (const updated of [
+        manager.setStatus(legacy as never, 0, true),
+        manager.batchSetStatus(legacy as never, [[1, true]]),
+      ]) {
+        const u = updated as Record<string, unknown>;
+        expect((u['@context'] as string[])).toContain('https://www.w3.org/ns/credentials/v2');
+        expect((u['@context'] as string[])).not.toContain('https://www.w3.org/2018/credentials/v1');
+        expect(u.validFrom).toBeDefined();
+        // Deprecated 1.1 terms must not survive onto the v2 document.
+        expect(u.issuanceDate).toBeUndefined();
+        expect(u.expirationDate).toBeUndefined();
+        // expirationDate migrated to validUntil (expiry preserved).
+        expect(u.validUntil).toBe('2999-01-01T00:00:00Z');
+        expect(validateCredential(updated)).toBe(true);
+      }
     });
 
     test('returns a new credential (immutable)', () => {

--- a/packages/sdk/tests/unit/vc/credential-hardening.test.ts
+++ b/packages/sdk/tests/unit/vc/credential-hardening.test.ts
@@ -38,13 +38,13 @@ describe('validateCredential VC 2.0 support (issue #264)', () => {
     expect(validateCredential(vc)).toBe(true);
   });
 
-  test('still accepts a v1-context credential with issuanceDate', () => {
+  test('rejects a v1-context credential (VCDM 1.1 no longer accepted, issue #300)', () => {
     const vc = {
       ...base,
       '@context': ['https://www.w3.org/2018/credentials/v1'],
       issuanceDate: new Date().toISOString(),
     } as unknown as VerifiableCredential;
-    expect(validateCredential(vc)).toBe(true);
+    expect(validateCredential(vc)).toBe(false);
   });
 
   test('rejects a credential without a v1 or v2 credentials context', () => {


### PR DESCRIPTION
## What

Two independent, reviewer-approved fixes:

- **#300 — Standardize on W3C VCDM 2.0.** `validateCredential` now requires the `https://www.w3.org/ns/credentials/v2` context and rejects credentials that present only the VCDM 1.1 (`2018/credentials/v1`) context. All SDK-emitted credentials use the v2 context and `validFrom` instead of `issuanceDate`.
- **#279 — Mark the migration subsystem experimental.** `MigrationManager` is no longer re-exported from the package root; it is experimental and unused in production.

## Why

**#300:** The SDK already *issued* 2.0 credentials (Issuer, StatusListManager) but still accepted and emitted 1.1 in places (validation accepted `hasVcV1`; resource/chain/presentation/recovery credentials emitted the 1.1 context + `issuanceDate`). The v2 context does **not** define `issuanceDate`, so any 2.0 credential carrying it fails safe-mode JSON-LD canonicalization unless an `@vocab` context silently absorbs the term into a non-standard predicate — a latent signing bug (`StatusListManager` emitted v2 + `issuanceDate`). Standardizing removes the ambiguity and reverses the 1.1 acceptance added in #264.

**#279:** `MigrationManager` (validation pipeline, checkpoints, rollback, audit, state machine) is documented as production safety machinery but `OriginalsSDK`/`LifecycleManager` never use it — they run their own migrate/publish/inscribe flow. Re-exporting it advertised unused machinery as a supported API.

## How

**#300**
- `utils/validation.ts`: require the v2 context; reject when it's absent. Timestamp check reads `validFrom ?? issuanceDate` (legacy reads still work).
- Emission → v2 + `validFrom`: `CredentialManager.createResourceCredential`, `createCredentialWithChain` (expiry → `validUntil`), `createPresentation`; `StatusListManager` (3 sites); `WebVHManager`/`KeyManager` key-recovery credentials.
- `types/credentials.ts`: add optional `validFrom`/`validUntil`; keep `issuanceDate`/`expirationDate` as deprecated read-only legacy fields.
- `LifecycleManager` structural check accepts `validFrom || issuanceDate`.
- The 1.1 JSON-LD context stays **preloaded** so previously-issued 1.1 credentials can still be read/verified cryptographically (issue scope item 3) — it is simply no longer accepted at the structural gate.

**#279**
- Remove `MigrationManager` and the `migration/types` wildcard from `src/index.ts`; re-export only `MigrationError` (the public event API references it). Add `@experimental` JSDoc and correct the CLAUDE.md architecture section. `MigrationManager` remains importable from its module path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] **Breaking change** — see below
- [x] Test addition or improvement

### Breaking changes

1. **A credential presenting only the VCDM 1.1 context is now rejected** by `validateCredential` / `deserializeCredential` / `OriginalsAsset.addCredential`. Migrate to `https://www.w3.org/ns/credentials/v2` + `validFrom`. (Reverses the 1.1 acceptance from #264. Legacy 1.1 credentials can still be read/verified — the 1.1 context remains loaded — but are not accepted as valid-for-new-use.)
2. **SDK-emitted credentials now carry `validFrom` instead of `issuanceDate`** (and `validUntil` instead of `expirationDate`). Consumers reading `.issuanceDate` on SDK-issued credentials should read `.validFrom` (or `.validFrom ?? .issuanceDate`). The Verifier's validity-period check already reads both.
3. **`MigrationManager` is no longer exported from the package root.** Import it from its module path if you accept its experimental status.

## Testing

- [x] **Unit/security/integration** — updated every fixture/assertion that depended on the 1.1 context or `issuanceDate` emission; reworked the dead "multi-sig signs plain VCDM 1.1" regression to exercise the securing-context append on a v2-era base.
- [x] **New security regression** — `tests/security/vcdm2-only-context.test.ts` asserts 1.1 rejection from the caller/attacker side (validateCredential + deserializeCredential).
- [x] **New export regression** — `tests/index.test.ts` asserts `MigrationManager` is absent from the public barrel but present at its module path.
- [x] **Full suite** (after `bun run build`): **3670 pass / 68 skip / 0 fail**. Typecheck clean. Lint **35 errors / 487 warnings**, identical to `origin/main` (0 added; the 35 errors are pre-existing).
- [x] **Adversarial self-review** — two independent review passes (signing/canonicalization correctness; de-export/cross-cutting API impact) found no defects.

## Notes

Closes #300, closes #279.

Scope decision for #300: the 1.1 acceptance gate and all 1.1 emission are removed; the 1.1 JSON-LD context is retained purely for backward-compatible *reading* of pre-existing credentials (issue scope item 3). A subset of signing/verification tests intentionally exercises that legacy-read path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTqs7DJvux5NtRCeHN1DXg)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Standardize SDK on VCDM 2.0 and mark migration subsystem as experimental
> - All credential-emitting methods (`CredentialManager`, `StatusListManager`, `KeyManager`, `WebVHManager`) now use the VCDM 2.0 context (`https://www.w3.org/ns/credentials/v2`) and `validFrom`/`validUntil` instead of `issuanceDate`/`expirationDate`.
> - `validateCredential` now rejects credentials that only carry the VCDM 1.1 context; `validFrom` is preferred with `issuanceDate` as a legacy fallback.
> - `LifecycleManager` structural checks accept either `validFrom` or `issuanceDate` for backward compatibility with existing assets.
> - `MigrationManager` is removed from the package root export; only `MigrationError` remains exported. It is still importable directly from its module path.
> - Risk: any caller passing VCDM 1.1-only credentials to `validateCredential` will now receive a rejection; previously issued credentials using only `issuanceDate` must be migrated or accessed via the legacy fallback path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc6facb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->