### PR TITLE
Phase 1: did:cel genesis layer — log-derived identity, first-class event types, evolving authority

### DIFF
--- a/.changeset/did-cel-genesis-layer.md
+++ b/.changeset/did-cel-genesis-layer.md
@@ -1,0 +1,5 @@
+---
+"@originals/sdk": minor
+---
+
+Phase 1 — did:cel genesis layer: identity is now derived from the event log rather than embedded. A new-shape genesis (`controller` present, no self-referential `did`/`layer`) yields a self-certifying `did:cel:` identifier via `deriveDidCel`, and `verifyEventLog` self-certifies it against the log (returning `assetDid`/`expectedDid`); legacy genesis logs continue to read `did`/`layer` verbatim through a dual-read path across `verifyEventLog`, the CEL managers, and the CLI. Adds first-class `migrate`/`transfer`/`rotateKey`/`update`/`deactivate` event types (managers and CLI emit and consume them directly instead of sniffing `update` payloads), a generic `appendEvent` entry point for all non-create events, and evolving authority where `rotateKey` hands off the authorized signing-key set. `appendEvent` requires `verificationMethod` in the proof so an omitting signer fails at construction, and genesis-shape detection is unified on the `controller===undefined && did!==undefined ⇒ legacy` rule across verifier, managers, and `inspect`.

--- a/docs/ORIGINALS_CEL_SPEC.md
+++ b/docs/ORIGINALS_CEL_SPEC.md
@@ -1,8 +1,8 @@
 # Originals CEL Application Specification
 
-**Version:** 1.0.0  
+**Version:** 1.1.0  
 **Status:** Draft  
-**Date:** January 2026
+**Date:** 2026-07-10
 
 ## Abstract
 
@@ -71,9 +71,12 @@ Every Originals asset is controlled by a Decentralized Identifier (DID). The con
 
 | Layer | DID Method | Resolution |
 |-------|------------|------------|
-| peer  | `did:peer` | Self-contained (numalgo 4) |
+| genesis (peer) | `did:cel` | Derived from the genesis event; self-certifying (see `specs/did-cel-method.md`) |
 | webvh | `did:webvh` | HTTP-based with version history |
 | btco  | `did:btco` | Bitcoin ordinals inscription |
+
+Legacy logs use `did:peer` (numalgo 4) as the genesis identity; new logs derive a
+`did:cel` from the genesis event.
 
 ### 2.2 Proof Requirements
 
@@ -130,6 +133,28 @@ Where:
 1. The first event (`create`) MUST NOT have a `previousEvent` field
 2. All subsequent events MUST include `previousEvent` referencing the prior event
 3. The hash MUST match the SHA-256 digest of the previous event's canonical form
+
+The canonical form covers only the committed fields `{ type, data, previousEvent? }` —
+never the `proof` array. Proofs carry the signature plus unsigned metadata, and
+witness proofs may be appended after the fact; chaining over them would make the link
+depend on data no signature commits to.
+
+### 2.4 Authority Evolution
+
+Authority over a log is **not** fixed for its lifetime. The initial authorized key is
+established by the genesis `controller` (bound fail-closed; see
+[`specs/did-cel-method.md`](../specs/did-cel-method.md) §3.1). Thereafter:
+
+- A fully valid `rotateKey` event (§5.6) **REPLACES** the authorized key set with the
+  new controller's keys. Replace, not union: retired keys are dead from that event
+  forward, and verifiers MUST reject post-rotation events signed by them.
+- A `rotateKey` MUST pass every check (chain, signature, current-set authorization,
+  target bindability) BEFORE the swap; a failed rotation MUST NOT rotate.
+- `migrate` and `transfer` events MUST NOT change the authorized key set.
+- **Post-transfer append authority (rotation-first).** After a non-cooperative
+  ownership transfer, the log accepts nothing from the new owner until their first
+  act is a `rotateKey` (backed on-chain by a reinscription proving sat control). Old-key
+  events timestamped after the transfer are rejected. See the design doc §5.
 
 ---
 
@@ -296,19 +321,21 @@ Within an event's `proof` array:
 
 ## 5. Event Types
 
-### 5.1 Create Event
+### 5.1 Create Event (Genesis)
 
-Initializes a new asset and establishes controller authority.
+Initializes a new asset and establishes controller authority. The genesis event is
+the preimage of the asset's `did:cel` identifier (see
+[`specs/did-cel-method.md`](../specs/did-cel-method.md)); the DID is **derived from**
+this event and therefore MUST NOT be embedded in it.
 
-#### 5.1.1 Structure
+#### 5.1.1 Structure (`CelAssetData` — current write shape)
 
 ```json
 {
   "type": "create",
   "data": {
     "name": "My Digital Artwork",
-    "did": "did:peer:4zQm...",
-    "layer": "peer",
+    "controller": "did:key:z6Mk...",
     "resources": [
       {
         "digestMultibase": "uXYZ...",
@@ -316,15 +343,15 @@ Initializes a new asset and establishes controller authority.
         "url": ["ipfs://Qm..."]
       }
     ],
-    "creator": "did:peer:4zQm...",
-    "createdAt": "2026-01-20T12:00:00Z"
+    "createdAt": "2026-01-20T12:00:00Z",
+    "nonce": "uAAAAAAAAAAAAAAAAAAAAAA"
   },
   "proof": [
     {
       "type": "DataIntegrityProof",
       "cryptosuite": "eddsa-jcs-2022",
       "created": "2026-01-20T12:00:00Z",
-      "verificationMethod": "did:peer:4zQm...#key-0",
+      "verificationMethod": "did:key:z6Mk...#z6Mk...",
       "proofPurpose": "assertionMethod",
       "proofValue": "z3FXQ..."
     }
@@ -337,18 +364,42 @@ Initializes a new asset and establishes controller authority.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `name` | string | Yes | Human-readable asset name |
-| `did` | string | Yes | Asset DID |
-| `layer` | string | Yes | Initial layer (`peer`) |
-| `resources` | array | Yes | Associated external resources |
-| `creator` | string | Yes | Creator DID |
+| `controller` | string | Yes | The **holder's** key DID (`did:key`, or a resolvable DID) — distinct from the derived asset `did:cel` |
+| `resources` | array | Yes | Associated external references (MAY be empty) |
 | `createdAt` | string | Yes | ISO 8601 creation timestamp |
+| `nonce` | string | Yes | Multibase base64url of 16 random bytes — collision insurance for the derived DID |
 
 #### 5.1.3 Rules
 
 - MUST be the first event in any log
 - MUST NOT have a `previousEvent` field
-- `creator` equals `did` at peer layer (self-issued)
+- MUST NOT contain a `did` field — identity is derived, not embedded
+- MUST carry exactly one controller proof (the unsigned proof array cannot
+  disambiguate an injected co-signer)
+- The genesis proof MUST bind to `controller`, fail-closed, with no
+  trust-on-first-use (see `specs/did-cel-method.md` §3.1)
 - `resources` array MAY be empty
+
+#### 5.1.4 Legacy genesis shape (`PeerAssetData`) — read-only
+
+Logs written by pre-`did:cel` releases embed the asset DID directly:
+
+```json
+{
+  "name": "My Digital Artwork",
+  "did": "did:peer:4zQm...",
+  "layer": "peer",
+  "resources": [ /* ... */ ],
+  "creator": "did:peer:4zQm...",
+  "createdAt": "2026-01-20T12:00:00Z"
+}
+```
+
+- Readers MUST continue to accept this shape (dual-accept); the reported asset DID is
+  the declared `data.did`.
+- Writers MUST NOT emit it; new assets use `CelAssetData` above.
+- Behavioral delta: a genesis whose `data.did` is a *malformed* long-form
+  `did:peer:4` now fails closed (previously trust-on-first-use).
 
 ### 5.2 Update Event
 
@@ -426,6 +477,122 @@ Permanently seals the event log, preventing further modifications.
 - Implementations MUST reject updates after deactivation
 - Double-deactivation is an error
 
+### 5.4 Migrate Event
+
+A first-class layer transition (previously folded into `update`). Records the asset
+earning a stronger resolution substrate. Does **not** change authority.
+
+#### 5.4.1 Structure
+
+```json
+{
+  "type": "migrate",
+  "data": {
+    "sourceDid": "did:cel:uEiD...",
+    "targetDid": "did:webvh:example.com:abc123",
+    "layer": "webvh",
+    "domain": "example.com",
+    "migratedAt": "2026-01-23T12:00:00Z"
+  },
+  "previousEvent": "uGHI...",
+  "proof": [ /* controller proof, + witness proof(s) as the target layer requires */ ]
+}
+```
+
+#### 5.4.2 Data Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `sourceDid` | string | Yes | The layer DID being migrated from |
+| `targetDid` | string | Yes | The newly minted layer DID |
+| `layer` | string | Yes | Target layer (`webvh` or `btco`) |
+| `migratedAt` | string | Yes | ISO 8601 timestamp |
+| `domain` | string | webvh | Hosting domain (webvh target) |
+| `txid` / `inscriptionId` | string | btco | Bitcoin anchor fields (btco target) |
+
+#### 5.4.3 Rules
+
+- MUST include `previousEvent` hash
+- MUST follow the one-way path `peer → webvh → btco` (see §6.2); reverse or
+  layer-skipping migrations are invalid
+- MUST NOT change the authorized key set — migration is not a key rotation
+- The asset's `did:cel` identity is unchanged; `targetDid` records a new substrate,
+  not a new identity
+
+### 5.5 Transfer Event
+
+Records an ownership hand-off. Ownership is the Bitcoin sat/UTXO (btco layer);
+transfer moves the sat and records the txid. Identity is unchanged and authority does
+**not** change — the recipient gains append authority only via a subsequent
+`rotateKey` (rotation-first rule; see §2.4 and the design doc §5).
+
+#### 5.5.1 Structure
+
+```json
+{
+  "type": "transfer",
+  "data": {
+    "previousOwner": "bc1q...sender",
+    "newOwner": "bc1q...recipient",
+    "txid": "abc123...",
+    "transferredAt": "2026-01-24T12:00:00Z"
+  },
+  "previousEvent": "uJKL...",
+  "proof": [ /* controller proof (still the pre-transfer controller) */ ]
+}
+```
+
+#### 5.5.2 Data Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `transferredAt` | string | Yes | ISO 8601 timestamp |
+| `txid` | string | SHOULD | Bitcoin transaction ID moving the sat |
+| `previousOwner` / `newOwner` | string | No | Surfaced in derived state metadata |
+
+#### 5.5.3 Rules
+
+- MUST include `previousEvent` hash
+- MUST NOT change the authorized key set — a `transfer` is not a `rotateKey`; the new
+  owner's key does not become a log signer until they rotate
+
+### 5.6 RotateKey Event
+
+Hands authority from the current controller to a new controller. This is the sole
+event type that changes the authorized key set.
+
+#### 5.6.1 Structure
+
+```json
+{
+  "type": "rotateKey",
+  "data": {
+    "newController": "did:key:z6MkNew...",
+    "rotatedAt": "2026-01-25T12:00:00Z"
+  },
+  "previousEvent": "uMNO...",
+  "proof": [ /* signed by the CURRENT (pre-rotation) controller */ ]
+}
+```
+
+#### 5.6.2 Data Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `newController` | string | Yes | The new controller DID — MUST be self-certifying (`did:key` or long-form `did:peer:4`) |
+| `rotatedAt` | string | Yes | ISO 8601 timestamp |
+
+#### 5.6.3 Rules
+
+- MUST include `previousEvent` hash
+- MUST be signed by a key in the authorized set as it stood when appended
+- MUST pass all checks BEFORE the set is swapped; a rotation that fails any check
+  MUST NOT rotate
+- `newController` MUST be self-certifying; a resolver-backed, missing, non-string, or
+  unbindable `newController` MUST fail the event and the log
+- REPLACES (not unions) the authorized key set — the retired keys are dead from this
+  event forward (see §2.4)
+
 ---
 
 ## 6. Migration Events
@@ -446,13 +613,15 @@ peer → webvh → btco
 
 ### 6.3 Migration Event Structure
 
-Migration events are `update` type events with specific data fields:
+Migrations are first-class `migrate` events (§5.4). Legacy logs may carry migrations
+as `update` events with the same data fields (`sourceDid` + `targetDid` + `layer`);
+readers MUST still recognize that legacy shape, but writers MUST emit `migrate`:
 
 ```json
 {
-  "type": "update",
+  "type": "migrate",
   "data": {
-    "sourceDid": "did:peer:4zQm...",
+    "sourceDid": "did:cel:uEiD...",
     "targetDid": "did:webvh:example.com:abc123",
     "layer": "webvh",
     "domain": "example.com",
@@ -529,7 +698,8 @@ The DID is derived from the Bitcoin ordinals inscription ID.
 
 ### 6.6 Detecting Migration Events
 
-Migration events are distinguished from regular updates by:
+A first-class migration is identified by its event `type` of `migrate`. For legacy
+logs that recorded migrations as `update` events, detection falls back to:
 
 1. Presence of both `sourceDid` and `targetDid` fields
 2. A `layer` field indicating the target layer
@@ -748,3 +918,4 @@ interface EventVerification {
 | Version | Date | Changes |
 |---------|------|---------|
 | 1.0.0 | 2026-01 | Initial release |
+| 1.1.0 | 2026-07-10 | `did:cel` genesis (`CelAssetData`, `did`-embedded shape marked legacy read-only); first-class `migrate`/`transfer`/`rotateKey` event types; evolving-authority / rotation semantics (§2.4). See `specs/did-cel-method.md`. |

--- a/docs/ORIGINALS_CEL_SPEC.md
+++ b/docs/ORIGINALS_CEL_SPEC.md
@@ -399,7 +399,8 @@ Logs written by pre-`did:cel` releases embed the asset DID directly:
   the declared `data.did`.
 - Writers MUST NOT emit it; new assets use `CelAssetData` above.
 - Behavioral delta: a genesis whose `data.did` is a *malformed* long-form
-  `did:peer:4` now fails closed (previously trust-on-first-use).
+  `did:peer:4` now fails closed — only when the genesis proof's `verificationMethod`
+  is itself a `did:key` (previously trust-on-first-use).
 
 ### 5.2 Update Event
 

--- a/docs/superpowers/plans/2026-07-10-phase1-did-cel.md
+++ b/docs/superpowers/plans/2026-07-10-phase1-did-cel.md
@@ -1,0 +1,784 @@
+# Phase 1: did:cel Genesis Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce `did:cel` — a genesis DID derived from the hash of the CEL create event — plus first-class `migrate`/`transfer`/`rotateKey` event types and an evolving-authority verifier, per the design spec `docs/superpowers/specs/2026-07-10-cel-backbone-did-cel-design.md` §2 and §7 Phase 1.
+
+**Architecture:** The DID is `did:cel:<digestMultibase(canonicalizeEntryForChain(genesisEvent))>` — the exact chain-digest expression already used for `previousEvent` links, so the log's second event's `previousEvent` equals the DID suffix by construction. The genesis event stops embedding the asset DID (it can't — the DID is derived FROM the event); it carries the holder's `controller` key DID instead, separating asset identity from holder identity. `verifyEventLog`'s authority set becomes evolving: `rotateKey` events REPLACE the authorized key set (hand-off semantics). Back-compat: dual-accept on read/verify (legacy `data.did` logs still verify), new-shape-only on write.
+
+**Tech Stack:** TypeScript, Bun, existing CEL subsystem (`src/cel/` — W3C CCG CEL profile, `eddsa-jcs-2022`).
+
+## Global Constraints
+
+- Run tests from `packages/sdk/` with `bun test`. Never import `tests/setup.bun.ts`.
+- Relative imports with `.js` extension inside src. Errors: match each file's existing style (`src/cel` mostly uses plain `Error`).
+- Multibase Multikey / did:key only for holder keys — never JWK.
+- **Verification must remain fail-closed**: any change to `verifyEventLog` that cannot positively authorize an event must fail it. Never weaken an existing check.
+- **Legacy logs keep verifying**: existing did:peer-shaped logs (`data.did` present) must pass verification unchanged. The adversarial suites (`tests/unit/cel/event-log-authorization.test.ts`, `hash-chain-tamper.test.ts`, `proof-verification.test.ts`, `tests/security/critical-high-fix-regressions.test.ts`) are the guard — they may be RENAMED/reframed as legacy-log tests but their assertions must keep passing (except where a task explicitly rewrites a test to the new write-shape; never delete an adversarial case without an equivalent).
+- Write path emits ONLY the new shapes (no dual-write, no flags).
+- Commit per task with `git commit --no-verify` (commitlint binary missing), conventional message, exact trailer: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- Branch: `worktree-phase1-did-cel` (stacked on Phase 0 / PR #383).
+- Baseline: full suite 3737 pass / 0 fail (CEL-CLI subprocess tests occasionally flaky).
+- Line anchors below were verified against this branch; if drifted, locate by the quoted code.
+
+---
+
+### Task 1: `celDid.ts` — did:cel derivation helpers
+
+**Files:**
+- Create: `packages/sdk/src/cel/celDid.ts`
+- Modify: `packages/sdk/src/cel/index.ts` (export), `packages/sdk/src/index.ts` (re-export next to the btcoDid exports)
+- Create: `packages/sdk/tests/unit/cel/celDid.test.ts`
+
+**Interfaces:**
+- Consumes: `computeDigestMultibase` (`src/cel/hash.ts:34`), `canonicalizeEntryForChain` (`src/cel/canonicalize.ts:91`), `digestMultibaseEquals` (`src/cel/hash.ts:86`), types `EventLog`/`LogEntry`.
+- Produces (later tasks depend on these exact names):
+  - `DID_CEL_PREFIX = 'did:cel:'`
+  - `deriveDidCel(log: EventLog): string` — throws on empty log or non-`create` first event
+  - `deriveDidCelFromGenesis(genesis: LogEntry): string` — throws unless `genesis.type === 'create'`
+  - `isDidCel(did: string): boolean`
+  - `didCelMatchesLog(did: string, log: EventLog): boolean` — suffix comparison via `digestMultibaseEquals`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// packages/sdk/tests/unit/cel/celDid.test.ts
+import { describe, test, expect } from 'bun:test';
+import { deriveDidCel, deriveDidCelFromGenesis, isDidCel, didCelMatchesLog, DID_CEL_PREFIX } from '../../../src/cel/celDid';
+import { createEventLog } from '../../../src/cel/algorithms/createEventLog';
+import { updateEventLog } from '../../../src/cel/algorithms/updateEventLog';
+import type { DataIntegrityProof } from '../../../src/cel/types';
+
+const fakeSigner = async (_data: unknown): Promise<DataIntegrityProof> => ({
+  type: 'DataIntegrityProof',
+  cryptosuite: 'eddsa-jcs-2022',
+  created: '2026-07-10T00:00:00Z',
+  verificationMethod: 'did:key:z6MkfakeSigner#z6MkfakeSigner',
+  proofPurpose: 'assertionMethod',
+  proofValue: 'zFakeSig'
+});
+
+async function makeLog() {
+  return createEventLog(
+    { name: 'A', controller: 'did:key:z6MkfakeSigner', resources: [], createdAt: '2026-07-10T00:00:00Z', nonce: 'u9zzz' },
+    { signer: fakeSigner, verificationMethod: 'did:key:z6MkfakeSigner#z6MkfakeSigner' }
+  );
+}
+
+describe('did:cel derivation', () => {
+  test('derives a stable did:cel with multihash-multibase suffix', async () => {
+    const log = await makeLog();
+    const did = deriveDidCel(log);
+    expect(did.startsWith(DID_CEL_PREFIX)).toBe(true);
+    expect(did.slice(DID_CEL_PREFIX.length).startsWith('u')).toBe(true); // base64url multibase
+    expect(deriveDidCel(log)).toBe(did); // deterministic
+    expect(deriveDidCelFromGenesis(log.events[0])).toBe(did);
+  });
+
+  test('INVARIANT: second event previousEvent equals the DID suffix', async () => {
+    const log = await makeLog();
+    const did = deriveDidCel(log);
+    const updated = await updateEventLog(log, { note: 'x' }, {
+      signer: fakeSigner, verificationMethod: 'did:key:z6MkfakeSigner#z6MkfakeSigner'
+    });
+    expect(updated.events[1].previousEvent).toBe(did.slice(DID_CEL_PREFIX.length));
+    expect(didCelMatchesLog(did, updated)).toBe(true);
+  });
+
+  test('proof does not affect the DID (proof excluded from digest)', async () => {
+    const log = await makeLog();
+    const mutated = { ...log, events: [{ ...log.events[0], proof: [{ ...log.events[0].proof[0], proofValue: 'zDifferent' }] }] };
+    expect(deriveDidCel(mutated as never)).toBe(deriveDidCel(log));
+  });
+
+  test('rejects empty logs and non-create genesis; isDidCel discriminates', async () => {
+    expect(() => deriveDidCel({ events: [] })).toThrow(/empty/i);
+    const log = await makeLog();
+    const badGenesis = { ...log.events[0], type: 'update' as const };
+    expect(() => deriveDidCelFromGenesis(badGenesis)).toThrow(/create/i);
+    expect(isDidCel('did:cel:uEiAabc')).toBe(true);
+    expect(isDidCel('did:peer:4zQm')).toBe(false);
+    expect(didCelMatchesLog('did:cel:uEiAwrong', log)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/sdk && bun test tests/unit/cel/celDid.test.ts`
+Expected: FAIL — module `src/cel/celDid` not found.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// packages/sdk/src/cel/celDid.ts
+/**
+ * did:cel — genesis identity derived from the CEL create event.
+ *
+ * did:cel:<digestMultibase(canonicalizeEntryForChain(genesisEvent))>
+ *
+ * Reuses the exact chain-link digest (proof excluded, {type,data} preimage
+ * for a first event), so a log's second event's `previousEvent` equals the
+ * DID suffix by construction. The genesis event must NOT embed the asset
+ * DID (it is derived from the event); the holder's key lives in
+ * `data.controller` instead.
+ */
+import type { EventLog, LogEntry } from './types.js';
+import { computeDigestMultibase, digestMultibaseEquals } from './hash.js';
+import { canonicalizeEntryForChain } from './canonicalize.js';
+
+export const DID_CEL_PREFIX = 'did:cel:';
+
+export function deriveDidCelFromGenesis(genesis: LogEntry): string {
+  if (genesis.type !== 'create') {
+    throw new Error('did:cel derives from a create event; got ' + String(genesis.type));
+  }
+  return DID_CEL_PREFIX + computeDigestMultibase(canonicalizeEntryForChain(genesis));
+}
+
+export function deriveDidCel(log: EventLog): string {
+  if (!log.events || log.events.length === 0) {
+    throw new Error('Cannot derive did:cel from an empty event log');
+  }
+  return deriveDidCelFromGenesis(log.events[0]);
+}
+
+export function isDidCel(did: string): boolean {
+  return typeof did === 'string' && did.startsWith(DID_CEL_PREFIX);
+}
+
+/** Suffix comparison via digestMultibaseEquals (tolerates legacy bare digests). */
+export function didCelMatchesLog(did: string, log: EventLog): boolean {
+  if (!isDidCel(did) || !log.events || log.events.length === 0) return false;
+  const expected = computeDigestMultibase(canonicalizeEntryForChain(log.events[0]));
+  return digestMultibaseEquals(did.slice(DID_CEL_PREFIX.length), expected);
+}
+```
+
+Exports: in `src/cel/index.ts` add `export { DID_CEL_PREFIX, deriveDidCel, deriveDidCelFromGenesis, isDidCel, didCelMatchesLog } from './celDid.js';` and mirror in `src/index.ts` next to the existing cel exports (~line 218).
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd packages/sdk && bun test tests/unit/cel/celDid.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/sdk/src packages/sdk/tests/unit/cel/celDid.test.ts
+git commit --no-verify -m "feat(cel): did:cel derivation helpers
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Event vocabulary — `migrate` | `transfer` | `rotateKey` in types + parsers
+
+**Files:**
+- Modify: `packages/sdk/src/cel/types.ts:37` (`EventType`)
+- Modify: `packages/sdk/src/cel/serialization/json.ts:134` (type whitelist in `parseEntry`)
+- Modify: `packages/sdk/src/cel/serialization/cbor.ts:85` (identical whitelist)
+- Test: extend `packages/sdk/tests/unit/cel/cbor-serialization.test.ts` and the JSON serialization test file (locate: `grep -rl "parseEventLogJson" packages/sdk/tests/unit/cel | head -3`)
+
+**Interfaces:**
+- Produces: `export type EventType = 'create' | 'update' | 'deactivate' | 'migrate' | 'transfer' | 'rotateKey';` — Tasks 3–8 depend on these exact literals.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the JSON serialization test file (adapt imports to that file's existing style):
+
+```typescript
+  test('round-trips migrate/transfer/rotateKey event types', () => {
+    const log = {
+      events: [
+        { type: 'create', data: { name: 'A' }, proof: [{ type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', created: 'x', verificationMethod: 'did:key:z6Mk#z6Mk', proofPurpose: 'assertionMethod', proofValue: 'z1' }] },
+        { type: 'migrate', data: { sourceDid: 'did:cel:uEiA', targetDid: 'did:webvh:x:example.com:a', layer: 'webvh', migratedAt: 'x' }, previousEvent: 'uEiB', proof: [{ type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', created: 'x', verificationMethod: 'did:key:z6Mk#z6Mk', proofPurpose: 'assertionMethod', proofValue: 'z2' }] },
+        { type: 'transfer', data: { previousOwner: 'did:key:z6Mk', newOwner: 'did:key:z6Mk2', transferredAt: 'x' }, previousEvent: 'uEiC', proof: [{ type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', created: 'x', verificationMethod: 'did:key:z6Mk#z6Mk', proofPurpose: 'assertionMethod', proofValue: 'z3' }] },
+        { type: 'rotateKey', data: { newController: 'did:key:z6Mk2', rotatedAt: 'x' }, previousEvent: 'uEiD', proof: [{ type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', created: 'x', verificationMethod: 'did:key:z6Mk#z6Mk', proofPurpose: 'assertionMethod', proofValue: 'z4' }] }
+      ]
+    };
+    const parsed = parseEventLogJson(serializeEventLogJson(log as never));
+    expect(parsed.events.map(e => e.type)).toEqual(['create', 'migrate', 'transfer', 'rotateKey']);
+  });
+```
+
+Mirror the same case in the CBOR test file using its serialize/parse pair.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd packages/sdk && bun test tests/unit/cel/`
+Expected: the new cases FAIL — parser rejects unknown event type (and/or TS type error).
+
+- [ ] **Step 3: Implement**
+
+`types.ts:37`:
+```typescript
+export type EventType = 'create' | 'update' | 'deactivate' | 'migrate' | 'transfer' | 'rotateKey';
+```
+
+In `json.ts:134` and `cbor.ts:85`, extend the whitelist array/condition to the same six literals (match each file's existing expression style exactly — if it's `type !== 'create' && type !== 'update' && ...`, extend the chain; if it's an array `.includes`, extend the array).
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd packages/sdk && bun test tests/unit/cel/`
+Expected: PASS (all — the strict parsers previously rejecting unknown types still reject genuinely unknown strings; add a negative assertion if the file has one pattern for it: `type: 'destroy'` still throws).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/sdk/src/cel packages/sdk/tests
+git commit --no-verify -m "feat(cel): first-class migrate/transfer/rotateKey event types in the profile
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `appendEvent` — generalize the append algorithm + typed wrappers
+
+**Files:**
+- Create: `packages/sdk/src/cel/algorithms/appendEvent.ts`
+- Modify: `packages/sdk/src/cel/algorithms/updateEventLog.ts` (delegate), `deactivateEventLog.ts` (delegate; keep its own guards)
+- Modify: `packages/sdk/src/cel/algorithms/index.ts` (export)
+- Create: `packages/sdk/tests/unit/cel/appendEvent.test.ts`
+
+**Interfaces:**
+- Consumes: Task 2's `EventType`.
+- Produces: `appendEvent(log: EventLog, type: Exclude<EventType, 'create'>, data: unknown, options: UpdateOptions): Promise<EventLog>` — signs `{ type, data, previousEvent }` (the exact payload `verifyEventLog` reconstructs), immutable append, preserves `previousLog`. Tasks 6–8 call it with `'migrate'`/`'transfer'`/`'rotateKey'`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// packages/sdk/tests/unit/cel/appendEvent.test.ts
+import { describe, test, expect } from 'bun:test';
+import { appendEvent } from '../../../src/cel/algorithms/appendEvent';
+import { createEventLog } from '../../../src/cel/algorithms/createEventLog';
+import { computeDigestMultibase } from '../../../src/cel/hash';
+import { canonicalizeEntryForChain } from '../../../src/cel/canonicalize';
+import type { DataIntegrityProof } from '../../../src/cel/types';
+
+const signedPayloads: unknown[] = [];
+const signer = async (data: unknown): Promise<DataIntegrityProof> => {
+  signedPayloads.push(data);
+  return { type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', created: 'x', verificationMethod: 'did:key:z6Mk#z6Mk', proofPurpose: 'assertionMethod', proofValue: 'zSig' };
+};
+
+describe('appendEvent', () => {
+  test('appends a typed event with correct chain link and signed payload', async () => {
+    const log = await createEventLog({ name: 'A' }, { signer, verificationMethod: 'did:key:z6Mk#z6Mk' });
+    const out = await appendEvent(log, 'migrate', { sourceDid: 'a', targetDid: 'b', layer: 'webvh', migratedAt: 'x' }, { signer, verificationMethod: 'did:key:z6Mk#z6Mk' });
+    const evt = out.events[1];
+    expect(evt.type).toBe('migrate');
+    expect(evt.previousEvent).toBe(computeDigestMultibase(canonicalizeEntryForChain(log.events[0])));
+    // signer received exactly { type, data, previousEvent } — what verifyEventLog reconstructs
+    expect(signedPayloads.at(-1)).toEqual({ type: 'migrate', data: evt.data, previousEvent: evt.previousEvent });
+    expect(log.events.length).toBe(1); // input not mutated
+  });
+
+  test('rejects empty logs and create type', async () => {
+    await expect(appendEvent({ events: [] }, 'update', {}, { signer, verificationMethod: 'x' })).rejects.toThrow(/empty/i);
+    // @ts-expect-error create is excluded at the type level; runtime guard too
+    await expect(appendEvent({ events: [{ type: 'create', data: {}, proof: [] }] }, 'create', {}, { signer, verificationMethod: 'x' })).rejects.toThrow(/create/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure** — `bun test tests/unit/cel/appendEvent.test.ts` → module not found.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// packages/sdk/src/cel/algorithms/appendEvent.ts
+/**
+ * Generic append for typed CEL events. The signed payload is exactly
+ * { type, data, previousEvent } — the shape verifyEventLog reconstructs —
+ * and the chain link is the digest of the previous entry (proof excluded).
+ */
+import type { EventLog, EventType, LogEntry, UpdateOptions, DataIntegrityProof } from '../types.js';
+import { computeDigestMultibase } from '../hash.js';
+import { canonicalizeEntryForChain } from '../canonicalize.js';
+
+export async function appendEvent(
+  log: EventLog,
+  type: Exclude<EventType, 'create'>,
+  data: unknown,
+  options: UpdateOptions
+): Promise<EventLog> {
+  const { signer } = options;
+  if ((type as EventType) === 'create') {
+    throw new Error('appendEvent cannot append a create event; use createEventLog');
+  }
+  if (!log.events || log.events.length === 0) {
+    throw new Error('Cannot append to an empty event log');
+  }
+  const lastEvent = log.events[log.events.length - 1];
+  const previousEvent = computeDigestMultibase(canonicalizeEntryForChain(lastEvent));
+  const eventBase = { type, data, previousEvent };
+  const proof: DataIntegrityProof = await signer(eventBase);
+  if (!proof.type || !proof.cryptosuite || !proof.proofValue) {
+    throw new Error('Invalid proof: missing required fields (type, cryptosuite, proofValue)');
+  }
+  const entry: LogEntry = { type, data, previousEvent, proof: [proof] };
+  return {
+    events: [...log.events, entry],
+    ...(log.previousLog ? { previousLog: log.previousLog } : {}),
+  };
+}
+```
+
+Then make `updateEventLog` delegate — replace its body (keep signature + JSDoc) with:
+
+```typescript
+export async function updateEventLog(
+  log: EventLog,
+  data: unknown,
+  options: UpdateOptions
+): Promise<EventLog> {
+  if (!log.events || log.events.length === 0) {
+    throw new Error('Cannot update an empty event log');
+  }
+  return appendEvent(log, 'update', data, options);
+}
+```
+
+`deactivateEventLog.ts`: keep ALL of its existing pre-checks (already-deactivated guard etc.) and replace only the event-construction tail (`previousEvent` computation through the return) with `return appendEvent(log, 'deactivate', data, options);` — read the file first and preserve every validation above the construction.
+
+Export `appendEvent` from `algorithms/index.ts`.
+
+- [ ] **Step 4: Run tests** — `bun test tests/unit/cel/` → PASS (the ~400 existing CEL tests confirm the delegation is behavior-identical; if the empty-log error message differs from the old `updateEventLog` text, keep `updateEventLog`'s own guard as shown so its message is unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/sdk/src/cel packages/sdk/tests
+git commit --no-verify -m "refactor(cel): generic appendEvent; update/deactivate delegate
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: New genesis shape — `CelAssetData` + PeerCelManager de-self-referencing
+
+**Files:**
+- Modify: `packages/sdk/src/cel/layers/PeerCelManager.ts` (the `PeerAssetData` interface ~30-43, `create()` ~110-143, `generatePeerDid` apparatus ~153-250, `update()` VM fallback ~286-292, `getCurrentState()` ~340-378)
+- Modify: `packages/sdk/src/cel/index.ts` / `src/index.ts` (export `CelAssetData`; keep `PeerAssetData` exported as deprecated alias type for legacy log reading)
+- Test: rewrite the creation-path cases in `packages/sdk/tests/unit/cel/PeerCelManager.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1's `deriveDidCel`.
+- Produces (Tasks 5–8 depend on these):
+  - `interface CelAssetData { name: string; controller: string; resources: ExternalReference[]; createdAt: string; nonce: string }` — NO `did`, NO `creator`, NO `layer`.
+  - `PeerCelManager.create(name, resources): Promise<{ log: EventLog; did: string }>` (was `Promise<EventLog>`) — `did` is the derived did:cel.
+  - `nonce`: multibase-encoded 16 random bytes (`u` + base64url), generated per create — collision insurance so identical `{name, controller, resources, createdAt}` never yields the same DID.
+
+- [ ] **Step 1: Write the failing test**
+
+Rewrite the creation block of `PeerCelManager.test.ts` (keep the file's existing signer fixtures — read them first and reuse):
+
+```typescript
+  test('create() returns a derived did:cel and a de-self-referenced genesis', async () => {
+    const manager = new PeerCelManager(signer, { verificationMethod: 'did:key:z6Mk...#z6Mk...' }); // reuse the file's fixture key
+    const { log, did } = await manager.create('My Asset', []);
+    expect(did.startsWith('did:cel:u')).toBe(true);
+    expect(deriveDidCel(log)).toBe(did);
+    const data = log.events[0].data as Record<string, unknown>;
+    expect(data.did).toBeUndefined();          // no self-reference
+    expect(data.creator).toBeUndefined();      // holder ≠ asset identity
+    expect(data.layer).toBeUndefined();        // genesis layer is definitional
+    expect(typeof data.controller).toBe('string');
+    expect((data.controller as string).startsWith('did:key:')).toBe(true);
+    expect(typeof data.nonce).toBe('string');
+  });
+
+  test('two identical creates yield different DIDs (nonce)', async () => {
+    const manager = new PeerCelManager(signer, { verificationMethod: 'did:key:z6Mk...#z6Mk...' });
+    const a = await manager.create('Same', []);
+    const b = await manager.create('Same', []);
+    expect(a.did).not.toBe(b.did);
+  });
+```
+
+- [ ] **Step 2: Run to verify failure** — create() returns an EventLog today; destructure fails / assertions fail.
+
+- [ ] **Step 3: Implement**
+
+In `PeerCelManager.ts`:
+1. Add `CelAssetData` (fields above, JSDoc noting the identity/holder separation); keep `PeerAssetData` as `/** @deprecated legacy genesis shape (pre-did:cel); still readable on the verify path */`.
+2. `create()`: derive `controller` from the signer the way the current code discovers the signer's did:key (the `discoverSignerPublicKey` probe ~229-234 — repurpose it: it currently feeds `generatePeerDid`; now its result IS the controller. If `config.verificationMethod` is a `did:key:...#fragment`, `controller` = the part before `#`). Build `data: CelAssetData` with `nonce: 'u' + base64url(crypto.getRandomValues(new Uint8Array(16)))` — use the existing `multibase.encode` util from `../utils/encoding.js` if that's what `hash.ts` imports (check `hash.ts:11` and reuse the same helper: `multibase.encode(bytes, 'base64url')`). Call `createEventLog(data, ...)` then `const did = deriveDidCel(log); return { log, did };`
+3. DELETE `generatePeerDid` (~153-215) and `generateRandomPublicKey` (~241-250) — grep the file for remaining references first.
+4. `update()` ~286-292: the fallback verification method must no longer be `` `${createData.did}#key-0` `` (a `did:cel:...#key-0` VM is unresolvable). New fallback: `config.verificationMethod`, else `` `${controller}#${controller.slice('did:key:'.length)}` `` (the canonical did:key VM), reading `controller` from the create event data; for legacy logs (`data.did` present, no `controller`) keep the old fallback expression.
+5. `getCurrentState()` ~340-378: `did` = `deriveDidCel(log)` when the genesis has `controller` (new shape) / `createData.did` when legacy; `creator` field in the returned state → keep the KEY but source it from `controller` on new logs (grep consumers of `getCurrentState().creator` first — `cli/inspect.ts` displays it); the `updateData.did`/`layer` override branches (~373-378) remain for legacy logs only (guard them on the legacy shape).
+
+- [ ] **Step 4: Run tests** — `bun test tests/unit/cel/PeerCelManager.test.ts` then the full cel dir. Rewrite remaining PeerCelManager creation-dependent tests to the new `{ log, did }` shape; tests exercising legacy-log READING keep their fixtures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/sdk/src packages/sdk/tests
+git commit --no-verify -m "feat(cel): de-self-referenced CelAssetData genesis + did:cel from PeerCelManager
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: `verifyEventLog` — did:cel self-certification branch + `assetDid`/`expectedDid`
+
+**Files:**
+- Modify: `packages/sdk/src/cel/algorithms/verifyEventLog.ts` (root-of-authority block ~744-799, esp. the self-cert read at ~777)
+- Modify: `packages/sdk/src/cel/types.ts` (`VerificationResult` ~99-106 gains `assetDid?: string`; `VerifyOptions` ~149-169 gains `expectedDid?: string`)
+- Create: `packages/sdk/tests/unit/cel/did-cel-verification.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1 helpers, Task 4's genesis shape.
+- Produces: shape-discriminated self-certification —
+  - genesis `data.controller` present & `data.did` absent → **did:cel branch**: root key must be a key of `data.controller` via the existing `selfCertifyingKeyHexes` machinery, FAIL CLOSED if controller is not a resolvable did:key (no TOFU fallback on this branch); `result.assetDid = deriveDidCel(log)`.
+  - genesis `data.did` present → legacy branch, byte-identical behavior; `result.assetDid = data.did`.
+  - `options.expectedDid` set → compare (did:cel via `didCelMatchesLog`, legacy via string equality); mismatch = verification failure.
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// packages/sdk/tests/unit/cel/did-cel-verification.test.ts
+// Build REAL signed logs: reuse the key/signer fixture pattern from
+// tests/unit/cel/event-log-authorization.test.ts (read it first — it
+// generates an Ed25519 keypair, builds a did:key, and a real eddsa-jcs-2022
+// signer). Reuse those helpers verbatim.
+import { describe, test, expect } from 'bun:test';
+import { verifyEventLog } from '../../../src/cel/algorithms/verifyEventLog';
+import { createEventLog } from '../../../src/cel/algorithms/createEventLog';
+import { deriveDidCel } from '../../../src/cel/celDid';
+// + the fixture helpers copied/imported per event-log-authorization.test.ts
+
+describe('did:cel self-certification', () => {
+  test('valid did:cel log verifies and reports assetDid', async () => {
+    const { signer, didKey, vm } = await makeRealSigner(); // fixture helper
+    const log = await createEventLog(
+      { name: 'A', controller: didKey, resources: [], createdAt: '2026-07-10T00:00:00Z', nonce: 'u1111' },
+      { signer, verificationMethod: vm }
+    );
+    const result = await verifyEventLog(log);
+    expect(result.verified).toBe(true);
+    expect(result.assetDid).toBe(deriveDidCel(log));
+  });
+
+  test('genesis signed by a key that is NOT the controller fails closed', async () => {
+    const { didKey } = await makeRealSigner();          // controller A
+    const other = await makeRealSigner();               // signer B
+    const log = await createEventLog(
+      { name: 'A', controller: didKey, resources: [], createdAt: 'x', nonce: 'u2222' },
+      { signer: other.signer, verificationMethod: other.vm }
+    );
+    const result = await verifyEventLog(log);
+    expect(result.verified).toBe(false);
+    expect(result.errors.join(' ')).toMatch(/controller/i);
+  });
+
+  test('non-did:key controller fails closed (no TOFU on the did:cel branch)', async () => {
+    const { signer, vm } = await makeRealSigner();
+    const log = await createEventLog(
+      { name: 'A', controller: 'did:webvh:x:example.com:a', resources: [], createdAt: 'x', nonce: 'u3333' },
+      { signer, verificationMethod: vm }
+    );
+    const result = await verifyEventLog(log);
+    expect(result.verified).toBe(false);
+  });
+
+  test('expectedDid mismatch fails; match passes (both shapes)', async () => {
+    const { signer, didKey, vm } = await makeRealSigner();
+    const log = await createEventLog(
+      { name: 'A', controller: didKey, resources: [], createdAt: 'x', nonce: 'u4444' },
+      { signer, verificationMethod: vm }
+    );
+    expect((await verifyEventLog(log, { expectedDid: deriveDidCel(log) })).verified).toBe(true);
+    expect((await verifyEventLog(log, { expectedDid: 'did:cel:uEiAwrong' })).verified).toBe(false);
+  });
+
+  test('legacy data.did logs verify exactly as before and report assetDid', async () => {
+    // Build a legacy-shaped log the way event-log-authorization.test.ts does
+    // (data: { did: didKeyOrPeer, ... }) and assert verified === true and
+    // result.assetDid === that did. This pins the dual-accept contract.
+  });
+});
+```
+
+(The legacy test body must be filled in from the fixture file's existing legacy-log construction — it exists there; copy it.)
+
+- [ ] **Step 2: Run to verify failure** — `assetDid` undefined / did:cel branch missing → controller-mismatch case passes verification when it must fail.
+
+- [ ] **Step 3: Implement**
+
+In the root-of-authority block (~761-785), replace the self-cert section with shape discrimination:
+
+```typescript
+    const genesisData = createEvent.data as { did?: unknown; controller?: unknown } | null | undefined;
+    const legacyDid = typeof genesisData?.did === 'string' ? genesisData.did : undefined;
+    const celController = legacyDid === undefined && typeof genesisData?.controller === 'string'
+      ? genesisData.controller
+      : undefined;
+
+    if (celController !== undefined) {
+      // did:cel genesis: the controller field DEFINES authority — the root key
+      // must be a key of data.controller. No TOFU fallback on this branch:
+      // an unbindable controller fails closed.
+      const controllerKeys = selfCertifyingKeyHexes(celController);
+      if (!controllerKeys || controllerKeys.size === 0 || !controllerKeys.has(rootKeyHex)) {
+        /* set authorityError exactly the way the existing did-mismatch path does
+           (~781-785), message: `create event proof key is not a key of the genesis
+           controller ${celController}` */
+      }
+    } else if (legacyDid !== undefined) {
+      /* existing lines 777-785 behavior, unchanged (did:key-VM pre-gate + TOFU
+         fallback semantics preserved verbatim) */
+    }
+    // neither field: existing behavior for shapeless logs (TOFU root) — unchanged.
+```
+
+Then, where the result object is assembled (find the `return`/result construction near the end of `verifyEventLog`), add:
+
+```typescript
+    // assetDid: derived for did:cel logs, declared for legacy logs.
+    let assetDid: string | undefined;
+    if (celController !== undefined) assetDid = deriveDidCelFromGenesis(createEvent);
+    else if (legacyDid !== undefined) assetDid = legacyDid;
+```
+
+…and `expectedDid` (early in the function or in the same authority block):
+
+```typescript
+    if (options?.expectedDid !== undefined && !optionsVerifierActive) {
+      const matches = celController !== undefined
+        ? didCelMatchesLog(options.expectedDid, log)
+        : options.expectedDid === legacyDid;
+      if (!matches) { /* push error `log does not back expected DID ${options.expectedDid}`, fail */ }
+    }
+```
+
+Adapt names to the function's real locals (`rootKeyHex`, error-accumulation pattern) — mirror the existing did-mismatch path's mechanics exactly (~781-785). Imports: `deriveDidCelFromGenesis`, `didCelMatchesLog` from `../celDid.js`. Add `assetDid?: string` to `VerificationResult` and `expectedDid?: string` to `VerifyOptions` with JSDoc.
+
+- [ ] **Step 4: Run tests** — new file + `bun test tests/unit/cel/ tests/security/` all PASS (legacy suites must be untouched-green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/sdk/src/cel packages/sdk/tests
+git commit --no-verify -m "feat(cel): did:cel self-certification branch in verifyEventLog + assetDid/expectedDid
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: `verifyEventLog` — evolving authority + `rotateKey` semantics
+
+**Files:**
+- Modify: `packages/sdk/src/cel/algorithms/verifyEventLog.ts` (the fixed `authorizedKeyIds` set built ~744-799 / consumed ~523-540; event loop ~802-811)
+- Create: `packages/sdk/tests/unit/cel/key-rotation-authority.test.ts`
+
+**Interfaces:**
+- Consumes: Tasks 2, 3, 5.
+- Produces: authority evolution — `rotateKey` data shape `{ newController: string; rotatedAt: string; reason?: string }`; on a fully valid rotateKey event, the authorized key set is **REPLACED** by `selfCertifyingKeyHexes(newController)` (hand-off semantics — design spec §2/§5); unbindable/empty `newController` fails closed; `migrate`/`transfer`/`update`/`deactivate` cause no authority change. Task 7's managers rely on this exact data shape.
+
+- [ ] **Step 1: Write the failing adversarial tests**
+
+```typescript
+// packages/sdk/tests/unit/cel/key-rotation-authority.test.ts
+// Reuse the real-signer fixtures from event-log-authorization.test.ts.
+import { describe, test, expect } from 'bun:test';
+import { verifyEventLog } from '../../../src/cel/algorithms/verifyEventLog';
+import { createEventLog } from '../../../src/cel/algorithms/createEventLog';
+import { appendEvent } from '../../../src/cel/algorithms/appendEvent';
+
+describe('rotateKey authority evolution', () => {
+  test('post-rotation events signed by the NEW key verify; log reports verified', async () => {
+    const a = await makeRealSigner(); const b = await makeRealSigner();
+    let log = await createEventLog({ name: 'A', controller: a.didKey, resources: [], createdAt: 'x', nonce: 'u1' }, { signer: a.signer, verificationMethod: a.vm });
+    log = await appendEvent(log, 'rotateKey', { newController: b.didKey, rotatedAt: 'x' }, { signer: a.signer, verificationMethod: a.vm });
+    log = await appendEvent(log, 'update', { note: 'signed by new key' }, { signer: b.signer, verificationMethod: b.vm });
+    expect((await verifyEventLog(log)).verified).toBe(true);
+  });
+
+  test('OLD key signing AFTER rotation fails (replace, not union)', async () => {
+    const a = await makeRealSigner(); const b = await makeRealSigner();
+    let log = await createEventLog({ name: 'A', controller: a.didKey, resources: [], createdAt: 'x', nonce: 'u2' }, { signer: a.signer, verificationMethod: a.vm });
+    log = await appendEvent(log, 'rotateKey', { newController: b.didKey, rotatedAt: 'x' }, { signer: a.signer, verificationMethod: a.vm });
+    log = await appendEvent(log, 'update', { note: 'stale key' }, { signer: a.signer, verificationMethod: a.vm });
+    const result = await verifyEventLog(log);
+    expect(result.verified).toBe(false);
+    expect(result.events[2].proofValid === false || result.errors.length > 0).toBe(true);
+  });
+
+  test('rotation signed by an UNAUTHORIZED key fails', async () => {
+    const a = await makeRealSigner(); const b = await makeRealSigner(); const mallory = await makeRealSigner();
+    let log = await createEventLog({ name: 'A', controller: a.didKey, resources: [], createdAt: 'x', nonce: 'u3' }, { signer: a.signer, verificationMethod: a.vm });
+    log = await appendEvent(log, 'rotateKey', { newController: mallory.didKey, rotatedAt: 'x' }, { signer: mallory.signer, verificationMethod: mallory.vm });
+    expect((await verifyEventLog(log)).verified).toBe(false);
+  });
+
+  test('unbindable newController fails closed', async () => {
+    const a = await makeRealSigner();
+    let log = await createEventLog({ name: 'A', controller: a.didKey, resources: [], createdAt: 'x', nonce: 'u4' }, { signer: a.signer, verificationMethod: a.vm });
+    log = await appendEvent(log, 'rotateKey', { newController: 'did:webvh:unresolvable:example.com:x', rotatedAt: 'x' }, { signer: a.signer, verificationMethod: a.vm });
+    expect((await verifyEventLog(log)).verified).toBe(false);
+  });
+
+  test('second rotation chains authority a→b→c; a and b both dead afterwards', async () => {
+    const a = await makeRealSigner(); const b = await makeRealSigner(); const c = await makeRealSigner();
+    let log = await createEventLog({ name: 'A', controller: a.didKey, resources: [], createdAt: 'x', nonce: 'u5' }, { signer: a.signer, verificationMethod: a.vm });
+    log = await appendEvent(log, 'rotateKey', { newController: b.didKey, rotatedAt: 'x' }, { signer: a.signer, verificationMethod: a.vm });
+    log = await appendEvent(log, 'rotateKey', { newController: c.didKey, rotatedAt: 'x' }, { signer: b.signer, verificationMethod: b.vm });
+    log = await appendEvent(log, 'update', { note: 'c signs' }, { signer: c.signer, verificationMethod: c.vm });
+    expect((await verifyEventLog(log)).verified).toBe(true);
+    const stale = await appendEvent(log, 'update', { note: 'b tries again' }, { signer: b.signer, verificationMethod: b.vm });
+    expect((await verifyEventLog(stale)).verified).toBe(false);
+  });
+
+  test('deactivate still seals the log regardless of rotation', async () => {
+    const a = await makeRealSigner(); const b = await makeRealSigner();
+    let log = await createEventLog({ name: 'A', controller: a.didKey, resources: [], createdAt: 'x', nonce: 'u6' }, { signer: a.signer, verificationMethod: a.vm });
+    log = await appendEvent(log, 'rotateKey', { newController: b.didKey, rotatedAt: 'x' }, { signer: a.signer, verificationMethod: a.vm });
+    log = await appendEvent(log, 'deactivate', { deactivatedAt: 'x' }, { signer: b.signer, verificationMethod: b.vm });
+    log = await appendEvent(log, 'update', { note: 'after seal' }, { signer: b.signer, verificationMethod: b.vm });
+    expect((await verifyEventLog(log)).verified).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure** — rotation events currently authorize only against the fixed genesis key set; the first test fails (new-key event rejected).
+
+- [ ] **Step 3: Implement**
+
+Restructure the authority mechanics minimally:
+1. Keep the root-of-authority setup building the initial set (with Task 5's branches). Rename nothing exported.
+2. In the sequential event loop (~802-811), thread a mutable `authorizedKeyIds` (it already exists — the change is that it can now be reassigned between iterations). Ensure the per-event authorization check (~523-540) reads the CURRENT set for the event being verified — if that check happens inside `verifyEvent` with the set passed as a parameter, pass the current set per iteration (verify the call site; the loop is already index-ordered).
+3. After an event at index i has passed ALL its checks (chain link, signature, authorized signer), if `event.type === 'rotateKey'`:
+
+```typescript
+      const rotation = event.data as { newController?: unknown } | null | undefined;
+      const newController = typeof rotation?.newController === 'string' ? rotation.newController : undefined;
+      const newKeys = newController ? selfCertifyingKeyHexes(newController) : null;
+      if (!newKeys || newKeys.size === 0) {
+        /* fail the event + the log: `rotateKey event ${i} has an unbindable newController` —
+           use the same error-accumulation pattern as the authority errors */
+      } else {
+        authorizedKeyIds = newKeys; // REPLACE — hand-off semantics (design spec §2/§5);
+                                    // keeping old keys would reopen the stale-key window.
+      }
+```
+
+4. Rotation events that FAIL any check must NOT rotate the set (order: validate first, then swap).
+5. `migrate`/`transfer` need no authority arm here (authorized-signer + existing gating witness checks apply to them exactly as to `update` — confirm no type-switch in the loop excludes them).
+6. Update the stale comment at ~728-729 ("no in-log key-rotation mechanism") to describe the evolving model.
+
+- [ ] **Step 4: Run tests** — new file PASS + `bun test tests/unit/cel/ tests/security/` all green (fixed-key legacy logs never contain rotateKey events, so their behavior is unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/sdk/src/cel packages/sdk/tests
+git commit --no-verify -m "feat(cel): evolving authority — rotateKey hands off the authorized key set
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Managers emit first-class types; state derivation dual-reads
+
+**Files:**
+- Modify: `packages/sdk/src/cel/layers/WebVHCelManager.ts` (migrate() ~160-185 emits `type:'migrate'` via `appendEvent`; source DID ~141-144 derives did:cel when genesis is new-shape; `generateWebVHDid` ~214-237 gains a `did:cel:` branch using the digest suffix as the id part; state replay ~291-345)
+- Modify: `packages/sdk/src/cel/layers/BtcoCelManager.ts` (migration detection ~201-217 by `type === 'migrate'` with legacy sniff kept; emit ~265 via `appendEvent(log, 'migrate', ...)`; source DID ~205 + creator ~318 dual-read; state replay ~329-427)
+- Modify: `packages/sdk/src/cel/OriginalsCel.ts` (`getCurrentLayer` ~436-458 by type-first with legacy field-sniff fallback; `update()` reserved-fields guard ~243-258 applies to legacy logs only; `getCurrentState` dispatch ~414-427)
+- Modify: `packages/sdk/src/cel/layers/PeerCelManager.ts` state replay arms for `migrate`/`transfer`/`rotateKey` (~359-399)
+- Test: extend `packages/sdk/tests/unit/cel/WebVHCelManager.test.ts` / `BtcoCelManager.test.ts` / the OriginalsCel test file (locate by grep) with: migrate emits `type:'migrate'` carrying `{sourceDid, targetDid, layer, migratedAt, ...}`; `getCurrentLayer` reads it; a legacy fixture log (update+sourceDid sniff) still reports its layer.
+
+**Interfaces:**
+- Consumes: Tasks 1–6 (esp. `appendEvent`, `deriveDidCel`).
+- Produces: migrate event data keeps the existing payload fields (`sourceDid`, `targetDid`, `layer`, `migratedAt`, + webvh's `domain` / btco's extras) — only the TYPE moves from `'update'` to `'migrate'`. Transfer event data: `{ previousOwner, newOwner, transferredAt, txid? }` (inner `type: 'transfer'` discriminator field dropped — the entry type carries it now).
+
+- [ ] **Step 1: Write the failing tests** — in each manager test file, a case asserting `migratedLog.events.at(-1)!.type === 'migrate'` (currently `'update'`), plus an OriginalsCel `getCurrentLayer` case over a new-shape log and over an existing legacy fixture (reuse a fixture already in the tests).
+
+- [ ] **Step 2: Run to verify failure.**
+
+- [ ] **Step 3: Implement** per the file list above. Rules:
+  - Every detection site becomes `event.type === 'migrate' ? <new> : <legacy sniff kept verbatim>` — do not delete the sniff branches (`update` + `sourceDid`+`layer`+`migratedAt`), they serve legacy logs.
+  - Source-DID reads (`createData.did`) become: `data.controller` present → `deriveDidCel(log)`; else `createData.did` (legacy).
+  - `generateWebVHDid` did:cel branch: use the DID suffix (already filesystem/URL-safe base64url) truncated to the same length the did:peer branch uses — mirror its truncation exactly.
+  - The `RESERVED_MIGRATION_FIELDS` guard on `update()` (~243-258): keep for updates (still prevents forging a legacy-shaped migration via update); new migrations don't hit it (they're `type:'migrate'`).
+
+- [ ] **Step 4: Run tests** — `bun test tests/unit/cel/ tests/integration/cel-lifecycle.test.ts` green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/sdk/src/cel packages/sdk/tests
+git commit --no-verify -m "feat(cel): managers emit first-class migrate/transfer; dual-read state derivation
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: CLI convergence
+
+**Files:**
+- Modify: `packages/sdk/src/cel/cli/migrate.ts` (`detectCurrentLayer` ~94-96, `getCurrentDid` ~123-125, emit ~438)
+- Modify: `packages/sdk/src/cel/cli/transfer.ts` (`getCurrentDid` ~74-76; the transfer event build ~237-274 — emit `type: 'transfer'` with data `{ previousOwner, newOwner, transferredAt }`, dropping the inner `type` discriminator; keep the sign-over-`{type,data,previousEvent}` mechanics, or switch to `appendEvent` if the signer shape allows — prefer `appendEvent`)
+- Modify: `packages/sdk/src/cel/cli/inspect.ts` (`isMigrationEvent` ~58-65 → legacy-only helper; state replay ~179-231; layer history ~254-262; per-event display switch ~443-471 gains `migrate`/`transfer`/`rotateKey` arms)
+- Modify: `packages/sdk/src/cel/cli/create.ts` (emits the new `CelAssetData` genesis via PeerCelManager — verify it routes through the manager; if it builds data inline, convert to the new shape + print the derived did:cel)
+- Test: `packages/sdk/tests/unit/cel/cli-inspect.test.ts`, `cel-cli-coverage.test.ts` — update constructed fixtures to new shapes; keep one legacy-fixture case per behavior.
+
+**Interfaces:** consumes Tasks 1–7; produces no new interfaces (CLI is a consumer).
+
+- [ ] **Step 1: Failing tests** — inspect displays a `migrate`-typed event in layer history; create prints a `did:cel:` id; transfer produces a `type:'transfer'` entry.
+- [ ] **Step 2: Verify failure.**
+- [ ] **Step 3: Implement** per file list; every detection = type-first, legacy-sniff fallback.
+- [ ] **Step 4: Run** `bun test tests/unit/cel/ tests/integration/cel-cli.integration.test.ts` (subprocess tests flaky — rerun once before judging).
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/sdk/src/cel packages/sdk/tests
+git commit --no-verify -m "feat(cel): CLI speaks first-class event types + did:cel
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Specs — did:cel method draft + CEL profile update
+
+**Files:**
+- Create: `specs/did-cel-method.md`
+- Modify: `docs/ORIGINALS_CEL_SPEC.md` (event-type vocabulary, genesis shape, rotation semantics)
+- Modify: `specs/protocol/README.md` (add did-cel-method.md to the authoritative list)
+
+**Interfaces:** none (docs).
+
+- [ ] **Step 1: Write `specs/did-cel-method.md`** — sections, with content matching the implemented behavior exactly (cite `src/cel/celDid.ts` and `verifyEventLog`):
+  1. **Abstract** — did:cel identifies an Originals asset by the multihash of its CEL genesis event; identity = the log, holders = keys the log establishes.
+  2. **Method syntax** — `did:cel:<multibase-base64url-multihash>` (`u` prefix, sha2-256 multihash `0x12 0x20`), derivation expression (JCS-canonicalized `{type:'create', data}`, proof excluded).
+  3. **Genesis event requirements** — MUST NOT contain `did`; MUST contain `controller` (a did:key), `name`, `resources`, `createdAt`, `nonce`; genesis proof MUST verify against a key of `controller` (fail closed).
+  4. **Resolution** — short form self-certifies the genesis given any copy of the log (`didCelMatchesLog`); resolving the LATEST state requires the log's current home (local / webvh-hosted / btco-anchored) — each higher layer is a stronger resolution substrate (design doc §3).
+  5. **Key rotation** — `rotateKey` event REPLACES the authorized key set; old keys are dead from that event forward; verifiers MUST reject post-rotation events signed by prior keys.
+  6. **Event vocabulary** — the six types and their data payloads (as implemented).
+  7. **Security considerations** — collision insurance nonce; proof-exclusion rationale (late witness proofs must not change identity); deactivation seals the log; registry note (check DIF registry for `cel` collision before publishing beyond draft).
+- [ ] **Step 2: Update `docs/ORIGINALS_CEL_SPEC.md`** — event-type table gains `migrate`/`transfer`/`rotateKey` with payload schemas; genesis section documents `CelAssetData` and marks the `did`-embedded shape legacy-read-only; authority section documents the evolving model.
+- [ ] **Step 3: Cross-check against code** — every MUST in the method spec corresponds to an implemented, tested behavior; list the test file next to each MUST in an appendix table.
+- [ ] **Step 4: Commit**
+
+```bash
+git add specs docs/ORIGINALS_CEL_SPEC.md
+git commit --no-verify -m "docs: did:cel method specification draft + CEL profile update
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Full-suite verification + final review
+
+- [ ] **Step 1:** `cd packages/sdk && bun test` — zero non-flaky failures. `bunx tsc --noEmit` clean. Changed-files eslint zero errors. `bun run build` clean.
+- [ ] **Step 2:** Final whole-branch review (fable) over `merge-base..HEAD` per subagent-driven-development, including the accumulated Minor roll-up.
+- [ ] **Step 3:** Fix Critical/Important findings; re-verify; commit stragglers.

--- a/packages/sdk/src/cel/OriginalsCel.ts
+++ b/packages/sdk/src/cel/OriginalsCel.ts
@@ -445,11 +445,16 @@ export class OriginalsCel {
       
       if (event.type === 'create') {
         currentLayer = (eventData.layer as CelLayer) || 'peer';
-      } else if (event.type === 'update' && eventData.sourceDid && eventData.layer && eventData.migratedAt) {
-        // This is a migration event. Both webvh and btco migrations carry
-        // {sourceDid, layer}; only webvh additionally carries targetDid, so
-        // keying off targetDid silently skipped btco migrations (added in the
-        // #228 refactor) and left the log detected as still at webvh.
+      } else if (
+        // Type-first: first-class 'migrate' events are migrations by type.
+        (event.type === 'migrate' && eventData?.layer) ||
+        // Legacy sniff kept verbatim: old logs record migrations as 'update'
+        // events. Both webvh and btco migrations carry {sourceDid, layer};
+        // only webvh additionally carries targetDid, so keying off targetDid
+        // silently skipped btco migrations (added in the #228 refactor) and
+        // left the log detected as still at webvh.
+        (event.type === 'update' && eventData.sourceDid && eventData.layer && eventData.migratedAt)
+      ) {
         currentLayer = eventData.layer as CelLayer;
       }
     }

--- a/packages/sdk/src/cel/OriginalsCel.ts
+++ b/packages/sdk/src/cel/OriginalsCel.ts
@@ -15,7 +15,7 @@
  *   signer: async (data) => createEdDsaProof(data, privateKey),
  * });
  * 
- * const log = await cel.create('My Asset', [
+ * const { log, did } = await cel.create('My Asset', [
  *   { digestMultibase: 'uXYZ...', mediaType: 'image/png' }
  * ]);
  * 

--- a/packages/sdk/src/cel/OriginalsCel.ts
+++ b/packages/sdk/src/cel/OriginalsCel.ts
@@ -187,19 +187,19 @@ export class OriginalsCel {
    * 
    * @param name - Human-readable name for the asset
    * @param resources - External resources associated with the asset
-   * @returns Promise resolving to an EventLog with the create event
-   * 
+   * @returns The genesis EventLog and the derived did:cel identifier
+   *
    * @throws Error if signer produces invalid proof
    * @throws Error if trying to create at non-peer layer
-   * 
+   *
    * @example
    * ```typescript
-   * const log = await cel.create('My Asset', [
+   * const { log, did } = await cel.create('My Asset', [
    *   createExternalReference(imageData, 'image/png')
    * ]);
    * ```
    */
-  async create(name: string, resources: ExternalReference[]): Promise<EventLog> {
+  async create(name: string, resources: ExternalReference[]): Promise<{ log: EventLog; did: string }> {
     // Assets can only be created at the peer layer
     // Other layers require migration from peer
     if (this.layer !== 'peer') {

--- a/packages/sdk/src/cel/algorithms/appendEvent.ts
+++ b/packages/sdk/src/cel/algorithms/appendEvent.ts
@@ -1,0 +1,81 @@
+/**
+ * appendEvent Algorithm
+ *
+ * Generic append for typed CEL events. The signed payload is exactly
+ * { type, data, previousEvent } — the shape verifyEventLog reconstructs —
+ * and the chain link is the digest of the previous entry (proof excluded).
+ *
+ * @see https://w3c-ccg.github.io/cel-spec/
+ */
+
+import type { EventLog, EventType, LogEntry, UpdateOptions, DataIntegrityProof } from '../types.js';
+import { computeDigestMultibase } from '../hash.js';
+import { canonicalizeEntryForChain } from '../canonicalize.js';
+
+/**
+ * Appends a typed event to an existing Cryptographic Event Log.
+ *
+ * The new event is cryptographically linked to the previous event
+ * via a hash of the last event (previousEvent field).
+ *
+ * @param log - The existing event log to append to
+ * @param type - The event type (any type except "create")
+ * @param data - The event data (schema varies by event type)
+ * @param options - Signing options including signer function and verification method
+ * @returns A new EventLog with the event appended (input is not mutated)
+ */
+export async function appendEvent(
+  log: EventLog,
+  type: Exclude<EventType, 'create'>,
+  data: unknown,
+  options: UpdateOptions
+): Promise<EventLog> {
+  const { signer } = options;
+
+  if ((type as EventType) === 'create') {
+    throw new Error('appendEvent cannot append a create event; use createEventLog');
+  }
+
+  // Validate input log
+  if (!log.events || log.events.length === 0) {
+    throw new Error('Cannot append to an empty event log');
+  }
+
+  // Get the last event to compute the hash chain link
+  const lastEvent = log.events[log.events.length - 1];
+
+  // Compute the digestMultibase of the last event
+  const previousEvent = computeDigestMultibase(canonicalizeEntryForChain(lastEvent));
+
+  // Create the event structure without proof first
+  const eventBase = {
+    type,
+    data,
+    previousEvent,
+  };
+
+  // Generate proof using the provided signer
+  const proof: DataIntegrityProof = await signer(eventBase);
+
+  // Validate the proof has required fields
+  if (!proof.type || !proof.cryptosuite || !proof.proofValue) {
+    throw new Error('Invalid proof: missing required fields (type, cryptosuite, proofValue)');
+  }
+
+  // Construct the complete log entry
+  const entry: LogEntry = {
+    type,
+    data,
+    previousEvent,
+    proof: [proof],
+  };
+
+  // Return a new event log (immutable - does not mutate input)
+  const eventLog: EventLog = {
+    events: [...log.events, entry],
+    // Preserve previousLog reference if it exists
+    ...(log.previousLog ? { previousLog: log.previousLog } : {}),
+  };
+
+  return eventLog;
+}

--- a/packages/sdk/src/cel/algorithms/appendEvent.ts
+++ b/packages/sdk/src/cel/algorithms/appendEvent.ts
@@ -57,9 +57,10 @@ export async function appendEvent(
   // Generate proof using the provided signer
   const proof: DataIntegrityProof = await signer(eventBase);
 
-  // Validate the proof has required fields
-  if (!proof.type || !proof.cryptosuite || !proof.proofValue) {
-    throw new Error('Invalid proof: missing required fields (type, cryptosuite, proofValue)');
+  // Validate the proof has required fields. Include verificationMethod so a
+  // signer that omits it fails loudly here rather than at verifyEventLog time.
+  if (!proof.type || !proof.cryptosuite || !proof.proofValue || !proof.verificationMethod) {
+    throw new Error('Invalid proof: missing required fields (type, cryptosuite, proofValue, verificationMethod)');
   }
 
   // Construct the complete log entry

--- a/packages/sdk/src/cel/algorithms/deactivateEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/deactivateEventLog.ts
@@ -7,9 +7,8 @@
  * @see https://w3c-ccg.github.io/cel-spec/
  */
 
-import type { EventLog, LogEntry, DeactivateOptions, DataIntegrityProof } from '../types.js';
-import { computeDigestMultibase } from '../hash.js';
-import { canonicalizeEntryForChain } from '../canonicalize.js';
+import type { EventLog, DeactivateOptions } from '../types.js';
+import { appendEvent } from './appendEvent.js';
 
 /**
  * Deactivates an event log by appending a final "deactivate" event.
@@ -41,8 +40,6 @@ export async function deactivateEventLog(
   reason: string,
   options: DeactivateOptions
 ): Promise<EventLog> {
-  const { signer } = options;
-
   // Validate input log
   if (!log.events || log.events.length === 0) {
     throw new Error('Cannot deactivate an empty event log');
@@ -54,44 +51,11 @@ export async function deactivateEventLog(
     throw new Error('Event log is already deactivated');
   }
 
-  // Compute the digestMultibase of the last event
-  const previousEvent = computeDigestMultibase(canonicalizeEntryForChain(lastEvent));
-
   // Deactivation data includes the reason
   const deactivationData = {
     reason,
     deactivatedAt: new Date().toISOString(),
   };
 
-  // Create the event structure without proof first
-  const eventBase = {
-    type: 'deactivate' as const,
-    data: deactivationData,
-    previousEvent,
-  };
-
-  // Generate proof using the provided signer
-  const proof: DataIntegrityProof = await signer(eventBase);
-
-  // Validate the proof has required fields
-  if (!proof.type || !proof.cryptosuite || !proof.proofValue) {
-    throw new Error('Invalid proof: missing required fields (type, cryptosuite, proofValue)');
-  }
-
-  // Construct the complete log entry
-  const entry: LogEntry = {
-    type: 'deactivate',
-    data: deactivationData,
-    previousEvent,
-    proof: [proof],
-  };
-
-  // Return a new event log (immutable - does not mutate input)
-  const eventLog: EventLog = {
-    events: [...log.events, entry],
-    // Preserve previousLog reference if it exists
-    ...(log.previousLog ? { previousLog: log.previousLog } : {}),
-  };
-
-  return eventLog;
+  return appendEvent(log, 'deactivate', deactivationData, options);
 }

--- a/packages/sdk/src/cel/algorithms/index.ts
+++ b/packages/sdk/src/cel/algorithms/index.ts
@@ -5,6 +5,7 @@
  */
 
 export { createEventLog } from './createEventLog.js';
+export { appendEvent } from './appendEvent.js';
 export { updateEventLog } from './updateEventLog.js';
 export { deactivateEventLog } from './deactivateEventLog.js';
 export { verifyEventLog, verifyDidKeyEd25519Proof } from './verifyEventLog.js';

--- a/packages/sdk/src/cel/algorithms/updateEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/updateEventLog.ts
@@ -7,9 +7,8 @@
  * @see https://w3c-ccg.github.io/cel-spec/
  */
 
-import type { EventLog, LogEntry, UpdateOptions, DataIntegrityProof } from '../types.js';
-import { computeDigestMultibase } from '../hash.js';
-import { canonicalizeEntryForChain } from '../canonicalize.js';
+import type { EventLog, UpdateOptions } from '../types.js';
+import { appendEvent } from './appendEvent.js';
 
 /**
  * Updates an event log by appending a new "update" event.
@@ -40,48 +39,9 @@ export async function updateEventLog(
   data: unknown,
   options: UpdateOptions
 ): Promise<EventLog> {
-  const { signer } = options;
-
-  // Validate input log
+  // Validate input log (preserved verbatim: message predates the generic guard in appendEvent)
   if (!log.events || log.events.length === 0) {
     throw new Error('Cannot update an empty event log');
   }
-
-  // Get the last event to compute the hash chain link
-  const lastEvent = log.events[log.events.length - 1];
-  
-  // Compute the digestMultibase of the last event
-  const previousEvent = computeDigestMultibase(canonicalizeEntryForChain(lastEvent));
-
-  // Create the event structure without proof first
-  const eventBase = {
-    type: 'update' as const,
-    data,
-    previousEvent,
-  };
-
-  // Generate proof using the provided signer
-  const proof: DataIntegrityProof = await signer(eventBase);
-
-  // Validate the proof has required fields
-  if (!proof.type || !proof.cryptosuite || !proof.proofValue) {
-    throw new Error('Invalid proof: missing required fields (type, cryptosuite, proofValue)');
-  }
-
-  // Construct the complete log entry
-  const entry: LogEntry = {
-    type: 'update',
-    data,
-    previousEvent,
-    proof: [proof],
-  };
-
-  // Return a new event log (immutable - does not mutate input)
-  const eventLog: EventLog = {
-    events: [...log.events, entry],
-    // Preserve previousLog reference if it exists
-    ...(log.previousLog ? { previousLog: log.previousLog } : {}),
-  };
-
-  return eventLog;
+  return appendEvent(log, 'update', data, options);
 }

--- a/packages/sdk/src/cel/algorithms/verifyEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/verifyEventLog.ts
@@ -20,6 +20,7 @@ import type {
 import { computeDigestMultibase, digestMultibaseEquals } from '../hash.js';
 import { canonicalizeEvent, canonicalizeEntryForChain } from '../canonicalize.js';
 import { multikey } from '../../crypto/Multikey.js';
+import { deriveDidCelFromGenesis, didCelMatchesLog } from '../celDid.js';
 
 /**
  * Validates the structural requirements of a DataIntegrityProof (field presence,
@@ -742,6 +743,18 @@ export async function verifyEventLog(
   // authorization (verifyEvent skips the controller-key binding on that path),
   // so this default authority check is skipped too — consistently.
   const createEvent = log.events[0];
+
+  // Genesis shape discrimination (drives both the authority binding below and
+  // the assetDid/expectedDid semantics). Legacy logs embed the asset DID in
+  // `data.did`; did:cel genesis logs carry the holder's key in `data.controller`
+  // and DERIVE the asset DID from the event (no self-reference). A non-string
+  // `data.did` is malformed and treated as absent.
+  const genesisData = createEvent.data as { did?: unknown; controller?: unknown } | null | undefined;
+  const legacyDid = typeof genesisData?.did === 'string' ? genesisData.did : undefined;
+  const celController = legacyDid === undefined && typeof genesisData?.controller === 'string'
+    ? genesisData.controller
+    : undefined;
+
   const authorizedKeyIds = new Set<string>();
   let authorityError: string | undefined;
   if (!options?.verifier) {
@@ -758,32 +771,63 @@ export async function verifyEventLog(
     } else {
       const rootKeyHex = await resolveControllerKeyHex(createControllerProofs[0].verificationMethod, options?.resolveKey);
       if (rootKeyHex) {
-        // Self-certifying binding: when the create event's `data.did` is a
-        // did:key or long-form did:peer:4, the identifier itself embeds the
-        // controller's key material, so the create-event signing key can be
-        // checked against it offline. Without this, an attacker can copy a
-        // victim's create event `data` verbatim, re-sign event 0 with their
-        // own did:key, and produce a "valid" provenance log for the victim's
-        // DID under the attacker's key.
-        //
-        // The check applies only when the create proof's verificationMethod
-        // is itself a did:key: that is the offline-checkable pattern the SDK
-        // emits (PeerCelManager embeds the signer's key in the generated
-        // did:peer). Resolver-backed verification methods (did:webvh, …)
-        // cannot embed their key in the asset DID at create time, so they
-        // keep trust-on-first-use — their authority is whatever the
-        // verifier's resolveKey vouches for. Non-self-certifying `data.did`
-        // methods also keep trust-on-first-use.
-        const dataDid = (createEvent.data as Record<string, unknown> | null | undefined)?.did;
-        const embeddedKeys = createControllerProofs[0].verificationMethod.startsWith('did:key:')
-          ? await selfCertifyingKeyHexes(dataDid)
-          : null;
-        if (embeddedKeys !== null && !embeddedKeys.has(rootKeyHex)) {
-          authorityError =
-            `Create event controller key (${createControllerProofs[0].verificationMethod}) is not a key ` +
-            `embedded in the self-certifying DID ${String(dataDid)}; the log was not created by that DID's controller.`;
+        if (celController !== undefined) {
+          // did:cel genesis: `data.controller` DEFINES authority — the create
+          // event's signing key MUST be a key of that controller. FAIL CLOSED,
+          // NEVER blind trust-on-first-use: without this an attacker can copy a
+          // victim's genesis `data` verbatim, re-sign event 0 with their own
+          // key, and mint a "valid" log for the victim's derived did:cel under
+          // the attacker's key.
+          //
+          // Two ways to bind, both fail-closed:
+          //  - self-certifying controller (did:key / long-form did:peer:4): its
+          //    key material is embedded, so the root key MUST be one of those
+          //    keys — checked offline, no resolver, no fallback.
+          //  - resolver-backed controller (did:webvh, …): its keys cannot be
+          //    enumerated offline, so the root proof's verificationMethod MUST
+          //    belong to the controller DID (proof VM DID === controller). The
+          //    resolver then vouches for that key and the signature is checked
+          //    downstream. A foreign-DID signer (e.g. a did:key claiming a
+          //    did:webvh controller) is not the controller and fails closed.
+          const controllerKeys = await selfCertifyingKeyHexes(celController);
+          const rootProofVm = createControllerProofs[0].verificationMethod;
+          const bound = controllerKeys !== null
+            ? controllerKeys.has(rootKeyHex)
+            : rootProofVm.split('#')[0] === celController;
+          if (!bound) {
+            authorityError =
+              `Create event proof key (${rootProofVm}) is not a key of ` +
+              `the genesis controller ${celController}; the log was not created by that controller.`;
+          } else {
+            authorizedKeyIds.add(rootKeyHex);
+          }
         } else {
-          authorizedKeyIds.add(rootKeyHex);
+          // Legacy / shapeless self-certifying binding (unchanged): when the
+          // create event's `data.did` is a did:key or long-form did:peer:4, the
+          // identifier itself embeds the controller's key material, so the
+          // create-event signing key can be checked against it offline. Without
+          // this, an attacker can copy a victim's create event `data` verbatim,
+          // re-sign event 0 with their own did:key, and produce a "valid"
+          // provenance log for the victim's DID under the attacker's key.
+          //
+          // The check applies only when the create proof's verificationMethod
+          // is itself a did:key: that is the offline-checkable pattern the SDK
+          // emits (PeerCelManager embeds the signer's key in the generated
+          // did:peer). Resolver-backed verification methods (did:webvh, …)
+          // cannot embed their key in the asset DID at create time, so they
+          // keep trust-on-first-use — their authority is whatever the
+          // verifier's resolveKey vouches for. Non-self-certifying `data.did`
+          // methods and shapeless logs also keep trust-on-first-use.
+          const embeddedKeys = createControllerProofs[0].verificationMethod.startsWith('did:key:')
+            ? await selfCertifyingKeyHexes(legacyDid)
+            : null;
+          if (embeddedKeys !== null && !embeddedKeys.has(rootKeyHex)) {
+            authorityError =
+              `Create event controller key (${createControllerProofs[0].verificationMethod}) is not a key ` +
+              `embedded in the self-certifying DID ${String(legacyDid)}; the log was not created by that DID's controller.`;
+          } else {
+            authorizedKeyIds.add(rootKeyHex);
+          }
         }
       } else {
         // The create event's key could not be resolved (e.g. a transient
@@ -810,6 +854,27 @@ export async function verifyEventLog(
     }
   }
 
+  // assetDid: the DERIVED did:cel for new-shape genesis logs, the declared
+  // data.did for legacy logs, absent for shapeless logs. Pure derivation — no
+  // authority machinery — so it is reported even on the custom-verifier path.
+  let assetDid: string | undefined;
+  if (celController !== undefined) assetDid = deriveDidCelFromGenesis(createEvent);
+  else if (legacyDid !== undefined) assetDid = legacyDid;
+
+  // expectedDid: reject a log that does not back the caller's expected DID.
+  // Scoped to the non-custom-verifier path — that path owns proof semantics and
+  // the authority binding above is skipped there. did:cel is matched by suffix
+  // derivation; legacy by string equality; a shapeless log backs no DID.
+  let expectedDidError: string | undefined;
+  if (options?.expectedDid !== undefined && !options?.verifier) {
+    const matches = celController !== undefined
+      ? didCelMatchesLog(options.expectedDid, log)
+      : options.expectedDid === legacyDid;
+    if (!matches) {
+      expectedDidError = `log does not back expected DID ${options.expectedDid}`;
+    }
+  }
+
   // Determine overall verification status (both proofs AND chain must be valid,
   // and the create event must establish a single unambiguous authority key).
   const allProofsValid = eventVerifications.every(ev => ev.proofValid);
@@ -818,10 +883,14 @@ export async function verifyEventLog(
   if (authorityError) {
     errors.unshift(authorityError);
   }
+  if (expectedDidError) {
+    errors.push(expectedDidError);
+  }
 
   return {
-    verified: allProofsValid && allChainsValid && !authorityError && !deactivationViolated,
+    verified: allProofsValid && allChainsValid && !authorityError && !deactivationViolated && !expectedDidError,
     errors,
     events: eventVerifications,
+    ...(assetDid !== undefined ? { assetDid } : {}),
   };
 }

--- a/packages/sdk/src/cel/algorithms/verifyEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/verifyEventLog.ts
@@ -177,12 +177,14 @@ async function dispatchVerify(
  * (did:key, or long-form did:peer numalgo-4 which embeds its DID document).
  *
  * Returns:
- * - a Set of hex-encoded keys when the DID is self-certifying and its key
- *   material could be extracted (possibly empty — meaning no Ed25519 key is
- *   embedded, so no Ed25519 controller proof can legitimately bind to it);
- * - null when the DID is not self-certifying or cannot be checked offline
- *   (short-form did:peer:4, other DID methods, resolution failure) — the
- *   caller then falls back to trust-on-first-use.
+ * - a Set of hex-encoded keys when the DID is self-certifying (possibly empty —
+ *   no Ed25519 key is embedded, or a long-form did:peer:4 whose embedded
+ *   document fails to parse — callers MUST fail closed on an empty set);
+ * - null when the DID is not self-certifying / not checkable offline
+ *   (short-form did:peer:4, other DID methods). Caller semantics on null
+ *   differ: the legacy `data.did` path keeps trust-on-first-use, the did:cel
+ *   genesis path falls back to VM-DID equality + resolver vouching, and the
+ *   rotateKey path fails closed (no proof-of-possession design yet).
  */
 async function selfCertifyingKeyHexes(did: unknown): Promise<Set<string> | null> {
   if (typeof did !== 'string') return null;
@@ -220,11 +222,11 @@ async function selfCertifyingKeyHexes(did: unknown): Promise<Set<string> | null>
       }
       return keys;
     } catch {
-      // Resolution failure: cannot check offline — fall back to TOFU rather
-      // than turning a library quirk into a false negative. (The attack this
-      // check blocks — re-signing a copied create event — requires the
-      // victim's DID, which does resolve.)
-      return null;
+      // A LONG-FORM did:peer:4 embeds its own document; if that document
+      // cannot be parsed the DID is malformed. Fail closed (empty set) rather
+      // than returning null and silently degrading to the caller's weaker
+      // fallback branch (TOFU / VM-equality).
+      return new Set();
     }
   }
 
@@ -725,9 +727,10 @@ export async function verifyEventLog(
     );
   }
 
-  // Establish the authorized controller key from the create event (event 0):
-  // the trust-on-first-use root of authority. The current CEL data model has
-  // no in-log key-rotation mechanism, so this key is fixed by the create event.
+  // Establish the INITIAL authorized controller key from the create event
+  // (event 0): the root of authority. The set is not fixed for the life of the
+  // log — a fully valid `rotateKey` event REPLACES it with the new controller's
+  // keys (hand-off semantics; see the rotation arm in the event loop below).
   //
   // SECURITY: the hash chain and the controller signature cover only
   // { type, data, previousEvent } — NOT the proof array. So an attacker can
@@ -755,7 +758,7 @@ export async function verifyEventLog(
     ? genesisData.controller
     : undefined;
 
-  const authorizedKeyIds = new Set<string>();
+  let authorizedKeyIds = new Set<string>();
   let authorityError: string | undefined;
   if (!options?.verifier) {
     // A non-array proof (missing, object, string, …) yields zero controller
@@ -842,11 +845,43 @@ export async function verifyEventLog(
     }
   }
 
-  // Verify each event's proofs and hash chain
+  // Verify each event's proofs and hash chain. The loop is index-ordered and
+  // `authorizedKeyIds` EVOLVES: each event is authorized against the set as it
+  // stood when the event was appended, and a fully valid rotateKey event swaps
+  // the set for subsequent iterations.
   for (let i = 0; i < log.events.length; i++) {
     const event = log.events[i];
     const previousEvent = i > 0 ? log.events[i - 1] : undefined;
     const eventResult = await verifyEvent(event, i, options?.verifier, previousEvent, options?.resolveKey, authorizedKeyIds, options?.ordinalsProvider);
+
+    // rotateKey hand-off. Order matters: the rotation event must pass ALL its
+    // checks (chain link, signature, CURRENT-set authorization, gating witness
+    // proofs) BEFORE the set is swapped — a failed rotation must not rotate.
+    // Skipped on the custom-verifier path, where the caller owns authorization.
+    if (!options?.verifier && event.type === 'rotateKey' && eventResult.proofValid && eventResult.chainValid) {
+      const rotation = event.data as { newController?: unknown } | null | undefined;
+      const newController = typeof rotation?.newController === 'string' ? rotation.newController : undefined;
+      // v1 requires a SELF-CERTIFYING newController (did:key, or long-form
+      // did:peer:4): its key material is embedded, so the hand-off target is
+      // checkable offline. Resolver-backed newControllers (did:webvh, …) fail
+      // closed — VM-DID equality has no meaning here (nothing is signed by the
+      // new key yet); supporting them needs a proof-of-possession design.
+      const newKeys = newController !== undefined ? await selfCertifyingKeyHexes(newController) : null;
+      if (!newKeys || newKeys.size === 0) {
+        // Unbindable target fails the EVENT (and therefore the log) — an
+        // accepted rotation to nowhere would strand or hijack the log.
+        eventResult.proofValid = false;
+        eventResult.errors.push(
+          `Event ${i}: rotateKey has an unbindable newController (${String(newController)}); ` +
+          `a rotation target must be a self-certifying DID carrying an Ed25519 key`
+        );
+      } else {
+        // REPLACE, not union — hand-off semantics (design spec §2/§5); keeping
+        // the old keys would reopen the stale-key window rotation closes.
+        authorizedKeyIds = newKeys;
+      }
+    }
+
     eventVerifications.push(eventResult);
 
     if (!eventResult.proofValid || !eventResult.chainValid) {

--- a/packages/sdk/src/cel/algorithms/verifyEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/verifyEventLog.ts
@@ -189,6 +189,15 @@ async function dispatchVerify(
 async function selfCertifyingKeyHexes(did: unknown): Promise<Set<string> | null> {
   if (typeof did !== 'string') return null;
 
+  // Cap before base58 decode (O(n²), per-event amplifiable via rotateKey): over
+  // the bound, fail closed (empty) for the prefixes we'd otherwise decode; null
+  // for everything else, matching this function's null-vs-empty semantics.
+  if (did.length > 2048) {
+    const selfCertifying = did.startsWith('did:key:')
+      || (did.startsWith('did:peer:4') && did.split(':').length >= 4);
+    return selfCertifying ? new Set() : null;
+  }
+
   if (did.startsWith('did:key:')) {
     // Pure local decode — a did:key IS its key, so a decode failure or a
     // non-Ed25519 key means no Ed25519 proof can be bound to it (empty set →

--- a/packages/sdk/src/cel/celDid.ts
+++ b/packages/sdk/src/cel/celDid.ts
@@ -1,0 +1,41 @@
+/**
+ * did:cel — genesis identity derived from the CEL create event.
+ *
+ * did:cel:<digestMultibase(canonicalizeEntryForChain(genesisEvent))>
+ *
+ * Reuses the exact chain-link digest (proof excluded, {type,data} preimage
+ * for a first event), so a log's second event's `previousEvent` equals the
+ * DID suffix by construction. The genesis event must NOT embed the asset
+ * DID (it is derived from the event); the holder's key lives in
+ * `data.controller` instead.
+ */
+import type { EventLog, LogEntry } from './types.js';
+import { computeDigestMultibase, digestMultibaseEquals } from './hash.js';
+import { canonicalizeEntryForChain } from './canonicalize.js';
+
+export const DID_CEL_PREFIX = 'did:cel:';
+
+export function deriveDidCelFromGenesis(genesis: LogEntry): string {
+  if (genesis.type !== 'create') {
+    throw new Error('did:cel derives from a create event; got ' + String(genesis.type));
+  }
+  return DID_CEL_PREFIX + computeDigestMultibase(canonicalizeEntryForChain(genesis));
+}
+
+export function deriveDidCel(log: EventLog): string {
+  if (!log.events || log.events.length === 0) {
+    throw new Error('Cannot derive did:cel from an empty event log');
+  }
+  return deriveDidCelFromGenesis(log.events[0]);
+}
+
+export function isDidCel(did: string): boolean {
+  return typeof did === 'string' && did.startsWith(DID_CEL_PREFIX);
+}
+
+/** Suffix comparison via digestMultibaseEquals (tolerates legacy bare digests). */
+export function didCelMatchesLog(did: string, log: EventLog): boolean {
+  if (!isDidCel(did) || !log.events || log.events.length === 0) return false;
+  const expected = computeDigestMultibase(canonicalizeEntryForChain(log.events[0]));
+  return digestMultibaseEquals(did.slice(DID_CEL_PREFIX.length), expected);
+}

--- a/packages/sdk/src/cel/celDid.ts
+++ b/packages/sdk/src/cel/celDid.ts
@@ -36,6 +36,7 @@ export function isDidCel(did: string): boolean {
 /** Suffix comparison via digestMultibaseEquals (tolerates legacy bare digests). */
 export function didCelMatchesLog(did: string, log: EventLog): boolean {
   if (!isDidCel(did) || !log.events || log.events.length === 0) return false;
-  const expected = computeDigestMultibase(canonicalizeEntryForChain(log.events[0]));
+  if (log.events[0].type !== 'create') return false; // create-check as guard, not a throw
+  const expected = deriveDidCelFromGenesis(log.events[0]).slice(DID_CEL_PREFIX.length);
   return digestMultibaseEquals(did.slice(DID_CEL_PREFIX.length), expected);
 }

--- a/packages/sdk/src/cel/cli/create.ts
+++ b/packages/sdk/src/cel/cli/create.ts
@@ -256,7 +256,8 @@ export async function createCommand(flags: CreateFlags): Promise<CreateResult> {
   
   let eventLog;
   try {
-    eventLog = await manager.create(flags.name, [resource]);
+    // did:cel surfacing in CLI output is Task 7/8; only the log is used here.
+    ({ log: eventLog } = await manager.create(flags.name, [resource]));
   } catch (e) {
     return {
       success: false,

--- a/packages/sdk/src/cel/cli/create.ts
+++ b/packages/sdk/src/cel/cli/create.ts
@@ -38,6 +38,8 @@ export interface CreateResult {
   success: boolean;
   message: string;
   log?: unknown;
+  /** The asset's derived did:cel identifier */
+  did?: string;
   keyGenerated?: boolean;
   privateKey?: string;
   publicKey?: string;
@@ -255,9 +257,9 @@ export async function createCommand(flags: CreateFlags): Promise<CreateResult> {
   });
   
   let eventLog;
+  let assetDid = '';
   try {
-    // did:cel surfacing in CLI output is Task 7/8; only the log is used here.
-    ({ log: eventLog } = await manager.create(flags.name, [resource]));
+    ({ log: eventLog, did: assetDid } = await manager.create(flags.name, [resource]));
   } catch (e) {
     return {
       success: false,
@@ -305,6 +307,10 @@ export async function createCommand(flags: CreateFlags): Promise<CreateResult> {
     }
   }
   
+  // Surface the derived did:cel on stderr (stdout carries the serialized log
+  // when no --output is given).
+  console.error(`\nAsset DID: ${assetDid}`);
+
   // Build result
   const result: CreateResult = {
     success: true,
@@ -312,6 +318,7 @@ export async function createCommand(flags: CreateFlags): Promise<CreateResult> {
       ? `Created CEL asset "${flags.name}" and saved to ${flags.output}`
       : `Created CEL asset "${flags.name}"`,
     log: eventLog,
+    did: assetDid,
     keyGenerated,
   };
   

--- a/packages/sdk/src/cel/cli/inspect.ts
+++ b/packages/sdk/src/cel/cli/inspect.ts
@@ -240,9 +240,13 @@ function deriveCurrentState(log: EventLog): AssetState {
       if (updateData.name !== undefined) state.name = updateData.name as string;
       if (updateData.resources !== undefined) state.resources = updateData.resources as ExternalReference[];
       if (updateData.updatedAt !== undefined) state.updatedAt = updateData.updatedAt as string;
-      if (updateData.did !== undefined) state.did = updateData.did as string;
-      if (updateData.targetDid !== undefined) state.did = updateData.targetDid as string;
-      if (updateData.layer !== undefined) state.layer = updateData.layer as 'peer' | 'webvh' | 'btco';
+      // Legacy logs only: new-shape did:cel genesis derives identity/layer, so a
+      // stray did/targetDid/layer field on an update event must not clobber it.
+      if (!isNewShapeGenesis) {
+        if (updateData.did !== undefined) state.did = updateData.did as string;
+        if (updateData.targetDid !== undefined) state.did = updateData.targetDid as string;
+        if (updateData.layer !== undefined) state.layer = updateData.layer as 'peer' | 'webvh' | 'btco';
+      }
 
       // Store migration data in metadata (legacy update-sniffed migrations)
       if (isMigrationEvent(updateData)) {

--- a/packages/sdk/src/cel/cli/inspect.ts
+++ b/packages/sdk/src/cel/cli/inspect.ts
@@ -212,8 +212,11 @@ function deriveCurrentState(log: EventLog): AssetState {
   // Dual-read the genesis. New shape (`controller` present): the asset DID is
   // DERIVED (did:cel), the creator is sourced from the controller, layer is
   // definitionally 'peer'. Legacy shape (`did` present): read verbatim.
+  // Match the verifier/manager pattern (PeerCelManager, Btco/WebVHCelManager):
+  // legacy iff `did` present and `controller` absent; everything else is new-shape.
   const createData = createEvent.data as Record<string, unknown>;
-  const isNewShapeGenesis = createData.controller !== undefined;
+  const isLegacyGenesis = createData.controller === undefined && createData.did !== undefined;
+  const isNewShapeGenesis = !isLegacyGenesis;
 
   // Initialize state from create event
   const state: AssetState = {

--- a/packages/sdk/src/cel/cli/inspect.ts
+++ b/packages/sdk/src/cel/cli/inspect.ts
@@ -10,9 +10,11 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import type { EventLog, DataIntegrityProof, WitnessProof, AssetState, ExternalReference } from '../types.js';
+import type { EventLog, LogEntry, DataIntegrityProof, WitnessProof, AssetState, ExternalReference } from '../types.js';
 import { parseEventLogJson } from '../serialization/json.js';
 import { parseEventLogCbor } from '../serialization/cbor.js';
+import { btcoDidFromSatoshi } from '../btcoDid.js';
+import { deriveDidCel } from '../celDid.js';
 
 /**
  * Flags parsed from command line arguments
@@ -53,15 +55,39 @@ function isWitnessProof(proof: DataIntegrityProof | WitnessProof): proof is Witn
 }
 
 /**
- * Check if event data contains migration information
+ * LEGACY-ONLY sniff: detects migrations recorded as `update`-typed events
+ * (pre-first-class-`migrate` logs). Kept verbatim as the fallback; new logs
+ * are detected type-first via `event.type === 'migrate'`.
  */
 function isMigrationEvent(data: unknown): data is MigrationData {
   if (typeof data !== 'object' || data === null) return false;
   const d = data as Record<string, unknown>;
   return (
-    ('sourceDid' in d && 'targetDid' in d) || 
+    ('sourceDid' in d && 'targetDid' in d) ||
     ('layer' in d && typeof d.layer === 'string' && ['peer', 'webvh', 'btco'].includes(d.layer))
   );
+}
+
+/**
+ * Derives the resolvable DID for a migration event: the targetDid when the
+ * signed data carries one (webvh), or did:btco:<satoshi> from the
+ * bitcoin-ordinals-2024 witness proof (btco — the satoshi is only known
+ * after inscription, so it isn't in the signed data).
+ */
+function resolveMigrationDid(event: LogEntry, data: Record<string, unknown>): string | undefined {
+  if (data.layer === 'btco') {
+    const proof = (event.proof as ReadonlyArray<unknown> | undefined)?.find(
+      (p): p is Record<string, unknown> =>
+        !!p && typeof p === 'object' && (p as Record<string, unknown>).cryptosuite === 'bitcoin-ordinals-2024'
+    );
+    const satoshi = proof?.satoshi;
+    if (satoshi !== undefined && satoshi !== null) {
+      // Network-scoped identifier read from the SIGNED migration data;
+      // legacy logs without one default to the bare mainnet form.
+      return btcoDidFromSatoshi(satoshi as string | number, data.network as string | undefined);
+    }
+  }
+  return data.targetDid as string | undefined;
 }
 
 /**
@@ -150,6 +176,9 @@ function getEventBadge(type: string): string {
   switch (type) {
     case 'create': return '🆕 CREATE';
     case 'update': return '✏️  UPDATE';
+    case 'migrate': return '🗺️  MIGRATE';
+    case 'transfer': return '🔁 TRANSFER';
+    case 'rotateKey': return '🔑 ROTATEKEY';
     case 'deactivate': return '🔒 DEACTIVATE';
     default: return `📋 ${type.toUpperCase()}`;
   }
@@ -180,15 +209,20 @@ function deriveCurrentState(log: EventLog): AssetState {
     throw new Error('First event must be a create event');
   }
 
+  // Dual-read the genesis. New shape (`controller` present): the asset DID is
+  // DERIVED (did:cel), the creator is sourced from the controller, layer is
+  // definitionally 'peer'. Legacy shape (`did` present): read verbatim.
   const createData = createEvent.data as Record<string, unknown>;
-  
+  const isNewShapeGenesis = createData.controller !== undefined;
+
   // Initialize state from create event
   const state: AssetState = {
-    did: (createData.did as string) || 'unknown',
+    did: isNewShapeGenesis ? deriveDidCel(log) : ((createData.did as string) || 'unknown'),
     name: createData.name as string,
     layer: (createData.layer as 'peer' | 'webvh' | 'btco') || 'peer',
     resources: (createData.resources as ExternalReference[]) || [],
-    creator: createData.creator as string,
+    creator: (createData.creator as string | undefined) ?? (createData.controller as string | undefined),
+    controller: createData.controller as string | undefined,
     createdAt: createData.createdAt as string,
     updatedAt: undefined,
     deactivated: false,
@@ -201,7 +235,7 @@ function deriveCurrentState(log: EventLog): AssetState {
 
     if (event.type === 'update') {
       const updateData = event.data as Record<string, unknown>;
-      
+
       // Update known fields
       if (updateData.name !== undefined) state.name = updateData.name as string;
       if (updateData.resources !== undefined) state.resources = updateData.resources as ExternalReference[];
@@ -209,8 +243,8 @@ function deriveCurrentState(log: EventLog): AssetState {
       if (updateData.did !== undefined) state.did = updateData.did as string;
       if (updateData.targetDid !== undefined) state.did = updateData.targetDid as string;
       if (updateData.layer !== undefined) state.layer = updateData.layer as 'peer' | 'webvh' | 'btco';
-      
-      // Store migration data in metadata
+
+      // Store migration data in metadata (legacy update-sniffed migrations)
       if (isMigrationEvent(updateData)) {
         state.metadata = state.metadata || {};
         if (updateData.sourceDid) state.metadata.sourceDid = updateData.sourceDid;
@@ -218,7 +252,7 @@ function deriveCurrentState(log: EventLog): AssetState {
         if (updateData.txid) state.metadata.txid = updateData.txid;
         if (updateData.inscriptionId) state.metadata.inscriptionId = updateData.inscriptionId;
       }
-      
+
       // Store other fields in metadata
       for (const [key, value] of Object.entries(updateData)) {
         if (!['name', 'resources', 'updatedAt', 'did', 'targetDid', 'layer', 'creator', 'createdAt', 'sourceDid', 'domain', 'txid', 'inscriptionId'].includes(key)) {
@@ -226,6 +260,39 @@ function deriveCurrentState(log: EventLog): AssetState {
           state.metadata[key] = value;
         }
       }
+    } else if (event.type === 'migrate') {
+      // First-class migration event: layer transition with the same payload
+      // fields legacy update-sniffed migrations carried. For btco the
+      // resolvable DID comes from the bitcoin witness proof's satoshi.
+      const migrationData = event.data as Record<string, unknown>;
+      const migratedDid = resolveMigrationDid(event, migrationData);
+      if (migratedDid !== undefined) state.did = migratedDid;
+      if (migrationData.layer !== undefined) state.layer = migrationData.layer as 'peer' | 'webvh' | 'btco';
+      if (migrationData.migratedAt !== undefined) state.updatedAt = migrationData.migratedAt as string;
+
+      state.metadata = state.metadata || {};
+      if (migrationData.sourceDid !== undefined) state.metadata.sourceDid = migrationData.sourceDid;
+      if (migrationData.domain !== undefined) state.metadata.domain = migrationData.domain;
+      // Bitcoin details live in the witness proof (added after signing).
+      const bitcoinProof = (event.proof as ReadonlyArray<unknown> | undefined)?.find(
+        (p): p is Record<string, unknown> =>
+          !!p && typeof p === 'object' && (p as Record<string, unknown>).cryptosuite === 'bitcoin-ordinals-2024'
+      );
+      if (bitcoinProof?.txid !== undefined) state.metadata.txid = bitcoinProof.txid;
+      if (bitcoinProof?.inscriptionId !== undefined) state.metadata.inscriptionId = bitcoinProof.inscriptionId;
+    } else if (event.type === 'transfer') {
+      // Ownership hand-off: surface the owners; identity (did) is unchanged.
+      const transferData = event.data as Record<string, unknown>;
+      if (transferData.transferredAt !== undefined) state.updatedAt = transferData.transferredAt as string;
+      state.metadata = state.metadata || {};
+      if (transferData.previousOwner !== undefined) state.metadata.previousOwner = transferData.previousOwner;
+      if (transferData.newOwner !== undefined) state.metadata.newOwner = transferData.newOwner;
+      if (transferData.txid !== undefined) state.metadata.txid = transferData.txid;
+    } else if (event.type === 'rotateKey') {
+      // Authority hand-off: the last rotation's newController is current.
+      const rotationData = event.data as Record<string, unknown>;
+      if (typeof rotationData?.newController === 'string') state.controller = rotationData.newController;
+      if (typeof rotationData?.rotatedAt === 'string') state.updatedAt = rotationData.rotatedAt;
     } else if (event.type === 'deactivate') {
       state.deactivated = true;
       const deactivateData = event.data as Record<string, unknown>;
@@ -250,16 +317,27 @@ function extractLayerHistory(log: EventLog): Array<{ layer: string; timestamp: s
   
   for (const event of log.events) {
     const data = event.data as Record<string, unknown>;
-    
-    if (event.type === 'create' && data.layer) {
+
+    if (event.type === 'create') {
+      // New-shape genesis carries neither layer (definitionally 'peer') nor
+      // did (derived did:cel); legacy genesis embeds both.
       history.push({
-        layer: data.layer as string,
+        layer: (data.layer as string) || 'peer',
         timestamp: (data.createdAt as string) || event.proof[0]?.created || 'unknown',
-        did: data.did as string,
+        did: (data.did as string | undefined) ??
+          (data.controller !== undefined ? deriveDidCel(log) : undefined),
       });
     }
-    
-    if (event.type === 'update' && isMigrationEvent(event.data)) {
+
+    if (event.type === 'migrate') {
+      // Type-first: first-class migration event.
+      history.push({
+        layer: (data.layer as string) ?? 'unknown',
+        timestamp: (data.migratedAt as string) ?? event.proof[0]?.created ?? 'unknown',
+        did: resolveMigrationDid(event, data) ?? 'unknown',
+      });
+    } else if (event.type === 'update' && isMigrationEvent(event.data)) {
+      // Legacy sniff kept verbatim.
       const migrationData = event.data;
       history.push({
         layer: migrationData.layer ?? 'unknown',
@@ -268,7 +346,7 @@ function extractLayerHistory(log: EventLog): Array<{ layer: string; timestamp: s
       });
     }
   }
-  
+
   return history;
 }
 
@@ -434,19 +512,33 @@ function outputInspection(log: EventLog, state: AssetState): void {
     console.log(`\n ${prefix} ${getEventBadge(event.type)}`);
     
     // Timestamp from proof
-    const timestamp = event.proof[0]?.created || data.createdAt || data.updatedAt || data.migratedAt || data.deactivatedAt;
+    const timestamp = event.proof[0]?.created || data.createdAt || data.updatedAt || data.migratedAt || data.transferredAt || data.rotatedAt || data.deactivatedAt;
     if (timestamp) {
       console.log(` ${connector}   📅 ${formatTimestamp(timestamp as string)}`);
     }
-    
+
     // Event-specific details
     if (event.type === 'create') {
       if (data.name) console.log(` ${connector}   Name: ${String(data.name)}`);
       if (data.did) console.log(` ${connector}   DID: ${formatDid(data.did as string)}`);
+      if (data.controller) console.log(` ${connector}   Controller: ${formatDid(data.controller as string)}`);
       if (data.layer) console.log(` ${connector}   Layer: ${String(data.layer)}`);
       if (data.resources && Array.isArray(data.resources)) {
         console.log(` ${connector}   Resources: ${data.resources.length} file(s)`);
       }
+    } else if (event.type === 'migrate') {
+      // First-class migration event
+      console.log(` ${connector}   Migrated to: ${(data.layer as string | undefined) ?? 'unknown'}`);
+      if (data.sourceDid) console.log(` ${connector}   From: ${formatDid(data.sourceDid as string)}`);
+      const migratedDid = resolveMigrationDid(event, data);
+      if (migratedDid) console.log(` ${connector}   To:   ${formatDid(migratedDid)}`);
+      if (data.domain) console.log(` ${connector}   Domain: ${data.domain as string}`);
+    } else if (event.type === 'transfer') {
+      if (data.previousOwner) console.log(` ${connector}   From: ${formatDid(data.previousOwner as string)}`);
+      if (data.newOwner) console.log(` ${connector}   To:   ${formatDid(data.newOwner as string)}`);
+    } else if (event.type === 'rotateKey') {
+      if (data.previousController) console.log(` ${connector}   From: ${formatDid(data.previousController as string)}`);
+      if (data.newController) console.log(` ${connector}   To:   ${formatDid(data.newController as string)}`);
     } else if (event.type === 'update') {
       // Show what changed
       const changes: string[] = [];

--- a/packages/sdk/src/cel/cli/migrate.ts
+++ b/packages/sdk/src/cel/cli/migrate.ts
@@ -24,6 +24,7 @@ import { serializeEventLogCbor } from '../serialization/cbor.js';
 import { multikey } from '../../crypto/Multikey.js';
 import { canonicalizeEvent } from '../canonicalize.js';
 import { btcoDidFromSatoshi } from '../btcoDid.js';
+import { deriveDidCel } from '../celDid.js';
 
 /**
  * Flags parsed from command line arguments
@@ -90,11 +91,15 @@ function detectCurrentLayer(log: EventLog): 'peer' | 'webvh' | 'btco' {
 
   for (const event of log.events) {
     const data = event.data as Record<string, unknown>;
-    
+
     if (event.type === 'create' && data.layer) {
       currentLayer = data.layer as 'peer' | 'webvh' | 'btco';
+    } else if (event.type === 'migrate' && data.layer) {
+      // Type-first: first-class 'migrate' events are migrations by type.
+      currentLayer = data.layer as 'peer' | 'webvh' | 'btco';
     } else if (event.type === 'update' && data.layer && data.sourceDid && data.migratedAt) {
-      // This is a migration event. Detect via sourceDid + migratedAt (present
+      // Legacy sniff kept verbatim: old logs record migrations as 'update'
+      // events. Detect via sourceDid + migratedAt (present
       // on both webvh and btco migrations, and reserved from regular updates);
       // btco migrations don't carry targetDid, so keying off targetDid left
       // btco logs mis-detected as webvh and bypassed the "cannot migrate from
@@ -119,14 +124,23 @@ function getCurrentDid(log: EventLog): string {
 
   for (const event of log.events) {
     const data = event.data as Record<string, unknown>;
-    
-    if (event.type === 'create' && data.did) {
-      currentDid = data.did as string;
+
+    if (event.type === 'create') {
+      // Dual-read the genesis: a new-shape genesis (`controller` present)
+      // derives its identity (did:cel); a legacy genesis embeds `did`.
+      if (data.did) {
+        currentDid = data.did as string;
+      } else if (data.controller !== undefined) {
+        currentDid = deriveDidCel(log);
+      }
+    } else if (event.type === 'migrate' && data.layer) {
+      // Type-first: first-class 'migrate' events are migrations by type.
+      currentDid = resolveMigrationDid(event, data) ?? currentDid;
     } else if (event.type === 'update' && data.sourceDid && data.layer && data.migratedAt) {
-      // Migration event. webvh migrations carry the resolvable targetDid; btco
-      // migrations derive did:btco:<satoshi> from the bitcoin witness proof
-      // (the satoshi is only known after inscription, so it isn't in the
-      // signed data).
+      // Legacy sniff kept verbatim. webvh migrations carry the resolvable
+      // targetDid; btco migrations derive did:btco:<satoshi> from the bitcoin
+      // witness proof (the satoshi is only known after inscription, so it
+      // isn't in the signed data).
       currentDid = resolveMigrationDid(event, data) ?? currentDid;
     }
   }

--- a/packages/sdk/src/cel/cli/transfer.ts
+++ b/packages/sdk/src/cel/cli/transfer.ts
@@ -17,9 +17,10 @@ import { parseEventLogCbor } from '../serialization/cbor.js';
 import { serializeEventLogJson } from '../serialization/json.js';
 import { serializeEventLogCbor } from '../serialization/cbor.js';
 import { multikey } from '../../crypto/Multikey.js';
-import { canonicalizeEvent, canonicalizeEntryForChain } from '../canonicalize.js';
-import { computeDigestMultibase } from '../hash.js';
+import { canonicalizeEvent } from '../canonicalize.js';
+import { appendEvent } from '../algorithms/appendEvent.js';
 import { btcoDidFromSatoshi } from '../btcoDid.js';
+import { deriveDidCel } from '../celDid.js';
 
 /**
  * Flags parsed from command line arguments
@@ -71,9 +72,20 @@ function getCurrentDid(log: EventLog): string {
 
   for (const event of log.events) {
     const data = event.data as Record<string, unknown>;
-    if (event.type === 'create' && data.did) {
-      currentDid = data.did as string;
-    } else if (event.type === 'update' && data.sourceDid && data.layer && data.migratedAt) {
+    if (event.type === 'create') {
+      // Dual-read the genesis: a new-shape genesis (`controller` present)
+      // derives its identity (did:cel); a legacy genesis embeds `did`.
+      if (data.did) {
+        currentDid = data.did as string;
+      } else if (data.controller !== undefined) {
+        currentDid = deriveDidCel(log);
+      }
+    } else if (
+      // Type-first: first-class 'migrate' events are migrations by type.
+      (event.type === 'migrate' && data.layer) ||
+      // Legacy sniff kept verbatim: old logs record migrations as 'update' events.
+      (event.type === 'update' && data.sourceDid && data.layer && data.migratedAt)
+    ) {
       // Migration event. webvh migrations carry the resolvable targetDid; btco
       // migrations derive did:btco:<satoshi> from the bitcoin witness proof.
       // Transfers happen at the btco layer, so getting this right matters for
@@ -234,44 +246,28 @@ export async function transferCommand(flags: TransferFlags): Promise<TransferRes
   // Create signer and sign the transfer event
   const signer = createSigner(privateKey, publicKey);
 
+  // First-class transfer event: the discriminator is the event type itself,
+  // not an inner data.type field.
   const transferData = {
-    type: 'transfer',
     previousOwner: currentDid,
     newOwner: flags.to,
     transferredAt: new Date().toISOString(),
   };
 
-  // Compute previous event hash first (same canonicalization as updateEventLog),
-  // then sign over the full event base so the signed payload matches what
-  // verifyEventLog reconstructs: { type, data, previousEvent }. Signing only
-  // `transferData` would produce a signature that verification cannot reproduce,
-  // yielding proofValid: false on every transferred log.
-  const lastEvent = eventLog.events[eventLog.events.length - 1];
-  const previousEvent = computeDigestMultibase(canonicalizeEntryForChain(lastEvent));
-
-  const eventBase = {
-    type: 'update' as const,
-    data: transferData,
-    previousEvent,
-  };
-
-  let proof: DataIntegrityProof;
+  // appendEvent signs exactly { type, data, previousEvent } — the shape
+  // verifyEventLog reconstructs — and computes the chain link itself.
   try {
-    proof = await signer(eventBase);
+    eventLog = await appendEvent(eventLog, 'transfer', transferData, {
+      signer,
+      verificationMethod: `did:key:${publicKey}#${publicKey}`,
+      proofPurpose: 'assertionMethod',
+    });
   } catch (e) {
     return {
       success: false,
       message: `Error: Failed to sign transfer: ${(e as Error).message}`,
     };
   }
-
-  // Append transfer event to log
-  eventLog.events.push({
-    type: 'update',
-    data: transferData,
-    proof: [proof],
-    previousEvent,
-  });
 
   // Serialize output
   const format = (flags.format || 'json').toLowerCase();

--- a/packages/sdk/src/cel/index.ts
+++ b/packages/sdk/src/cel/index.ts
@@ -8,6 +8,7 @@
 export * from './types.js';
 export * from './hash.js';
 export * from './canonicalize.js';
+export { DID_CEL_PREFIX, deriveDidCel, deriveDidCelFromGenesis, isDidCel, didCelMatchesLog } from './celDid.js';
 export * from './algorithms/index.js';
 export * from './witnesses/index.js';
 export * from './serialization/index.js';

--- a/packages/sdk/src/cel/layers/BtcoCelManager.ts
+++ b/packages/sdk/src/cel/layers/BtcoCelManager.ts
@@ -18,6 +18,7 @@ import { BitcoinWitness } from '../witnesses/BitcoinWitness.js';
 import type { BitcoinManager } from '../../bitcoin/BitcoinManager.js';
 import type { CelSigner } from './PeerCelManager.js';
 import { btcoDidPrefix } from '../btcoDid.js';
+import { deriveDidCel } from '../celDid.js';
 
 /**
  * Configuration options for BtcoCelManager
@@ -202,7 +203,11 @@ export class BtcoCelManager {
       const eventData = event.data as Record<string, unknown>;
       
       if (event.type === 'create') {
-        currentDid = eventData.did as string;
+        // Dual-read: new-shape genesis (controller present) derives its
+        // identity (did:cel); legacy genesis embeds `did` and is read verbatim.
+        currentDid = eventData.controller !== undefined
+          ? deriveDidCel(webvhLog)
+          : (eventData.did as string);
         currentLayer = eventData.layer as string || 'peer';
       } else if (event.type === 'update' && eventData.sourceDid && eventData.layer && eventData.migratedAt) {
         // This is a migration event. Detect via sourceDid (present on both

--- a/packages/sdk/src/cel/layers/BtcoCelManager.ts
+++ b/packages/sdk/src/cel/layers/BtcoCelManager.ts
@@ -12,7 +12,7 @@
  */
 
 import type { EventLog, ExternalReference, UpdateOptions, AssetState } from '../types.js';
-import { updateEventLog } from '../algorithms/updateEventLog.js';
+import { appendEvent } from '../algorithms/appendEvent.js';
 import { witnessEvent } from '../algorithms/witnessEvent.js';
 import { BitcoinWitness } from '../witnesses/BitcoinWitness.js';
 import type { BitcoinManager } from '../../bitcoin/BitcoinManager.js';
@@ -209,13 +209,18 @@ export class BtcoCelManager {
           ? deriveDidCel(webvhLog)
           : (eventData.did as string);
         currentLayer = eventData.layer as string || 'peer';
-      } else if (event.type === 'update' && eventData.sourceDid && eventData.layer && eventData.migratedAt) {
-        // This is a migration event. Detect via sourceDid (present on both
-        // webvh and btco migrations) rather than targetDid (webvh-only), so a
-        // log already migrated to btco is recognised as such and the terminal
-        // guard below correctly rejects a second btco migration. webvh
-        // migrations carry the resolvable targetDid; btco migrations don't, but
-        // migrate() only proceeds from the webvh layer anyway.
+      } else if (
+        // Type-first: first-class 'migrate' events are migrations by type.
+        (event.type === 'migrate' && eventData?.layer) ||
+        // Legacy sniff kept verbatim: old logs record migrations as 'update'
+        // events. Detect via sourceDid (present on both webvh and btco
+        // migrations) rather than targetDid (webvh-only), so a log already
+        // migrated to btco is recognised as such and the terminal guard below
+        // correctly rejects a second btco migration. webvh migrations carry
+        // the resolvable targetDid; btco migrations don't, but migrate() only
+        // proceeds from the webvh layer anyway.
+        (event.type === 'update' && eventData.sourceDid && eventData.layer && eventData.migratedAt)
+      ) {
         currentLayer = eventData.layer as string;
         currentDid = (eventData.targetDid as string) ?? (eventData.sourceDid as string);
       }
@@ -266,8 +271,8 @@ export class BtcoCelManager {
       proofPurpose: this.config.proofPurpose,
     };
 
-    // Create the (final, signed) update event with the migration data.
-    const updatedLog = await updateEventLog(webvhLog, migrationData, updateOptions);
+    // Append the (final, signed) first-class migrate event with the migration data.
+    const updatedLog = await appendEvent(webvhLog, 'migrate', migrationData, updateOptions);
 
     // Add the Bitcoin witness proof (REQUIRED at btco layer). This attests the
     // already-signed event content and appends the txid/inscriptionId; it does
@@ -311,16 +316,21 @@ export class BtcoCelManager {
       throw new Error('First event must be a create event');
     }
 
-    // Extract initial state from create event
+    // Extract initial state from create event. Dual-read the genesis: a
+    // new-shape genesis (`controller` present) derives its identity (did:cel)
+    // and sources the creator from the controller; a legacy genesis embeds
+    // `did`/`creator` and is read verbatim.
     const createData = createEvent.data as Record<string, unknown>;
-    
+    const isLegacyGenesis = createData.controller === undefined && createData.did !== undefined;
+
     // Initialize state from create event
     const state: AssetState = {
-      did: createData.did as string,
+      did: isLegacyGenesis ? (createData.did as string) : deriveDidCel(log),
       name: createData.name as string | undefined,
       layer: (createData.layer as 'peer' | 'webvh' | 'btco') || 'peer',
       resources: (createData.resources as ExternalReference[]) || [],
-      creator: createData.creator as string | undefined,
+      creator: (createData.creator as string | undefined) ?? (createData.controller as string | undefined),
+      controller: createData.controller as string | undefined,
       createdAt: createData.createdAt as string | undefined,
       updatedAt: undefined,
       deactivated: false,
@@ -331,13 +341,15 @@ export class BtcoCelManager {
     for (let i = 1; i < log.events.length; i++) {
       const event = log.events[i];
 
-      if (event.type === 'update') {
+      if (event.type === 'update' || event.type === 'migrate') {
         const updateData = event.data as Record<string, unknown>;
-        
-        // Check if this is a migration event. Migration events carry a
-        // sourceDid + layer; regular updates don't. (btco migrations no longer
-        // carry targetDid in the signed data — see below.)
-        if (updateData.sourceDid && updateData.layer && updateData.migratedAt) {
+
+        // Type-first: first-class 'migrate' events are migrations by type.
+        // Legacy logs record migrations as 'update' events — the sniff via
+        // sourceDid + layer (regular updates don't carry them) is kept
+        // verbatim as fallback. (btco migrations no longer carry targetDid in
+        // the signed data — see below.)
+        if (event.type === 'migrate' || (updateData.sourceDid && updateData.layer && updateData.migratedAt)) {
           // Migration event - update DID and layer
           state.layer = updateData.layer as 'peer' | 'webvh' | 'btco';
           state.updatedAt = updateData.migratedAt as string;
@@ -420,7 +432,9 @@ export class BtcoCelManager {
         // those events alone — for an ordinary update, an application-defined
         // `network` field must still flow through to metadata.
         const excludedKeys = ['name', 'resources', 'updatedAt', 'did', 'layer', 'creator', 'createdAt', 'sourceDid', 'targetDid', 'domain', 'migratedAt', 'txid', 'inscriptionId'];
-        if (updateData.sourceDid && updateData.layer === 'btco' && updateData.migratedAt) {
+        const isBtcoMigration = updateData.layer === 'btco' &&
+          (event.type === 'migrate' || (updateData.sourceDid && updateData.migratedAt));
+        if (isBtcoMigration) {
           excludedKeys.push('network');
         }
         for (const [key, value] of Object.entries(updateData)) {
@@ -428,6 +442,31 @@ export class BtcoCelManager {
             state.metadata = state.metadata || {};
             state.metadata[key] = value;
           }
+        }
+      } else if (event.type === 'transfer') {
+        // Ownership hand-off: surface the owners; identity (did) is unchanged.
+        const transferData = event.data as Record<string, unknown>;
+        if (transferData.transferredAt !== undefined) {
+          state.updatedAt = transferData.transferredAt as string;
+        }
+        state.metadata = state.metadata || {};
+        if (transferData.previousOwner !== undefined) {
+          state.metadata.previousOwner = transferData.previousOwner;
+        }
+        if (transferData.newOwner !== undefined) {
+          state.metadata.newOwner = transferData.newOwner;
+        }
+        if (transferData.txid !== undefined) {
+          state.metadata.txid = transferData.txid;
+        }
+      } else if (event.type === 'rotateKey') {
+        // Authority hand-off: the last rotation's newController is current.
+        const rotationData = event.data as Record<string, unknown>;
+        if (typeof rotationData?.newController === 'string') {
+          state.controller = rotationData.newController;
+        }
+        if (typeof rotationData?.rotatedAt === 'string') {
+          state.updatedAt = rotationData.rotatedAt;
         }
       } else if (event.type === 'deactivate') {
         state.deactivated = true;

--- a/packages/sdk/src/cel/layers/PeerCelManager.ts
+++ b/packages/sdk/src/cel/layers/PeerCelManager.ts
@@ -319,6 +319,7 @@ export class PeerCelManager {
       layer: isLegacy ? (createData.layer as 'peer') : 'peer',
       resources: [...(createData.resources ?? [])],
       creator: isLegacy ? createData.creator : createData.controller,
+      controller: createData.controller,
       createdAt: createData.createdAt,
       updatedAt: undefined,
       deactivated: false,
@@ -359,9 +360,54 @@ export class PeerCelManager {
             state.metadata[key] = value;
           }
         }
+      } else if (event.type === 'migrate') {
+        // First-class migration event: layer transition with the same payload
+        // fields legacy update-sniffed migrations carried.
+        const migrationData = event.data as Record<string, unknown>;
+        if (migrationData.targetDid !== undefined) {
+          state.did = migrationData.targetDid as string;
+        }
+        if (migrationData.layer !== undefined) {
+          state.layer = migrationData.layer as 'peer' | 'webvh' | 'btco';
+        }
+        if (migrationData.migratedAt !== undefined) {
+          state.updatedAt = migrationData.migratedAt as string;
+        }
+        state.metadata = state.metadata || {};
+        if (migrationData.sourceDid !== undefined) {
+          state.metadata.sourceDid = migrationData.sourceDid;
+        }
+        if (migrationData.domain !== undefined) {
+          state.metadata.domain = migrationData.domain;
+        }
+      } else if (event.type === 'transfer') {
+        // Ownership hand-off: surface the owners; identity (did) is unchanged.
+        const transferData = event.data as Record<string, unknown>;
+        if (transferData.transferredAt !== undefined) {
+          state.updatedAt = transferData.transferredAt as string;
+        }
+        state.metadata = state.metadata || {};
+        if (transferData.previousOwner !== undefined) {
+          state.metadata.previousOwner = transferData.previousOwner;
+        }
+        if (transferData.newOwner !== undefined) {
+          state.metadata.newOwner = transferData.newOwner;
+        }
+        if (transferData.txid !== undefined) {
+          state.metadata.txid = transferData.txid;
+        }
+      } else if (event.type === 'rotateKey') {
+        // Authority hand-off: the last rotation's newController is current.
+        const rotationData = event.data as Record<string, unknown>;
+        if (typeof rotationData?.newController === 'string') {
+          state.controller = rotationData.newController;
+        }
+        if (typeof rotationData?.rotatedAt === 'string') {
+          state.updatedAt = rotationData.rotatedAt;
+        }
       } else if (event.type === 'deactivate') {
         state.deactivated = true;
-        
+
         // Extract deactivation details
         const deactivateData = event.data as Record<string, unknown>;
         if (deactivateData.deactivatedAt !== undefined) {

--- a/packages/sdk/src/cel/layers/PeerCelManager.ts
+++ b/packages/sdk/src/cel/layers/PeerCelManager.ts
@@ -1,16 +1,20 @@
 /**
- * PeerCelManager - CEL Manager for did:peer Layer
- * 
- * Creates and manages Originals assets in the did:peer layer (Layer 0).
- * This is the initial layer for creating new assets with local control.
- * No witnesses are required at this layer.
- * 
- * @see https://identity.foundation/peer-did-method-spec/
+ * PeerCelManager - CEL Manager for the genesis (peer) layer
+ *
+ * Creates and manages Originals assets at the genesis layer (Layer 0).
+ * The asset's identity is a `did:cel` derived from the signed create event;
+ * the holder's key DID lives in the genesis `controller` field. No witnesses
+ * are required at this layer.
+ *
+ * Legacy logs whose genesis embeds a did:peer (`PeerAssetData`) remain
+ * readable on the update/getCurrentState paths.
  */
 
 import type { EventLog, ExternalReference, DataIntegrityProof, CreateOptions, UpdateOptions, AssetState } from '../types.js';
 import { createEventLog } from '../algorithms/createEventLog.js';
 import { updateEventLog } from '../algorithms/updateEventLog.js';
+import { deriveDidCel } from '../celDid.js';
+import { multibase } from '../../utils/encoding.js';
 
 /**
  * Configuration options for PeerCelManager
@@ -25,7 +29,30 @@ export interface PeerCelConfig {
 }
 
 /**
- * Asset data stored in the create event
+ * Genesis (create-event) data for a did:cel asset.
+ *
+ * The asset's identity (`did:cel`) is DERIVED FROM this event, so the event
+ * must NOT embed it. Identity, holder, and ownership are distinct axes:
+ * `controller` is the HOLDER's key DID (a `did:key`), never the asset DID.
+ * The `nonce` guarantees two otherwise-identical genesis events derive
+ * different DIDs.
+ */
+export interface CelAssetData {
+  /** Asset name */
+  name: string;
+  /** The holder's key DID (did:key) — distinct from the derived asset did:cel */
+  controller: string;
+  /** External resources associated with the asset */
+  resources: ExternalReference[];
+  /** ISO 8601 creation timestamp */
+  createdAt: string;
+  /** Multibase base64url of 16 random bytes — collision insurance for the derived DID */
+  nonce: string;
+}
+
+/**
+ * @deprecated Legacy genesis shape (pre-did:cel). Still readable on the verify
+ * and getCurrentState paths; the write path now emits {@link CelAssetData}.
  */
 export interface PeerAssetData {
   /** Asset name */
@@ -48,23 +75,23 @@ export interface PeerAssetData {
 export type CelSigner = (data: unknown) => Promise<DataIntegrityProof>;
 
 /**
- * PeerCelManager - Manages CEL-based assets in the did:peer layer
- * 
- * The peer layer is the initial layer for creating new Originals assets.
+ * PeerCelManager - Manages CEL-based assets at the genesis layer
+ *
+ * The genesis layer is the initial layer for creating new Originals assets.
  * Assets at this layer:
- * - Have a did:peer identifier
- * - Are controlled by the creator's key pair
+ * - Have a did:cel identifier derived from the signed create event
+ * - Are controlled by the holder's key pair (genesis `controller`)
  * - Do not require witnesses (empty witness array)
  * - Can be migrated to did:webvh or did:btco layers
- * 
+ *
  * @example
  * ```typescript
  * const manager = new PeerCelManager(async (data) => {
  *   // Sign with your private key
  *   return createEdDsaProof(data, privateKey);
  * });
- * 
- * const log = await manager.create('My Asset', [
+ *
+ * const { log, did } = await manager.create('My Asset', [
  *   { digestMultibase: 'uXYZ...', mediaType: 'image/png' }
  * ]);
  * ```
@@ -92,22 +119,27 @@ export class PeerCelManager {
   }
 
   /**
-   * Creates a new asset with a did:peer identifier and CEL event log
-   * 
+   * Creates a new asset: builds the de-self-referenced genesis event and
+   * derives the asset's `did:cel` from it.
+   *
    * This method:
-   * 1. Generates a new did:peer DID using the verification method from config
-   * 2. Creates a "create" event with the asset data
+   * 1. Determines the holder's `controller` DID from the signer/config
+   * 2. Creates a "create" event carrying {@link CelAssetData} (no asset DID —
+   *    identity is derived, not embedded)
    * 3. Signs the event using the provided signer
-   * 4. Returns an EventLog containing the initial create event
-   * 
+   * 4. Derives the `did:cel` from the signed genesis event
+   *
    * @param name - Human-readable name for the asset
    * @param resources - External resources associated with the asset
-   * @returns Promise resolving to an EventLog with the create event
-   * 
+   * @returns The genesis EventLog and the derived `did:cel`
+   *
    * @throws Error if signer produces invalid proof
-   * @throws Error if DID generation fails
+   * @throws Error if the controller cannot be determined
    */
-  async create(name: string, resources: ExternalReference[]): Promise<EventLog> {
+  async create(
+    name: string,
+    resources: ExternalReference[]
+  ): Promise<{ log: EventLog; did: string }> {
     // Validate inputs
     if (!name || typeof name !== 'string') {
       throw new Error('Asset name is required and must be a string');
@@ -116,137 +148,71 @@ export class PeerCelManager {
       throw new Error('Resources must be an array');
     }
 
-    // Generate did:peer DID for this asset
-    const did = await this.generatePeerDid();
+    // The holder's key DID — the asset DID is derived, never embedded here.
+    const controller = await this.resolveController();
 
-    // Prepare asset data for the create event
-    const assetData: PeerAssetData = {
+    // Prepare de-self-referenced genesis data. nonce = 'u' + base64url(16 bytes)
+    // so identical {name, controller, resources, createdAt} never collide.
+    const assetData: CelAssetData = {
       name,
-      did,
-      layer: 'peer',
+      controller,
       resources,
-      creator: did, // Creator is the same as asset DID for peer layer
       createdAt: new Date().toISOString(),
+      nonce: multibase.encode(crypto.getRandomValues(new Uint8Array(16)), 'base64url'),
     };
 
-    // Build create options
+    // Build create options. createEventLog signs over {type,data} only; the VM
+    // is set to the controller's canonical did:key VM for real signers.
     const createOptions: CreateOptions = {
       signer: this.signer,
-      verificationMethod: this.config.verificationMethod || `${did}#key-0`,
+      verificationMethod: this.config.verificationMethod || this.canonicalControllerVm(controller),
       proofPurpose: this.config.proofPurpose,
     };
 
-    // Create the event log with a create event
-    const eventLog = await createEventLog(assetData, createOptions);
+    // Create the event log, then derive the did:cel from the signed genesis.
+    const log = await createEventLog(assetData, createOptions);
+    const did = deriveDidCel(log);
 
-    return eventLog;
+    return { log, did };
   }
 
   /**
-   * Generates a new did:peer DID (numalgo 4 - long form)
-   * 
-   * Uses @aviarytech/did-peer library to create a numalgo 4 DID
-   * which embeds the full DID document for self-contained resolution.
-   * 
-   * @returns Promise resolving to a did:peer string
+   * Determines the holder's controller DID. Prefers `config.verificationMethod`;
+   * otherwise probes the signer for the verificationMethod it reports (the probe
+   * signature is discarded). The controller is the DID portion (before '#').
+   *
+   * A signing FAILURE propagates rather than being swallowed: an asset whose
+   * controller cannot be established is unusable, so failing loudly at creation
+   * time beats emitting a log that cannot be authored against.
    */
-  private async generatePeerDid(): Promise<string> {
-    // Dynamically import did-peer library
-    let didPeerMod: any;
-    try {
-      didPeerMod = await import('@aviarytech/did-peer');
-    } catch (err) {
+  private async resolveController(): Promise<string> {
+    const vm =
+      this.config.verificationMethod ?? (await this.discoverSignerVerificationMethod());
+    if (!vm) {
       throw new Error(
-        'Failed to import @aviarytech/did-peer. Make sure it is installed: npm install @aviarytech/did-peer'
+        'Cannot determine controller: no verificationMethod in config and the signer did not report one'
       );
     }
+    const hashIdx = vm.indexOf('#');
+    return hashIdx > 0 ? vm.slice(0, hashIdx) : vm;
+  }
 
-    // If we have a verification method with a public key, use it
-    // Otherwise, generate a placeholder DID using a random key
-    // In production, the signer's verification method should be used
-    
-    // For did:peer numalgo 4, we need a verification method
-    // The verification method should come from the config or be derived from the signer
-    
-    // Generate a DID using numalgo 4 (long-form with embedded DID document)
-    // We'll use a simple verification method structure
-    let publicKeyMultibase: string;
-    
-    // The did:peer:4 identifier is SELF-CERTIFYING: it embeds its DID
-    // document, so verification (verifyEventLog) requires the create event's
-    // signing key to be one of the embedded keys. The embedded key must
-    // therefore be the CONTROLLER's key, not a random one:
-    // 1. a did:key verificationMethod in config carries the key directly;
-    // 2. otherwise, discover the signer's key with a probe signature (the
-    //    signer reports its verificationMethod in every proof it produces);
-    // 3. only fall back to a random key when neither reveals a did:key —
-    //    such logs cannot pass the self-certifying binding check.
-    if (this.config.verificationMethod && this.config.verificationMethod.includes('did:key:')) {
-      // Extract the public key from did:key format
-      const keyMatch = this.config.verificationMethod.match(/did:key:(z[a-zA-Z0-9]+)/);
-      publicKeyMultibase = keyMatch ? keyMatch[1] : await this.generateRandomPublicKey();
-    } else {
-      publicKeyMultibase =
-        (await this.discoverSignerPublicKey()) ?? (await this.generateRandomPublicKey());
+  /** The controller's canonical verification method (`<did>#<key>` for did:key). */
+  private canonicalControllerVm(controller: string): string {
+    if (controller.startsWith('did:key:')) {
+      return `${controller}#${controller.slice('did:key:'.length)}`;
     }
-
-    // Create did:peer using numalgo 4. did:peer:4 is deterministic over the
-    // embedded document, so a document containing only the (reused) controller
-    // key would produce the SAME DID for every asset created with that key.
-    // A second, per-asset random verification method keeps each asset's DID
-    // unique while the controller key stays embedded for the self-certifying
-    // binding check.
-    const did: string = await didPeerMod.createNumAlgo4(
-      [
-        {
-          type: 'Multikey',
-          publicKeyMultibase,
-        },
-        {
-          type: 'Multikey',
-          publicKeyMultibase: await this.generateRandomPublicKey(),
-        }
-      ],
-      undefined, // services
-      undefined  // alsoKnownAs
-    );
-
-    return did;
+    return `${controller}#key-0`;
   }
 
   /**
-   * Discovers the signer's public multikey by asking it to sign a probe
-   * payload and reading the `did:key:` verificationMethod it reports on the
-   * resulting proof. The probe signature is discarded.
-   *
-   * Returns null only when the signer does not use a did:key verification
-   * method (its create proofs then aren't subject to the self-certifying
-   * binding check either). A signing FAILURE propagates: swallowing it would
-   * fall back to a random embedded key, and a did:key signer's create event
-   * would later fail verifyEventLog's binding check — a silently
-   * unverifiable asset instead of a clear error at creation time.
+   * Reads the verificationMethod the signer reports by asking it to sign a
+   * discarded probe payload. Returns null when the signer reports no string VM.
    */
-  private async discoverSignerPublicKey(): Promise<string | null> {
+  private async discoverSignerVerificationMethod(): Promise<string | null> {
     const probeProof = await this.signer({ type: 'originals-vm-discovery-probe' });
     const vm = probeProof?.verificationMethod;
-    const keyMatch = typeof vm === 'string' ? vm.match(/^did:key:(z[a-zA-Z0-9]+)/) : null;
-    return keyMatch ? keyMatch[1] : null;
-  }
-
-  /**
-   * Generates a random Ed25519 public key for DID creation
-   *
-   * @returns Promise resolving to a multibase-encoded public key
-   */
-  private async generateRandomPublicKey(): Promise<string> {
-    // Use @noble/ed25519 for key generation
-    const ed25519 = await import('@noble/ed25519');
-    const privateKeyBytes = ed25519.utils.randomSecretKey();
-    const publicKeyBytes = await (ed25519 as any).getPublicKeyAsync(privateKeyBytes);
-    
-    // Import multikey encoder
-    const { multikey } = await import('../../crypto/Multikey.js');
-    return multikey.encodePublicKey(publicKeyBytes as Uint8Array, 'Ed25519');
+    return typeof vm === 'string' ? vm : null;
   }
 
   /**
@@ -282,14 +248,18 @@ export class PeerCelManager {
       throw new Error('Cannot update a deactivated event log');
     }
 
-    // Get the DID from the create event for verification method construction
-    const createData = log.events[0].data as PeerAssetData;
-    const did = createData.did;
+    // Derive the fallback verification method from the create event. New-shape
+    // logs must NOT fall back to `did:cel:...#key-0` (unresolvable) — use the
+    // controller's canonical did:key VM; legacy logs keep the old expression.
+    const createData = log.events[0].data as Partial<CelAssetData & PeerAssetData>;
+    const fallbackVm = createData.controller
+      ? this.canonicalControllerVm(createData.controller)
+      : `${createData.did}#key-0`;
 
     // Build update options using the same signer
     const updateOptions: UpdateOptions = {
       signer: this.signer,
-      verificationMethod: this.config.verificationMethod || `${did}#key-0`,
+      verificationMethod: this.config.verificationMethod || fallbackVm,
       proofPurpose: this.config.proofPurpose,
     };
 
@@ -336,16 +306,19 @@ export class PeerCelManager {
       throw new Error('First event must be a create event');
     }
 
-    // Extract initial state from create event
-    const createData = createEvent.data as PeerAssetData;
-    
+    // Dual-read the genesis. New shape (`controller` present): the asset DID is
+    // derived (did:cel), `creator` is sourced from the controller, layer is
+    // definitionally 'peer'. Legacy shape (`did` present): read verbatim.
+    const createData = createEvent.data as Partial<CelAssetData & PeerAssetData>;
+    const isLegacy = createData.controller === undefined && createData.did !== undefined;
+
     // Initialize state from create event
     const state: AssetState = {
-      did: createData.did,
-      name: createData.name,
-      layer: createData.layer,
-      resources: [...createData.resources],
-      creator: createData.creator,
+      did: isLegacy ? (createData.did as string) : deriveDidCel(log),
+      name: createData.name as string,
+      layer: isLegacy ? (createData.layer as 'peer') : 'peer',
+      resources: [...(createData.resources ?? [])],
+      creator: isLegacy ? createData.creator : createData.controller,
       createdAt: createData.createdAt,
       updatedAt: undefined,
       deactivated: false,
@@ -370,10 +343,12 @@ export class PeerCelManager {
         if (updateData.updatedAt !== undefined) {
           state.updatedAt = updateData.updatedAt as string;
         }
-        if (updateData.did !== undefined) {
+        // did/layer overrides are a legacy-log affordance only: new-shape logs
+        // derive identity from the genesis (did:cel) and never rewrite it here.
+        if (isLegacy && updateData.did !== undefined) {
           state.did = updateData.did as string;
         }
-        if (updateData.layer !== undefined) {
+        if (isLegacy && updateData.layer !== undefined) {
           state.layer = updateData.layer as 'peer' | 'webvh' | 'btco';
         }
         

--- a/packages/sdk/src/cel/layers/WebVHCelManager.ts
+++ b/packages/sdk/src/cel/layers/WebVHCelManager.ts
@@ -15,6 +15,7 @@ import { updateEventLog } from '../algorithms/updateEventLog.js';
 import { witnessEvent } from '../algorithms/witnessEvent.js';
 import type { WitnessService } from '../witnesses/WitnessService.js';
 import type { CelSigner } from './PeerCelManager.js';
+import { deriveDidCel } from '../celDid.js';
 
 /**
  * Configuration options for WebVHCelManager
@@ -136,10 +137,14 @@ export class WebVHCelManager {
       throw new Error('First event must be a create event');
     }
 
-    // Extract source data
+    // Extract source data. Dual-read: a new-shape genesis (`controller`
+    // present) derives its identity from the event — the did:cel IS the
+    // source; a legacy genesis embeds `did` and is read verbatim.
     const createData = createEvent.data as Record<string, unknown>;
-    const sourceDid = createData.did as string;
-    
+    const sourceDid = createData.controller !== undefined
+      ? deriveDidCel(peerLog)
+      : (createData.did as string);
+
     if (!sourceDid) {
       throw new Error('Create event must have a did field');
     }

--- a/packages/sdk/src/cel/layers/WebVHCelManager.ts
+++ b/packages/sdk/src/cel/layers/WebVHCelManager.ts
@@ -11,7 +11,7 @@
  */
 
 import type { EventLog, ExternalReference, UpdateOptions, AssetState } from '../types.js';
-import { updateEventLog } from '../algorithms/updateEventLog.js';
+import { appendEvent } from '../algorithms/appendEvent.js';
 import { witnessEvent } from '../algorithms/witnessEvent.js';
 import type { WitnessService } from '../witnesses/WitnessService.js';
 import type { CelSigner } from './PeerCelManager.js';
@@ -180,8 +180,8 @@ export class WebVHCelManager {
       proofPurpose: this.config.proofPurpose,
     };
 
-    // Create the update event with migration data
-    let updatedLog = await updateEventLog(peerLog, migrationData, updateOptions);
+    // Append the first-class migrate event with the migration data
+    let updatedLog = await appendEvent(peerLog, 'migrate', migrationData, updateOptions);
 
     // Add witness proofs if witnesses are configured
     if (this.witnesses.length > 0) {
@@ -227,6 +227,11 @@ export class WebVHCelManager {
       const peerPart = sourceDid.replace('did:peer:', '');
       // Take first 32 chars of the peer DID identifier for brevity
       idPart = peerPart.substring(0, Math.min(32, peerPart.length));
+    } else if (sourceDid.startsWith('did:cel:')) {
+      // did:cel suffix is a base64url digest (already URL-safe); truncate it
+      // exactly the way the did:peer branch truncates its identifier.
+      const celPart = sourceDid.replace('did:cel:', '');
+      idPart = celPart.substring(0, Math.min(32, celPart.length));
     } else if (sourceDid.startsWith('did:key:')) {
       // For key DIDs, extract the key portion
       idPart = sourceDid.replace('did:key:', '').substring(0, 32);
@@ -273,16 +278,21 @@ export class WebVHCelManager {
       throw new Error('First event must be a create event');
     }
 
-    // Extract initial state from create event
+    // Extract initial state from create event. Dual-read the genesis: a
+    // new-shape genesis (`controller` present) derives its identity (did:cel)
+    // and sources the creator from the controller; a legacy genesis embeds
+    // `did`/`creator` and is read verbatim.
     const createData = createEvent.data as Record<string, unknown>;
-    
+    const isLegacyGenesis = createData.controller === undefined && createData.did !== undefined;
+
     // Initialize state from create event
     const state: AssetState = {
-      did: createData.did as string,
+      did: isLegacyGenesis ? (createData.did as string) : deriveDidCel(log),
       name: createData.name as string | undefined,
       layer: (createData.layer as 'peer' | 'webvh' | 'btco') || 'peer',
       resources: (createData.resources as ExternalReference[]) || [],
-      creator: createData.creator as string | undefined,
+      creator: (createData.creator as string | undefined) ?? (createData.controller as string | undefined),
+      controller: createData.controller as string | undefined,
       createdAt: createData.createdAt as string | undefined,
       updatedAt: undefined,
       deactivated: false,
@@ -293,15 +303,17 @@ export class WebVHCelManager {
     for (let i = 1; i < log.events.length; i++) {
       const event = log.events[i];
 
-      if (event.type === 'update') {
+      if (event.type === 'update' || event.type === 'migrate') {
         const updateData = event.data as Record<string, unknown>;
-        
-        // Check if this is a migration event. Detect via sourceDid + layer
-        // (present on BOTH webvh and btco migrations) rather than targetDid
-        // (webvh-only): keying off targetDid would misclassify a btco
-        // migration as a regular update. Mirrors OriginalsCel.getCurrentLayer
-        // and BtcoCelManager.getCurrentState.
-        if (updateData.sourceDid && updateData.layer && updateData.migratedAt) {
+
+        // Type-first: first-class 'migrate' events are migrations by type.
+        // Legacy logs record migrations as 'update' events — the sniff via
+        // sourceDid + layer (present on BOTH webvh and btco migrations)
+        // rather than targetDid (webvh-only) is kept verbatim as fallback:
+        // keying off targetDid would misclassify a btco migration as a
+        // regular update. Mirrors OriginalsCel.getCurrentLayer and
+        // BtcoCelManager.getCurrentState.
+        if (event.type === 'migrate' || (updateData.sourceDid && updateData.layer && updateData.migratedAt)) {
           // Migration event - update DID and layer
           if (updateData.targetDid) {
             state.did = updateData.targetDid as string;
@@ -338,6 +350,31 @@ export class WebVHCelManager {
             state.metadata = state.metadata || {};
             state.metadata[key] = value;
           }
+        }
+      } else if (event.type === 'transfer') {
+        // Ownership hand-off: surface the owners; identity (did) is unchanged.
+        const transferData = event.data as Record<string, unknown>;
+        if (transferData.transferredAt !== undefined) {
+          state.updatedAt = transferData.transferredAt as string;
+        }
+        state.metadata = state.metadata || {};
+        if (transferData.previousOwner !== undefined) {
+          state.metadata.previousOwner = transferData.previousOwner;
+        }
+        if (transferData.newOwner !== undefined) {
+          state.metadata.newOwner = transferData.newOwner;
+        }
+        if (transferData.txid !== undefined) {
+          state.metadata.txid = transferData.txid;
+        }
+      } else if (event.type === 'rotateKey') {
+        // Authority hand-off: the last rotation's newController is current.
+        const rotationData = event.data as Record<string, unknown>;
+        if (typeof rotationData?.newController === 'string') {
+          state.controller = rotationData.newController;
+        }
+        if (typeof rotationData?.rotatedAt === 'string') {
+          state.updatedAt = rotationData.rotatedAt;
         }
       } else if (event.type === 'deactivate') {
         state.deactivated = true;

--- a/packages/sdk/src/cel/serialization/cbor.ts
+++ b/packages/sdk/src/cel/serialization/cbor.ts
@@ -82,7 +82,7 @@ function parseEntry(entry: unknown): LogEntry {
   const e = entry as Record<string, unknown>;
   
   // Validate type
-  if (e.type !== 'create' && e.type !== 'update' && e.type !== 'deactivate') {
+  if (e.type !== 'create' && e.type !== 'update' && e.type !== 'deactivate' && e.type !== 'migrate' && e.type !== 'transfer' && e.type !== 'rotateKey') {
     throw new Error(`Invalid entry type: ${e.type}`);
   }
   

--- a/packages/sdk/src/cel/serialization/json.ts
+++ b/packages/sdk/src/cel/serialization/json.ts
@@ -131,7 +131,7 @@ function parseEntry(entry: unknown): LogEntry {
   const e = entry as Record<string, unknown>;
   
   // Validate type
-  if (e.type !== 'create' && e.type !== 'update' && e.type !== 'deactivate') {
+  if (e.type !== 'create' && e.type !== 'update' && e.type !== 'deactivate' && e.type !== 'migrate' && e.type !== 'transfer' && e.type !== 'rotateKey') {
     throw new Error(`Invalid entry type: ${e.type}`);
   }
   

--- a/packages/sdk/src/cel/types.ts
+++ b/packages/sdk/src/cel/types.ts
@@ -107,6 +107,7 @@ export interface VerificationResult {
    * The asset DID this log backs, when derivable from the genesis event:
    * the DERIVED `did:cel:<digest>` for new-shape (`data.controller`) logs, or
    * the declared `data.did` for legacy logs. Absent for shapeless logs.
+   * Informational: it is a trust statement only when `verified` is true.
    */
   assetDid?: string;
 }

--- a/packages/sdk/src/cel/types.ts
+++ b/packages/sdk/src/cel/types.ts
@@ -196,6 +196,8 @@ export interface AssetState {
   resources: ExternalReference[];
   /** Creator DID */
   creator?: string;
+  /** Current controller key DID: genesis `controller`, handed off by rotateKey */
+  controller?: string;
   /** Creation timestamp */
   createdAt?: string;
   /** Last update timestamp */

--- a/packages/sdk/src/cel/types.ts
+++ b/packages/sdk/src/cel/types.ts
@@ -34,7 +34,7 @@ export interface ExternalReference {
 /**
  * Event type for log entries
  */
-export type EventType = 'create' | 'update' | 'deactivate';
+export type EventType = 'create' | 'update' | 'deactivate' | 'migrate' | 'transfer' | 'rotateKey';
 
 /**
  * Log Entry - a single event in the cryptographic event log

--- a/packages/sdk/src/cel/types.ts
+++ b/packages/sdk/src/cel/types.ts
@@ -103,6 +103,12 @@ export interface VerificationResult {
   errors: string[];
   /** Per-event verification details */
   events: EventVerification[];
+  /**
+   * The asset DID this log backs, when derivable from the genesis event:
+   * the DERIVED `did:cel:<digest>` for new-shape (`data.controller`) logs, or
+   * the declared `data.did` for legacy logs. Absent for shapeless logs.
+   */
+  assetDid?: string;
 }
 
 /**
@@ -166,6 +172,13 @@ export interface VerifyOptions {
    * `verifier` path, where the caller owns proof semantics.)
    */
   ordinalsProvider?: OrdinalsLookup;
+  /**
+   * When set, the log must back this exact asset DID or verification fails.
+   * did:cel expected DIDs are compared via suffix derivation
+   * (`didCelMatchesLog`); legacy DIDs by string equality against `data.did`.
+   * Ignored on the custom `verifier` path (which owns proof semantics).
+   */
+  expectedDid?: string;
 }
 
 /**

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -232,7 +232,12 @@ export {
   createExternalReference,
   verifyExternalReference,
 } from './cel/ExternalReferenceManager.js';
-export { PeerCelManager } from './cel/layers/PeerCelManager.js';
+export {
+  PeerCelManager,
+  type CelAssetData,
+  type PeerAssetData,
+  type PeerCelConfig,
+} from './cel/layers/PeerCelManager.js';
 export { WebVHCelManager } from './cel/layers/WebVHCelManager.js';
 export { BtcoCelManager } from './cel/layers/BtcoCelManager.js';
 export type { WitnessService } from './cel/witnesses/WitnessService.js';

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -222,6 +222,13 @@ export {
 } from './cel/hash.js';
 export { witnessSigningBytes } from './cel/canonicalize.js';
 export {
+  DID_CEL_PREFIX,
+  deriveDidCel,
+  deriveDidCelFromGenesis,
+  isDidCel,
+  didCelMatchesLog,
+} from './cel/celDid.js';
+export {
   createExternalReference,
   verifyExternalReference,
 } from './cel/ExternalReferenceManager.js';

--- a/packages/sdk/tests/integration/cel-lifecycle.test.ts
+++ b/packages/sdk/tests/integration/cel-lifecycle.test.ts
@@ -167,7 +167,7 @@ describe('Integration: CEL Lifecycle', () => {
       
       // Validate migration event was added
       expect(webvhLog.events).toHaveLength(2);
-      expect(webvhLog.events[1].type).toBe('update'); // Migration is an update event
+      expect(webvhLog.events[1].type).toBe('migrate'); // Migration is a first-class event
       
       const migrationData = webvhLog.events[1].data as Record<string, unknown>;
       expect(migrationData.layer).toBe('webvh');

--- a/packages/sdk/tests/integration/cel-lifecycle.test.ts
+++ b/packages/sdk/tests/integration/cel-lifecycle.test.ts
@@ -81,7 +81,7 @@ describe('Integration: CEL Lifecycle', () => {
     test('create peer asset, update, then verify passes', async () => {
       // Step 1: Create a new asset at peer layer
       const resources = [createTestResource('asset1')];
-      const log = await peerManager.create('My Test Asset', resources);
+      const { log } = await peerManager.create('My Test Asset', resources);
       
       // Validate create event structure
       expect(log.events).toHaveLength(1);
@@ -92,8 +92,11 @@ describe('Integration: CEL Lifecycle', () => {
       
       const createData = log.events[0].data as Record<string, unknown>;
       expect(createData.name).toBe('My Test Asset');
-      expect(createData.layer).toBe('peer');
-      expect(createData.did).toMatch(/^did:peer:/);
+      // De-self-referenced genesis: identity is derived (did:cel), not embedded
+      expect(createData.did).toBeUndefined();
+      expect(createData.layer).toBeUndefined();
+      expect(typeof createData.controller).toBe('string');
+      expect(typeof createData.nonce).toBe('string');
 
       // Step 2: Update the asset
       const updatedLog = await peerManager.update(log, {
@@ -126,7 +129,7 @@ describe('Integration: CEL Lifecycle', () => {
 
     test('multiple sequential updates maintain valid hash chain', async () => {
       // Create initial asset
-      const log = await peerManager.create('Multi-Update Asset', [createTestResource()]);
+      const { log } = await peerManager.create('Multi-Update Asset', [createTestResource()]);
       
       // Apply multiple updates
       let currentLog = log;
@@ -156,7 +159,7 @@ describe('Integration: CEL Lifecycle', () => {
   describe('Migration: peer → webvh', () => {
     test('migrate peer to webvh adds migration event', async () => {
       // Create a peer asset
-      const peerLog = await peerManager.create('Migratable Asset', [createTestResource('migrate')]);
+      const { log: peerLog } = await peerManager.create('Migratable Asset', [createTestResource('migrate')]);
       
       // Create webvh manager and migrate
       const webvhManager = new WebVHCelManager(signer, 'example.com');
@@ -168,7 +171,7 @@ describe('Integration: CEL Lifecycle', () => {
       
       const migrationData = webvhLog.events[1].data as Record<string, unknown>;
       expect(migrationData.layer).toBe('webvh');
-      expect(migrationData.sourceDid).toMatch(/^did:peer:/);
+      expect(migrationData.sourceDid).toMatch(/^did:cel:/);
       expect(migrationData.targetDid).toMatch(/^did:webvh:example\.com:/);
       expect(migrationData.domain).toBe('example.com');
       expect(migrationData.migratedAt).toBeDefined();
@@ -186,14 +189,15 @@ describe('Integration: CEL Lifecycle', () => {
       const originalName = 'Preserved Asset Name';
       const resources = [createTestResource('preserved')];
       
-      const peerLog = await peerManager.create(originalName, resources);
+      const { log: peerLog } = await peerManager.create(originalName, resources);
       const webvhManager = new WebVHCelManager(signer, 'test.domain.com');
       const webvhLog = await webvhManager.migrate(peerLog);
       
       // Original create event should be unchanged
       const createData = webvhLog.events[0].data as Record<string, unknown>;
       expect(createData.name).toBe(originalName);
-      expect(createData.layer).toBe('peer');
+      expect(createData.layer).toBeUndefined();
+      expect(typeof createData.controller).toBe('string');
       
       // getCurrentState should reflect migration
       const state = webvhManager.getCurrentState(webvhLog);
@@ -206,7 +210,7 @@ describe('Integration: CEL Lifecycle', () => {
   describe('Tampered log detection', () => {
     test('tampered log verification fails with specific error', async () => {
       // Create a valid log
-      const log = await peerManager.create('Tamperable Asset', [createTestResource()]);
+      const { log } = await peerManager.create('Tamperable Asset', [createTestResource()]);
       const updatedLog = await peerManager.update(log, { value: 'original' });
       
       // Verify original is valid
@@ -262,7 +266,7 @@ describe('Integration: CEL Lifecycle', () => {
     });
 
     test('missing proof array causes verification failure', async () => {
-      const log = await peerManager.create('No Proof Asset', [createTestResource()]);
+      const { log } = await peerManager.create('No Proof Asset', [createTestResource()]);
       
       // Remove proof array from event
       const noProofLog: EventLog = {
@@ -282,7 +286,7 @@ describe('Integration: CEL Lifecycle', () => {
   describe('Hash chain integrity', () => {
     test('broken hash chain verification fails', async () => {
       // Create a log with multiple events
-      const log = await peerManager.create('Chain Test Asset', [createTestResource()]);
+      const { log } = await peerManager.create('Chain Test Asset', [createTestResource()]);
       const log2 = await peerManager.update(log, { step: 1 });
       const log3 = await peerManager.update(log2, { step: 2 });
       
@@ -313,7 +317,7 @@ describe('Integration: CEL Lifecycle', () => {
     });
 
     test('first event with previousEvent causes verification failure', async () => {
-      const log = await peerManager.create('First Event Test', [createTestResource()]);
+      const { log } = await peerManager.create('First Event Test', [createTestResource()]);
       
       // Add previousEvent to first event (which should not have one)
       const badFirstEventLog: EventLog = {
@@ -333,7 +337,7 @@ describe('Integration: CEL Lifecycle', () => {
     });
 
     test('second event missing previousEvent causes verification failure', async () => {
-      const log = await peerManager.create('Missing Link Test', [createTestResource()]);
+      const { log } = await peerManager.create('Missing Link Test', [createTestResource()]);
       const updatedLog = await peerManager.update(log, { value: 1 });
       
       // Remove previousEvent from second event
@@ -360,7 +364,7 @@ describe('Integration: CEL Lifecycle', () => {
   describe('Deactivation seals log', () => {
     test('deactivate seals log - further updates rejected', async () => {
       // Create and update an asset
-      const log = await peerManager.create('Deactivatable Asset', [createTestResource()]);
+      const { log } = await peerManager.create('Deactivatable Asset', [createTestResource()]);
       const updatedLog = await peerManager.update(log, { preDeactivate: true });
       
       // Deactivate the log
@@ -401,7 +405,7 @@ describe('Integration: CEL Lifecycle', () => {
     });
 
     test('deactivated log state reflects deactivation', async () => {
-      const log = await peerManager.create('State Test Asset', [createTestResource()]);
+      const { log } = await peerManager.create('State Test Asset', [createTestResource()]);
       const deactivatedLog = await deactivateEventLog(
         log,
         'Testing state reflection',
@@ -417,7 +421,7 @@ describe('Integration: CEL Lifecycle', () => {
     });
 
     test('cannot migrate deactivated log', async () => {
-      const peerLog = await peerManager.create('Unmigrateable Asset', [createTestResource()]);
+      const { log: peerLog } = await peerManager.create('Unmigrateable Asset', [createTestResource()]);
       const deactivatedLog = await deactivateEventLog(
         peerLog,
         'Blocking migration',
@@ -440,7 +444,7 @@ describe('Integration: CEL Lifecycle', () => {
       });
       
       // Create asset
-      const log = await cel.create('Unified SDK Asset', [createTestResource()]);
+      const { log } = await cel.create('Unified SDK Asset', [createTestResource()]);
       expect(log.events[0].type).toBe('create');
       
       // Update asset
@@ -469,7 +473,7 @@ describe('Integration: CEL Lifecycle', () => {
       });
       
       // Create at peer layer
-      const peerLog = await cel.create('Migrate via Unified', [createTestResource()]);
+      const { log: peerLog } = await cel.create('Migrate via Unified', [createTestResource()]);
       
       // Migrate to webvh
       const webvhLog = await cel.migrate(peerLog, 'webvh');

--- a/packages/sdk/tests/unit/cel/BtcoCelManager.test.ts
+++ b/packages/sdk/tests/unit/cel/BtcoCelManager.test.ts
@@ -125,7 +125,68 @@ describe('BtcoCelManager', () => {
       const btcoLog = await manager.migrate(webvhLog);
 
       const migrationEvent = btcoLog.events[2];
-      expect(migrationEvent.type).toBe('update');
+      expect(migrationEvent.type).toBe('migrate');
+    });
+
+    it('emits a first-class migrate event carrying the migration payload', async () => {
+      const webvhLog = await createWebvhLog();
+      const btcoLog = await manager.migrate(webvhLog);
+
+      const migrationEvent = btcoLog.events.at(-1)!;
+      expect(migrationEvent.type).toBe('migrate');
+
+      const data = migrationEvent.data as Record<string, unknown>;
+      expect(data.sourceDid).toMatch(/^did:webvh:/);
+      expect(data.layer).toBe('btco');
+      expect(data.migratedAt).toBeDefined();
+      expect((data as { type?: unknown }).type).toBeUndefined();
+    });
+
+    it('migrates a log whose webvh migration is a legacy update event (sniff kept)', async () => {
+      // Old fixture logs record the peer→webvh migration as an 'update' event;
+      // the btco migration detection must keep recognising them.
+      const mockProof = {
+        type: 'DataIntegrityProof',
+        cryptosuite: 'eddsa-jcs-2022',
+        created: '2020-01-01T00:00:00.000Z',
+        verificationMethod: 'did:key:zLegacy#key-0',
+        proofPurpose: 'assertionMethod',
+        proofValue: 'zLegacy',
+      };
+      const legacyWebvhLog: EventLog = {
+        events: [
+          {
+            type: 'create',
+            data: {
+              name: 'Legacy Asset',
+              did: 'did:peer:4zLegacyDid',
+              layer: 'peer',
+              resources: [],
+              creator: 'did:peer:4zLegacyDid',
+              createdAt: '2020-01-01T00:00:00.000Z',
+            },
+            proof: [mockProof],
+          },
+          {
+            type: 'update',
+            data: {
+              sourceDid: 'did:peer:4zLegacyDid',
+              targetDid: 'did:webvh:example.com:legacy',
+              layer: 'webvh',
+              domain: 'example.com',
+              migratedAt: '2020-01-02T00:00:00.000Z',
+            },
+            previousEvent: 'uLegacyDigest',
+            proof: [mockProof],
+          },
+        ],
+      };
+
+      const btcoLog = await manager.migrate(legacyWebvhLog);
+      const migrationData = btcoLog.events.at(-1)!.data as Record<string, unknown>;
+      expect(btcoLog.events.at(-1)!.type).toBe('migrate');
+      expect(migrationData.sourceDid).toBe('did:webvh:example.com:legacy');
+      expect(migrationData.layer).toBe('btco');
     });
 
     it('should include sourceDid in migration data', async () => {
@@ -459,6 +520,74 @@ describe('BtcoCelManager', () => {
       expect(state.deactivated).toBe(false);
     });
 
+    it('replays a fully legacy btco log (update-sniffed migrations)', () => {
+      // Old fixture logs record migrations as 'update' events; replay must keep
+      // deriving the did:btco identifier from the witness proof + signed network.
+      const mockProof = {
+        type: 'DataIntegrityProof',
+        cryptosuite: 'eddsa-jcs-2022',
+        created: '2020-01-01T00:00:00.000Z',
+        verificationMethod: 'did:key:zLegacy#key-0',
+        proofPurpose: 'assertionMethod',
+        proofValue: 'zLegacy',
+      };
+      const legacyBtcoLog: EventLog = {
+        events: [
+          {
+            type: 'create',
+            data: {
+              name: 'Legacy Asset',
+              did: 'did:peer:4zLegacyDid',
+              layer: 'peer',
+              resources: [],
+              creator: 'did:peer:4zLegacyDid',
+              createdAt: '2020-01-01T00:00:00.000Z',
+            },
+            proof: [mockProof],
+          },
+          {
+            type: 'update',
+            data: {
+              sourceDid: 'did:peer:4zLegacyDid',
+              targetDid: 'did:webvh:example.com:legacy',
+              layer: 'webvh',
+              domain: 'example.com',
+              migratedAt: '2020-01-02T00:00:00.000Z',
+            },
+            previousEvent: 'uLegacy1',
+            proof: [mockProof],
+          },
+          {
+            type: 'update',
+            data: {
+              sourceDid: 'did:webvh:example.com:legacy',
+              layer: 'btco',
+              network: 'mainnet',
+              migratedAt: '2020-01-03T00:00:00.000Z',
+            },
+            previousEvent: 'uLegacy2',
+            proof: [
+              mockProof,
+              {
+                ...mockProof,
+                cryptosuite: 'bitcoin-ordinals-2024',
+                txid: 'legacytxid',
+                inscriptionId: 'legacytxidi0',
+                satoshi: '5555555555',
+                witnessedAt: '2020-01-03T00:00:00.000Z',
+              },
+            ],
+          },
+        ],
+      };
+
+      const state = manager.getCurrentState(legacyBtcoLog);
+      expect(state.layer).toBe('btco');
+      expect(state.did).toBe('did:btco:5555555555');
+      expect(state.metadata?.txid).toBe('legacytxid');
+      expect(state.metadata?.sourceDid).toBe('did:webvh:example.com:legacy');
+    });
+
     it('should throw for empty log', () => {
       expect(() => manager.getCurrentState({ events: [] })).toThrow(
         'Cannot get state from an empty event log'
@@ -543,12 +672,12 @@ describe('BtcoCelManager', () => {
       expect(btcoLog.events[0].type).toBe('create');
       expect(btcoLog.events[0].previousEvent).toBeUndefined();
 
-      // Second event: webvh migration
-      expect(btcoLog.events[1].type).toBe('update');
+      // Second event: webvh migration (first-class type)
+      expect(btcoLog.events[1].type).toBe('migrate');
       expect(btcoLog.events[1].previousEvent).toBeDefined();
 
-      // Third event: btco migration
-      expect(btcoLog.events[2].type).toBe('update');
+      // Third event: btco migration (first-class type)
+      expect(btcoLog.events[2].type).toBe('migrate');
       expect(btcoLog.events[2].previousEvent).toBeDefined();
     });
 

--- a/packages/sdk/tests/unit/cel/BtcoCelManager.test.ts
+++ b/packages/sdk/tests/unit/cel/BtcoCelManager.test.ts
@@ -42,7 +42,7 @@ const createFailingBitcoinManager = (): BitcoinManager => ({
 // Helper to create a webvh layer log for testing
 const createWebvhLog = async (): Promise<EventLog> => {
   const peerManager = new PeerCelManager(createMockSigner());
-  const peerLog = await peerManager.create('Test Asset', [
+  const { log: peerLog } = await peerManager.create('Test Asset', [
     { digestMultibase: 'uTestHash123', mediaType: 'image/png' },
   ]);
   
@@ -53,9 +53,9 @@ const createWebvhLog = async (): Promise<EventLog> => {
 // Helper to create a peer layer log for testing
 const createPeerLog = async (): Promise<EventLog> => {
   const peerManager = new PeerCelManager(createMockSigner());
-  return peerManager.create('Test Asset', [
+  return (await peerManager.create('Test Asset', [
     { digestMultibase: 'uTestHash123', mediaType: 'image/png' },
-  ]);
+  ])).log;
 };
 
 
@@ -485,7 +485,7 @@ describe('BtcoCelManager', () => {
     it('should complete full migration cycle', async () => {
       // Create peer asset
       const peerManager = new PeerCelManager(createMockSigner());
-      const peerLog = await peerManager.create('My Artwork', [
+      const { log: peerLog } = await peerManager.create('My Artwork', [
         { digestMultibase: 'uArtworkHash', mediaType: 'image/jpeg' },
       ]);
 
@@ -522,7 +522,7 @@ describe('BtcoCelManager', () => {
         { digestMultibase: 'uHash1', mediaType: 'image/png' },
         { digestMultibase: 'uHash2', mediaType: 'video/mp4' },
       ];
-      const peerLog = await peerManager.create('Multi-Resource', resources);
+      const { log: peerLog } = await peerManager.create('Multi-Resource', resources);
 
       const webvhManager = new WebVHCelManager(createMockSigner(), 'example.com');
       const webvhLog = await webvhManager.migrate(peerLog);

--- a/packages/sdk/tests/unit/cel/OriginalsCel.test.ts
+++ b/packages/sdk/tests/unit/cel/OriginalsCel.test.ts
@@ -427,12 +427,83 @@ describe('OriginalsCel', () => {
       const migrated = await cel.migrate(log, 'webvh');
 
       expect(migrated.events).toHaveLength(2);
-      expect(migrated.events[1].type).toBe('update');
-      
+      expect(migrated.events[1].type).toBe('migrate');
+
       const data = migrated.events[1].data as any;
       expect(data.layer).toBe('webvh');
       expect(data.targetDid).toMatch(/^did:webvh:/);
       expect(data.domain).toBe('example.com');
+    });
+
+    it('detects the layer from first-class migrate events', async () => {
+      const cel = new OriginalsCel({
+        layer: 'peer',
+        signer: mockSigner,
+        config: { webvh: { domain: 'example.com' } },
+      });
+
+      const { log } = await cel.create('Test', []);
+      const migrated = await cel.migrate(log, 'webvh');
+
+      expect(migrated.events.at(-1)!.type).toBe('migrate');
+      expect(cel.getCurrentState(migrated).layer).toBe('webvh');
+      // getCurrentLayer must read the typed event: already-at guard fires.
+      await expect(cel.migrate(migrated, 'webvh')).rejects.toThrow(
+        'Log is already at webvh layer'
+      );
+    });
+
+    it('still detects the layer from a legacy update-sniffed migration log', async () => {
+      // Old fixture logs record migrations as 'update' events carrying
+      // sourceDid+layer+migratedAt; they must keep reporting their layer.
+      const cel = new OriginalsCel({
+        layer: 'peer',
+        signer: mockSigner,
+        config: { webvh: { domain: 'example.com' } },
+      });
+      const mockProof = {
+        type: 'DataIntegrityProof',
+        cryptosuite: 'eddsa-jcs-2022',
+        created: '2020-01-01T00:00:00.000Z',
+        verificationMethod: 'did:key:zLegacy#key-0',
+        proofPurpose: 'assertionMethod',
+        proofValue: 'zLegacy',
+      };
+      const legacyLog: EventLog = {
+        events: [
+          {
+            type: 'create',
+            data: {
+              name: 'Legacy Asset',
+              did: 'did:peer:4zLegacyDid',
+              layer: 'peer',
+              resources: [],
+              creator: 'did:peer:4zLegacyDid',
+              createdAt: '2020-01-01T00:00:00.000Z',
+            },
+            proof: [mockProof],
+          },
+          {
+            type: 'update',
+            data: {
+              sourceDid: 'did:peer:4zLegacyDid',
+              targetDid: 'did:webvh:example.com:legacy',
+              layer: 'webvh',
+              domain: 'example.com',
+              migratedAt: '2020-01-02T00:00:00.000Z',
+            },
+            previousEvent: 'uLegacyDigest',
+            proof: [mockProof],
+          },
+        ],
+      };
+
+      const state = cel.getCurrentState(legacyLog);
+      expect(state.layer).toBe('webvh');
+      expect(state.did).toBe('did:webvh:example.com:legacy');
+      await expect(cel.migrate(legacyLog, 'webvh')).rejects.toThrow(
+        'Log is already at webvh layer'
+      );
     });
 
     it('throws error for migration to same layer', async () => {

--- a/packages/sdk/tests/unit/cel/OriginalsCel.test.ts
+++ b/packages/sdk/tests/unit/cel/OriginalsCel.test.ts
@@ -166,7 +166,7 @@ describe('OriginalsCel', () => {
         },
       ];
 
-      const log = await cel.create('Test Asset', resources);
+      const { log } = await cel.create('Test Asset', resources);
 
       expect(log).toBeDefined();
       expect(log.events).toHaveLength(1);
@@ -174,7 +174,10 @@ describe('OriginalsCel', () => {
       
       const data = log.events[0].data as any;
       expect(data.name).toBe('Test Asset');
-      expect(data.layer).toBe('peer');
+      // De-self-referenced genesis: no embedded did/layer, holder in controller
+      expect(data.did).toBeUndefined();
+      expect(data.layer).toBeUndefined();
+      expect(typeof data.controller).toBe('string');
       expect(data.resources).toHaveLength(1);
     });
 
@@ -194,16 +197,17 @@ describe('OriginalsCel', () => {
       );
     });
 
-    it('generates did:peer DID for new assets', async () => {
+    it('returns a derived did:cel for new assets', async () => {
       const cel = new OriginalsCel({
         layer: 'peer',
         signer: mockSigner,
       });
 
-      const log = await cel.create('Test', []);
+      const { log, did } = await cel.create('Test', []);
       const data = log.events[0].data as any;
 
-      expect(data.did).toMatch(/^did:peer:/);
+      expect(did).toMatch(/^did:cel:u/);
+      expect(data.did).toBeUndefined();
     });
 
     it('includes proof in create event', async () => {
@@ -212,7 +216,7 @@ describe('OriginalsCel', () => {
         signer: mockSigner,
       });
 
-      const log = await cel.create('Test', []);
+      const { log } = await cel.create('Test', []);
 
       expect(log.events[0].proof).toHaveLength(1);
       expect(log.events[0].proof[0].type).toBe('DataIntegrityProof');
@@ -238,7 +242,7 @@ describe('OriginalsCel', () => {
         signer: mockSigner,
       });
 
-      const log = await cel.create('Test', []);
+      const { log } = await cel.create('Test', []);
       const updated = await cel.update(log, { description: 'Updated' });
 
       expect(updated.events).toHaveLength(2);
@@ -255,7 +259,7 @@ describe('OriginalsCel', () => {
         signer: mockSigner,
       });
 
-      const log = await cel.create('Test', []);
+      const { log } = await cel.create('Test', []);
       const updated = await cel.update(log, { foo: 'bar' });
 
       expect(updated.events[1].previousEvent).toBeDefined();
@@ -269,7 +273,7 @@ describe('OriginalsCel', () => {
         layer: 'peer',
         signer: mockSigner,
       });
-      const log = await cel.create('Test', []);
+      const { log } = await cel.create('Test', []);
 
       for (const badData of [
         { sourceDid: 'did:peer:x', layer: 'peer' },
@@ -292,7 +296,7 @@ describe('OriginalsCel', () => {
         signer: mockSigner,
       });
 
-      const log = await cel.create('Test', []);
+      const { log } = await cel.create('Test', []);
       const updated = await cel.update(log, { foo: 'bar' });
 
       expect(updated.events[0]).toEqual(log.events[0]);
@@ -304,7 +308,7 @@ describe('OriginalsCel', () => {
         signer: mockSigner,
       });
 
-      const log = await cel.create('Test', []);
+      const { log } = await cel.create('Test', []);
       const originalLength = log.events.length;
       
       await cel.update(log, { foo: 'bar' });
@@ -322,7 +326,7 @@ describe('OriginalsCel', () => {
         signer: realSigner,
       });
 
-      const log = await cel.create('Test', []);
+      const { log } = await cel.create('Test', []);
       const result = await cel.verify(log);
 
       expect(result.verified).toBe(true);
@@ -336,7 +340,7 @@ describe('OriginalsCel', () => {
         signer: realSigner,
       });
 
-      const log = await cel.create('Test', []);
+      const { log } = await cel.create('Test', []);
       const updated = await cel.update(log, { foo: 'bar' });
       const result = await cel.verify(updated);
 
@@ -351,7 +355,7 @@ describe('OriginalsCel', () => {
         signer: realSigner,
       });
 
-      const log = await cel.create('Test', []);
+      const { log } = await cel.create('Test', []);
       const result = await cel.verify(log);
 
       expect(result.events).toHaveLength(1);
@@ -381,7 +385,7 @@ describe('OriginalsCel', () => {
         signer: realSigner,
       });
 
-      const log = await cel.create('Test', []);
+      const { log } = await cel.create('Test', []);
 
       // Tamper with the proof
       log.events[0].proof[0].proofValue = 'zinvalid';
@@ -397,7 +401,7 @@ describe('OriginalsCel', () => {
         signer: mockSigner,
       });
 
-      const log = await cel.create('Test', []);
+      const { log } = await cel.create('Test', []);
       const customVerifier = vi.fn(async () => true);
 
       const result = await cel.verify(log, { verifier: customVerifier });
@@ -419,7 +423,7 @@ describe('OriginalsCel', () => {
         },
       });
 
-      const log = await cel.create('Test', []);
+      const { log } = await cel.create('Test', []);
       const migrated = await cel.migrate(log, 'webvh');
 
       expect(migrated.events).toHaveLength(2);
@@ -437,7 +441,7 @@ describe('OriginalsCel', () => {
         signer: mockSigner,
       });
 
-      const log = await cel.create('Test', []);
+      const { log } = await cel.create('Test', []);
 
       await expect(cel.migrate(log, 'peer')).rejects.toThrow(
         'Log is already at peer layer'
@@ -459,7 +463,7 @@ describe('OriginalsCel', () => {
         layer: 'peer',
         signer: mockSigner,
       });
-      const log = await peerCel.create('Test', []);
+      const { log } = await peerCel.create('Test', []);
       const webvhLog = await cel.migrate(log, 'webvh');
 
       await expect(cel.migrate(webvhLog, 'peer' as any)).rejects.toThrow(
@@ -478,7 +482,7 @@ describe('OriginalsCel', () => {
         },
       });
 
-      const log = await cel.create('Test', []);
+      const { log } = await cel.create('Test', []);
 
       await expect(cel.migrate(log, 'btco')).rejects.toThrow(
         'Cannot migrate directly from peer to btco'
@@ -491,7 +495,7 @@ describe('OriginalsCel', () => {
         signer: mockSigner,
       });
 
-      const log = await cel.create('Test', []);
+      const { log } = await cel.create('Test', []);
 
       await expect(cel.migrate(log, 'webvh')).rejects.toThrow(
         'WebVH operations require a domain'
@@ -504,7 +508,7 @@ describe('OriginalsCel', () => {
         signer: mockSigner,
       });
 
-      const log = await cel.create('Test', []);
+      const { log } = await cel.create('Test', []);
       const migrated = await cel.migrate(log, 'webvh', { domain: 'test.com' });
 
       const data = migrated.events[1].data as any;
@@ -526,7 +530,7 @@ describe('OriginalsCel', () => {
         },
       });
 
-      const peerLog = await cel.create('Test', []);
+      const { log: peerLog } = await cel.create('Test', []);
       const webvhLog = await cel.migrate(peerLog, 'webvh');
       const btcoLog = await cel.migrate(webvhLog, 'btco');
 
@@ -556,7 +560,7 @@ describe('OriginalsCel', () => {
         },
       });
 
-      const peerLog = await cel.create('Test', []);
+      const { log: peerLog } = await cel.create('Test', []);
       const webvhLog = await cel.migrate(peerLog, 'webvh');
       const btcoLog = await cel.migrate(webvhLog, 'btco');
 
@@ -580,7 +584,7 @@ describe('OriginalsCel', () => {
         },
       });
 
-      const peerLog = await cel.create('Test', []);
+      const { log: peerLog } = await cel.create('Test', []);
       const webvhLog = await cel.migrate(peerLog, 'webvh');
       const btcoLog = await cel.migrate(webvhLog, 'btco');
 
@@ -598,7 +602,7 @@ describe('OriginalsCel', () => {
         },
       });
 
-      const log = await cel.create('Test', []);
+      const { log } = await cel.create('Test', []);
       const webvhLog = await cel.migrate(log, 'webvh');
 
       await expect(cel.migrate(webvhLog, 'btco')).rejects.toThrow(
@@ -614,7 +618,7 @@ describe('OriginalsCel', () => {
         signer: mockSigner,
       });
 
-      const log = await cel.create('Test Asset', [
+      const { log } = await cel.create('Test Asset', [
         { digestMultibase: 'uXYZ', mediaType: 'image/png' },
       ]);
 
@@ -624,7 +628,7 @@ describe('OriginalsCel', () => {
       expect(state.layer).toBe('peer');
       expect(state.resources).toHaveLength(1);
       expect(state.deactivated).toBe(false);
-      expect(state.did).toMatch(/^did:peer:/);
+      expect(state.did).toMatch(/^did:cel:/);
     });
 
     it('returns updated state after update', async () => {
@@ -633,7 +637,7 @@ describe('OriginalsCel', () => {
         signer: mockSigner,
       });
 
-      const log = await cel.create('Original', []);
+      const { log } = await cel.create('Original', []);
       const updated = await cel.update(log, { name: 'Updated Name' });
 
       const state = cel.getCurrentState(updated);
@@ -653,7 +657,7 @@ describe('OriginalsCel', () => {
         },
       });
 
-      const log = await cel.create('Test', []);
+      const { log } = await cel.create('Test', []);
       const migrated = await cel.migrate(log, 'webvh');
 
       const state = cel.getCurrentState(migrated);
@@ -669,7 +673,7 @@ describe('OriginalsCel', () => {
         signer: mockSigner,
       });
 
-      const log = await cel.create('Test', []);
+      const { log } = await cel.create('Test', []);
       const updated = await cel.update(log, { 
         customField: 'custom value',
         tags: ['art', 'digital'],
@@ -735,7 +739,7 @@ describe('OriginalsCel', () => {
       };
 
       // Create
-      const peerLog = await cel.create('My Original', [
+      const { log: peerLog } = await cel.create('My Original', [
         { digestMultibase: 'uXYZ', mediaType: 'image/png' },
       ]);
       expect((await cel.verify(peerLog)).verified).toBe(true);

--- a/packages/sdk/tests/unit/cel/PeerCelManager.test.ts
+++ b/packages/sdk/tests/unit/cel/PeerCelManager.test.ts
@@ -503,6 +503,95 @@ describe('PeerCelManager', () => {
       expect(state.creator).toBe(MOCK_CONTROLLER);
     });
 
+    test('state controller is the genesis controller before any rotation', async () => {
+      const { log } = await manager.create('Test Asset', []);
+
+      const state = manager.getCurrentState(log);
+
+      expect(state.controller).toBe(MOCK_CONTROLLER);
+    });
+
+    test('rotateKey replay hands the controller off to the last newController', async () => {
+      const { log } = await manager.create('Test Asset', []);
+      const rotatedLog: EventLog = {
+        events: [
+          ...log.events,
+          {
+            type: 'rotateKey',
+            data: { newController: 'did:key:z6MkFirstRotation', rotatedAt: '2026-01-01T00:00:00.000Z' },
+            previousEvent: 'uRotate1',
+            proof: log.events[0].proof,
+          },
+          {
+            type: 'rotateKey',
+            data: { newController: 'did:key:z6MkSecondRotation', rotatedAt: '2026-02-01T00:00:00.000Z' },
+            previousEvent: 'uRotate2',
+            proof: log.events[0].proof,
+          },
+        ],
+      };
+
+      const state = manager.getCurrentState(rotatedLog);
+
+      expect(state.controller).toBe('did:key:z6MkSecondRotation');
+    });
+
+    test('transfer replay records owners in metadata and bumps updatedAt', async () => {
+      const { log } = await manager.create('Test Asset', []);
+      const transferredLog: EventLog = {
+        events: [
+          ...log.events,
+          {
+            type: 'transfer',
+            data: {
+              previousOwner: MOCK_CONTROLLER,
+              newOwner: 'bc1qnewowner',
+              transferredAt: '2026-03-01T00:00:00.000Z',
+              txid: 'cafebabe',
+            },
+            previousEvent: 'uTransfer',
+            proof: log.events[0].proof,
+          },
+        ],
+      };
+
+      const state = manager.getCurrentState(transferredLog);
+
+      expect(state.metadata?.previousOwner).toBe(MOCK_CONTROLLER);
+      expect(state.metadata?.newOwner).toBe('bc1qnewowner');
+      expect(state.metadata?.txid).toBe('cafebabe');
+      expect(state.updatedAt).toBe('2026-03-01T00:00:00.000Z');
+    });
+
+    test('first-class migrate replay updates layer, did, and migration metadata', async () => {
+      const { log, did } = await manager.create('Test Asset', []);
+      const migratedLog: EventLog = {
+        events: [
+          ...log.events,
+          {
+            type: 'migrate',
+            data: {
+              sourceDid: did,
+              targetDid: 'did:webvh:example.com:abc123',
+              layer: 'webvh',
+              domain: 'example.com',
+              migratedAt: '2026-04-01T00:00:00.000Z',
+            },
+            previousEvent: 'uMigrate',
+            proof: log.events[0].proof,
+          },
+        ],
+      };
+
+      const state = manager.getCurrentState(migratedLog);
+
+      expect(state.layer).toBe('webvh');
+      expect(state.did).toBe('did:webvh:example.com:abc123');
+      expect(state.metadata?.sourceDid).toBe(did);
+      expect(state.metadata?.domain).toBe('example.com');
+      expect(state.updatedAt).toBe('2026-04-01T00:00:00.000Z');
+    });
+
     test('state has createdAt from create event', async () => {
       const { log } = await manager.create('Test Asset', []);
       const createData = log.events[0].data as CelAssetData;

--- a/packages/sdk/tests/unit/cel/PeerCelManager.test.ts
+++ b/packages/sdk/tests/unit/cel/PeerCelManager.test.ts
@@ -1,8 +1,13 @@
 import { describe, test, expect, beforeEach } from 'bun:test';
-import { PeerCelManager, PeerCelConfig, PeerAssetData, CelSigner } from '../../../src/cel/layers/PeerCelManager';
+import { PeerCelManager, PeerCelConfig, CelAssetData, CelSigner } from '../../../src/cel/layers/PeerCelManager';
 import type { DataIntegrityProof, EventLog, ExternalReference, AssetState } from '../../../src/cel/types';
 import { verifyEventLog } from '../../../src/cel/algorithms/verifyEventLog';
 import { deactivateEventLog } from '../../../src/cel/algorithms/deactivateEventLog';
+import { deriveDidCel } from '../../../src/cel/celDid';
+
+// The did:key the default mock signer reports as its verificationMethod; the
+// controller derived from the create event equals the DID portion (before '#').
+const MOCK_CONTROLLER = 'did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK';
 
 /**
  * Mock signer that creates a valid DataIntegrityProof structure.
@@ -14,7 +19,7 @@ function createMockSigner(verificationMethod?: string): CelSigner {
       type: 'DataIntegrityProof',
       cryptosuite: 'eddsa-jcs-2022',
       created: new Date().toISOString(),
-      verificationMethod: verificationMethod || 'did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK#z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK',
+      verificationMethod: verificationMethod || `${MOCK_CONTROLLER}#z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK`,
       proofPurpose: 'assertionMethod',
       proofValue: 'z' + Buffer.from('mock-signature-' + JSON.stringify(data).slice(0, 50)).toString('base64'),
     };
@@ -51,12 +56,31 @@ describe('PeerCelManager', () => {
       manager = new PeerCelManager(createMockSigner());
     });
 
+    test('returns a derived did:cel and a de-self-referenced genesis', async () => {
+      const { log, did } = await manager.create('My Asset', []);
+      expect(did.startsWith('did:cel:u')).toBe(true);
+      expect(deriveDidCel(log)).toBe(did);
+      const data = log.events[0].data as Record<string, unknown>;
+      expect(data.did).toBeUndefined();          // no self-reference
+      expect(data.creator).toBeUndefined();      // holder ≠ asset identity
+      expect(data.layer).toBeUndefined();        // genesis layer is definitional
+      expect(typeof data.controller).toBe('string');
+      expect((data.controller as string).startsWith('did:key:')).toBe(true);
+      expect(typeof data.nonce).toBe('string');
+    });
+
+    test('two identical creates yield different DIDs (nonce)', async () => {
+      const a = await manager.create('Same', []);
+      const b = await manager.create('Same', []);
+      expect(a.did).not.toBe(b.did);
+    });
+
     test('creates an event log with a single create event', async () => {
       const resources: ExternalReference[] = [
         { digestMultibase: 'uXYZ123abc', mediaType: 'image/png' }
       ];
 
-      const log = await manager.create('My Asset', resources);
+      const { log } = await manager.create('My Asset', resources);
 
       expect(log).toBeDefined();
       expect(log.events).toBeInstanceOf(Array);
@@ -65,41 +89,32 @@ describe('PeerCelManager', () => {
 
     test('create event has type "create"', async () => {
       const resources: ExternalReference[] = [];
-      const log = await manager.create('Test Asset', resources);
+      const { log } = await manager.create('Test Asset', resources);
 
       expect(log.events[0].type).toBe('create');
     });
 
     test('create event has no previousEvent (first event in log)', async () => {
       const resources: ExternalReference[] = [];
-      const log = await manager.create('Test Asset', resources);
+      const { log } = await manager.create('Test Asset', resources);
 
       expect(log.events[0].previousEvent).toBeUndefined();
     });
 
     test('asset data includes name', async () => {
       const resources: ExternalReference[] = [];
-      const log = await manager.create('My Beautiful Asset', resources);
-      const data = log.events[0].data as PeerAssetData;
+      const { log } = await manager.create('My Beautiful Asset', resources);
+      const data = log.events[0].data as CelAssetData;
 
       expect(data.name).toBe('My Beautiful Asset');
     });
 
-    test('asset data includes did:peer identifier', async () => {
+    test('asset data includes controller (the holder did:key)', async () => {
       const resources: ExternalReference[] = [];
-      const log = await manager.create('Test Asset', resources);
-      const data = log.events[0].data as PeerAssetData;
+      const { log } = await manager.create('Test Asset', resources);
+      const data = log.events[0].data as CelAssetData;
 
-      expect(data.did).toBeDefined();
-      expect(data.did.startsWith('did:peer:')).toBe(true);
-    });
-
-    test('asset data includes layer as "peer"', async () => {
-      const resources: ExternalReference[] = [];
-      const log = await manager.create('Test Asset', resources);
-      const data = log.events[0].data as PeerAssetData;
-
-      expect(data.layer).toBe('peer');
+      expect(data.controller).toBe(MOCK_CONTROLLER);
     });
 
     test('asset data includes provided resources', async () => {
@@ -107,26 +122,27 @@ describe('PeerCelManager', () => {
         { digestMultibase: 'uHash1', mediaType: 'image/png', url: ['https://example.com/1.png'] },
         { digestMultibase: 'uHash2', mediaType: 'video/mp4' },
       ];
-      const log = await manager.create('Test Asset', resources);
-      const data = log.events[0].data as PeerAssetData;
+      const { log } = await manager.create('Test Asset', resources);
+      const data = log.events[0].data as CelAssetData;
 
       expect(data.resources).toEqual(resources);
     });
 
-    test('asset data includes creator (same as DID for peer layer)', async () => {
+    test('asset data includes a nonce (multibase base64url, 16 bytes)', async () => {
       const resources: ExternalReference[] = [];
-      const log = await manager.create('Test Asset', resources);
-      const data = log.events[0].data as PeerAssetData;
+      const { log } = await manager.create('Test Asset', resources);
+      const data = log.events[0].data as CelAssetData;
 
-      expect(data.creator).toBe(data.did);
+      expect(typeof data.nonce).toBe('string');
+      expect(data.nonce.startsWith('u')).toBe(true);
     });
 
     test('asset data includes createdAt timestamp', async () => {
       const beforeCreate = new Date().toISOString();
       const resources: ExternalReference[] = [];
-      const log = await manager.create('Test Asset', resources);
+      const { log } = await manager.create('Test Asset', resources);
       const afterCreate = new Date().toISOString();
-      const data = log.events[0].data as PeerAssetData;
+      const data = log.events[0].data as CelAssetData;
 
       expect(data.createdAt).toBeDefined();
       // Verify it's a valid ISO timestamp between before and after
@@ -136,7 +152,7 @@ describe('PeerCelManager', () => {
 
     test('event has at least one proof', async () => {
       const resources: ExternalReference[] = [];
-      const log = await manager.create('Test Asset', resources);
+      const { log } = await manager.create('Test Asset', resources);
 
       expect(log.events[0].proof).toBeInstanceOf(Array);
       expect(log.events[0].proof.length).toBeGreaterThanOrEqual(1);
@@ -144,7 +160,7 @@ describe('PeerCelManager', () => {
 
     test('proof uses eddsa-jcs-2022 cryptosuite', async () => {
       const resources: ExternalReference[] = [];
-      const log = await manager.create('Test Asset', resources);
+      const { log } = await manager.create('Test Asset', resources);
       const proof = log.events[0].proof[0];
 
       expect(proof.cryptosuite).toBe('eddsa-jcs-2022');
@@ -152,7 +168,7 @@ describe('PeerCelManager', () => {
 
     test('proof has type DataIntegrityProof', async () => {
       const resources: ExternalReference[] = [];
-      const log = await manager.create('Test Asset', resources);
+      const { log } = await manager.create('Test Asset', resources);
       const proof = log.events[0].proof[0];
 
       expect(proof.type).toBe('DataIntegrityProof');
@@ -160,7 +176,7 @@ describe('PeerCelManager', () => {
 
     test('no witness proofs are added (empty for peer layer)', async () => {
       const resources: ExternalReference[] = [];
-      const log = await manager.create('Test Asset', resources);
+      const { log } = await manager.create('Test Asset', resources);
 
       // Only one proof (controller proof), no witness proofs
       expect(log.events[0].proof).toHaveLength(1);
@@ -189,36 +205,29 @@ describe('PeerCelManager', () => {
     });
 
     test('accepts empty resources array', async () => {
-      const log = await manager.create('Test Asset', []);
-      const data = log.events[0].data as PeerAssetData;
+      const { log } = await manager.create('Test Asset', []);
+      const data = log.events[0].data as CelAssetData;
 
       expect(data.resources).toEqual([]);
     });
   });
 
-  describe('DID generation', () => {
-    test('generates unique DIDs for each asset', async () => {
+  describe('DID derivation', () => {
+    test('derives a distinct did:cel for each asset (nonce insurance)', async () => {
       const manager = new PeerCelManager(createMockSigner());
-      const resources: ExternalReference[] = [];
 
-      const log1 = await manager.create('Asset 1', resources);
-      const log2 = await manager.create('Asset 2', resources);
+      const a = await manager.create('Asset 1', []);
+      const b = await manager.create('Asset 2', []);
 
-      const data1 = log1.events[0].data as PeerAssetData;
-      const data2 = log2.events[0].data as PeerAssetData;
-
-      expect(data1.did).not.toBe(data2.did);
+      expect(a.did).not.toBe(b.did);
     });
 
-    test('generates did:peer numalgo 4 (long form) DID', async () => {
+    test('derives a did:cel identifier', async () => {
       const manager = new PeerCelManager(createMockSigner());
-      const resources: ExternalReference[] = [];
 
-      const log = await manager.create('Test Asset', resources);
-      const data = log.events[0].data as PeerAssetData;
+      const { did } = await manager.create('Test Asset', []);
 
-      // Numalgo 4 DIDs start with did:peer:4
-      expect(data.did.startsWith('did:peer:4')).toBe(true);
+      expect(did.startsWith('did:cel:')).toBe(true);
     });
   });
 
@@ -229,7 +238,7 @@ describe('PeerCelManager', () => {
         { digestMultibase: 'uTestHash123', mediaType: 'image/png' }
       ];
 
-      const log = await manager.create('My Original', resources);
+      const { log } = await manager.create('My Original', resources);
 
       // Verify the log
       const result = await verifyEventLog(log);
@@ -247,7 +256,7 @@ describe('PeerCelManager', () => {
       const manager = new PeerCelManager(createMockSigner());
       const resources: ExternalReference[] = [];
 
-      const log: EventLog = await manager.create('Test Asset', resources);
+      const { log } = await manager.create('Test Asset', resources);
 
       // Verify structure
       expect(log.events).toBeDefined();
@@ -264,10 +273,23 @@ describe('PeerCelManager', () => {
         { verificationMethod: customVm }
       );
 
-      const log = await manager.create('Test Asset', []);
+      const { log } = await manager.create('Test Asset', []);
       const proof = log.events[0].proof[0];
 
       expect(proof.verificationMethod).toBe(customVm);
+    });
+
+    test('controller from config verificationMethod is the DID before the fragment', async () => {
+      const customVm = 'did:key:z6MkCustomKey#key-0';
+      const manager = new PeerCelManager(
+        createMockSigner(customVm),
+        { verificationMethod: customVm }
+      );
+
+      const { log } = await manager.create('Test Asset', []);
+      const data = log.events[0].data as CelAssetData;
+
+      expect(data.controller).toBe('did:key:z6MkCustomKey');
     });
 
     test('uses custom proofPurpose from config', async () => {
@@ -284,7 +306,7 @@ describe('PeerCelManager', () => {
         proofPurpose: 'authentication',
       });
 
-      const log = await manager.create('Test Asset', []);
+      const { log } = await manager.create('Test Asset', []);
       const proof = log.events[0].proof[0];
 
       expect(proof.proofPurpose).toBe('authentication');
@@ -301,8 +323,8 @@ describe('PeerCelManager', () => {
         { digestMultibase: 'uDocHash', mediaType: 'application/pdf' },
       ];
 
-      const log = await manager.create('Multi-Resource Asset', resources);
-      const data = log.events[0].data as PeerAssetData;
+      const { log } = await manager.create('Multi-Resource Asset', resources);
+      const data = log.events[0].data as CelAssetData;
 
       expect(data.resources).toHaveLength(4);
       expect(data.resources).toEqual(resources);
@@ -312,8 +334,8 @@ describe('PeerCelManager', () => {
       const manager = new PeerCelManager(createMockSigner());
       const unicodeName = 'アート作品 🎨 Œuvre d\'art';
 
-      const log = await manager.create(unicodeName, []);
-      const data = log.events[0].data as PeerAssetData;
+      const { log } = await manager.create(unicodeName, []);
+      const data = log.events[0].data as CelAssetData;
 
       expect(data.name).toBe(unicodeName);
     });
@@ -322,8 +344,8 @@ describe('PeerCelManager', () => {
       const manager = new PeerCelManager(createMockSigner());
       const longName = 'A'.repeat(1000);
 
-      const log = await manager.create(longName, []);
-      const data = log.events[0].data as PeerAssetData;
+      const { log } = await manager.create(longName, []);
+      const data = log.events[0].data as CelAssetData;
 
       expect(data.name).toBe(longName);
     });
@@ -337,7 +359,7 @@ describe('PeerCelManager', () => {
     });
 
     test('appends an update event to the log', async () => {
-      const log = await manager.create('Test Asset', []);
+      const { log } = await manager.create('Test Asset', []);
       const updatedLog = await manager.update(log, { name: 'Updated Name' });
 
       expect(updatedLog.events).toHaveLength(2);
@@ -345,7 +367,7 @@ describe('PeerCelManager', () => {
     });
 
     test('update event contains provided data', async () => {
-      const log = await manager.create('Test Asset', []);
+      const { log } = await manager.create('Test Asset', []);
       const updateData = { name: 'New Name', description: 'A description' };
       const updatedLog = await manager.update(log, updateData);
 
@@ -356,7 +378,7 @@ describe('PeerCelManager', () => {
 
     test('update event includes updatedAt timestamp', async () => {
       const beforeUpdate = new Date().toISOString();
-      const log = await manager.create('Test Asset', []);
+      const { log } = await manager.create('Test Asset', []);
       const updatedLog = await manager.update(log, { name: 'New Name' });
       const afterUpdate = new Date().toISOString();
 
@@ -368,7 +390,7 @@ describe('PeerCelManager', () => {
     });
 
     test('update event has previousEvent linking to last event', async () => {
-      const log = await manager.create('Test Asset', []);
+      const { log } = await manager.create('Test Asset', []);
       const updatedLog = await manager.update(log, { name: 'New Name' });
 
       expect(updatedLog.events[1].previousEvent).toBeDefined();
@@ -377,9 +399,9 @@ describe('PeerCelManager', () => {
     });
 
     test('does not mutate original log', async () => {
-      const log = await manager.create('Test Asset', []);
+      const { log } = await manager.create('Test Asset', []);
       const originalEventCount = log.events.length;
-      
+
       await manager.update(log, { name: 'New Name' });
 
       expect(log.events).toHaveLength(originalEventCount);
@@ -396,7 +418,7 @@ describe('PeerCelManager', () => {
     });
 
     test('throws error when updating deactivated log', async () => {
-      const log = await manager.create('Test Asset', []);
+      const { log } = await manager.create('Test Asset', []);
       const deactivatedLog = await deactivateEventLog(log, 'No longer needed', {
         signer: createMockSigner(),
         verificationMethod: 'did:key:z6Mk#key-0',
@@ -407,7 +429,7 @@ describe('PeerCelManager', () => {
     });
 
     test('supports multiple sequential updates', async () => {
-      const log = await manager.create('Test Asset', []);
+      const { log } = await manager.create('Test Asset', []);
       const log2 = await manager.update(log, { name: 'Name 2' });
       const log3 = await manager.update(log2, { name: 'Name 3' });
 
@@ -423,7 +445,7 @@ describe('PeerCelManager', () => {
     });
 
     test('update has valid proof', async () => {
-      const log = await manager.create('Test Asset', []);
+      const { log } = await manager.create('Test Asset', []);
       const updatedLog = await manager.update(log, { name: 'New Name' });
 
       const proof = updatedLog.events[1].proof[0];
@@ -433,7 +455,7 @@ describe('PeerCelManager', () => {
     });
 
     test('handles non-object data by wrapping in value field', async () => {
-      const log = await manager.create('Test Asset', []);
+      const { log } = await manager.create('Test Asset', []);
       const updatedLog = await manager.update(log, 'simple string value');
 
       const eventData = updatedLog.events[1].data as Record<string, unknown>;
@@ -452,7 +474,7 @@ describe('PeerCelManager', () => {
       const resources: ExternalReference[] = [
         { digestMultibase: 'uHash1', mediaType: 'image/png' }
       ];
-      const log = await manager.create('My Asset', resources);
+      const { log } = await manager.create('My Asset', resources);
 
       const state = manager.getCurrentState(log);
 
@@ -462,29 +484,28 @@ describe('PeerCelManager', () => {
       expect(state.deactivated).toBe(false);
     });
 
-    test('state has did from create event', async () => {
-      const log = await manager.create('Test Asset', []);
-      const createData = log.events[0].data as PeerAssetData;
+    test('state did is the derived did:cel from the create event', async () => {
+      const { log, did } = await manager.create('Test Asset', []);
 
       const state = manager.getCurrentState(log);
 
-      expect(state.did).toBe(createData.did);
-      expect(state.did.startsWith('did:peer:')).toBe(true);
+      expect(state.did).toBe(did);
+      expect(state.did.startsWith('did:cel:')).toBe(true);
     });
 
-    test('state has creator from create event', async () => {
-      const log = await manager.create('Test Asset', []);
-      const createData = log.events[0].data as PeerAssetData;
+    test('state creator is the controller from the create event', async () => {
+      const { log } = await manager.create('Test Asset', []);
+      const createData = log.events[0].data as CelAssetData;
 
       const state = manager.getCurrentState(log);
 
-      expect(state.creator).toBe(createData.creator);
-      expect(state.creator).toBe(state.did); // For peer layer, creator === did
+      expect(state.creator).toBe(createData.controller);
+      expect(state.creator).toBe(MOCK_CONTROLLER);
     });
 
     test('state has createdAt from create event', async () => {
-      const log = await manager.create('Test Asset', []);
-      const createData = log.events[0].data as PeerAssetData;
+      const { log } = await manager.create('Test Asset', []);
+      const createData = log.events[0].data as CelAssetData;
 
       const state = manager.getCurrentState(log);
 
@@ -492,7 +513,7 @@ describe('PeerCelManager', () => {
     });
 
     test('reflects updated name after update event', async () => {
-      const log = await manager.create('Original Name', []);
+      const { log } = await manager.create('Original Name', []);
       const updatedLog = await manager.update(log, { name: 'New Name' });
 
       const state = manager.getCurrentState(updatedLog);
@@ -504,8 +525,8 @@ describe('PeerCelManager', () => {
       const initialResources: ExternalReference[] = [
         { digestMultibase: 'uHash1', mediaType: 'image/png' }
       ];
-      const log = await manager.create('Test Asset', initialResources);
-      
+      const { log } = await manager.create('Test Asset', initialResources);
+
       const newResources: ExternalReference[] = [
         { digestMultibase: 'uHash2', mediaType: 'video/mp4' }
       ];
@@ -517,7 +538,7 @@ describe('PeerCelManager', () => {
     });
 
     test('has updatedAt after update event', async () => {
-      const log = await manager.create('Test Asset', []);
+      const { log } = await manager.create('Test Asset', []);
       const updatedLog = await manager.update(log, { name: 'New Name' });
 
       const state = manager.getCurrentState(updatedLog);
@@ -526,10 +547,10 @@ describe('PeerCelManager', () => {
     });
 
     test('stores custom fields in metadata', async () => {
-      const log = await manager.create('Test Asset', []);
-      const updatedLog = await manager.update(log, { 
+      const { log } = await manager.create('Test Asset', []);
+      const updatedLog = await manager.update(log, {
         customField: 'custom value',
-        anotherField: 123 
+        anotherField: 123
       });
 
       const state = manager.getCurrentState(updatedLog);
@@ -540,7 +561,7 @@ describe('PeerCelManager', () => {
     });
 
     test('applies multiple updates sequentially', async () => {
-      const log = await manager.create('Name 1', []);
+      const { log } = await manager.create('Name 1', []);
       const log2 = await manager.update(log, { name: 'Name 2', version: 1 });
       const log3 = await manager.update(log2, { name: 'Name 3', version: 2 });
 
@@ -551,7 +572,7 @@ describe('PeerCelManager', () => {
     });
 
     test('marks state as deactivated after deactivate event', async () => {
-      const log = await manager.create('Test Asset', []);
+      const { log } = await manager.create('Test Asset', []);
       const deactivatedLog = await deactivateEventLog(log, 'Asset retired', {
         signer: createMockSigner(),
         verificationMethod: 'did:key:z6Mk#key-0',
@@ -593,17 +614,76 @@ describe('PeerCelManager', () => {
 
       expect(() => manager.getCurrentState(invalidLog)).toThrow('First event must be a create event');
     });
+
+    describe('legacy did:peer logs (back-compat read path)', () => {
+      // A hand-built genesis in the pre-did:cel shape (embeds did/layer/creator).
+      // getCurrentState must keep reading these verbatim.
+      function legacyLog(did: string): EventLog {
+        return {
+          events: [{
+            type: 'create',
+            data: {
+              name: 'Legacy Asset',
+              did,
+              layer: 'peer',
+              resources: [{ digestMultibase: 'uHash', mediaType: 'image/png' }],
+              creator: did,
+              createdAt: '2020-01-01T00:00:00Z',
+            },
+            proof: [{
+              type: 'DataIntegrityProof',
+              cryptosuite: 'eddsa-jcs-2022',
+              created: '2020-01-01T00:00:00Z',
+              verificationMethod: `${did}#key-0`,
+              proofPurpose: 'assertionMethod',
+              proofValue: 'zMock',
+            }],
+          }],
+        };
+      }
+
+      test('preserves did/creator/layer from a legacy genesis', () => {
+        const did = 'did:peer:4zLegacy123';
+        const state = manager.getCurrentState(legacyLog(did));
+
+        expect(state.did).toBe(did);
+        expect(state.creator).toBe(did);
+        expect(state.layer).toBe('peer');
+      });
+
+      test('applies legacy did/layer override on update events', () => {
+        const did = 'did:peer:4zLegacy123';
+        const log = legacyLog(did);
+        log.events.push({
+          type: 'update',
+          data: { did: 'did:webvh:example.com:asset', layer: 'webvh', updatedAt: '2020-02-01T00:00:00Z' },
+          previousEvent: 'uPrev',
+          proof: [{
+            type: 'DataIntegrityProof',
+            cryptosuite: 'eddsa-jcs-2022',
+            created: '2020-02-01T00:00:00Z',
+            verificationMethod: `${did}#key-0`,
+            proofPurpose: 'assertionMethod',
+            proofValue: 'zMock',
+          }],
+        });
+
+        const state = manager.getCurrentState(log);
+        expect(state.did).toBe('did:webvh:example.com:asset');
+        expect(state.layer).toBe('webvh');
+      });
+    });
   });
 
   describe('integration: create then update then getCurrentState', () => {
     test('full lifecycle shows updated state', async () => {
       const manager = new PeerCelManager(createMockSigner());
-      
+
       // Create asset
       const initialResources: ExternalReference[] = [
         { digestMultibase: 'uOriginalHash', mediaType: 'image/png' }
       ];
-      const log = await manager.create('Original Name', initialResources);
+      const { log } = await manager.create('Original Name', initialResources);
 
       // Verify initial state
       const initialState = manager.getCurrentState(log);
@@ -615,7 +695,7 @@ describe('PeerCelManager', () => {
       const newResources: ExternalReference[] = [
         { digestMultibase: 'uNewHash', mediaType: 'video/mp4' }
       ];
-      const updatedLog = await manager.update(log, { 
+      const updatedLog = await manager.update(log, {
         name: 'Updated Name',
         resources: newResources,
         description: 'Now with video!'
@@ -628,7 +708,7 @@ describe('PeerCelManager', () => {
       expect(updatedState.metadata?.description).toBe('Now with video!');
       expect(updatedState.deactivated).toBe(false);
       expect(updatedState.updatedAt).toBeDefined();
-      
+
       // Original create data should still be preserved
       expect(updatedState.did).toBe(initialState.did);
       expect(updatedState.creator).toBe(initialState.creator);
@@ -637,8 +717,8 @@ describe('PeerCelManager', () => {
 
     test('updated log passes verification', async () => {
       const manager = new PeerCelManager(createMockSigner());
-      
-      const log = await manager.create('Test Asset', []);
+
+      const { log } = await manager.create('Test Asset', []);
       const updatedLog = await manager.update(log, { name: 'New Name' });
 
       // Verify the updated log

--- a/packages/sdk/tests/unit/cel/WebVHCelManager.test.ts
+++ b/packages/sdk/tests/unit/cel/WebVHCelManager.test.ts
@@ -40,9 +40,9 @@ const createMockWitness = (): WitnessService => ({
 // Helper to create a peer layer log for testing
 const createPeerLog = async (): Promise<EventLog> => {
   const peerManager = new PeerCelManager(createMockSigner());
-  return peerManager.create('Test Asset', [
+  return (await peerManager.create('Test Asset', [
     { digestMultibase: 'uTestHash123', mediaType: 'image/png' },
-  ]);
+  ])).log;
 };
 
 describe('WebVHCelManager', () => {
@@ -140,7 +140,8 @@ describe('WebVHCelManager', () => {
       const migrationData = webvhLog.events[1].data as Record<string, unknown>;
       expect(migrationData.sourceDid).toBeDefined();
       expect(typeof migrationData.sourceDid).toBe('string');
-      expect((migrationData.sourceDid as string).startsWith('did:peer:')).toBe(true);
+      // New-shape genesis: the source identity is the derived did:cel
+      expect((migrationData.sourceDid as string).startsWith('did:cel:')).toBe(true);
     });
 
     it('should include targetDid with webvh format', async () => {
@@ -453,7 +454,7 @@ describe('WebVHCelManager', () => {
     it('should complete full migration cycle', async () => {
       // Create peer asset
       const peerManager = new PeerCelManager(createMockSigner());
-      const peerLog = await peerManager.create('My Artwork', [
+      const { log: peerLog } = await peerManager.create('My Artwork', [
         { digestMultibase: 'uArtworkHash', mediaType: 'image/jpeg' },
       ]);
 
@@ -485,7 +486,7 @@ describe('WebVHCelManager', () => {
         { digestMultibase: 'uHash1', mediaType: 'image/png' },
         { digestMultibase: 'uHash2', mediaType: 'video/mp4' },
       ];
-      const peerLog = await peerManager.create('Multi-Resource', resources);
+      const { log: peerLog } = await peerManager.create('Multi-Resource', resources);
 
       const webvhManager = new WebVHCelManager(createMockSigner(), 'example.com');
       const webvhLog = await webvhManager.migrate(peerLog);

--- a/packages/sdk/tests/unit/cel/WebVHCelManager.test.ts
+++ b/packages/sdk/tests/unit/cel/WebVHCelManager.test.ts
@@ -130,7 +130,39 @@ describe('WebVHCelManager', () => {
       const webvhLog = await manager.migrate(peerLog);
 
       const migrationEvent = webvhLog.events[1];
-      expect(migrationEvent.type).toBe('update');
+      expect(migrationEvent.type).toBe('migrate');
+    });
+
+    it('emits a first-class migrate event carrying the migration payload', async () => {
+      const peerLog = await createPeerLog();
+      const webvhLog = await manager.migrate(peerLog);
+
+      const migrationEvent = webvhLog.events.at(-1)!;
+      expect(migrationEvent.type).toBe('migrate');
+
+      const data = migrationEvent.data as Record<string, unknown>;
+      expect(data.sourceDid).toMatch(/^did:cel:/);
+      expect(data.targetDid).toMatch(/^did:webvh:example\.com:/);
+      expect(data.layer).toBe('webvh');
+      expect(data.domain).toBe('example.com');
+      expect(data.migratedAt).toBeDefined();
+      // The entry type carries the discriminator; no inner data.type field.
+      expect((data as { type?: unknown }).type).toBeUndefined();
+    });
+
+    it('derives the webvh id part from the did:cel suffix, truncated like did:peer', async () => {
+      const peerLog = await createPeerLog();
+      const webvhLog = await manager.migrate(peerLog);
+
+      const data = webvhLog.events[1].data as Record<string, unknown>;
+      const sourceDid = data.sourceDid as string;
+      expect(sourceDid.startsWith('did:cel:')).toBe(true);
+
+      const suffix = sourceDid.slice('did:cel:'.length);
+      const expectedId = suffix
+        .substring(0, Math.min(32, suffix.length))
+        .replace(/[^a-zA-Z0-9]/g, '');
+      expect(data.targetDid).toBe(`did:webvh:example.com:${expectedId}`);
     });
 
     it('should include sourceDid in migration data', async () => {
@@ -426,6 +458,105 @@ describe('WebVHCelManager', () => {
       expect(state.deactivated).toBe(false);
     });
 
+    it('replays a legacy update-sniffed migration (old fixture logs)', () => {
+      // Legacy logs record migrations as 'update' events sniffed by
+      // sourceDid+layer+migratedAt — they must keep replaying.
+      const manager = new WebVHCelManager(createMockSigner(), 'example.com');
+      const mockProof = {
+        type: 'DataIntegrityProof',
+        cryptosuite: 'eddsa-jcs-2022',
+        created: '2020-01-01T00:00:00.000Z',
+        verificationMethod: 'did:key:zLegacy#key-0',
+        proofPurpose: 'assertionMethod',
+        proofValue: 'zLegacy',
+      };
+      const legacyLog: EventLog = {
+        events: [
+          {
+            type: 'create',
+            data: {
+              name: 'Legacy Asset',
+              did: 'did:peer:4zLegacyDid',
+              layer: 'peer',
+              resources: [],
+              creator: 'did:peer:4zLegacyDid',
+              createdAt: '2020-01-01T00:00:00.000Z',
+            },
+            proof: [mockProof],
+          },
+          {
+            type: 'update',
+            data: {
+              sourceDid: 'did:peer:4zLegacyDid',
+              targetDid: 'did:webvh:example.com:legacy',
+              layer: 'webvh',
+              domain: 'example.com',
+              migratedAt: '2020-01-02T00:00:00.000Z',
+            },
+            previousEvent: 'uLegacyDigest',
+            proof: [mockProof],
+          },
+        ],
+      };
+
+      const state = manager.getCurrentState(legacyLog);
+      expect(state.layer).toBe('webvh');
+      expect(state.did).toBe('did:webvh:example.com:legacy');
+      expect(state.metadata?.sourceDid).toBe('did:peer:4zLegacyDid');
+      expect(state.metadata?.domain).toBe('example.com');
+    });
+
+    it('surfaces the controller and applies rotateKey hand-off in replay', async () => {
+      const manager = new WebVHCelManager(createMockSigner(), 'example.com');
+      const peerLog = await createPeerLog();
+      const webvhLog = await manager.migrate(peerLog);
+
+      const genesisController = (webvhLog.events[0].data as Record<string, unknown>).controller as string;
+      expect(manager.getCurrentState(webvhLog).controller).toBe(genesisController);
+
+      const rotatedLog: EventLog = {
+        events: [
+          ...webvhLog.events,
+          {
+            type: 'rotateKey',
+            data: { newController: 'did:key:z6MkNewController', rotatedAt: '2026-01-01T00:00:00.000Z' },
+            previousEvent: 'uRotate',
+            proof: webvhLog.events[0].proof,
+          },
+        ],
+      };
+      const state = manager.getCurrentState(rotatedLog);
+      expect(state.controller).toBe('did:key:z6MkNewController');
+    });
+
+    it('replays first-class transfer events into owner metadata', async () => {
+      const manager = new WebVHCelManager(createMockSigner(), 'example.com');
+      const peerLog = await createPeerLog();
+      const webvhLog = await manager.migrate(peerLog);
+
+      const transferredLog: EventLog = {
+        events: [
+          ...webvhLog.events,
+          {
+            type: 'transfer',
+            data: {
+              previousOwner: 'did:key:z6MkOldOwner',
+              newOwner: 'bc1qnewowner',
+              transferredAt: '2026-02-01T00:00:00.000Z',
+              txid: 'feedface',
+            },
+            previousEvent: 'uTransfer',
+            proof: webvhLog.events[0].proof,
+          },
+        ],
+      };
+      const state = manager.getCurrentState(transferredLog);
+      expect(state.metadata?.previousOwner).toBe('did:key:z6MkOldOwner');
+      expect(state.metadata?.newOwner).toBe('bc1qnewowner');
+      expect(state.metadata?.txid).toBe('feedface');
+      expect(state.updatedAt).toBe('2026-02-01T00:00:00.000Z');
+    });
+
     it('should throw for empty log', () => {
       const manager = new WebVHCelManager(createMockSigner(), 'example.com');
       expect(() => manager.getCurrentState({ events: [] })).toThrow(
@@ -504,8 +635,8 @@ describe('WebVHCelManager', () => {
       expect(webvhLog.events[0].type).toBe('create');
       expect(webvhLog.events[0].previousEvent).toBeUndefined();
 
-      // Second event: migration update
-      expect(webvhLog.events[1].type).toBe('update');
+      // Second event: first-class migration event
+      expect(webvhLog.events[1].type).toBe('migrate');
       expect(webvhLog.events[1].previousEvent).toBeDefined();
     });
   });

--- a/packages/sdk/tests/unit/cel/appendEvent.test.ts
+++ b/packages/sdk/tests/unit/cel/appendEvent.test.ts
@@ -1,0 +1,31 @@
+import { describe, test, expect } from 'bun:test';
+import { appendEvent } from '../../../src/cel/algorithms/appendEvent';
+import { createEventLog } from '../../../src/cel/algorithms/createEventLog';
+import { computeDigestMultibase } from '../../../src/cel/hash';
+import { canonicalizeEntryForChain } from '../../../src/cel/canonicalize';
+import type { DataIntegrityProof } from '../../../src/cel/types';
+
+const signedPayloads: unknown[] = [];
+const signer = async (data: unknown): Promise<DataIntegrityProof> => {
+  signedPayloads.push(data);
+  return { type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', created: 'x', verificationMethod: 'did:key:z6Mk#z6Mk', proofPurpose: 'assertionMethod', proofValue: 'zSig' };
+};
+
+describe('appendEvent', () => {
+  test('appends a typed event with correct chain link and signed payload', async () => {
+    const log = await createEventLog({ name: 'A' }, { signer, verificationMethod: 'did:key:z6Mk#z6Mk' });
+    const out = await appendEvent(log, 'migrate', { sourceDid: 'a', targetDid: 'b', layer: 'webvh', migratedAt: 'x' }, { signer, verificationMethod: 'did:key:z6Mk#z6Mk' });
+    const evt = out.events[1];
+    expect(evt.type).toBe('migrate');
+    expect(evt.previousEvent).toBe(computeDigestMultibase(canonicalizeEntryForChain(log.events[0])));
+    // signer received exactly { type, data, previousEvent } — what verifyEventLog reconstructs
+    expect(signedPayloads.at(-1)).toEqual({ type: 'migrate', data: evt.data, previousEvent: evt.previousEvent });
+    expect(log.events.length).toBe(1); // input not mutated
+  });
+
+  test('rejects empty logs and create type', async () => {
+    await expect(appendEvent({ events: [] }, 'update', {}, { signer, verificationMethod: 'x' })).rejects.toThrow(/empty/i);
+    // @ts-expect-error create is excluded at the type level; runtime guard too
+    await expect(appendEvent({ events: [{ type: 'create', data: {}, proof: [] }] }, 'create', {}, { signer, verificationMethod: 'x' })).rejects.toThrow(/create/i);
+  });
+});

--- a/packages/sdk/tests/unit/cel/cbor-serialization.test.ts
+++ b/packages/sdk/tests/unit/cel/cbor-serialization.test.ts
@@ -702,6 +702,19 @@ describe('CEL CBOR Serialization', () => {
       expect(parsed.events[1].type).toBe('deactivate');
       expect((parsed.events[1].data as { reason: string }).reason).toBe('No longer needed');
     });
+
+    test('round-trips migrate/transfer/rotateKey event types', () => {
+      const log = {
+        events: [
+          { type: 'create', data: { name: 'A' }, proof: [{ type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', created: 'x', verificationMethod: 'did:key:z6Mk#z6Mk', proofPurpose: 'assertionMethod', proofValue: 'z1' }] },
+          { type: 'migrate', data: { sourceDid: 'did:cel:uEiA', targetDid: 'did:webvh:x:example.com:a', layer: 'webvh', migratedAt: 'x' }, previousEvent: 'uEiB', proof: [{ type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', created: 'x', verificationMethod: 'did:key:z6Mk#z6Mk', proofPurpose: 'assertionMethod', proofValue: 'z2' }] },
+          { type: 'transfer', data: { previousOwner: 'did:key:z6Mk', newOwner: 'did:key:z6Mk2', transferredAt: 'x' }, previousEvent: 'uEiC', proof: [{ type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', created: 'x', verificationMethod: 'did:key:z6Mk#z6Mk', proofPurpose: 'assertionMethod', proofValue: 'z3' }] },
+          { type: 'rotateKey', data: { newController: 'did:key:z6Mk2', rotatedAt: 'x' }, previousEvent: 'uEiD', proof: [{ type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', created: 'x', verificationMethod: 'did:key:z6Mk#z6Mk', proofPurpose: 'assertionMethod', proofValue: 'z4' }] }
+        ]
+      };
+      const parsed = parseEventLogCbor(serializeEventLogCbor(log as never));
+      expect(parsed.events.map(e => e.type)).toEqual(['create', 'migrate', 'transfer', 'rotateKey']);
+    });
   });
 
   describe('optional created field (type/serialization parity)', () => {

--- a/packages/sdk/tests/unit/cel/cel-cli-coverage.test.ts
+++ b/packages/sdk/tests/unit/cel/cel-cli-coverage.test.ts
@@ -86,6 +86,7 @@ function makeMockSigner(vm = 'did:key:z6MkMock#key-1'): (data: unknown) => Promi
   });
 }
 
+/** LEGACY genesis shape (pre-did:cel) — kept as the legacy-fixture per behavior. */
 function makePeerAssetData(name: string) {
   return {
     name,
@@ -94,6 +95,17 @@ function makePeerAssetData(name: string) {
     resources: [],
     creator: 'did:peer:4z123456789abcdef',
     createdAt: new Date().toISOString(),
+  };
+}
+
+/** New-shape genesis (CelAssetData): identity derived (did:cel), controller = holder key DID. */
+function makeCelAssetData(name: string, controller = 'did:key:z6MkMock') {
+  return {
+    name,
+    controller,
+    resources: [],
+    createdAt: new Date().toISOString(),
+    nonce: 'uQ292ZXJhZ2VOb25jZTAx',
   };
 }
 
@@ -117,11 +129,13 @@ afterEach(() => {
 
 describe('CEL-CLI-002/security: verify with tampered hash chain', () => {
   it('returns verified=false and reports chain-integrity error', async () => {
-    // Build a valid 2-event log with real crypto.
+    // Build a valid 2-event log with real crypto over a NEW-SHAPE genesis
+    // (controller = the signer's did:key).
     const { signer, verificationMethod } = await makeRealDidKeySigner();
     const opts = { signer, verificationMethod, proofPurpose: 'assertionMethod' };
+    const controller = verificationMethod.split('#')[0];
 
-    let log = await createEventLog(makePeerAssetData('Chain Test'), opts);
+    let log = await createEventLog(makeCelAssetData('Chain Test', controller), opts);
     log = await updateEventLog(log, { note: 'v2' }, opts);
 
     // Tamper: replace previousEvent hash on the second event.
@@ -152,8 +166,9 @@ describe('CEL-CLI-002/security: verify with invalid proof signature', () => {
   it('returns verified=false and reports signature/proof error', async () => {
     // Build a log with a real did:key verificationMethod but replace the
     // proofValue with a wrong signature (same multibase prefix, bad bytes).
+    // New-shape genesis: controller = the signer's did:key.
     const { signer, verificationMethod } = await makeRealDidKeySigner();
-    const log = await createEventLog(makePeerAssetData('Bad Sig'), {
+    const log = await createEventLog(makeCelAssetData('Bad Sig', verificationMethod.split('#')[0]), {
       signer,
       verificationMethod,
       proofPurpose: 'assertionMethod',
@@ -198,12 +213,40 @@ describe('CEL-CLI-002/security: verify with invalid proof signature', () => {
 // ═══════════════════════════════════════════════════════════════════════════════
 
 describe('CEL-CLI-003/happy: inspect layer history (peer→webvh)', () => {
-  it('shows both layers in history and updated DID/layer in state', async () => {
+  it('shows both layers with a first-class migrate event over a did:cel genesis', async () => {
+    const { appendEvent } = await import('../../../src/cel/algorithms/appendEvent');
+    const { deriveDidCel } = await import('../../../src/cel/celDid');
+    const signer = makeMockSigner();
+    const opts = { signer, verificationMethod: 'did:key:z6MkMock#key-1', proofPurpose: 'assertionMethod' };
+
+    let log = await createEventLog(makeCelAssetData('Migrated Asset'), opts);
+    const sourceDid = deriveDidCel(log);
+    log = await appendEvent(log, 'migrate', {
+      sourceDid,
+      targetDid: 'did:webvh:example.com:asset1',
+      layer: 'webvh',
+      domain: 'example.com',
+      migratedAt: '2026-01-01T10:00:00Z',
+    }, opts);
+
+    const filePath = path.join(tempDir, 'migrated-firstclass.cel.json');
+    fs.writeFileSync(filePath, serializeEventLogJson(log));
+
+    const result = await inspectCommand({ log: filePath });
+
+    expect(result.success).toBe(true);
+    expect(result.state?.layer).toBe('webvh');
+    expect(result.state?.did).toBe('did:webvh:example.com:asset1');
+    expect(result.state?.metadata?.sourceDid).toBe(sourceDid);
+  });
+
+  it('shows both layers in history and updated DID/layer in state (legacy update-sniffed fixture)', async () => {
     const signer = makeMockSigner();
     const opts = { signer, verificationMethod: 'did:key:z6MkMock#key-1', proofPurpose: 'assertionMethod' };
 
     let log = await createEventLog(makePeerAssetData('Migrated Asset'), opts);
-    // Simulate a webvh migration update event (same shape as WebVHCelManager).
+    // Simulate a webvh migration update event (legacy shape — kept as the
+    // legacy-fixture case for the update-sniff fallback).
     log = await updateEventLog(log, {
       sourceDid: 'did:peer:4z123456789abcdef',
       targetDid: 'did:webvh:example.com:asset1',

--- a/packages/sdk/tests/unit/cel/cel-core-coverage.test.ts
+++ b/packages/sdk/tests/unit/cel/cel-core-coverage.test.ts
@@ -92,13 +92,13 @@ describe('CEL-CORE-012/happy – webvh→btco migration via BtcoCelManager', () 
     btcoLog = await btcoMgr.migrate(webvhLog);
   });
 
-  it('final event has type="update", layer="btco", sourceDid starts with did:webvh:, targetDid starts with did:btco:', () => {
-    // The btco migration appends a third event (create + webvh-update + btco-update).
+  it('final event has type="migrate", layer="btco", sourceDid starts with did:webvh:, targetDid starts with did:btco:', () => {
+    // The btco migration appends a third event (create + webvh-migrate + btco-migrate).
     const finalEvent = btcoLog.events[btcoLog.events.length - 1];
     const data = finalEvent.data as Record<string, unknown>;
 
-    // Event type
-    expect(finalEvent.type).toBe('update');
+    // Event type: migrations are first-class migrate events now
+    expect(finalEvent.type).toBe('migrate');
 
     // Layer label
     expect(data.layer).toBe('btco');

--- a/packages/sdk/tests/unit/cel/cel-core-coverage.test.ts
+++ b/packages/sdk/tests/unit/cel/cel-core-coverage.test.ts
@@ -72,7 +72,7 @@ const createMockBitcoinManager = (): BitcoinManager =>
 /** Build a webvh-layer event log (peer → webvh migration). */
 const buildWebvhLog = async (): Promise<EventLog> => {
   const peerMgr = new PeerCelManager(createMockSigner());
-  const peerLog = await peerMgr.create('Coverage Asset', [
+  const { log: peerLog } = await peerMgr.create('Coverage Asset', [
     { digestMultibase: 'uCoverageHash', mediaType: 'image/png' },
   ]);
   const webvhMgr = new WebVHCelManager(createMockSigner(), 'coverage.example.com');

--- a/packages/sdk/tests/unit/cel/celDid.test.ts
+++ b/packages/sdk/tests/unit/cel/celDid.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect } from 'bun:test';
+import { deriveDidCel, deriveDidCelFromGenesis, isDidCel, didCelMatchesLog, DID_CEL_PREFIX } from '../../../src/cel/celDid';
+import { createEventLog } from '../../../src/cel/algorithms/createEventLog';
+import { updateEventLog } from '../../../src/cel/algorithms/updateEventLog';
+import type { DataIntegrityProof } from '../../../src/cel/types';
+
+const fakeSigner = async (_data: unknown): Promise<DataIntegrityProof> => ({
+  type: 'DataIntegrityProof',
+  cryptosuite: 'eddsa-jcs-2022',
+  created: '2026-07-10T00:00:00Z',
+  verificationMethod: 'did:key:z6MkfakeSigner#z6MkfakeSigner',
+  proofPurpose: 'assertionMethod',
+  proofValue: 'zFakeSig'
+});
+
+async function makeLog() {
+  return createEventLog(
+    { name: 'A', controller: 'did:key:z6MkfakeSigner', resources: [], createdAt: '2026-07-10T00:00:00Z', nonce: 'u9zzz' },
+    { signer: fakeSigner, verificationMethod: 'did:key:z6MkfakeSigner#z6MkfakeSigner' }
+  );
+}
+
+describe('did:cel derivation', () => {
+  test('derives a stable did:cel with multihash-multibase suffix', async () => {
+    const log = await makeLog();
+    const did = deriveDidCel(log);
+    expect(did.startsWith(DID_CEL_PREFIX)).toBe(true);
+    expect(did.slice(DID_CEL_PREFIX.length).startsWith('u')).toBe(true); // base64url multibase
+    expect(deriveDidCel(log)).toBe(did); // deterministic
+    expect(deriveDidCelFromGenesis(log.events[0])).toBe(did);
+  });
+
+  test('INVARIANT: second event previousEvent equals the DID suffix', async () => {
+    const log = await makeLog();
+    const did = deriveDidCel(log);
+    const updated = await updateEventLog(log, { note: 'x' }, {
+      signer: fakeSigner, verificationMethod: 'did:key:z6MkfakeSigner#z6MkfakeSigner'
+    });
+    expect(updated.events[1].previousEvent).toBe(did.slice(DID_CEL_PREFIX.length));
+    expect(didCelMatchesLog(did, updated)).toBe(true);
+  });
+
+  test('proof does not affect the DID (proof excluded from digest)', async () => {
+    const log = await makeLog();
+    const mutated = { ...log, events: [{ ...log.events[0], proof: [{ ...log.events[0].proof[0], proofValue: 'zDifferent' }] }] };
+    expect(deriveDidCel(mutated as never)).toBe(deriveDidCel(log));
+  });
+
+  test('rejects empty logs and non-create genesis; isDidCel discriminates', async () => {
+    expect(() => deriveDidCel({ events: [] })).toThrow(/empty/i);
+    const log = await makeLog();
+    const badGenesis = { ...log.events[0], type: 'update' as const };
+    expect(() => deriveDidCelFromGenesis(badGenesis)).toThrow(/create/i);
+    expect(isDidCel('did:cel:uEiAabc')).toBe(true);
+    expect(isDidCel('did:peer:4zQm')).toBe(false);
+    expect(didCelMatchesLog('did:cel:uEiAwrong', log)).toBe(false);
+  });
+});

--- a/packages/sdk/tests/unit/cel/celDid.test.ts
+++ b/packages/sdk/tests/unit/cel/celDid.test.ts
@@ -55,4 +55,11 @@ describe('did:cel derivation', () => {
     expect(isDidCel('did:peer:4zQm')).toBe(false);
     expect(didCelMatchesLog('did:cel:uEiAwrong', log)).toBe(false);
   });
+
+  test('didCelMatchesLog returns false when the first event is not a create', async () => {
+    const log = await makeLog();
+    const did = deriveDidCel(log);
+    const notCreate = { ...log, events: [{ ...log.events[0], type: 'update' as const }] };
+    expect(didCelMatchesLog(did, notCreate as never)).toBe(false);
+  });
 });

--- a/packages/sdk/tests/unit/cel/cli-create.test.ts
+++ b/packages/sdk/tests/unit/cel/cli-create.test.ts
@@ -181,8 +181,11 @@ describe('CLI create command', () => {
       // Validate asset data
       const data = log.events[0].data as any;
       expect(data.name).toBe('Test JSON Asset');
-      expect(data.layer).toBe('peer');
-      expect(data.did).toMatch(/^did:peer:/);
+      // De-self-referenced genesis: identity is derived (did:cel), not embedded
+      expect(data.did).toBeUndefined();
+      expect(data.layer).toBeUndefined();
+      expect(data.controller).toMatch(/^did:key:/);
+      expect(data.nonce).toMatch(/^u/);
       expect(data.resources).toHaveLength(1);
       expect(data.resources[0].mediaType).toBe('image/png');
       expect(data.resources[0].digestMultibase).toBeDefined();
@@ -230,7 +233,8 @@ describe('CLI create command', () => {
       // Validate asset data
       const data = log.events[0].data as any;
       expect(data.name).toBe('Test CBOR Asset');
-      expect(data.layer).toBe('peer');
+      expect(data.layer).toBeUndefined();
+      expect(data.controller).toMatch(/^did:key:/);
     });
     
     it('CBOR output is smaller than JSON output', async () => {

--- a/packages/sdk/tests/unit/cel/cli-create.test.ts
+++ b/packages/sdk/tests/unit/cel/cli-create.test.ts
@@ -189,6 +189,31 @@ describe('CLI create command', () => {
       expect(data.resources).toHaveLength(1);
       expect(data.resources[0].mediaType).toBe('image/png');
       expect(data.resources[0].digestMultibase).toBeDefined();
+
+      // The derived did:cel is surfaced in the command result and printed.
+      expect(result.did).toMatch(/^did:cel:/);
+    });
+
+    it('prints the derived did:cel to stderr', async () => {
+      const outputPath = path.join(tempDir, 'did-print.cel.json');
+
+      const errored: string[] = [];
+      const orig = console.error;
+      console.error = (...args: unknown[]) => errored.push(args.join(' '));
+      let result;
+      try {
+        result = await createCommand({
+          name: 'DID Print Asset',
+          file: testFilePath,
+          output: outputPath,
+        });
+      } finally {
+        console.error = orig;
+      }
+
+      expect(result.success).toBe(true);
+      expect(result.did).toMatch(/^did:cel:/);
+      expect(errored.join('\n')).toContain(result.did!);
     });
     
     it('uses JSON format by default', async () => {

--- a/packages/sdk/tests/unit/cel/cli-inspect.test.ts
+++ b/packages/sdk/tests/unit/cel/cli-inspect.test.ts
@@ -240,8 +240,36 @@ describe('CLI Inspect Command', () => {
       expect(result.state?.name).toBe('Version 3');
       expect(result.state?.metadata?.custom).toBe('value');
     });
+
+    it('does not let a stray did/layer field on an update event clobber a new-shape derived identity', async () => {
+      const signer = createMockSigner();
+      const options = {
+        signer,
+        verificationMethod: 'did:key:z6MkTest#key-1',
+        proofPurpose: 'assertionMethod',
+      };
+
+      const assetData = createCelAssetData('Genesis Asset');
+      let log = await createEventLog(assetData, options);
+      const expectedDid = deriveDidCel(log);
+
+      // Stray did/layer fields on a plain update must be ignored for new-shape logs.
+      log = await updateEventLog(log, {
+        layer: 'btco',
+        did: 'did:btco:999',
+      }, options);
+
+      const filePath = path.join(tempDir, 'new-shape-stray-update.cel.json');
+      fs.writeFileSync(filePath, serializeEventLogJson(log));
+
+      const result = await inspectCommand({ log: filePath });
+
+      expect(result.success).toBe(true);
+      expect(result.state?.did).toBe(expectedDid);
+      expect(result.state?.layer).toBe('peer');
+    });
   });
-  
+
   describe('witness attestations', () => {
     it('extracts witness proofs from events', async () => {
       const signer = createMockSigner();

--- a/packages/sdk/tests/unit/cel/cli-inspect.test.ts
+++ b/packages/sdk/tests/unit/cel/cli-inspect.test.ts
@@ -12,6 +12,8 @@ import { inspectCommand, InspectFlags } from '../../../src/cel/cli/inspect';
 import { createEventLog } from '../../../src/cel/algorithms/createEventLog';
 import { updateEventLog } from '../../../src/cel/algorithms/updateEventLog';
 import { deactivateEventLog } from '../../../src/cel/algorithms/deactivateEventLog';
+import { appendEvent } from '../../../src/cel/algorithms/appendEvent';
+import { deriveDidCel } from '../../../src/cel/celDid';
 import { serializeEventLogJson } from '../../../src/cel/serialization/json';
 import { serializeEventLogCbor } from '../../../src/cel/serialization/cbor';
 import type { DataIntegrityProof, WitnessProof, EventLog, ExternalReference } from '../../../src/cel/types';
@@ -28,7 +30,8 @@ function createMockSigner(verificationMethod: string = 'did:key:z6MkTest#key-1')
   });
 }
 
-// Create an asset data object similar to what PeerCelManager creates
+// LEGACY genesis shape (pre-did:cel): embeds did/layer/creator.
+// Kept as the legacy-fixture per behavior; the write path emits CelAssetData.
 function createPeerAssetData(name: string, resources: ExternalReference[] = []) {
   return {
     name,
@@ -37,6 +40,17 @@ function createPeerAssetData(name: string, resources: ExternalReference[] = []) 
     resources,
     creator: 'did:peer:4z123456789abcdef',
     createdAt: new Date().toISOString(),
+  };
+}
+
+// New-shape genesis (CelAssetData): identity is DERIVED (did:cel), never embedded.
+function createCelAssetData(name: string, resources: ExternalReference[] = []) {
+  return {
+    name,
+    controller: 'did:key:z6MkTest',
+    resources,
+    createdAt: new Date().toISOString(),
+    nonce: 'uVGVzdE5vbmNlMTIzNDU2',
   };
 }
 
@@ -115,7 +129,7 @@ describe('CLI Inspect Command', () => {
         proofPurpose: 'assertionMethod',
       };
       
-      const assetData = createPeerAssetData('Original Name');
+      const assetData = createCelAssetData('Original Name');
       let log = await createEventLog(assetData, options);
       log = await updateEventLog(log, { name: 'Updated Name', description: 'A description' }, options);
       log = await updateEventLog(log, { version: 2 }, options);
@@ -161,21 +175,25 @@ describe('CLI Inspect Command', () => {
       const resources: ExternalReference[] = [
         { digestMultibase: 'uXYZ123', mediaType: 'image/png' }
       ];
-      const assetData = createPeerAssetData('Asset With Resources', resources);
+      const assetData = createCelAssetData('Asset With Resources', resources);
       const log = await createEventLog(assetData, {
         signer,
         verificationMethod: 'did:key:z6MkTest#key-1',
         proofPurpose: 'assertionMethod',
       });
-      
+
       const filePath = path.join(tempDir, 'with-resources.cel.json');
       fs.writeFileSync(filePath, serializeEventLogJson(log));
-      
+
       const result = await inspectCommand({ log: filePath });
-      
+
       expect(result.success).toBe(true);
       expect(result.state?.resources).toHaveLength(1);
       expect(result.state?.resources[0].mediaType).toBe('image/png');
+      // New-shape genesis: the DID is derived (did:cel), the creator is the controller.
+      expect(result.state?.did).toBe(deriveDidCel(log));
+      expect(result.state?.creator).toBe('did:key:z6MkTest');
+      expect(result.state?.layer).toBe('peer');
     });
     
     it('shows deactivated state correctly', async () => {
@@ -186,7 +204,7 @@ describe('CLI Inspect Command', () => {
         proofPurpose: 'assertionMethod',
       };
       
-      const assetData = createPeerAssetData('To Be Deactivated');
+      const assetData = createCelAssetData('To Be Deactivated');
       let log = await createEventLog(assetData, options);
       log = await deactivateEventLog(log, 'No longer needed', options);
       
@@ -344,18 +362,18 @@ describe('CLI Inspect Command', () => {
       expect(result.state?.metadata?.sourceDid).toBe('did:peer:4z123456789abcdef');
     });
     
-    it('shows full migration path from peer to btco', async () => {
+    it('shows full migration path from peer to btco (legacy update-sniffed events)', async () => {
       const signer = createMockSigner();
       const options = {
         signer,
         verificationMethod: 'did:key:z6MkTest#key-1',
         proofPurpose: 'assertionMethod',
       };
-      
+
       // Create initial peer asset
       const assetData = createPeerAssetData('Full Migration Asset');
       let log = await createEventLog(assetData, options);
-      
+
       // Simulate webvh migration
       log = await updateEventLog(log, {
         sourceDid: 'did:peer:4z123456789abcdef',
@@ -364,7 +382,7 @@ describe('CLI Inspect Command', () => {
         domain: 'example.com',
         migratedAt: '2026-01-20T10:00:00Z',
       }, options);
-      
+
       // Simulate btco migration
       log = await updateEventLog(log, {
         sourceDid: 'did:webvh:example.com:asset123',
@@ -374,16 +392,240 @@ describe('CLI Inspect Command', () => {
         inscriptionId: 'inscription123',
         migratedAt: '2026-01-20T11:00:00Z',
       }, options);
-      
+
       const filePath = path.join(tempDir, 'full-migration.cel.json');
       fs.writeFileSync(filePath, serializeEventLogJson(log));
-      
+
       const result = await inspectCommand({ log: filePath });
-      
+
       expect(result.success).toBe(true);
       expect(result.state?.layer).toBe('btco');
       expect(result.state?.did).toBe('did:btco:inscription123');
       expect(result.state?.metadata?.txid).toBe('abc123def456');
+    });
+  });
+
+  describe('first-class event types (did:cel era)', () => {
+    const witnessProofFor = (satoshi: string) => ({
+      type: 'DataIntegrityProof' as const,
+      cryptosuite: 'bitcoin-ordinals-2024',
+      created: '2026-01-20T11:00:00Z',
+      verificationMethod: 'did:btco:witness#key-1',
+      proofPurpose: 'assertionMethod',
+      proofValue: 'z3BitcoinWitnessProof',
+      witnessedAt: '2026-01-20T11:00:00Z',
+      txid: 'abc123def456',
+      inscriptionId: 'inscription123i0',
+      satoshi,
+    });
+
+    it('state replay applies a migrate-typed event (layer, did, sourceDid)', async () => {
+      const signer = createMockSigner();
+      const options = {
+        signer,
+        verificationMethod: 'did:key:z6MkTest#key-1',
+        proofPurpose: 'assertionMethod',
+      };
+
+      let log = await createEventLog(createCelAssetData('Migrating Asset'), options);
+      const sourceDid = deriveDidCel(log);
+      log = await appendEvent(log, 'migrate', {
+        sourceDid,
+        targetDid: 'did:webvh:example.com:asset123',
+        layer: 'webvh',
+        domain: 'example.com',
+        migratedAt: '2026-01-20T10:00:00Z',
+      }, options);
+
+      const filePath = path.join(tempDir, 'first-class-migrate.cel.json');
+      fs.writeFileSync(filePath, serializeEventLogJson(log));
+
+      const result = await inspectCommand({ log: filePath });
+
+      expect(result.success).toBe(true);
+      expect(result.state?.layer).toBe('webvh');
+      expect(result.state?.did).toBe('did:webvh:example.com:asset123');
+      expect(result.state?.metadata?.sourceDid).toBe(sourceDid);
+      expect(result.state?.metadata?.domain).toBe('example.com');
+      expect(result.state?.updatedAt).toBe('2026-01-20T10:00:00Z');
+    });
+
+    it('displays migrate-typed events in the layer history section', async () => {
+      const signer = createMockSigner();
+      const options = {
+        signer,
+        verificationMethod: 'did:key:z6MkTest#key-1',
+        proofPurpose: 'assertionMethod',
+      };
+
+      let log = await createEventLog(createCelAssetData('History Asset'), options);
+      log = await appendEvent(log, 'migrate', {
+        sourceDid: deriveDidCel(log),
+        targetDid: 'did:webvh:example.com:hist1',
+        layer: 'webvh',
+        domain: 'example.com',
+        migratedAt: '2026-01-20T10:00:00Z',
+      }, options);
+
+      const filePath = path.join(tempDir, 'history.cel.json');
+      fs.writeFileSync(filePath, serializeEventLogJson(log));
+
+      const logged: string[] = [];
+      const orig = console.log;
+      console.log = (...args: unknown[]) => logged.push(args.join(' '));
+      let result;
+      try {
+        result = await inspectCommand({ log: filePath });
+      } finally {
+        console.log = orig;
+      }
+
+      expect(result.success).toBe(true);
+      const output = logged.join('\n');
+      // Layer history section renders only when >1 entries — the migrate-typed
+      // event must contribute the webvh entry.
+      expect(output).toContain('LAYER HISTORY');
+      expect(output).toContain('WebVH');
+      // Timeline shows a MIGRATE badge for the first-class event.
+      expect(output).toContain('MIGRATE');
+    });
+
+    it('derives did:btco from the bitcoin witness proof on a migrate-typed btco event', async () => {
+      const signer = createMockSigner();
+      const options = {
+        signer,
+        verificationMethod: 'did:key:z6MkTest#key-1',
+        proofPurpose: 'assertionMethod',
+      };
+
+      let log = await createEventLog(createCelAssetData('Btco Asset'), options);
+      log = await appendEvent(log, 'migrate', {
+        sourceDid: deriveDidCel(log),
+        targetDid: 'did:webvh:example.com:btco1',
+        layer: 'webvh',
+        domain: 'example.com',
+        migratedAt: '2026-01-20T10:00:00Z',
+      }, options);
+      log = await appendEvent(log, 'migrate', {
+        sourceDid: 'did:webvh:example.com:btco1',
+        layer: 'btco',
+        migratedAt: '2026-01-20T11:00:00Z',
+      }, options);
+
+      // Attach the bitcoin witness proof carrying the satoshi (added after
+      // signing, as BtcoCelManager does).
+      const last = log.events[log.events.length - 1];
+      log = {
+        events: [
+          ...log.events.slice(0, -1),
+          { ...last, proof: [...last.proof, witnessProofFor('123456789')] },
+        ],
+      };
+
+      const filePath = path.join(tempDir, 'btco-migrate.cel.json');
+      fs.writeFileSync(filePath, serializeEventLogJson(log));
+
+      const result = await inspectCommand({ log: filePath });
+
+      expect(result.success).toBe(true);
+      expect(result.state?.layer).toBe('btco');
+      expect(result.state?.did).toBe('did:btco:123456789');
+      expect(result.state?.metadata?.txid).toBe('abc123def456');
+      expect(result.state?.metadata?.inscriptionId).toBe('inscription123i0');
+    });
+
+    it('state replay applies a transfer-typed event (owners, timestamp; identity unchanged)', async () => {
+      const signer = createMockSigner();
+      const options = {
+        signer,
+        verificationMethod: 'did:key:z6MkTest#key-1',
+        proofPurpose: 'assertionMethod',
+      };
+
+      let log = await createEventLog(createCelAssetData('Owned Asset'), options);
+      const did = deriveDidCel(log);
+      log = await appendEvent(log, 'transfer', {
+        previousOwner: did,
+        newOwner: 'bc1qnewowner',
+        transferredAt: '2026-01-21T09:00:00Z',
+      }, options);
+
+      const filePath = path.join(tempDir, 'transferred.cel.json');
+      fs.writeFileSync(filePath, serializeEventLogJson(log));
+
+      const result = await inspectCommand({ log: filePath });
+
+      expect(result.success).toBe(true);
+      expect(result.state?.did).toBe(did);
+      expect(result.state?.metadata?.previousOwner).toBe(did);
+      expect(result.state?.metadata?.newOwner).toBe('bc1qnewowner');
+      expect(result.state?.updatedAt).toBe('2026-01-21T09:00:00Z');
+    });
+
+    it('state replay applies a rotateKey-typed event (controller hand-off)', async () => {
+      const signer = createMockSigner();
+      const options = {
+        signer,
+        verificationMethod: 'did:key:z6MkTest#key-1',
+        proofPurpose: 'assertionMethod',
+      };
+
+      let log = await createEventLog(createCelAssetData('Rotating Asset'), options);
+      log = await appendEvent(log, 'rotateKey', {
+        previousController: 'did:key:z6MkTest',
+        newController: 'did:key:z6MkNewController',
+        rotatedAt: '2026-01-22T08:00:00Z',
+      }, options);
+
+      const filePath = path.join(tempDir, 'rotated.cel.json');
+      fs.writeFileSync(filePath, serializeEventLogJson(log));
+
+      const result = await inspectCommand({ log: filePath });
+
+      expect(result.success).toBe(true);
+      expect(result.state?.controller).toBe('did:key:z6MkNewController');
+      expect(result.state?.updatedAt).toBe('2026-01-22T08:00:00Z');
+    });
+
+    it('timeline displays TRANSFER and ROTATEKEY badges with details', async () => {
+      const signer = createMockSigner();
+      const options = {
+        signer,
+        verificationMethod: 'did:key:z6MkTest#key-1',
+        proofPurpose: 'assertionMethod',
+      };
+
+      let log = await createEventLog(createCelAssetData('Badge Asset'), options);
+      log = await appendEvent(log, 'transfer', {
+        previousOwner: deriveDidCel(log),
+        newOwner: 'bc1qbadges',
+        transferredAt: '2026-01-21T09:00:00Z',
+      }, options);
+      log = await appendEvent(log, 'rotateKey', {
+        previousController: 'did:key:z6MkTest',
+        newController: 'did:key:z6MkNext',
+        rotatedAt: '2026-01-22T08:00:00Z',
+      }, options);
+
+      const filePath = path.join(tempDir, 'badges.cel.json');
+      fs.writeFileSync(filePath, serializeEventLogJson(log));
+
+      const logged: string[] = [];
+      const orig = console.log;
+      console.log = (...args: unknown[]) => logged.push(args.join(' '));
+      let result;
+      try {
+        result = await inspectCommand({ log: filePath });
+      } finally {
+        console.log = orig;
+      }
+
+      expect(result.success).toBe(true);
+      const output = logged.join('\n');
+      expect(output).toContain('TRANSFER');
+      expect(output).toContain('ROTATEKEY');
+      expect(output).toContain('bc1qbadges');
+      expect(output).toContain('did:key:z6MkNext');
     });
   });
   

--- a/packages/sdk/tests/unit/cel/cli-migrate.test.ts
+++ b/packages/sdk/tests/unit/cel/cli-migrate.test.ts
@@ -192,7 +192,7 @@ describe('CLI Migrate Command', () => {
       // Verify output log has migration event
       const migratedLog = parseEventLogJson(fs.readFileSync(outputPath, 'utf-8'));
       expect(migratedLog.events.length).toBe(2); // create + migration
-      expect(migratedLog.events[1].type).toBe('update');
+      expect(migratedLog.events[1].type).toBe('migrate');
       
       const migrationData = migratedLog.events[1].data as Record<string, unknown>;
       expect(migrationData.layer).toBe('webvh');

--- a/packages/sdk/tests/unit/cel/cli-migration-chain.test.ts
+++ b/packages/sdk/tests/unit/cel/cli-migration-chain.test.ts
@@ -1,0 +1,190 @@
+/**
+ * CLI two-step migration chain (Task 8 — closes the Task 7 review break)
+ *
+ * Drives the full CLI chain over MANAGER-PRODUCED logs:
+ *   create (did:cel genesis) → migrate --to webvh → migrate --to btco → transfer
+ *
+ * The Task 7 break: `migrate --to webvh` writes a `migrate`-typed event, but
+ * the CLI's detectCurrentLayer/getCurrentDid sniffed only `update`-typed
+ * migration events, so the follow-up `migrate --to btco` mis-detected layer
+ * `peer` and threw "Cannot migrate directly from peer to btco".
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { createCommand } from '../../../src/cel/cli/create';
+import { migrateCommand } from '../../../src/cel/cli/migrate';
+import { transferCommand } from '../../../src/cel/cli/transfer';
+import { parseEventLogJson } from '../../../src/cel/serialization/json';
+import { multikey } from '../../../src/crypto/Multikey';
+
+async function createTestWallet(dir: string): Promise<string> {
+  const ed25519 = await import('@noble/ed25519');
+  const privateKeyBytes = ed25519.utils.randomSecretKey();
+  const privateKey = multikey.encodePrivateKey(privateKeyBytes as Uint8Array, 'Ed25519');
+  const walletPath = path.join(dir, 'chain-wallet.key');
+  fs.writeFileSync(walletPath, privateKey);
+  return walletPath;
+}
+
+describe('CLI two-step migration chain (peer → webvh → btco)', () => {
+  let tempDir: string;
+  let contentPath: string;
+  let walletPath: string;
+
+  beforeEach(async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cel-chain-test-'));
+    contentPath = path.join(tempDir, 'content.txt');
+    fs.writeFileSync(contentPath, 'chain test content');
+    walletPath = await createTestWallet(tempDir);
+  });
+
+  afterEach(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('create surfaces the derived did:cel in its result', async () => {
+    const outputPath = path.join(tempDir, 'asset.cel.json');
+    const result = await createCommand({
+      name: 'Chain Asset',
+      file: contentPath,
+      key: walletPath,
+      output: outputPath,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.did).toBeDefined();
+    expect(result.did!.startsWith('did:cel:')).toBe(true);
+  });
+
+  it('migrates a fresh did:cel-genesis log to webvh, then to btco, then transfers', async () => {
+    const peerPath = path.join(tempDir, 'asset.cel.json');
+    const webvhPath = path.join(tempDir, 'asset.webvh.cel.json');
+    const btcoPath = path.join(tempDir, 'asset.btco.cel.json');
+    const transferredPath = path.join(tempDir, 'asset.transferred.cel.json');
+
+    // Step 0: create — new-shape genesis (no embedded did/layer)
+    const createResult = await createCommand({
+      name: 'Chain Asset',
+      file: contentPath,
+      key: walletPath,
+      output: peerPath,
+    });
+    expect(createResult.success).toBe(true);
+
+    // Step 1: peer → webvh (writes a first-class `migrate` event)
+    const webvhResult = await migrateCommand({
+      log: peerPath,
+      to: 'webvh',
+      domain: 'example.com',
+      wallet: walletPath,
+      output: webvhPath,
+    });
+    expect(webvhResult.success).toBe(true);
+    expect(webvhResult.sourceDid).toMatch(/^did:cel:/);
+    expect(webvhResult.targetDid).toContain('did:webvh:example.com');
+
+    const webvhLog = parseEventLogJson(fs.readFileSync(webvhPath, 'utf-8'));
+    expect(webvhLog.events[webvhLog.events.length - 1].type).toBe('migrate');
+
+    // Step 2: webvh → btco — the Task 7 break: detection must see the
+    // `migrate`-typed event and report layer webvh, not peer.
+    const btcoResult = await migrateCommand({
+      log: webvhPath,
+      to: 'btco',
+      wallet: walletPath,
+      output: btcoPath,
+    });
+    expect(btcoResult.success).toBe(true);
+    expect(btcoResult.message).not.toContain('Cannot migrate directly');
+    expect(btcoResult.targetLayer).toBe('btco');
+    expect(btcoResult.sourceDid).toContain('did:webvh:example.com');
+    expect(btcoResult.targetDid).toContain('did:btco');
+
+    const btcoLog = parseEventLogJson(fs.readFileSync(btcoPath, 'utf-8'));
+    expect(btcoLog.events.map(e => e.type)).toEqual(['create', 'migrate', 'migrate']);
+
+    // Step 3: btco is terminal — a further migration must be rejected.
+    const terminalResult = await migrateCommand({
+      log: btcoPath,
+      to: 'webvh',
+      domain: 'other.com',
+      wallet: walletPath,
+    });
+    expect(terminalResult.success).toBe(false);
+    expect(terminalResult.message).toContain('Cannot migrate from btco layer');
+
+    // Step 4: transfer emits a first-class `transfer` event whose
+    // previousOwner is the resolvable did:btco (derived from the witness proof).
+    const transferResult = await transferCommand({
+      log: btcoPath,
+      to: 'bc1qnewownerchain',
+      wallet: walletPath,
+      output: transferredPath,
+    });
+    expect(transferResult.success).toBe(true);
+    expect(transferResult.previousOwner).toContain('did:btco');
+
+    const transferredLog = parseEventLogJson(fs.readFileSync(transferredPath, 'utf-8'));
+    const transferEvent = transferredLog.events[transferredLog.events.length - 1];
+    expect(transferEvent.type).toBe('transfer');
+    const transferData = transferEvent.data as Record<string, unknown>;
+    // No inner discriminator — the type lives on the event itself.
+    expect(transferData.type).toBeUndefined();
+    expect(transferData.previousOwner).toContain('did:btco');
+    expect(transferData.newOwner).toBe('bc1qnewownerchain');
+    expect(transferData.transferredAt).toBeDefined();
+  });
+
+  it('legacy update-sniffed migration chain still detects webvh (fallback kept)', async () => {
+    // Legacy log: genesis embeds did/layer; migration recorded as an `update`.
+    const { createEventLog } = await import('../../../src/cel/algorithms/createEventLog');
+    const { updateEventLog } = await import('../../../src/cel/algorithms/updateEventLog');
+    const { serializeEventLogJson } = await import('../../../src/cel/serialization/json');
+
+    const signer = async (data: unknown) => ({
+      type: 'DataIntegrityProof' as const,
+      cryptosuite: 'eddsa-jcs-2022',
+      created: new Date().toISOString(),
+      verificationMethod: 'did:key:z6MkLegacy#key-1',
+      proofPurpose: 'assertionMethod',
+      proofValue: 'z3LegacyMockProof',
+    });
+    const opts = { signer, verificationMethod: 'did:key:z6MkLegacy#key-1', proofPurpose: 'assertionMethod' };
+
+    let log = await createEventLog({
+      name: 'Legacy Asset',
+      did: 'did:peer:4z6MkLegacyChain',
+      layer: 'peer',
+      resources: [],
+      creator: 'did:peer:4z6MkLegacyChain',
+      createdAt: new Date().toISOString(),
+    }, opts);
+    log = await updateEventLog(log, {
+      sourceDid: 'did:peer:4z6MkLegacyChain',
+      targetDid: 'did:webvh:example.com:legacyid',
+      layer: 'webvh',
+      domain: 'example.com',
+      migratedAt: new Date().toISOString(),
+    }, opts);
+
+    const legacyPath = path.join(tempDir, 'legacy.cel.json');
+    const btcoPath = path.join(tempDir, 'legacy.btco.cel.json');
+    fs.writeFileSync(legacyPath, serializeEventLogJson(log));
+
+    const result = await migrateCommand({
+      log: legacyPath,
+      to: 'btco',
+      wallet: walletPath,
+      output: btcoPath,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.sourceDid).toBe('did:webvh:example.com:legacyid');
+    expect(result.targetLayer).toBe('btco');
+  });
+});

--- a/packages/sdk/tests/unit/cel/cli-publish.test.ts
+++ b/packages/sdk/tests/unit/cel/cli-publish.test.ts
@@ -121,7 +121,7 @@ describe('CLI Publish Command', () => {
 
       const publishedLog = parseEventLogJson(fs.readFileSync(outputPath, 'utf-8'));
       expect(publishedLog.events.length).toBe(2);
-      expect(publishedLog.events[1].type).toBe('update');
+      expect(publishedLog.events[1].type).toBe('migrate');
 
       const migrationData = publishedLog.events[1].data as Record<string, unknown>;
       expect(migrationData.layer).toBe('webvh');

--- a/packages/sdk/tests/unit/cel/cli-transfer.test.ts
+++ b/packages/sdk/tests/unit/cel/cli-transfer.test.ts
@@ -201,10 +201,11 @@ describe('CLI Transfer Command', () => {
       expect(transferredLog.events.length).toBe(2); // create + transfer
 
       const transferEvent = transferredLog.events[1];
-      expect(transferEvent.type).toBe('update');
+      // First-class event type: the discriminator lives on the event, not in data.
+      expect(transferEvent.type).toBe('transfer');
 
       const transferData = transferEvent.data as Record<string, unknown>;
-      expect(transferData.type).toBe('transfer');
+      expect(transferData.type).toBeUndefined();
       expect(transferData.previousOwner).toBe('did:peer:4z6MkTestPeerDid12345');
       expect(transferData.newOwner).toBe('bc1qtest');
       expect(transferData.transferredAt).toBeDefined();

--- a/packages/sdk/tests/unit/cel/did-cel-verification.test.ts
+++ b/packages/sdk/tests/unit/cel/did-cel-verification.test.ts
@@ -1,0 +1,99 @@
+/**
+ * did:cel self-certification branch in verifyEventLog.
+ *
+ * New-shape genesis events carry the holder's key in `data.controller` and NO
+ * `data.did` (the asset DID is DERIVED — did:cel). For these logs the root key
+ * MUST be a key of `data.controller`, fail-closed with no trust-on-first-use
+ * fallback. Legacy `data.did` logs keep their exact prior behavior.
+ *
+ * Uses REAL Ed25519 signing (the eddsa-jcs-2022 signer pattern from
+ * event-log-authorization.test.ts), so cryptographic + authority checks run.
+ */
+import { describe, test, expect } from 'bun:test';
+import * as ed25519 from '@noble/ed25519';
+import { multikey } from '../../../src/crypto/Multikey';
+import { canonicalizeEvent } from '../../../src/cel/canonicalize';
+import { verifyEventLog } from '../../../src/cel/algorithms/verifyEventLog';
+import { createEventLog } from '../../../src/cel/algorithms/createEventLog';
+import { deriveDidCel } from '../../../src/cel/celDid';
+
+// A real eddsa-jcs-2022 signer exposing its holder did:key + canonical VM.
+async function makeRealSigner() {
+  const priv = crypto.getRandomValues(new Uint8Array(32));
+  const pub = await ed25519.getPublicKeyAsync(priv);
+  const pubMb = multikey.encodePublicKey(pub, 'Ed25519');
+  const didKey = `did:key:${pubMb}`;
+  const vm = `${didKey}#${pubMb}`;
+  const signer = async (data: unknown) => ({
+    type: 'DataIntegrityProof',
+    cryptosuite: 'eddsa-jcs-2022',
+    created: '2020-01-01T00:00:00Z',
+    verificationMethod: vm,
+    proofPurpose: 'assertionMethod',
+    proofValue: multikey.encodeMultibase(
+      new Uint8Array(await ed25519.signAsync(canonicalizeEvent(data), priv))
+    ),
+  });
+  return { signer, didKey, vm };
+}
+
+describe('did:cel self-certification', () => {
+  test('valid did:cel log verifies and reports assetDid', async () => {
+    const { signer, didKey, vm } = await makeRealSigner();
+    const log = await createEventLog(
+      { name: 'A', controller: didKey, resources: [], createdAt: '2026-07-10T00:00:00Z', nonce: 'u1111' },
+      { signer, verificationMethod: vm }
+    );
+    const result = await verifyEventLog(log);
+    expect(result.verified).toBe(true);
+    expect(result.assetDid).toBe(deriveDidCel(log));
+  });
+
+  test('genesis signed by a key that is NOT the controller fails closed', async () => {
+    const { didKey } = await makeRealSigner();          // controller A
+    const other = await makeRealSigner();               // signer B
+    const log = await createEventLog(
+      { name: 'A', controller: didKey, resources: [], createdAt: 'x', nonce: 'u2222' },
+      { signer: other.signer, verificationMethod: other.vm }
+    );
+    const result = await verifyEventLog(log);
+    expect(result.verified).toBe(false);
+    expect(result.errors.join(' ')).toMatch(/controller/i);
+  });
+
+  test('non-did:key controller fails closed (no TOFU on the did:cel branch)', async () => {
+    const { signer, vm } = await makeRealSigner();
+    const log = await createEventLog(
+      { name: 'A', controller: 'did:webvh:x:example.com:a', resources: [], createdAt: 'x', nonce: 'u3333' },
+      { signer, verificationMethod: vm }
+    );
+    const result = await verifyEventLog(log);
+    expect(result.verified).toBe(false);
+  });
+
+  test('expectedDid mismatch fails; match passes (did:cel)', async () => {
+    const { signer, didKey, vm } = await makeRealSigner();
+    const log = await createEventLog(
+      { name: 'A', controller: didKey, resources: [], createdAt: 'x', nonce: 'u4444' },
+      { signer, verificationMethod: vm }
+    );
+    expect((await verifyEventLog(log, { expectedDid: deriveDidCel(log) })).verified).toBe(true);
+    expect((await verifyEventLog(log, { expectedDid: 'did:cel:uEiAwrong' })).verified).toBe(false);
+  });
+
+  test('legacy data.did logs verify exactly as before and report assetDid', async () => {
+    // Legacy shape: the asset DID is embedded in data.did (a self-certifying
+    // did:key). This pins the dual-accept contract — legacy must stay green.
+    const { signer, didKey, vm } = await makeRealSigner();
+    const log = await createEventLog(
+      { name: 'A', did: didKey, layer: 'peer', resources: [], creator: didKey, createdAt: '2020-01-01T00:00:00Z' },
+      { signer, verificationMethod: vm }
+    );
+    const result = await verifyEventLog(log);
+    expect(result.verified).toBe(true);
+    expect(result.assetDid).toBe(didKey);
+    // expectedDid on legacy is string equality.
+    expect((await verifyEventLog(log, { expectedDid: didKey })).verified).toBe(true);
+    expect((await verifyEventLog(log, { expectedDid: 'did:key:zWrong' })).verified).toBe(false);
+  });
+});

--- a/packages/sdk/tests/unit/cel/did-cel-verification.test.ts
+++ b/packages/sdk/tests/unit/cel/did-cel-verification.test.ts
@@ -81,6 +81,49 @@ describe('did:cel self-certification', () => {
     expect((await verifyEventLog(log, { expectedDid: 'did:cel:uEiAwrong' })).verified).toBe(false);
   });
 
+  test('resolver-backed genesis forgery backstop: attacker key + victim VM string fails against an honest resolver', async () => {
+    // VM-equality (root proof VM === data.controller) alone must never suffice
+    // for a resolver-backed (non-did:key) controller: the resolved key must
+    // also cryptographically verify the signature. An attacker who stamps the
+    // victim's exact VM but signs with their own key must fail closed.
+    const victimPriv = crypto.getRandomValues(new Uint8Array(32));
+    const victimPub = await ed25519.getPublicKeyAsync(victimPriv);
+    const attackerPriv = crypto.getRandomValues(new Uint8Array(32));
+    const victimVm = 'did:webvh:example.com:victim#key-0';
+
+    // Signs with the given private key but stamps an arbitrary claimed VM
+    // (the "different key, claimed VM" pattern from event-log-authorization.test.ts).
+    const vmSigner = (priv: Uint8Array, vm: string) => async (data: unknown) => ({
+      type: 'DataIntegrityProof',
+      cryptosuite: 'eddsa-jcs-2022',
+      created: '2020-01-01T00:00:00Z',
+      verificationMethod: vm,
+      proofPurpose: 'assertionMethod',
+      proofValue: multikey.encodeMultibase(
+        new Uint8Array(await ed25519.signAsync(canonicalizeEvent(data), priv))
+      ),
+    });
+
+    // Honest resolver: returns the VICTIM's real key for the victim's VM.
+    const resolveKey = async (vm: string) => (vm === victimVm ? victimPub : null);
+
+    const forgedLog = await createEventLog(
+      { name: 'A', controller: 'did:webvh:example.com:victim', resources: [], createdAt: 'x', nonce: 'uForge1' },
+      { signer: vmSigner(attackerPriv, victimVm) as any, verificationMethod: victimVm }
+    );
+    const forgedResult = await verifyEventLog(forgedLog, { resolveKey });
+    expect(forgedResult.verified).toBe(false);
+
+    // Sibling positive control: same genesis, same VM + resolver, but actually
+    // signed by the victim's own key — must verify.
+    const legitLog = await createEventLog(
+      { name: 'A', controller: 'did:webvh:example.com:victim', resources: [], createdAt: 'x', nonce: 'uForge2' },
+      { signer: vmSigner(victimPriv, victimVm) as any, verificationMethod: victimVm }
+    );
+    const legitResult = await verifyEventLog(legitLog, { resolveKey });
+    expect(legitResult.verified).toBe(true);
+  });
+
   test('legacy data.did logs verify exactly as before and report assetDid', async () => {
     // Legacy shape: the asset DID is embedded in data.did (a self-certifying
     // did:key). This pins the dual-accept contract — legacy must stay green.

--- a/packages/sdk/tests/unit/cel/event-log-authorization.test.ts
+++ b/packages/sdk/tests/unit/cel/event-log-authorization.test.ts
@@ -78,7 +78,7 @@ describe('CEL event-log authorization and btco verifiability', () => {
   it('a real webvh→btco migration produces a verifiable log', async () => {
     const signer = makeSigner();
     const peer = new PeerCelManager(signer as any);
-    let log = await peer.create('Asset', [{ digestMultibase: 'uHash', mediaType: 'image/png' }]);
+    let { log } = await peer.create('Asset', [{ digestMultibase: 'uHash', mediaType: 'image/png' }]);
     log = await new WebVHCelManager(signer as any, 'example.com').migrate(log);
     const { manager, ordinalsProvider } = mockBitcoin();
     const btcoLog = await new BtcoCelManager(signer as any, manager).migrate(log);
@@ -106,7 +106,7 @@ describe('CEL event-log authorization and btco verifiability', () => {
   it('reports a clear "content is missing" diagnostic when the witness inscription has no content', async () => {
     const signer = makeSigner();
     const peer = new PeerCelManager(signer as any);
-    let log = await peer.create('Asset', [{ digestMultibase: 'uHash', mediaType: 'image/png' }]);
+    let { log } = await peer.create('Asset', [{ digestMultibase: 'uHash', mediaType: 'image/png' }]);
     log = await new WebVHCelManager(signer as any, 'example.com').migrate(log);
     const { manager } = mockBitcoin();
     const btcoLog = await new BtcoCelManager(signer as any, manager).migrate(log);
@@ -131,21 +131,42 @@ describe('CEL event-log authorization and btco verifiability', () => {
     expect(result.errors.some(e => /not valid JSON/.test(e))).toBe(false);
   });
 
-  it('rejects a create event re-signed by a different key than the one embedded in the did:peer', async () => {
+  it('rejects a LEGACY create event re-signed by a different key than the one embedded in the did:peer', async () => {
     // Attack: copy a victim's create event `data` verbatim (including the
     // victim's self-certifying did:peer:4) and re-sign event 0 with the
     // attacker's own did:key. The log is internally consistent, but the
     // create key is not embedded in the DID — verification must fail.
+    //
+    // Legacy fixture: the write path no longer emits `data.did` (did:cel
+    // genesis is de-self-referenced), but logs in this shape exist and the
+    // verify READ path must keep rejecting this forgery on them.
     const victim = makeSigner();
-    const log = await new PeerCelManager(victim as any).create('Victim Asset', []);
+    const victimVm = (await victim({ probe: true })).verificationMethod;
+    const victimKeyMb = victimVm.slice('did:key:'.length).split('#')[0];
+    const didPeerMod = await import('@aviarytech/did-peer');
+    const victimDid: string = await didPeerMod.createNumAlgo4(
+      [{ type: 'Multikey', publicKeyMultibase: victimKeyMb }],
+      undefined,
+      undefined
+    );
+    const legacyData = {
+      name: 'Victim Asset',
+      did: victimDid,
+      layer: 'peer',
+      resources: [],
+      creator: victimDid,
+      createdAt: '2020-01-01T00:00:00Z',
+    };
+    const victimProof = await victim({ type: 'create', data: legacyData });
+    const log = { events: [{ type: 'create', data: legacyData, proof: [victimProof] }] };
+
+    // Sanity: the victim's own legacy log passes the self-certifying binding.
+    const legit = await verifyEventLog(log as any);
+    expect(legit.verified).toBe(true);
 
     const attacker = makeSigner();
-    const createEvent = log.events[0];
-    const attackerProof = await attacker({ type: createEvent.type, data: createEvent.data });
-    const forged = {
-      ...log,
-      events: [{ ...createEvent, proof: [attackerProof] }],
-    };
+    const attackerProof = await attacker({ type: 'create', data: legacyData });
+    const forged = { events: [{ type: 'create', data: legacyData, proof: [attackerProof] }] };
 
     const result = await verifyEventLog(forged as any);
     expect(result.verified).toBe(false);
@@ -154,7 +175,7 @@ describe('CEL event-log authorization and btco verifiability', () => {
 
   it('derives btco state without a BitcoinManager (network read from signed data)', async () => {
     const signer = makeSigner();
-    let log = await new PeerCelManager(signer as any).create('Asset', []);
+    let { log } = await new PeerCelManager(signer as any).create('Asset', []);
     log = await new WebVHCelManager(signer as any, 'example.com').migrate(log);
     const btcoLog = await new BtcoCelManager(signer as any, mockBitcoin().manager).migrate(log);
 
@@ -172,7 +193,7 @@ describe('CEL event-log authorization and btco verifiability', () => {
     // sourceDid/layer fields but no migratedAt must replay as a regular
     // update: the name change applies and the layer does not flip.
     const signer = makeSigner();
-    let log = await new PeerCelManager(signer as any).create('Asset', []);
+    let { log } = await new PeerCelManager(signer as any).create('Asset', []);
     const webvhManager = new WebVHCelManager(signer as any, 'example.com');
     log = await webvhManager.migrate(log);
     log = await updateEventLog(log, { sourceDid: 'did:example:app-field', layer: 'btco', name: 'renamed' }, {
@@ -190,7 +211,7 @@ describe('CEL event-log authorization and btco verifiability', () => {
 
   it('rejects an event appended by a key not authorized by the create event', async () => {
     const owner = makeSigner();
-    const log = await new PeerCelManager(owner as any).create('Owner Asset', []);
+    const { log } = await new PeerCelManager(owner as any).create('Owner Asset', []);
 
     // Attacker signs an update with their own unrelated key.
     const attacker = makeSigner();
@@ -210,7 +231,7 @@ describe('CEL event-log authorization and btco verifiability', () => {
     // append their own valid controller proof to event 0 (keeping the owner's)
     // and, without this guard, become an authorized signer for later events.
     const owner = makeSigner();
-    const log = await new PeerCelManager(owner as any).create('Owner Asset', []);
+    const { log } = await new PeerCelManager(owner as any).create('Owner Asset', []);
 
     const attacker = makeSigner();
     const ev0 = log.events[0];
@@ -231,7 +252,7 @@ describe('CEL event-log authorization and btco verifiability', () => {
   it('accepts an update signed by the same controller key', async () => {
     const owner = makeSigner();
     const peer = new PeerCelManager(owner as any);
-    let log = await peer.create('Owner Asset', []);
+    let { log } = await peer.create('Owner Asset', []);
     log = await peer.update(log, { name: 'v2' });
 
     const result = await verifyEventLog(log);
@@ -264,7 +285,7 @@ describe('CEL event-log authorization and btco verifiability', () => {
       const resolveKey = async (_vm: string) => pub;
 
       const create = new PeerCelManager(vmSigner(priv, 'did:webvh:example.com:alice#key-0') as any);
-      let log = await create.create('Asset', []);
+      let { log } = await create.create('Asset', []);
       log = await new PeerCelManager(vmSigner(priv, 'did:webvh:example.com:alice#key-alias') as any)
         .update(log, { name: 'v2' });
 
@@ -282,7 +303,7 @@ describe('CEL event-log authorization and btco verifiability', () => {
       const resolveKey = async (vm: string) => (vm.endsWith('#key-1') ? pubB : pubA);
 
       const create = new PeerCelManager(vmSigner(privA, 'did:webvh:example.com:alice#key-0') as any);
-      let log = await create.create('Asset', []);
+      let { log } = await create.create('Asset', []);
       log = await new PeerCelManager(vmSigner(privB, 'did:webvh:example.com:alice#key-1') as any)
         .update(log, { name: 'hijacked' });
 

--- a/packages/sdk/tests/unit/cel/json-serialization.test.ts
+++ b/packages/sdk/tests/unit/cel/json-serialization.test.ts
@@ -630,6 +630,19 @@ describe('CEL JSON Serialization', () => {
       expect(parsed.events[1].type).toBe('deactivate');
       expect((parsed.events[1].data as { reason: string }).reason).toBe('No longer needed');
     });
+
+    test('round-trips migrate/transfer/rotateKey event types', () => {
+      const log = {
+        events: [
+          { type: 'create', data: { name: 'A' }, proof: [{ type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', created: 'x', verificationMethod: 'did:key:z6Mk#z6Mk', proofPurpose: 'assertionMethod', proofValue: 'z1' }] },
+          { type: 'migrate', data: { sourceDid: 'did:cel:uEiA', targetDid: 'did:webvh:x:example.com:a', layer: 'webvh', migratedAt: 'x' }, previousEvent: 'uEiB', proof: [{ type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', created: 'x', verificationMethod: 'did:key:z6Mk#z6Mk', proofPurpose: 'assertionMethod', proofValue: 'z2' }] },
+          { type: 'transfer', data: { previousOwner: 'did:key:z6Mk', newOwner: 'did:key:z6Mk2', transferredAt: 'x' }, previousEvent: 'uEiC', proof: [{ type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', created: 'x', verificationMethod: 'did:key:z6Mk#z6Mk', proofPurpose: 'assertionMethod', proofValue: 'z3' }] },
+          { type: 'rotateKey', data: { newController: 'did:key:z6Mk2', rotatedAt: 'x' }, previousEvent: 'uEiD', proof: [{ type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', created: 'x', verificationMethod: 'did:key:z6Mk#z6Mk', proofPurpose: 'assertionMethod', proofValue: 'z4' }] }
+        ]
+      };
+      const parsed = parseEventLogJson(serializeEventLogJson(log as never));
+      expect(parsed.events.map(e => e.type)).toEqual(['create', 'migrate', 'transfer', 'rotateKey']);
+    });
   });
 
   describe('optional created field (type/serialization parity)', () => {

--- a/packages/sdk/tests/unit/cel/key-rotation-authority.test.ts
+++ b/packages/sdk/tests/unit/cel/key-rotation-authority.test.ts
@@ -1,0 +1,157 @@
+/**
+ * rotateKey authority evolution in verifyEventLog.
+ *
+ * A fully valid rotateKey event REPLACES the authorized key set with the new
+ * controller's keys (hand-off semantics — design spec §2/§5; replace, not
+ * union: keeping old keys would reopen the stale-key window). A rotation that
+ * fails ANY check must not rotate; an unbindable newController fails the event
+ * AND the log.
+ *
+ * Uses REAL Ed25519 signing (the eddsa-jcs-2022 signer pattern from
+ * did-cel-verification.test.ts / event-log-authorization.test.ts).
+ */
+import { describe, test, expect } from 'bun:test';
+import * as ed25519 from '@noble/ed25519';
+import { multikey } from '../../../src/crypto/Multikey';
+import { canonicalizeEvent } from '../../../src/cel/canonicalize';
+import { verifyEventLog } from '../../../src/cel/algorithms/verifyEventLog';
+import { createEventLog } from '../../../src/cel/algorithms/createEventLog';
+import { appendEvent } from '../../../src/cel/algorithms/appendEvent';
+
+// A real eddsa-jcs-2022 signer exposing its holder did:key + canonical VM.
+async function makeRealSigner() {
+  const priv = crypto.getRandomValues(new Uint8Array(32));
+  const pub = await ed25519.getPublicKeyAsync(priv);
+  const pubMb = multikey.encodePublicKey(pub, 'Ed25519');
+  const didKey = `did:key:${pubMb}`;
+  const vm = `${didKey}#${pubMb}`;
+  const signer = async (data: unknown) => ({
+    type: 'DataIntegrityProof',
+    cryptosuite: 'eddsa-jcs-2022',
+    created: '2020-01-01T00:00:00Z',
+    verificationMethod: vm,
+    proofPurpose: 'assertionMethod',
+    proofValue: multikey.encodeMultibase(
+      new Uint8Array(await ed25519.signAsync(canonicalizeEvent(data), priv))
+    ),
+  });
+  return { signer, didKey, vm };
+}
+
+describe('rotateKey authority evolution', () => {
+  test('post-rotation events signed by the NEW key verify; log reports verified', async () => {
+    const a = await makeRealSigner(); const b = await makeRealSigner();
+    let log = await createEventLog(
+      { name: 'A', controller: a.didKey, resources: [], createdAt: 'x', nonce: 'u1' },
+      { signer: a.signer, verificationMethod: a.vm }
+    );
+    log = await appendEvent(log, 'rotateKey', { newController: b.didKey, rotatedAt: 'x' }, { signer: a.signer, verificationMethod: a.vm });
+    log = await appendEvent(log, 'update', { note: 'signed by new key' }, { signer: b.signer, verificationMethod: b.vm });
+    expect((await verifyEventLog(log)).verified).toBe(true);
+  });
+
+  test('OLD key signing AFTER rotation fails (replace, not union)', async () => {
+    const a = await makeRealSigner(); const b = await makeRealSigner();
+    let log = await createEventLog(
+      { name: 'A', controller: a.didKey, resources: [], createdAt: 'x', nonce: 'u2' },
+      { signer: a.signer, verificationMethod: a.vm }
+    );
+    log = await appendEvent(log, 'rotateKey', { newController: b.didKey, rotatedAt: 'x' }, { signer: a.signer, verificationMethod: a.vm });
+    log = await appendEvent(log, 'update', { note: 'stale key' }, { signer: a.signer, verificationMethod: a.vm });
+    const result = await verifyEventLog(log);
+    expect(result.verified).toBe(false);
+    expect(result.events[2].proofValid === false || result.errors.length > 0).toBe(true);
+  });
+
+  test('rotation signed by an UNAUTHORIZED key fails — and does NOT rotate', async () => {
+    const a = await makeRealSigner(); const mallory = await makeRealSigner();
+    let log = await createEventLog(
+      { name: 'A', controller: a.didKey, resources: [], createdAt: 'x', nonce: 'u3' },
+      { signer: a.signer, verificationMethod: a.vm }
+    );
+    log = await appendEvent(log, 'rotateKey', { newController: mallory.didKey, rotatedAt: 'x' }, { signer: mallory.signer, verificationMethod: mallory.vm });
+    expect((await verifyEventLog(log)).verified).toBe(false);
+
+    // The failed rotation must not have swapped the set: mallory's would-be
+    // "new" key stays unauthorized for subsequent events...
+    const escalated = await appendEvent(log, 'update', { note: 'mallory escalates' }, { signer: mallory.signer, verificationMethod: mallory.vm });
+    const escalatedResult = await verifyEventLog(escalated);
+    expect(escalatedResult.verified).toBe(false);
+    expect(escalatedResult.events[2].proofValid).toBe(false);
+
+    // ...while the REAL controller remains authorized (its event verifies,
+    // even though the log as a whole stays failed because of event 1).
+    const recovered = await appendEvent(log, 'update', { note: 'a still controls' }, { signer: a.signer, verificationMethod: a.vm });
+    const recoveredResult = await verifyEventLog(recovered);
+    expect(recoveredResult.verified).toBe(false); // event 1 still poisons the log
+    expect(recoveredResult.events[2].proofValid).toBe(true); // but a's key never rotated out
+  });
+
+  test('unbindable newController fails closed (event AND log)', async () => {
+    const a = await makeRealSigner();
+    let log = await createEventLog(
+      { name: 'A', controller: a.didKey, resources: [], createdAt: 'x', nonce: 'u4' },
+      { signer: a.signer, verificationMethod: a.vm }
+    );
+    log = await appendEvent(log, 'rotateKey', { newController: 'did:webvh:unresolvable:example.com:x', rotatedAt: 'x' }, { signer: a.signer, verificationMethod: a.vm });
+    const result = await verifyEventLog(log);
+    expect(result.verified).toBe(false);
+    expect(result.events[1].proofValid).toBe(false);
+    expect(result.errors.some(e => /newController/.test(e))).toBe(true);
+  });
+
+  test('missing/non-string newController fails closed', async () => {
+    const a = await makeRealSigner();
+    let log = await createEventLog(
+      { name: 'A', controller: a.didKey, resources: [], createdAt: 'x', nonce: 'u4b' },
+      { signer: a.signer, verificationMethod: a.vm }
+    );
+    log = await appendEvent(log, 'rotateKey', { rotatedAt: 'x' }, { signer: a.signer, verificationMethod: a.vm });
+    const result = await verifyEventLog(log);
+    expect(result.verified).toBe(false);
+    expect(result.errors.some(e => /newController/.test(e))).toBe(true);
+  });
+
+  test('second rotation chains authority a→b→c; a and b both dead afterwards', async () => {
+    const a = await makeRealSigner(); const b = await makeRealSigner(); const c = await makeRealSigner();
+    let log = await createEventLog(
+      { name: 'A', controller: a.didKey, resources: [], createdAt: 'x', nonce: 'u5' },
+      { signer: a.signer, verificationMethod: a.vm }
+    );
+    log = await appendEvent(log, 'rotateKey', { newController: b.didKey, rotatedAt: 'x' }, { signer: a.signer, verificationMethod: a.vm });
+    log = await appendEvent(log, 'rotateKey', { newController: c.didKey, rotatedAt: 'x' }, { signer: b.signer, verificationMethod: b.vm });
+    log = await appendEvent(log, 'update', { note: 'c signs' }, { signer: c.signer, verificationMethod: c.vm });
+    expect((await verifyEventLog(log)).verified).toBe(true);
+
+    const staleB = await appendEvent(log, 'update', { note: 'b tries again' }, { signer: b.signer, verificationMethod: b.vm });
+    expect((await verifyEventLog(staleB)).verified).toBe(false);
+    const staleA = await appendEvent(log, 'update', { note: 'a tries again' }, { signer: a.signer, verificationMethod: a.vm });
+    expect((await verifyEventLog(staleA)).verified).toBe(false);
+  });
+
+  test('deactivate still seals the log regardless of rotation', async () => {
+    const a = await makeRealSigner(); const b = await makeRealSigner();
+    let log = await createEventLog(
+      { name: 'A', controller: a.didKey, resources: [], createdAt: 'x', nonce: 'u6' },
+      { signer: a.signer, verificationMethod: a.vm }
+    );
+    log = await appendEvent(log, 'rotateKey', { newController: b.didKey, rotatedAt: 'x' }, { signer: a.signer, verificationMethod: a.vm });
+    log = await appendEvent(log, 'deactivate', { deactivatedAt: 'x' }, { signer: b.signer, verificationMethod: b.vm });
+    log = await appendEvent(log, 'update', { note: 'after seal' }, { signer: b.signer, verificationMethod: b.vm });
+    expect((await verifyEventLog(log)).verified).toBe(false);
+  });
+
+  test('migrate/transfer cause no authority change (old key keeps working)', async () => {
+    const a = await makeRealSigner(); const b = await makeRealSigner();
+    let log = await createEventLog(
+      { name: 'A', controller: a.didKey, resources: [], createdAt: 'x', nonce: 'u7' },
+      { signer: a.signer, verificationMethod: a.vm }
+    );
+    log = await appendEvent(log, 'transfer', { newController: b.didKey, transferredAt: 'x' }, { signer: a.signer, verificationMethod: a.vm });
+    log = await appendEvent(log, 'update', { note: 'a still signs' }, { signer: a.signer, verificationMethod: a.vm });
+    expect((await verifyEventLog(log)).verified).toBe(true);
+    // transfer is NOT a key rotation: b's key does not become a log signer.
+    const forged = await appendEvent(log, 'update', { note: 'b forges' }, { signer: b.signer, verificationMethod: b.vm });
+    expect((await verifyEventLog(forged)).verified).toBe(false);
+  });
+});

--- a/packages/sdk/tests/unit/cel/key-rotation-authority.test.ts
+++ b/packages/sdk/tests/unit/cel/key-rotation-authority.test.ts
@@ -141,6 +141,38 @@ describe('rotateKey authority evolution', () => {
     expect((await verifyEventLog(log)).verified).toBe(false);
   });
 
+  test('oversized newController fails closed (length cap before base58 decode)', async () => {
+    const a = await makeRealSigner();
+    let log = await createEventLog(
+      { name: 'A', controller: a.didKey, resources: [], createdAt: 'x', nonce: 'u8' },
+      { signer: a.signer, verificationMethod: a.vm }
+    );
+    // A did:key far beyond the 2048-char cap must not be decoded; fail closed.
+    log = await appendEvent(log, 'rotateKey', { newController: 'did:key:z' + 'A'.repeat(500_000), rotatedAt: 'x' }, { signer: a.signer, verificationMethod: a.vm });
+    const result = await verifyEventLog(log);
+    expect(result.verified).toBe(false);
+    expect(result.events[1].proofValid).toBe(false);
+    expect(result.errors.some(e => /newController/.test(e))).toBe(true);
+  });
+
+  test('stale OLD key cannot rotate authority to an attacker after being replaced', async () => {
+    const a = await makeRealSigner(); const b = await makeRealSigner(); const mallory = await makeRealSigner();
+    let log = await createEventLog(
+      { name: 'A', controller: a.didKey, resources: [], createdAt: 'x', nonce: 'u8b' },
+      { signer: a.signer, verificationMethod: a.vm }
+    );
+    // a → b: b now holds authority, a is dead.
+    log = await appendEvent(log, 'rotateKey', { newController: b.didKey, rotatedAt: 'x' }, { signer: a.signer, verificationMethod: a.vm });
+    // Stale a signs a rotateKey naming mallory — must fail (a no longer authorized).
+    log = await appendEvent(log, 'rotateKey', { newController: mallory.didKey, rotatedAt: 'x' }, { signer: a.signer, verificationMethod: a.vm });
+    expect((await verifyEventLog(log)).verified).toBe(false);
+    // mallory never gained authority: an update she signs still fails.
+    const forged = await appendEvent(log, 'update', { note: 'mallory' }, { signer: mallory.signer, verificationMethod: mallory.vm });
+    const forgedResult = await verifyEventLog(forged);
+    expect(forgedResult.verified).toBe(false);
+    expect(forgedResult.events[3].proofValid).toBe(false);
+  });
+
   test('migrate/transfer cause no authority change (old key keeps working)', async () => {
     const a = await makeRealSigner(); const b = await makeRealSigner();
     let log = await createEventLog(

--- a/specs/did-cel-method.md
+++ b/specs/did-cel-method.md
@@ -1,0 +1,269 @@
+# The did:cel DID Method
+
+**Version:** 0.1
+**Status:** Draft
+**Date:** 2026-07-10
+
+> Draft method specification. The normative source of truth is the implementation
+> in `packages/sdk/src/cel/` (notably `celDid.ts` and `algorithms/verifyEventLog.ts`)
+> and its test suite; every **MUST** below is pinned to a test in
+> [Appendix A](#appendix-a-normative-must--pinning-test). Before publishing beyond
+> draft, check the [DIF](https://identity.foundation/) / W3C DID method registry for
+> a `cel` name collision.
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**, **SHOULD**, **MAY**
+are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+---
+
+## 1. Abstract
+
+`did:cel` identifies an Originals asset by the multihash of its Cryptographic Event
+Log (CEL) genesis event. The identifier is **derived from** the log, not assigned to
+it: given any copy of the log, anyone recomputes the genesis digest and compares it
+to the DID.
+
+The three axes the Originals model keeps distinct map onto the log as follows:
+
+- **Identity** is the CEL, addressed by `did:cel:<genesis-digest>`.
+- **Holders / issuers** are parties' own key DIDs, established by the genesis
+  `controller` and handed off by signed `rotateKey` events.
+- **Ownership** is the Bitcoin sat/UTXO, and exists only at the `did:btco` layer.
+
+A `did:cel` is the genesis layer of an asset that may later earn stronger resolution
+substrates (`did:webvh`, `did:btco`). It is the log-native replacement for the
+`did:peer` genesis previously used by the SDK.
+
+---
+
+## 2. Method syntax
+
+```
+did-cel        = "did:cel:" genesis-digest
+genesis-digest = multibase-base64url-multihash
+```
+
+- The method name is `cel`.
+- The method-specific identifier is a Multibase-encoded Multihash: the `'u'`
+  Multibase prefix (base64url, no padding) followed by a sha2-256 Multihash
+  (multicodec `0x12`, length `0x20`) of the canonicalized genesis event. It
+  therefore always begins with `u` (e.g. `did:cel:uEiD...`).
+- Implementations **MUST** derive the identifier as:
+
+  ```
+  did:cel: + computeDigestMultibase( canonicalizeEntryForChain(genesisEvent) )
+  ```
+
+  where `canonicalizeEntryForChain` emits the JCS-canonicalized committed fields of
+  the genesis event — `{ type: "create", data }`, with `previousEvent` absent for a
+  first event — as UTF-8 bytes, and `computeDigestMultibase` prepends the sha2-256
+  Multihash header and Multibase-encodes.
+- The genesis event's `proof` array **MUST NOT** contribute to the identifier.
+  Excluding the proof is a security requirement: witness proofs may be appended to
+  the genesis after the fact, and a late proof **MUST NOT** change the asset's
+  identity (see §7).
+- This is exactly the digest function the CEL hash chain uses for `previousEvent`
+  links. Consequently the following invariant holds and **MUST** be preserved by
+  writers: **the log's second event's `previousEvent` field equals the DID suffix**
+  (the `did:cel:` prefix removed).
+
+No new cryptography is introduced; `did:cel` reuses the existing chain-digest
+primitive verbatim.
+
+---
+
+## 3. Genesis event requirements
+
+The genesis event is the first entry of the log. It **MUST** be a `create` event and
+**MUST NOT** carry a `previousEvent` field.
+
+Its `data` (the `CelAssetData` shape) **MUST**:
+
+- **NOT** contain a `did` field. The asset DID is derived from the event, so
+  embedding it would be self-referential (the DID depends on the bytes that would
+  contain it) and conflates identity with the holder key. A genesis whose `data`
+  carries `controller` and no `did` is a `did:cel` genesis; a genesis whose `data`
+  carries `did` is a *legacy* log (see §8).
+- contain `controller` — the **holder's key DID** (a `did:key`, or another resolvable
+  DID; see below), distinct from the derived asset DID.
+- contain `name` (string), `resources` (array of external references, MAY be empty),
+  and `createdAt` (ISO 8601 string).
+- contain `nonce` — Multibase base64url of 16 random bytes. The nonce is **REQUIRED**
+  as collision insurance: two genesis events with identical
+  `{name, controller, resources, createdAt}` **MUST** still derive distinct DIDs.
+
+### 3.1 Genesis authority binding (fail-closed)
+
+The genesis proof establishes who controls the log. Verification **MUST** bind the
+genesis signing key to `data.controller`, and **MUST** fail closed on any doubt —
+there is **no trust-on-first-use** on the `did:cel` path. The create event **MUST**
+carry exactly one controller proof (its proof array is unsigned, so additional
+controller proofs cannot be disambiguated from an injected co-signer and **MUST**
+fail the log).
+
+Two binding modes apply, selected by the controller DID:
+
+1. **Self-certifying controller** — `did:key`, or long-form `did:peer:4` (which
+   embeds its DID document). Its key material is enumerable offline, so the genesis
+   proof's key **MUST** be one of the embedded Ed25519 keys. Checked with no
+   resolver; fail closed if it is not among them.
+2. **Resolver-backed controller** — `did:webvh` and other methods whose keys are not
+   embedded in the identifier. The genesis proof's verification-method DID (the part
+   before `#`) **MUST** byte-equal `data.controller`, **and** the caller's resolver
+   **MUST** vouch a key that cryptographically verifies the signature. VM-DID
+   equality alone is insufficient: an attacker who stamps the victim's exact
+   verification method but signs with their own key **MUST** fail against an honest
+   resolver.
+
+Without a resolver, a resolver-backed controller cannot be bound and **MUST** fail
+closed.
+
+---
+
+## 4. Resolution
+
+`did:cel` resolution has two questions with two different answers:
+
+- **Genesis (self-certifying) resolution.** The short form self-certifies the
+  *genesis* given any copy of the log: recompute `canonicalizeEntryForChain` over
+  event 0, compare to the DID suffix (`didCelMatchesLog`), and verify the genesis
+  authority binding (§3.1). This requires no network and no registry — the DID *is*
+  the commitment to the genesis. A resolver **MUST** reject a log whose recomputed
+  genesis digest does not match the DID suffix.
+- **Latest-state resolution.** Resolving the *current* head of the asset requires
+  fetching the log from wherever it currently lives. This is by design: each higher
+  layer is precisely "a stronger place to resolve the latest from."
+
+  | Where the log lives | Resolution substrate |
+  |---|---|
+  | local / exported bundle | the log itself (offline) |
+  | `did:webvh` hosted | HTTPS + signed version history |
+  | `did:btco` anchored | Bitcoin (inscription commits to the log head) |
+
+A long form (embedding the genesis event in the identifier for fully offline genesis
+resolution, analogous to `did:peer:4`) is out of scope for v0.1.
+
+---
+
+## 5. Key rotation
+
+Authority over the log is not fixed for its lifetime. A `rotateKey` event hands
+control from the current key set to a new controller.
+
+- A `rotateKey` event **REPLACES** the authorized key set with the new controller's
+  keys. This is replace, not union: old keys are dead from that event forward.
+- Verifiers **MUST** reject any post-rotation event signed by a key that a prior
+  rotation retired (or by the original genesis key after it has been rotated out).
+- A `rotateKey` event **MUST** itself pass every check — chain link, signature, and
+  authorization against the key set *as it stood when the event was appended* —
+  **before** the set is swapped. A rotation that fails any check **MUST NOT** rotate;
+  the retired key set stays in force so a failed hijack cannot strand the log.
+- The `rotateKey` `newController` **MUST** be a self-certifying DID (`did:key` or
+  long-form `did:peer:4`) carrying an Ed25519 key. A resolver-backed `newController`
+  (e.g. `did:webvh`) **MUST** fail closed: nothing is signed by the new key at
+  rotation time, so there is no proof of possession to bind it (a design for this is
+  deferred). A missing, non-string, or unbindable `newController` **MUST** fail the
+  event and therefore the log.
+- Rotations chain: `a → b → c` leaves only `c` authorized; both `a` and `b` are dead.
+
+---
+
+## 6. Event vocabulary
+
+The Originals CEL profile defines six event types. `create`, `update`, and
+`deactivate` are inherited from the base CEL profile; `migrate`, `transfer`, and
+`rotateKey` are first-class Originals additions (previously folded into `update`).
+The genesis event is always `create`; every subsequent event carries a
+`previousEvent` chain link and at least one controller proof.
+
+| Type | Purpose | Notable `data` fields |
+|---|---|---|
+| `create` | Genesis; establishes identity + controller | `name`, `controller`, `resources`, `createdAt`, `nonce` (§3) |
+| `update` | Mutate metadata / resources | `name?`, `resources?`, `updatedAt`, arbitrary metadata |
+| `migrate` | Layer transition (new resolution substrate) | `sourceDid`, `targetDid`, `layer`, `migratedAt`, `domain?` |
+| `transfer` | Ownership hand-off (identity unchanged) | `previousOwner?`, `newOwner?`, `txid?`, `transferredAt` |
+| `rotateKey` | Authority hand-off (§5) | `newController`, `rotatedAt` |
+| `deactivate` | Seals the log permanently | `reason?`, `deactivatedAt` |
+
+Authority semantics differ by type and **MUST** be honored:
+
+- `rotateKey` **REPLACES** the authorized key set (§5).
+- `migrate` and `transfer` **MUST NOT** change the authorized key set — a `transfer`
+  is not a key rotation, so the recipient's key does not become a log signer until a
+  subsequent `rotateKey` (post-transfer append authority is rotation-gated; see the
+  design doc §5).
+- `deactivate` seals the log: any event after a `deactivate` **MUST** cause the whole
+  log to fail verification, even if each individual signature and chain link is
+  valid.
+
+---
+
+## 7. Security considerations
+
+- **Collision insurance (nonce).** The derived DID is a hash of the genesis `data`;
+  without entropy, two assets with identical metadata created at the same instant
+  would collide. The **REQUIRED** `nonce` guarantees distinct identifiers.
+- **Proof exclusion.** The identifier and the hash chain cover only the committed
+  fields `{ type, data, previousEvent? }`, never the `proof` array. Witness proofs
+  may be appended to any event after the fact; if identity or the chain depended on
+  proofs, a late witness proof would retroactively change the DID or break every
+  later link. Identity **MUST** depend only on what the controller signed.
+- **No trust-on-first-use on the `did:cel` path.** An attacker who copies a victim's
+  genesis `data` verbatim, re-signs event 0 with their own key, and publishes it
+  would otherwise mint a "valid" log for the victim's derived DID under the
+  attacker's key. The fail-closed binding of §3.1 (both modes) blocks this.
+- **Single genesis authority.** The create event **MUST** carry exactly one
+  controller proof; the unsigned proof array cannot otherwise disambiguate the real
+  root of authority from an injected co-signer.
+- **Deactivation seals the log.** A sealed log **MUST NOT** be extended; verifiers
+  fail closed on any post-`deactivate` event.
+- **Registry.** `cel` is not yet a registered DID method name. Check the DIF/W3C DID
+  method registry for a collision before publishing beyond draft.
+
+---
+
+## 8. Legacy compatibility
+
+Logs written by pre-`did:cel` SDK releases embed the asset DID in `data.did` (the
+`PeerAssetData` shape, typically a `did:peer:4`). These remain verifiable on a
+dual-accept read path:
+
+- Readers **MUST** accept a legacy `data.did` genesis and keep its exact prior
+  verification behavior (self-certifying binding when `data.did` is a `did:key` or
+  long-form `did:peer:4`; trust-on-first-use otherwise). For such logs the reported
+  asset DID is the declared `data.did`, and `expectedDid` matching is string
+  equality (versus suffix derivation for `did:cel`).
+- Writers **MUST** emit only the new `CelAssetData` shape (no `data.did`).
+- **Documented behavioral delta:** a genesis whose `data.did` is a *malformed*
+  long-form `did:peer:4` (its embedded document fails to parse) now **fails closed**,
+  where earlier releases fell back to trust-on-first-use.
+
+---
+
+## Appendix A: normative MUST → pinning test
+
+Every test path is relative to `packages/sdk/tests/unit/cel/`.
+
+| # | Normative requirement | Pinning test |
+|---|---|---|
+| 1 | Identifier is `did:cel:` + Multibase base64url sha2-256 Multihash (suffix starts `u`) | `celDid.test.ts` — "derives a stable did:cel with multihash-multibase suffix" |
+| 2 | DID derived from `canonicalizeEntryForChain(genesis)`; proof excluded | `celDid.test.ts` — "proof does not affect the DID (proof excluded from digest)" |
+| 3 | Invariant: second event's `previousEvent` equals the DID suffix | `celDid.test.ts` — "INVARIANT: second event previousEvent equals the DID suffix" |
+| 4 | Genesis MUST be a `create` event; empty/non-create rejected | `celDid.test.ts` — "rejects empty logs and non-create genesis" |
+| 5 | Genesis `data` carries `controller` + `nonce` (no `did`); nonce is a Multibase base64url string | `PeerCelManager.test.ts` — "asset data includes a nonce (multibase base64url, 16 bytes)" |
+| 6 | Nonce guarantees distinct DIDs for identical metadata | `PeerCelManager.test.ts` — "two identical creates yield different DIDs (nonce)" / "derives a distinct did:cel for each asset (nonce insurance)" |
+| 7 | Valid `did:cel` log verifies and reports the derived `assetDid` | `did-cel-verification.test.ts` — "valid did:cel log verifies and reports assetDid" |
+| 8 | Self-certifying controller: genesis key not in the controller fails closed | `did-cel-verification.test.ts` — "genesis signed by a key that is NOT the controller fails closed" |
+| 9 | Resolver-backed controller: VM-equality alone insufficient; resolved key must verify | `did-cel-verification.test.ts` — "resolver-backed genesis forgery backstop..." |
+| 10 | Resolver-backed controller with no resolver fails closed (no TOFU) | `did-cel-verification.test.ts` — "non-did:key controller fails closed (no TOFU on the did:cel branch)" |
+| 11 | `expectedDid` mismatch fails; suffix match passes | `did-cel-verification.test.ts` — "expectedDid mismatch fails; match passes (did:cel)" |
+| 12 | Create event MUST carry exactly one controller proof | `event-log-authorization.test.ts`; `verifyEventLog.test.ts` |
+| 13 | `rotateKey` REPLACES the key set; post-rotation events by prior keys rejected | `key-rotation-authority.test.ts` — "OLD key signing AFTER rotation fails (replace, not union)" |
+| 14 | Post-rotation events by the new key verify | `key-rotation-authority.test.ts` — "post-rotation events signed by the NEW key verify" |
+| 15 | A failed rotation MUST NOT rotate the set | `key-rotation-authority.test.ts` — "rotation signed by an UNAUTHORIZED key fails — and does NOT rotate" |
+| 16 | `newController` MUST be self-certifying; unbindable/missing fails the event + log | `key-rotation-authority.test.ts` — "unbindable newController fails closed"; "missing/non-string newController fails closed" |
+| 17 | Rotations chain (a→b→c); retired keys dead | `key-rotation-authority.test.ts` — "second rotation chains authority a→b→c" |
+| 18 | `migrate`/`transfer` MUST NOT change authority | `key-rotation-authority.test.ts` — "migrate/transfer cause no authority change (old key keeps working)" |
+| 19 | `deactivate` seals the log; post-deactivate events fail | `key-rotation-authority.test.ts` — "deactivate still seals the log regardless of rotation"; `deactivateEventLog.test.ts` |
+| 20 | Chain link: `previousEvent` equals digest of prior committed fields | `appendEvent.test.ts` — "appends a typed event with correct chain link and signed payload"; `hash-chain-tamper.test.ts` |
+| 21 | Legacy `data.did` logs verify as before; report declared DID | `did-cel-verification.test.ts` — "legacy data.did logs verify exactly as before and report assetDid" |

--- a/specs/did-cel-method.md
+++ b/specs/did-cel-method.md
@@ -235,7 +235,8 @@ dual-accept read path:
   equality (versus suffix derivation for `did:cel`).
 - Writers **MUST** emit only the new `CelAssetData` shape (no `data.did`).
 - **Documented behavioral delta:** a genesis whose `data.did` is a *malformed*
-  long-form `did:peer:4` (its embedded document fails to parse) now **fails closed**,
+  long-form `did:peer:4` (its embedded document fails to parse) now **fails closed**
+  (only when the genesis proof's `verificationMethod` is itself a `did:key`),
   where earlier releases fell back to trust-on-first-use.
 
 ---

--- a/specs/protocol/README.md
+++ b/specs/protocol/README.md
@@ -13,6 +13,7 @@ spec it cited.
 Authoritative documents:
 - `originals-whitepaper.md` — protocol vision
 - `docs/ORIGINALS_CEL_SPEC.md` + `packages/sdk/src/cel/` — CEL mechanics
+- `specs/did-cel-method.md` — the `did:cel` genesis DID method (draft, pinned to `src/cel/` tests)
 - `docs/superpowers/specs/2026-07-10-cel-backbone-did-cel-design.md` — current direction
 - `ORIGINALS_PROTOCOL_SPECIFICATION.md` — corroborating (agent-written, Nov 2025)
 


### PR DESCRIPTION
## Summary

Phase 1 of the CEL-backbone plan (stacked on #383; design spec `docs/superpowers/specs/2026-07-10-cel-backbone-did-cel-design.md` §2/§7, plan `docs/superpowers/plans/2026-07-10-phase1-did-cel.md`). Introduces **`did:cel`** — the asset's genesis DID derived from the multihash of its CEL create event — completing the identity/holder separation:

- **`did:cel` derivation** (`src/cel/celDid.ts`): `did:cel:<digestMultibase(canonicalizeEntryForChain(genesis))>` — reuses the exact chain-link digest (proof excluded), so a log's second event's `previousEvent` equals the DID suffix by construction. Zero new cryptography.
- **De-self-referenced genesis** (`CelAssetData`): the create event carries the holder's `controller` key DID + a collision-insurance `nonce` — never the asset DID (it's derived FROM the event). `PeerCelManager.create` returns `{ log, did }`.
- **Self-certification inverted** in `verifyEventLog`: two fail-closed binding modes — self-certifying controllers (did:key, long-form did:peer:4) via embedded-key membership; resolver-backed controllers via VM-DID byte-equality + resolver-vouched key. **No TOFU on the did:cel path.** New `assetDid`/`expectedDid` surfaces. Content-addressing makes the controller attacker-immutable: identifier trickery yields a *different* DID, not a forgery.
- **First-class `migrate` / `transfer` / `rotateKey` event types** (six-type vocabulary in types + strict JSON/CBOR parsers, generic `appendEvent`), replacing field-sniffed `update` events across managers and CLI (legacy sniffs kept as read fallbacks).
- **Evolving authority**: a fully valid `rotateKey` event REPLACES the authorized key set (validate-before-swap; unbindable newController fails event AND log; self-certifying newControllers only) — key rotation with stable identity, which did:peer structurally cannot do.
- **Specs**: `specs/did-cel-method.md` (Draft v0.1, every MUST pinned to a named test in Appendix A) + `docs/ORIGINALS_CEL_SPEC.md` v1.1.0.

Back-compat: dual-accept on read (legacy `data.did` logs verify unchanged — adversarial suites retained as legacy pins), new-shape-only on write. One documented fail-closed delta: a malformed long-form did:peer:4 `data.did` (when the genesis proof is a did:key) now fails closed instead of TOFU.

## Review

Task-by-task spec+quality gates, with **fable security reviews** on the verifier tasks: both binding-mode designs and the rotation hand-off were adversarially adjudicated (six attack vectors each verified closed in code, including the resolver-backed genesis forgery backstop and stale-key re-seizure). Final whole-branch review verdict: ready to merge after fixes — all landed, including a 2048-char DID cap closing a per-rotateKey-amplifiable O(n²) base58 decode.

Phase-2 carry-forwards (explicit, so they don't evaporate): DIDManager.resolveDID did:cel wiring + LifecycleManager convergence; post-transfer stale-key rejection (design §5, needs btco chain data); shapeless-genesis `expectedDid` inconsistency; CLI btco mock BitcoinManager; `UpdateOptions.verificationMethod` advisory JSDoc.

## Test plan

- Full suite: 3792 pass / 70 skip / 0 fail (219+ files); tsc clean; build clean; changed-files eslint at pre-existing baseline (zero net-new).
- New adversarial coverage: forged-controller genesis, resolver-backed forgery backstop, stale-key post-rotation (update AND rotateKey), rotation-chain a→b→c, unbindable/oversized newController, deactivate-seals-regardless, CLI two-step migration chain, legacy fixtures pinned per behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Introduce did:cel identity derivation, first-class event types, and key rotation authority to the CEL SDK
> - Adds a new `did:cel` DID method ([celDid.ts](https://github.com/onionoriginals/sdk/pull/385/files#diff-985e0830b943a24536fc200105a8a6bc16965af6bdb3b9ae80ac032c65cc4060)): the asset DID is now derived deterministically from the genesis event's canonical hash rather than embedded in the genesis payload, so the genesis no longer carries `did` or `layer` fields but instead carries `controller` (a did:key) and a random `nonce`.
> - `PeerCelManager.create` now returns `{ log, did }` instead of a bare `EventLog`; all callers (CLI, managers, tests) are updated to destructure accordingly.
> - Adds first-class event types `migrate`, `transfer`, and `rotateKey` to `EventType` and to CBOR/JSON parsers; managers emit `migrate` instead of `update` for migrations, and `transfer`/`rotateKey` are handled in state replay across all layers.
> - Introduces `appendEvent` ([appendEvent.ts](https://github.com/onionoriginals/sdk/pull/385/files#diff-b5098aff67616636b3c2094ef3fc266cf8c13f62cae1f90535530a0d4b4976fd)) as a shared primitive for appending any non-create event; `updateEventLog` and `deactivateEventLog` are refactored to delegate to it.
> - `verifyEventLog` gains did:cel authority binding (controller must match signer), `rotateKey` replay that replaces the authorized key set, `expectedDid` checking, and fail-closed behavior for malformed or oversized DIDs.
> - Risk: `PeerCelManager.create` is a breaking API change (return type changed); `deactivateEventLog` and `updateEventLog` now require `proof.verificationMethod` to be present; malformed long-form `did:peer:4` in genesis now fails closed instead of falling through.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3efbf4a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->