### PR TITLE
test(#362): assert already-shipped behaviour + wire TTI budget into landing CI

### DIFF
--- a/.changeset/smart-guests-buy.md
+++ b/.changeset/smart-guests-buy.md
@@ -1,0 +1,8 @@
+---
+---
+
+Tests-only + CI change (issue #362): adds missing assertions for already-shipped
+behaviour (JWT sign/verify + #352 hardening, `canonicalizeSatoshi`, the VCDM 2.0
+`validFrom` branch, and CLI-level CEL controller-key TOFU / btco-anchor gating)
+and wires the throttled-network TTI budget check into `landing:ci`. No published
+package behaviour changes, so this changeset is intentionally empty.

--- a/apps/landing/scripts/ci.mjs
+++ b/apps/landing/scripts/ci.mjs
@@ -79,9 +79,24 @@ const smoke = spawnSync(
   [fileURLToPath(new URL('./smoke.mjs', import.meta.url)), `${base}?smoke=1`],
   { cwd: appDir, stdio: 'inherit' }
 );
-stopServer();
 if (smoke.status !== 0) {
+  stopServer();
   console.error('[landing-ci] FAILED: smoke test');
   process.exit(smoke.status ?? 1);
 }
-console.log('\n[landing-ci] PASS — build clean, lifecycle ran, zero console errors');
+
+// Throttled-network TTI budget check (tti.mjs). Runs against the same preview
+// server as the smoke test so the CI gate actually enforces the interactivity
+// floor (issue #362 / LANDING-011) instead of the script only existing on disk.
+console.log('\n[landing-ci] throttled-network TTI budget check');
+const tti = spawnSync(
+  process.execPath,
+  [fileURLToPath(new URL('./tti.mjs', import.meta.url)), base],
+  { cwd: appDir, stdio: 'inherit' }
+);
+stopServer();
+if (tti.status !== 0) {
+  console.error('[landing-ci] FAILED: TTI budget check');
+  process.exit(tti.status ?? 1);
+}
+console.log('\n[landing-ci] PASS — build clean, lifecycle ran, zero console errors, TTI within budget');

--- a/packages/auth/tests/jwt.test.ts
+++ b/packages/auth/tests/jwt.test.ts
@@ -153,6 +153,75 @@ describe('jwt', () => {
     });
   });
 
+  describe('security hardening (#352)', () => {
+    test('full sign → verify round trip preserves the payload end-to-end', () => {
+      // A dedicated end-to-end assertion: sign a token, then verify the exact
+      // same string and confirm every claim survives the round trip.
+      const token = signToken('sub_org_e2e', 'roundtrip@example.com', 'session_e2e', {
+        secret: TEST_SECRET,
+      });
+      const payload = verifyToken(token, { secret: TEST_SECRET });
+      expect(payload.sub).toBe('sub_org_e2e');
+      expect(payload.email).toBe('roundtrip@example.com');
+      expect(payload.sessionToken).toBe('session_e2e');
+      expect(payload.iss).toBe('originals-auth');
+      expect(payload.aud).toBe('originals-api');
+      expect(typeof payload.iat).toBe('number');
+      expect(payload.exp).toBeGreaterThan(payload.iat);
+    });
+
+    test('verifyToken rejects an unsigned alg:none token', () => {
+      // Algorithm-confusion guard: a token forged with `"alg":"none"` (no
+      // signature) must be rejected because verify pins the HS256 family.
+      const b64url = (obj: object) =>
+        Buffer.from(JSON.stringify(obj)).toString('base64url');
+      const header = b64url({ alg: 'none', typ: 'JWT' });
+      const now = Math.floor(Date.now() / 1000);
+      const body = b64url({
+        sub: 'sub_org_123',
+        email: 'attacker@example.com',
+        iss: 'originals-auth',
+        aud: 'originals-api',
+        iat: now,
+        exp: now + 3600,
+      });
+      // alg:none tokens carry an empty signature segment.
+      const forged = `${header}.${body}.`;
+      expect(() => verifyToken(forged, { secret: TEST_SECRET })).toThrow('Invalid token');
+    });
+
+    test('signToken rejects a secret shorter than 32 characters', () => {
+      expect(() =>
+        signToken('sub_org_123', 'user@example.com', undefined, { secret: 'short-secret' })
+      ).toThrow('JWT secret must be at least 32 characters');
+    });
+
+    test('verifyToken rejects a secret shorter than 32 characters', () => {
+      const token = signToken('sub_org_123', 'user@example.com', undefined, {
+        secret: TEST_SECRET,
+      });
+      expect(() => verifyToken(token, { secret: 'short-secret' })).toThrow(
+        'JWT secret must be at least 32 characters'
+      );
+    });
+
+    test('rejects a short JWT_SECRET sourced from the environment', () => {
+      process.env.JWT_SECRET = 'too-short';
+      expect(() => signToken('sub_org_123', 'user@example.com')).toThrow(
+        'JWT secret must be at least 32 characters'
+      );
+    });
+
+    test('accepts a secret of exactly 32 characters', () => {
+      const exactly32 = 'a'.repeat(32);
+      const token = signToken('sub_org_123', 'user@example.com', undefined, {
+        secret: exactly32,
+      });
+      const payload = verifyToken(token, { secret: exactly32 });
+      expect(payload.sub).toBe('sub_org_123');
+    });
+  });
+
   describe('getAuthCookieConfig', () => {
     test('returns correct cookie config with defaults', () => {
       const config = getAuthCookieConfig('jwt_token_here');

--- a/packages/sdk/tests/unit/cel/cli-verify.test.ts
+++ b/packages/sdk/tests/unit/cel/cli-verify.test.ts
@@ -338,6 +338,114 @@ describe('CLI Verify Command', () => {
     });
   });
   
+  describe('controller-key TOFU authorization', () => {
+    it('returns verified: false when a later event is signed by a key not authorized by the create event', async () => {
+      // Event 0 establishes the trust-on-first-use controller key (signer A).
+      // A subsequent event signed by a *different* did:key (signer B) is
+      // cryptographically valid on its own, but is not authorized by the log's
+      // create event, so the CLI must fail closed.
+      const signerA = await createRealDidKeySigner();
+      const signerB = await createRealDidKeySigner();
+      expect(signerA.verificationMethod).not.toBe(signerB.verificationMethod);
+
+      let log = await createEventLog({ name: 'TOFU Asset' }, {
+        signer: signerA.signer,
+        verificationMethod: signerA.verificationMethod,
+        proofPurpose: 'assertionMethod',
+      });
+      log = await updateEventLog(log, { description: 'Rogue update' }, {
+        signer: signerB.signer,
+        verificationMethod: signerB.verificationMethod,
+        proofPurpose: 'assertionMethod',
+      });
+
+      const filePath = path.join(tempDir, 'tofu-unauthorized.cel.json');
+      fs.writeFileSync(filePath, serializeEventLogJson(log));
+
+      const result = await verifyCommand({ log: filePath });
+
+      expect(result.success).toBe(true);
+      expect(result.verified).toBe(false);
+      // The second event's controller proof is rejected as unauthorized.
+      expect(result.result?.events[1].proofValid).toBe(false);
+      expect(
+        result.result?.errors.some((e) =>
+          e.includes("is not authorized by the log's create event")
+        )
+      ).toBe(true);
+    });
+
+    it('returns verified: true when every event is signed by the create-event controller key', async () => {
+      // Control case: the same signer authorizes every event, so TOFU passes.
+      const signer = await createRealDidKeySigner();
+      const options = {
+        signer: signer.signer,
+        verificationMethod: signer.verificationMethod,
+        proofPurpose: 'assertionMethod',
+      };
+
+      let log = await createEventLog({ name: 'TOFU Asset' }, options);
+      log = await updateEventLog(log, { description: 'Authorized update' }, options);
+
+      const filePath = path.join(tempDir, 'tofu-authorized.cel.json');
+      fs.writeFileSync(filePath, serializeEventLogJson(log));
+
+      const result = await verifyCommand({ log: filePath });
+
+      expect(result.success).toBe(true);
+      expect(result.verified).toBe(true);
+    });
+  });
+
+  describe('btco-anchor gating', () => {
+    it('fails closed on a bitcoin-ordinals witness proof because the CLI wires no ordinalsProvider', async () => {
+      // A `bitcoin-ordinals-2024` witness proof defines a btco log's resolvable
+      // on-chain identity, so it GATES the result. The CLI does not supply an
+      // ordinalsProvider, so the anchor cannot be confirmed and verification
+      // must fail closed rather than trusting attacker-editable satoshi fields.
+      const { signer, verificationMethod } = await createRealDidKeySigner();
+      const log = await createEventLog({ name: 'Anchored Asset' }, {
+        signer,
+        verificationMethod,
+        proofPurpose: 'assertionMethod',
+      });
+
+      const bitcoinWitnessProof = {
+        type: 'DataIntegrityProof',
+        cryptosuite: 'bitcoin-ordinals-2024',
+        created: new Date().toISOString(),
+        verificationMethod: 'did:btco:1066296127976657#0',
+        proofPurpose: 'assertionMethod',
+        proofValue: 'zBitcoinAnchorProof',
+        witnessedAt: '2026-01-20T12:00:00Z',
+        satoshi: '1066296127976657',
+        inscriptionId: 'abc123i0',
+        txid: 'abc123',
+      } as unknown as WitnessProof;
+
+      const anchoredLog: EventLog = {
+        events: [{
+          ...log.events[0],
+          proof: [...log.events[0].proof, bitcoinWitnessProof],
+        }],
+      };
+
+      const filePath = path.join(tempDir, 'btco-anchored.cel.json');
+      fs.writeFileSync(filePath, serializeEventLogJson(anchoredLog));
+
+      const result = await verifyCommand({ log: filePath });
+
+      expect(result.success).toBe(true);
+      // Bitcoin-anchor failure gates the result — unlike ordinary witnesses.
+      expect(result.verified).toBe(false);
+      expect(
+        result.result?.errors.some((e) =>
+          e.includes('cannot be verified without an ordinalsProvider')
+        )
+      ).toBe(true);
+    });
+  });
+
   describe('error handling', () => {
     it('handles invalid JSON gracefully', async () => {
       const filePath = path.join(tempDir, 'invalid.cel.json');

--- a/packages/sdk/tests/unit/cel/cli-verify.test.ts
+++ b/packages/sdk/tests/unit/cel/cli-verify.test.ts
@@ -367,7 +367,7 @@ describe('CLI Verify Command', () => {
       expect(result.success).toBe(true);
       expect(result.verified).toBe(false);
       // The second event's controller proof is rejected as unauthorized.
-      expect(result.result?.events[1].proofValid).toBe(false);
+      expect(result.result?.events[1]?.proofValid).toBe(false);
       expect(
         result.result?.errors?.some((e) =>
           e.includes("is not authorized by the log's create event")

--- a/packages/sdk/tests/unit/cel/cli-verify.test.ts
+++ b/packages/sdk/tests/unit/cel/cli-verify.test.ts
@@ -369,7 +369,7 @@ describe('CLI Verify Command', () => {
       // The second event's controller proof is rejected as unauthorized.
       expect(result.result?.events[1].proofValid).toBe(false);
       expect(
-        result.result?.errors.some((e) =>
+        result.result?.errors?.some((e) =>
           e.includes("is not authorized by the log's create event")
         )
       ).toBe(true);
@@ -439,7 +439,7 @@ describe('CLI Verify Command', () => {
       // Bitcoin-anchor failure gates the result — unlike ordinary witnesses.
       expect(result.verified).toBe(false);
       expect(
-        result.result?.errors.some((e) =>
+        result.result?.errors?.some((e) =>
           e.includes('cannot be verified without an ordinalsProvider')
         )
       ).toBe(true);

--- a/packages/sdk/tests/unit/utils/satoshi-validation.test.ts
+++ b/packages/sdk/tests/unit/utils/satoshi-validation.test.ts
@@ -353,6 +353,20 @@ describe('satoshi-validation', () => {
   });
 
   describe('canonicalizeSatoshi', () => {
+    // Assert both that the call throws AND that it throws the INVALID_SATOSHI
+    // structured error — a bare toThrow() would let an unrelated failure (e.g.
+    // a TypeError) satisfy a test named for INVALID_SATOSHI.
+    const expectInvalidSatoshi = (fn: () => unknown) => {
+      let caught: unknown;
+      try {
+        fn();
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeDefined();
+      expect((caught as StructuredError).code).toBe('INVALID_SATOSHI');
+    };
+
     test('returns the canonical decimal string for a plain number', () => {
       expect(canonicalizeSatoshi(42)).toBe('42');
     });
@@ -388,30 +402,23 @@ describe('satoshi-validation', () => {
     });
 
     test('throws INVALID_SATOSHI for an out-of-range value', () => {
-      expect(() => canonicalizeSatoshi(MAX_SATOSHI_SUPPLY + 1)).toThrow();
+      expectInvalidSatoshi(() => canonicalizeSatoshi(MAX_SATOSHI_SUPPLY + 1));
     });
 
     test('throws INVALID_SATOSHI for a non-numeric string', () => {
-      expect(() => canonicalizeSatoshi('not-a-number')).toThrow();
+      expectInvalidSatoshi(() => canonicalizeSatoshi('not-a-number'));
     });
 
     test('throws INVALID_SATOSHI for a negative value', () => {
-      expect(() => canonicalizeSatoshi(-1)).toThrow();
+      expectInvalidSatoshi(() => canonicalizeSatoshi(-1));
     });
 
     test('throws INVALID_SATOSHI for a decimal value', () => {
-      expect(() => canonicalizeSatoshi('1.5')).toThrow();
+      expectInvalidSatoshi(() => canonicalizeSatoshi('1.5'));
     });
 
     test('thrown error carries the INVALID_SATOSHI code', () => {
-      let caught: unknown;
-      try {
-        canonicalizeSatoshi('bad');
-      } catch (e) {
-        caught = e;
-      }
-      expect(caught).toBeDefined();
-      expect((caught as StructuredError).code).toBe('INVALID_SATOSHI');
+      expectInvalidSatoshi(() => canonicalizeSatoshi('bad'));
     });
   });
 

--- a/packages/sdk/tests/unit/utils/satoshi-validation.test.ts
+++ b/packages/sdk/tests/unit/utils/satoshi-validation.test.ts
@@ -404,12 +404,14 @@ describe('satoshi-validation', () => {
     });
 
     test('thrown error carries the INVALID_SATOSHI code', () => {
+      let caught: unknown;
       try {
         canonicalizeSatoshi('bad');
-        throw new Error('expected canonicalizeSatoshi to throw');
       } catch (e) {
-        expect((e as StructuredError).code).toBe('INVALID_SATOSHI');
+        caught = e;
       }
+      expect(caught).toBeDefined();
+      expect((caught as StructuredError).code).toBe('INVALID_SATOSHI');
     });
   });
 

--- a/packages/sdk/tests/unit/utils/satoshi-validation.test.ts
+++ b/packages/sdk/tests/unit/utils/satoshi-validation.test.ts
@@ -1,9 +1,10 @@
 import { describe, test, expect } from 'bun:test';
-import { 
-  validateSatoshiNumber, 
-  parseSatoshiIdentifier, 
+import {
+  validateSatoshiNumber,
+  parseSatoshiIdentifier,
   assertValidSatoshi,
-  MAX_SATOSHI_SUPPLY 
+  canonicalizeSatoshi,
+  MAX_SATOSHI_SUPPLY
 } from '../../../src/utils/satoshi-validation';
 import { StructuredError } from '../../../src/utils/telemetry';
 
@@ -348,6 +349,67 @@ describe('satoshi-validation', () => {
       const result = validateSatoshiNumber(-5);
       expect(result.valid).toBe(false);
       expect(result.error).toBeDefined();
+    });
+  });
+
+  describe('canonicalizeSatoshi', () => {
+    test('returns the canonical decimal string for a plain number', () => {
+      expect(canonicalizeSatoshi(42)).toBe('42');
+    });
+
+    test('returns the canonical decimal string for a numeric string', () => {
+      expect(canonicalizeSatoshi('42')).toBe('42');
+    });
+
+    test('strips leading zeros', () => {
+      expect(canonicalizeSatoshi('007')).toBe('7');
+    });
+
+    test('strips surrounding whitespace', () => {
+      expect(canonicalizeSatoshi(' 42 ')).toBe('42');
+    });
+
+    test('canonicalizes zero', () => {
+      expect(canonicalizeSatoshi('0')).toBe('0');
+      expect(canonicalizeSatoshi('000')).toBe('0');
+      expect(canonicalizeSatoshi(0)).toBe('0');
+    });
+
+    test('canonicalizes the maximum supply value', () => {
+      expect(canonicalizeSatoshi(MAX_SATOSHI_SUPPLY)).toBe(String(MAX_SATOSHI_SUPPLY));
+      expect(canonicalizeSatoshi(String(MAX_SATOSHI_SUPPLY))).toBe(String(MAX_SATOSHI_SUPPLY));
+    });
+
+    test('produces identical output for whitespace/leading-zero variants of the same satoshi', () => {
+      const forms = ['42', ' 42', '42 ', '042', ' 042 '];
+      for (const form of forms) {
+        expect(canonicalizeSatoshi(form)).toBe('42');
+      }
+    });
+
+    test('throws INVALID_SATOSHI for an out-of-range value', () => {
+      expect(() => canonicalizeSatoshi(MAX_SATOSHI_SUPPLY + 1)).toThrow();
+    });
+
+    test('throws INVALID_SATOSHI for a non-numeric string', () => {
+      expect(() => canonicalizeSatoshi('not-a-number')).toThrow();
+    });
+
+    test('throws INVALID_SATOSHI for a negative value', () => {
+      expect(() => canonicalizeSatoshi(-1)).toThrow();
+    });
+
+    test('throws INVALID_SATOSHI for a decimal value', () => {
+      expect(() => canonicalizeSatoshi('1.5')).toThrow();
+    });
+
+    test('thrown error carries the INVALID_SATOSHI code', () => {
+      try {
+        canonicalizeSatoshi('bad');
+        throw new Error('expected canonicalizeSatoshi to throw');
+      } catch (e) {
+        expect((e as StructuredError).code).toBe('INVALID_SATOSHI');
+      }
     });
   });
 

--- a/packages/sdk/tests/unit/utils/validation.test.ts
+++ b/packages/sdk/tests/unit/utils/validation.test.ts
@@ -27,6 +27,65 @@ describe('validation utils', () => {
     expect(validateCredential(vc)).toBe(true);
   });
 
+  test('validateCredential accepts a VC 2.0 credential using validFrom', () => {
+    // VCDM 2.0 replaces issuanceDate with validFrom (#259–#264). The credential
+    // below carries *only* validFrom — no legacy issuanceDate — and must pass.
+    const vc: any = {
+      '@context': ['https://www.w3.org/ns/credentials/v2'],
+      type: ['VerifiableCredential'],
+      issuer: 'did:peer:abc',
+      validFrom: new Date().toISOString(),
+      credentialSubject: { id: 'did:peer:abc', foo: 'bar' }
+    };
+    expect(validateCredential(vc)).toBe(true);
+  });
+
+  test('validateCredential rejects a VC 2.0 credential with no validFrom or issuanceDate', () => {
+    const vc: any = {
+      '@context': ['https://www.w3.org/ns/credentials/v2'],
+      type: ['VerifiableCredential'],
+      issuer: 'did:peer:abc',
+      credentialSubject: { id: 'did:peer:abc' }
+    };
+    expect(validateCredential(vc)).toBe(false);
+  });
+
+  test('validateCredential rejects a VC 2.0 credential whose validFrom is not a valid ISO timestamp', () => {
+    const vc: any = {
+      '@context': ['https://www.w3.org/ns/credentials/v2'],
+      type: ['VerifiableCredential'],
+      issuer: 'did:peer:abc',
+      validFrom: 'not-a-date',
+      credentialSubject: { id: 'did:peer:abc' }
+    };
+    expect(validateCredential(vc)).toBe(false);
+  });
+
+  test('validateCredential rejects a credential missing the VCDM 2.0 context even when validFrom is present', () => {
+    const vc: any = {
+      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      type: ['VerifiableCredential'],
+      issuer: 'did:peer:abc',
+      validFrom: new Date().toISOString(),
+      credentialSubject: { id: 'did:peer:abc' }
+    };
+    expect(validateCredential(vc)).toBe(false);
+  });
+
+  test('validateCredential prefers validFrom when both validFrom and issuanceDate are present', () => {
+    const vc: any = {
+      '@context': ['https://www.w3.org/ns/credentials/v2'],
+      type: ['VerifiableCredential'],
+      issuer: 'did:peer:abc',
+      validFrom: new Date().toISOString(),
+      issuanceDate: 'not-a-date',
+      credentialSubject: { id: 'did:peer:abc' }
+    };
+    // validFrom takes precedence over issuanceDate, so the invalid legacy field
+    // is ignored and the credential validates.
+    expect(validateCredential(vc)).toBe(true);
+  });
+
   test('validateCredential accepts issuer object with DID id', () => {
     const vc: any = {
       '@context': ['https://www.w3.org/ns/credentials/v2'],


### PR DESCRIPTION
## What

Adds the missing direct assertions for six behaviours from issue #362 that already ship in production/demo code paths, and wires the existing throttled-network TTI check into the landing CI gate.

## Why

Closes #362 (partially — see "Deferred" below).

These are features whose behaviour ships in production/demo code but had **no direct test asserting the specific behaviour** — the code exists and works; the *assertion* was missing. This PR fills the unblocked "quick win" and "wire existing checks into CI" items from the issue's suggested triage.

## How

Test additions (no production code changed):

- **AUTH-003** (`packages/auth/tests/jwt.test.ts`) — an explicit end-to-end `signToken → verifyToken` round trip, plus the #352 hardening: reject an unsigned `alg:none` token (HS256 pin), and reject secrets shorter than 32 chars for both `signToken` and `verifyToken` (config secret + `JWT_SECRET` env), with a 32-char boundary case.
- **UTILS-008** (`satoshi-validation.test.ts`) — direct unit tests for `canonicalizeSatoshi`: leading-zero/whitespace stripping, zero, max-supply, cross-form equivalence, and `INVALID_SATOSHI` error-code assertions.
- **UTILS-012** (`validation.test.ts`) — the VCDM 2.0 `validFrom` branch: accepts a `validFrom`-only credential, rejects missing/invalid `validFrom`, still gates on the 2.0 `@context`, and prefers `validFrom` over a legacy `issuanceDate`.
- **CEL-CLI-002** (`cli-verify.test.ts`) — drives controller-key TOFU authorization and btco-anchor gating **through the `cel verify` CLI**: an event signed by a key not authorized by the create event fails closed, and a `bitcoin-ordinals-2024` witness proof fails closed because the CLI wires no `ordinalsProvider`.
- **LANDING-011** (`apps/landing/scripts/ci.mjs`) — runs `tti.mjs` inside `landing:ci` against the already-running preview server, so the throttled-network TTI budget is actually enforced instead of only existing on disk.

### Deferred (intentionally, per the issue's triage)

- **CEL-CORE-026** and **UTILS-001** real-provider anchor verification are **blocked on #328** (real Ordinals provider).
- Landing unit tests **004–008** are lower priority (demo app; the headless smoke test already covers "doesn't crash").

## Type of Change

- [x] Test addition or improvement

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [ ] I have updated JSDoc comments for any changed public APIs — n/a, no public API changed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Testing

- [x] Unit tests — new tests pass in isolation and within their suites; full `packages/auth` (213 pass) and `packages/sdk` cel/utils suites (1081 pass) green after `bun run build`. Lint reports 0 errors.
- [ ] Integration tests
- [ ] Manual testing

## Screenshots / Output (if applicable)

```
packages/auth/tests/jwt.test.ts            31 pass  0 fail
.../unit/utils/satoshi-validation.test.ts  +11 tests (canonicalizeSatoshi)
.../unit/utils/validation.test.ts          +5 tests (validFrom branch)
.../unit/cel/cli-verify.test.ts            18 pass  0 fail (+3 TOFU/btco)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkwX2KoHak51XvE1Ys1xYE)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Assert already-shipped behaviour and wire TTI budget check into landing CI
> - Adds a throttled-network Time To Interactive budget check to [ci.mjs](https://github.com/onionoriginals/sdk/pull/363/files#diff-8c767f36e064cf9d0543c1bbed73e2147154425964fc201c794032b01039a213) by spawning `tti.mjs` against the preview server; the CI script now fails if the TTI check exits non-zero.
> - Adds security hardening tests to [jwt.test.ts](https://github.com/onionoriginals/sdk/pull/363/files#diff-3eddab55720998721172c260135bf24b936fdf4bdb9aa495b4e4009777a673bc) covering sign/verify round-trips, `alg:none` rejection, and minimum 32-character secret enforcement.
> - Adds controller-key TOFU authorization and btco-anchor gating tests to [cli-verify.test.ts](https://github.com/onionoriginals/sdk/pull/363/files#diff-e30b111b17247f228a98f71e914f888d3eef2927df9cbbe1b479c1c24ada9edd), asserting that mismatched controller keys and missing `ordinalsProvider` both cause verification to fail closed.
> - Adds `canonicalizeSatoshi` tests in [satoshi-validation.test.ts](https://github.com/onionoriginals/sdk/pull/363/files#diff-c030d332f59a93e0e899af42ed282e42033311564a956f5545e23f90ab484bdb) and VCDM 2.0 `validFrom` handling tests in [validation.test.ts](https://github.com/onionoriginals/sdk/pull/363/files#diff-d06b1c3e169c1d1642e6ab9c7f4b2e756fe52fbc4d0eb20b83f1f1c4ba5cd052).
> - Behavioral Change: landing CI will now fail builds that exceed the TTI budget, which was not previously enforced.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5bf5a6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->