### PR TITLE
fix(migration): enforce real credential + storage validation (#283)

### DIFF
--- a/.changeset/issue-283-credential-validation.md
+++ b/.changeset/issue-283-credential-validation.md
@@ -1,0 +1,5 @@
+---
+"@originals/sdk": patch
+---
+
+Enforce real credential verification in the migration ValidationPipeline (#283). `CredentialValidator` now cryptographically verifies each signed credential via `CredentialManager` and fails hard (`CREDENTIAL_VERIFICATION_FAILED`) on tampered/forged credentials; real credentials flow through `migrate()` via a typed `MigrationOptions.credentials` channel instead of the never-populated `metadata.credentials`.

--- a/packages/sdk/src/migration/types.ts
+++ b/packages/sdk/src/migration/types.ts
@@ -53,6 +53,7 @@ export interface MigrationOptions {
     resumable: boolean;                 // Support resume
   };
   estimateCostOnly?: boolean;           // Return cost estimate without migrating
+  credentials?: VerifiableCredential[]; // Asset's real credentials to validate before migrating (typed channel; supersedes metadata.credentials)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   metadata?: Record<string, any>;       // Additional migration metadata
   domain?: string;                      // For webvh migrations

--- a/packages/sdk/src/migration/validation/CredentialValidator.ts
+++ b/packages/sdk/src/migration/validation/CredentialValidator.ts
@@ -30,8 +30,10 @@ import { CredentialManager } from '../../vc/CredentialManager.js';
  *     ERROR, so migrating an asset carrying an invalid credential now fails.
  *
  * Levels:
- *  - Hard error  → missing mandatory W3C VC fields, OR a signed credential that
- *                  fails cryptographic verification.
+ *  - Hard error  → missing mandatory W3C VC fields, a signed credential that
+ *                  fails cryptographic verification, OR a signed credential that
+ *                  cannot be verified because no CredentialManager was injected
+ *                  (fail closed rather than accept an unverifiable proof).
  *  - Warning     → a credential with no proof (unsigned; signing may be completed
  *                  post-migration).
  *  - No action   → no credentials attached (valid; issuance happens post-migration),
@@ -105,9 +107,21 @@ export class CredentialValidator implements IValidator {
           continue;
         }
 
+        // Fail closed: a signed credential we cannot verify (no manager injected)
+        // must not pass, or a forged proof would slip through unchecked (#283).
+        if (!this.credentialManager) {
+          errors.push({
+            code: 'CREDENTIAL_VERIFICATION_UNAVAILABLE',
+            message: `Credential at index ${i} carries a proof but no CredentialManager is available to verify it`,
+            field: `credentials[${i}]`,
+            details: { index: i }
+          });
+          continue;
+        }
+
         // Real cryptographic verification — this is what makes the check able to
         // fail on a genuinely-invalid credential rather than passing vacuously.
-        if (this.credentialManager) {
+        {
           let verified = false;
           try {
             verified = await this.credentialManager.verifyCredential(cred as VerifiableCredential);

--- a/packages/sdk/src/migration/validation/CredentialValidator.ts
+++ b/packages/sdk/src/migration/validation/CredentialValidator.ts
@@ -1,5 +1,5 @@
 /**
- * CredentialValidator - Validates credential compatibility for migration
+ * CredentialValidator - Validates the migrating asset's real credentials
  */
 
 import {
@@ -9,30 +9,40 @@ import {
   ValidationWarning,
   IValidator
 } from '../types.js';
-import { OriginalsConfig } from '../../types/index.js';
+import { OriginalsConfig, VerifiableCredential } from '../../types/index.js';
+import { CredentialManager } from '../../vc/CredentialManager.js';
 
 /**
- * Required top-level fields for a structurally well-formed W3C Verifiable Credential.
- * We do NOT re-verify cryptographic proofs here — that is the job of CredentialManager.
- * The goal is to catch obviously malformed credentials (missing mandatory fields)
- * before committing to a migration that will fail later.
+ * Validates the credentials attached to the asset being migrated.
  *
- * Design decision (DEF-020): conservative structural check only.
- * - Hard error  → credential is missing one or more mandatory W3C VC fields
- *                 (@context, type, issuer, credentialSubject).
- * - Warning     → credential is present but structurally ambiguous (e.g. unusual
- *                 shapes we can't fully validate without schema resolution).
- * - No action   → no credentials attached (valid; issuance happens post-migration).
+ * Previously this validator was vacuous (issue #283): it only read
+ * `options.metadata.credentials`, a key nothing in the migration flow ever
+ * populated, and — even when present — only checked that four W3C fields
+ * existed. A forged or tampered credential therefore always passed.
  *
- * Credentials are supplied via options.metadata.credentials as an array of
- * plain objects (not yet signed, or already-signed VCs attached to the asset).
+ * The fix has two parts:
+ *  1. Real data in — credentials now arrive on the typed `options.credentials`
+ *     channel (callers pass the asset's actual `credentials`; `metadata.credentials`
+ *     is still read for back-compat).
+ *  2. Real check — each structurally-valid credential that carries a proof is
+ *     cryptographically VERIFIED via CredentialManager. A credential that fails
+ *     verification (tampered payload, unresolvable/forged issuer key) is a HARD
+ *     ERROR, so migrating an asset carrying an invalid credential now fails.
+ *
+ * Levels:
+ *  - Hard error  → missing mandatory W3C VC fields, OR a signed credential that
+ *                  fails cryptographic verification.
+ *  - Warning     → a credential with no proof (unsigned; signing may be completed
+ *                  post-migration).
+ *  - No action   → no credentials attached (valid; issuance happens post-migration),
+ *                  or credentialIssuance explicitly false.
  */
 export class CredentialValidator implements IValidator {
   constructor(
-    private config: OriginalsConfig
+    private config: OriginalsConfig,
+    private credentialManager?: CredentialManager
   ) {}
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   async validate(options: MigrationOptions): Promise<MigrationValidationResult> {
     const errors: ValidationError[] = [];
     const warnings: ValidationWarning[] = [];
@@ -43,8 +53,8 @@ export class CredentialValidator implements IValidator {
         return this.createResult(errors, warnings);
       }
 
-      // Retrieve credentials from metadata (optional — no credentials is valid)
-      const rawCredentials = options.metadata?.['credentials'];
+      // Prefer the typed channel; fall back to the legacy metadata key.
+      const rawCredentials = options.credentials ?? options.metadata?.['credentials'];
       if (!rawCredentials) {
         // Nothing to validate; credentials will be issued post-migration
         return this.createResult(errors, warnings);
@@ -59,7 +69,7 @@ export class CredentialValidator implements IValidator {
           errors.push({
             code: 'MALFORMED_CREDENTIAL',
             message: `Credential at index ${i} is not an object`,
-            field: `metadata.credentials[${i}]`,
+            field: `credentials[${i}]`,
             details: { index: i, received: typeof cred }
           });
           continue;
@@ -69,7 +79,6 @@ export class CredentialValidator implements IValidator {
 
         // Check mandatory W3C VC fields
         const missing: string[] = [];
-
         if (!c['@context']) missing.push('@context');
         if (!c['type']) missing.push('type');
         if (!c['issuer']) missing.push('issuer');
@@ -79,9 +88,46 @@ export class CredentialValidator implements IValidator {
           errors.push({
             code: 'MALFORMED_CREDENTIAL',
             message: `Credential at index ${i} is missing required fields: ${missing.join(', ')}`,
-            field: `metadata.credentials[${i}]`,
+            field: `credentials[${i}]`,
             details: { index: i, missingFields: missing }
           });
+          continue; // can't meaningfully verify a structurally-broken credential
+        }
+
+        // Unsigned credential: acceptable pre-migration, but flag it so the
+        // caller knows a proof still has to be issued.
+        if (!c['proof']) {
+          warnings.push({
+            code: 'UNSIGNED_CREDENTIAL',
+            message: `Credential at index ${i} has no proof; it must be signed before/at migration`,
+            field: `credentials[${i}]`
+          });
+          continue;
+        }
+
+        // Real cryptographic verification — this is what makes the check able to
+        // fail on a genuinely-invalid credential rather than passing vacuously.
+        if (this.credentialManager) {
+          let verified = false;
+          try {
+            verified = await this.credentialManager.verifyCredential(cred as VerifiableCredential);
+          } catch (verifyError) {
+            errors.push({
+              code: 'CREDENTIAL_VERIFICATION_FAILED',
+              message: `Credential at index ${i} could not be verified: ${verifyError instanceof Error ? verifyError.message : String(verifyError)}`,
+              field: `credentials[${i}]`,
+              details: { index: i }
+            });
+            continue;
+          }
+          if (!verified) {
+            errors.push({
+              code: 'CREDENTIAL_VERIFICATION_FAILED',
+              message: `Credential at index ${i} failed cryptographic verification`,
+              field: `credentials[${i}]`,
+              details: { index: i }
+            });
+          }
         }
       }
 

--- a/packages/sdk/src/migration/validation/ValidationPipeline.ts
+++ b/packages/sdk/src/migration/validation/ValidationPipeline.ts
@@ -35,7 +35,7 @@ export class ValidationPipeline {
 
   private initializeValidators(): void {
     this.validators.set('did', new DIDCompatibilityValidator(this.config, this.didManager));
-    this.validators.set('credential', new CredentialValidator(this.config));
+    this.validators.set('credential', new CredentialValidator(this.config, this.credentialManager));
     this.validators.set('storage', new StorageValidator(this.config));
     this.validators.set('lifecycle', new LifecycleValidator(this.config, this.didManager));
     if (this.bitcoinManager) {

--- a/packages/sdk/tests/unit/migration/validation/CredentialValidator.test.ts
+++ b/packages/sdk/tests/unit/migration/validation/CredentialValidator.test.ts
@@ -170,6 +170,20 @@ describe('CredentialValidator (issue #283: vacuous credential check)', () => {
     expect(result.valid).toBe(false);
     expect(result.errors.map(e => e.code)).toContain('CREDENTIAL_VERIFICATION_FAILED');
   });
+
+  test('[fail-closed] a signed credential fails when no CredentialManager is injected to verify it', async () => {
+    // Direct instantiation without a manager must NOT silently pass a proof it
+    // cannot check — otherwise a forged credential slips through (Greptile P2).
+    const validator = new CredentialValidator(baseConfig);
+
+    const result = await validator.validate({
+      ...baseOptions,
+      credentials: [structurallyValidSignedCredential()]
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.map(e => e.code)).toContain('CREDENTIAL_VERIFICATION_UNAVAILABLE');
+  });
 });
 
 describe('ValidationPipeline wires real credential verification (issue #283)', () => {

--- a/packages/sdk/tests/unit/migration/validation/CredentialValidator.test.ts
+++ b/packages/sdk/tests/unit/migration/validation/CredentialValidator.test.ts
@@ -1,0 +1,192 @@
+/**
+ * CredentialValidator unit tests (issue #283)
+ *
+ * Before the fix the validator was VACUOUS: it read only
+ * `options.metadata.credentials` (a key the migration flow never populated) and,
+ * even when a credential was present, only checked that four W3C fields existed.
+ * Any structurally-complete object — including a forged or tampered credential —
+ * passed.
+ *
+ * The fix (a) reads the asset's real credentials from the typed
+ * `options.credentials` channel and (b) cryptographically VERIFIES each signed
+ * credential via CredentialManager, so a genuinely-invalid credential now fails.
+ *
+ * The `[proof-of-fix]` tests below assert exactly the input that PASSED under the
+ * old behavior and now correctly FAILS.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { OriginalsSDK } from '../../../../src';
+import { CredentialValidator } from '../../../../src/migration/validation/CredentialValidator';
+import { ValidationPipeline } from '../../../../src/migration/validation/ValidationPipeline';
+import { CredentialManager } from '../../../../src/vc/CredentialManager';
+import type { OriginalsConfig, VerifiableCredential } from '../../../../src/types';
+import * as secp256k1 from '@noble/secp256k1';
+import { multikey } from '../../../../src/crypto/Multikey';
+
+const baseConfig: OriginalsConfig = {
+  network: 'regtest',
+  webvhNetwork: 'magby',
+  defaultKeyType: 'ES256K',
+  enableLogging: false,
+};
+
+const baseOptions = {
+  sourceDid: 'did:peer:z6MkValid123',
+  targetLayer: 'webvh' as const,
+  domain: 'example.com',
+};
+
+// A structurally-complete, SIGNED-LOOKING credential (has all four W3C fields
+// plus a proof). Under the old validator this always passed.
+function structurallyValidSignedCredential(): VerifiableCredential {
+  return {
+    '@context': ['https://www.w3.org/2018/credentials/v1'],
+    type: ['VerifiableCredential', 'ResourceCreated'],
+    issuer: 'did:peer:z6MkValid123',
+    issuanceDate: new Date().toISOString(),
+    credentialSubject: { id: 'did:peer:z6MkValid123', resourceId: 'res-1' },
+    proof: {
+      type: 'DataIntegrityProof',
+      created: new Date().toISOString(),
+      verificationMethod: 'did:peer:z6MkValid123#key-1',
+      proofPurpose: 'assertionMethod',
+      proofValue: 'zForgedSignatureValue'
+    }
+  } as VerifiableCredential;
+}
+
+// Minimal CredentialManager stub whose verifyCredential result is controllable.
+function credManagerReturning(verified: boolean): CredentialManager {
+  return { verifyCredential: async () => verified } as unknown as CredentialManager;
+}
+
+async function signRealCredential() {
+  const sdk = OriginalsSDK.create({ defaultKeyType: 'ES256K' });
+  const sk = secp256k1.utils.randomSecretKey();
+  const pk = secp256k1.getPublicKey(sk, true);
+  const skMb = multikey.encodePrivateKey(sk, 'Secp256k1');
+  const pkMb = multikey.encodePublicKey(pk, 'Secp256k1');
+  const vc: VerifiableCredential = {
+    '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
+    type: ['VerifiableCredential', 'ResourceCreated'],
+    issuer: `did:key:${pkMb}`,
+    issuanceDate: new Date().toISOString(),
+    credentialSubject: { id: 'did:peer:z6MkValid123', resourceId: 'res-1' } as any
+  };
+  const signed = await sdk.credentials.signCredential(vc, skMb, `did:key:${pkMb}`);
+  return { sdk, signed };
+}
+
+describe('CredentialValidator (issue #283: vacuous credential check)', () => {
+  test('[proof-of-fix] a structurally-complete but cryptographically-invalid credential now FAILS', async () => {
+    // This input has all four W3C fields + a proof, so the OLD validator returned
+    // valid=true. It must now fail because the signature does not verify.
+    const validator = new CredentialValidator(baseConfig, credManagerReturning(false));
+
+    const result = await validator.validate({
+      ...baseOptions,
+      credentials: [structurallyValidSignedCredential()]
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.map(e => e.code)).toContain('CREDENTIAL_VERIFICATION_FAILED');
+  });
+
+  test('[proof-of-fix] a genuinely tampered credential fails real cryptographic verification', async () => {
+    const { sdk, signed } = await signRealCredential();
+    // Sanity: the untampered credential verifies.
+    expect(await sdk.credentials.verifyCredential(signed)).toBe(true);
+
+    // Tamper with the payload after signing.
+    const tampered = {
+      ...signed,
+      credentialSubject: { ...(signed.credentialSubject as any), resourceId: 'res-EVIL' }
+    } as VerifiableCredential;
+
+    const validator = new CredentialValidator(baseConfig, sdk.credentials);
+    const result = await validator.validate({ ...baseOptions, credentials: [tampered] });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.map(e => e.code)).toContain('CREDENTIAL_VERIFICATION_FAILED');
+  });
+
+  test('[happy] a genuinely signed, untampered credential passes', async () => {
+    const { sdk, signed } = await signRealCredential();
+    const validator = new CredentialValidator(baseConfig, sdk.credentials);
+
+    const result = await validator.validate({ ...baseOptions, credentials: [signed] });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test('[structural] a credential missing mandatory W3C fields is a hard error', async () => {
+    const validator = new CredentialValidator(baseConfig, credManagerReturning(true));
+
+    const result = await validator.validate({
+      ...baseOptions,
+      // Missing issuer + credentialSubject.
+      credentials: [{ '@context': ['x'], type: ['VerifiableCredential'] } as any]
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.map(e => e.code)).toContain('MALFORMED_CREDENTIAL');
+  });
+
+  test('[unsigned] a credential with no proof is a warning, not an error', async () => {
+    const validator = new CredentialValidator(baseConfig, credManagerReturning(false));
+    const { proof, ...unsigned } = structurallyValidSignedCredential() as any;
+
+    const result = await validator.validate({ ...baseOptions, credentials: [unsigned] });
+
+    expect(result.valid).toBe(true);
+    expect(result.warnings.map(w => w.code)).toContain('UNSIGNED_CREDENTIAL');
+  });
+
+  test('[skip] no credentials attached is valid (issuance happens post-migration)', async () => {
+    const validator = new CredentialValidator(baseConfig, credManagerReturning(false));
+    const result = await validator.validate({ ...baseOptions });
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test('[skip] credentialIssuance:false short-circuits even with an invalid credential', async () => {
+    const validator = new CredentialValidator(baseConfig, credManagerReturning(false));
+    const result = await validator.validate({
+      ...baseOptions,
+      credentialIssuance: false,
+      credentials: [structurallyValidSignedCredential()]
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test('[compat] credentials on the legacy metadata.credentials channel are still validated', async () => {
+    const validator = new CredentialValidator(baseConfig, credManagerReturning(false));
+    const result = await validator.validate({
+      ...baseOptions,
+      metadata: { credentials: [structurallyValidSignedCredential()] }
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.map(e => e.code)).toContain('CREDENTIAL_VERIFICATION_FAILED');
+  });
+});
+
+describe('ValidationPipeline wires real credential verification (issue #283)', () => {
+  test('[wiring] an invalid signed credential fails the whole pipeline', async () => {
+    const sdk = OriginalsSDK.create({ ...baseConfig });
+    const pipeline = new ValidationPipeline(
+      (sdk as any).config,
+      sdk.did,
+      credManagerReturning(false)
+    );
+
+    const result = await pipeline.validate({
+      ...baseOptions,
+      credentials: [structurallyValidSignedCredential()]
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.map(e => e.code)).toContain('CREDENTIAL_VERIFICATION_FAILED');
+  });
+});


### PR DESCRIPTION
## What

Fixes the vacuous `CredentialValidator` in the (experimental) migration subsystem so migration validation can actually fail on a genuinely-invalid credential.

## Why

Issue #283: `CredentialValidator` only inspected `options.metadata.credentials` — a key nothing in the migration flow ever populated — and, even when a credential *was* present, checked only that four W3C fields existed. A forged or tampered credential therefore always passed. The credential check was structurally incapable of failing on the condition it claimed to check.

## How

- **Real data in:** added a typed `MigrationOptions.credentials` channel (supersedes the buried `metadata.credentials`, which is still read for back-compat) so callers feed the asset's actual credentials through to validation. `MigrationManager.migrate()` already forwards the full `options` to the `ValidationPipeline`, so these now reach the validator.
- **Real check:** `ValidationPipeline` now passes the `CredentialManager` into `CredentialValidator`, which **cryptographically verifies** every signed credential via `credentialManager.verifyCredential`. Verification failure (tampered payload, unresolvable/forged issuer key) is a **hard error** (`CREDENTIAL_VERIFICATION_FAILED`). Unsigned credentials warn (`UNSIGNED_CREDENTIAL`); missing mandatory W3C fields still error (`MALFORMED_CREDENTIAL`).

### StorageValidator

The `StorageValidator` half of #283 (`valid` structurally always `true`) was **already fixed by #318**: it now emits `STORAGE_ADAPTER_INCOMPATIBLE` (adapter present but not persistable) and `PARTIAL_MODE_STORAGE_REQUIRED` (resumable partial mode without persistable storage) as errors. #318 deliberately replaced the phantom `putChunk` probe (no shipped adapter ever had `putChunk`) with a real `resolveMigrationStorage` capability check, and keeps webvh + no-adapter a *warning* because the webvh migration operation does not persist through the storage adapter. Committed tests assert that behavior, so `StorageValidator` is left unchanged rather than regressed.

## Tests

New `tests/unit/migration/validation/CredentialValidator.test.ts` includes `[proof-of-fix]` cases: a structurally-complete signed credential that PASSED under the old behavior now FAILS (both via a stub verifier and via a genuinely-signed-then-tampered credential using real ES256K signing), plus structural/unsigned/skip/back-compat/pipeline-wiring coverage.

- `bun test tests/unit/migration tests/unit/vc` → **723 pass, 0 fail** (40 files)
- New file: **9 pass, 0 fail**
- `tsc --noEmit`: clean for changed files

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce cryptographic credential verification in migration `ValidationPipeline`
> - `CredentialValidator` now reads credentials from `MigrationOptions.credentials` (falling back to `metadata.credentials`) and verifies signed credentials via `CredentialManager.verifyCredential`.
> - Unsigned credentials (no `proof`) produce a non-fatal `UNSIGNED_CREDENTIAL` warning; signed credentials that fail verification produce a `CREDENTIAL_VERIFICATION_FAILED` error.
> - If a signed credential is present but no `CredentialManager` is injected, validation fails with `CREDENTIAL_VERIFICATION_UNAVAILABLE` (fail-closed).
> - `ValidationPipeline` now passes its `CredentialManager` instance into `CredentialValidator` so verification runs automatically during `pipeline.validate()`.
> - Behavioral Change: error field paths now reference `credentials[i]` instead of `metadata.credentials[i]`; previously signed credentials were not verified at all.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67c1c54.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->