### PR TITLE
feat(cel): first-anchor-wins did:cel uniqueness (Part B, #396)

### DIFF
--- a/.changeset/did-cel-uniqueness-first-anchor-wins.md
+++ b/.changeset/did-cel-uniqueness-first-anchor-wins.md
@@ -1,0 +1,19 @@
+---
+"@originals/sdk": patch
+---
+
+did:cel uniqueness — first-anchor-wins. A btco-anchored did:cel log now verifies
+only when its anchored sat is the canonical one (the sat of the log's earliest
+on-chain anchoring, lowest confirmed block height grouped by sat), closing the
+malicious-controller duping case where one did:cel is signed onto two sats. Adds
+the `getAnchoringsForDidCel(didCel)` provider capability (implemented on
+OrdMockProvider) and back-links the did:cel in the inscribed btco document's
+alsoKnownAs so anchorings are enumerable. Fail-closed: a provider that cannot
+enumerate or an anchoring missing a block height → UNIQUENESS_UNVERIFIABLE; a
+same-block tie between different sats → AMBIGUOUS_CANONICAL; a non-canonical sat
+→ NON_CANONICAL_ANCHOR. Follow-up to the signed-anchored-sat binding.
+
+Compatibility note: because the check is part of the btco verification contract
+(not opt-in), a btco-anchored did:cel log whose inscribed document predates this
+release and therefore lacks the did:cel back-link in alsoKnownAs will now fail
+UNIQUENESS_UNVERIFIABLE until re-anchored with the current writer shape.

--- a/docs/superpowers/specs/2026-07-13-did-cel-uniqueness-first-anchor-wins-design.md
+++ b/docs/superpowers/specs/2026-07-13-did-cel-uniqueness-first-anchor-wins-design.md
@@ -123,8 +123,13 @@ provider: `getAnchoringsForDidCel(Z)` → `[{X, 100}, {Y, 200}]` → canonical `
 → `Y !== X` → `NON_CANONICAL_ANCHOR`. Bob's log fails; he is protected. Alice's
 `X`-branch verifies as canonical. The controller cannot reorder history — the
 first anchor is immutable — and cannot sell the single canonical sat twice (a sat
-is owned by one UTXO holder). A non-controller cannot pre-empt with an earlier
-anchor because anchoring requires the controller key.
+is owned by one UTXO holder). A non-controller cannot *steal*: making a rival
+branch itself verify requires forging the genesis controller's signatures, which
+they cannot. Note the asymmetry, though — canonicality is computed from *any*
+inscription that back-links `Z` in `alsoKnownAs`, and enumeration does not check
+that the anchoring is controller-signed or commits to a valid head of this log.
+So while a non-controller cannot steal, they *can deny* (see §7, third-party
+denial): this is a fail-closed griefing vector, not a theft vector.
 
 ## 7. Residuals
 
@@ -137,6 +142,20 @@ anchor because anchoring requires the controller key.
   provider's content index. A provider that fails to return an existing earlier
   anchoring could wrongly bless a dupe. This is the same trust already placed in
   the provider for witness/ownership reads; out of scope to eliminate here.
+- **Third-party denial (griefing):** `getAnchoringsForDidCel` enumerates *any*
+  inscription whose `alsoKnownAs` back-links `Z`, with no requirement that the
+  inscription be controller-signed or that its `OriginalsCelAnchor` commit to a
+  valid head of this log. So a non-controller who inscribes
+  `{alsoKnownAs:["did:cel:Z"]}` on their own sat at the same block as (→
+  `AMBIGUOUS_CANONICAL`) or, by front-running before confirmation, an earlier
+  block than the honest first anchoring (→ `NON_CANONICAL_ANCHOR`) can
+  permanently DENY the honest log. This is **deny-only** — the attacker cannot
+  make their own branch verify (that needs the genesis controller's signatures),
+  so no theft/duping is opened, and already-confirmed anchorings cannot be
+  retro-denied (block heights are immutable); the exposure is mempool
+  front-running of *new* mints into a permanent brick, fail-closed. Eliminating
+  it is a follow-up: require competitor anchorings to be controller-authenticated
+  or to head-commit to this log before they count toward canonicality.
 
 ## 8. Testing spine
 

--- a/packages/sdk/src/adapters/providers/OrdMockProvider.ts
+++ b/packages/sdk/src/adapters/providers/OrdMockProvider.ts
@@ -107,6 +107,29 @@ export class OrdMockProvider implements OrdinalsProvider {
     return this.state.ownershipBySatoshi.get(satoshi) ?? null;
   }
 
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async getAnchoringsForDidCel(didCel: string): Promise<Array<{
+    satoshi: string;
+    inscriptionId: string;
+    blockHeight?: number;
+  }>> {
+    const out: Array<{ satoshi: string; inscriptionId: string; blockHeight?: number }> = [];
+    for (const rec of this.state.inscriptionsById.values()) {
+      if (rec.satoshi === undefined) continue;
+      let content: unknown;
+      try {
+        content = JSON.parse(rec.content.toString('utf8'));
+      } catch {
+        continue; // non-JSON inscription — not a DID document
+      }
+      const aka = (content as { alsoKnownAs?: unknown } | null)?.alsoKnownAs;
+      if (Array.isArray(aka) && aka.includes(didCel)) {
+        out.push({ satoshi: rec.satoshi, inscriptionId: rec.inscriptionId, blockHeight: rec.blockHeight });
+      }
+    }
+    return out;
+  }
+
   async transferInscription(inscriptionId: string, toAddress: string, _options?: { feeRate?: number }) {
     const rec = this.state.inscriptionsById.get(inscriptionId);
     if (!rec) {

--- a/packages/sdk/src/adapters/types.ts
+++ b/packages/sdk/src/adapters/types.ts
@@ -72,6 +72,18 @@ export interface OrdinalsProvider {
    * must never rewrite the inscribed DID document from it.
    */
   getSatOwnership?(satoshi: string): Promise<{ address: string; outpoint: string } | null>;
+  /**
+   * Enumerate every on-chain btco DID-doc anchoring whose `alsoKnownAs`
+   * back-links this did:cel (first-anchor-wins uniqueness). Production
+   * providers implement this via a content/metadata index (an `ord` instance
+   * or a service such as the QuickNode Ordinals add-on). `blockHeight` is the
+   * canonical ordering signal; a missing height fails uniqueness closed.
+   */
+  getAnchoringsForDidCel?(didCel: string): Promise<Array<{
+    satoshi: string;
+    inscriptionId: string;
+    blockHeight?: number;
+  }>>;
   transferInscription(
     inscriptionId: string,
     toAddress: string,

--- a/packages/sdk/src/cel/algorithms/verifyEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/verifyEventLog.ts
@@ -625,6 +625,13 @@ async function verifyUniqueness(
 
   const canonicalSat = canonicalSats[0];
   if (anchoredSat.satoshi !== canonicalSat) {
+    // Distinguish a genuine competing mint from a self-inflicted enumeration
+    // gap: if the log's OWN anchored sat is absent from the enumeration, the
+    // real cause is a missing back-link (its inscribed did:btco doc did not list
+    // this did:cel in alsoKnownAs), not a rival dupe. Both fail closed.
+    if (!earliestBySat.has(anchoredSat.satoshi)) {
+      return `NON_CANONICAL_ANCHOR: the log's own anchoring sat ${anchoredSat.satoshi} for ${didCel} is absent from the on-chain enumeration — its inscribed did:btco document may be missing the did:cel back-link in alsoKnownAs; the canonical (earliest-anchored) sat is ${canonicalSat}`;
+    }
     return `NON_CANONICAL_ANCHOR: the log is anchored on satoshi ${anchoredSat.satoshi} for ${didCel}, but the canonical (earliest-anchored) sat is ${canonicalSat}; this is a non-canonical dupe`;
   }
 

--- a/packages/sdk/src/cel/algorithms/verifyEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/verifyEventLog.ts
@@ -563,6 +563,75 @@ async function verifyHeadFreshness(
 }
 
 /**
+ * did:cel uniqueness — first-anchor-wins (follow-up to the signed-anchored-sat
+ * spec). The canonical sat for a did:cel is the sat of its EARLIEST on-chain
+ * anchoring: the lowest confirmed block height, GROUPED BY SAT. Multiple
+ * inscriptions on the same sat (migrate + rotation reinscriptions) do not
+ * compete — only a different, earlier sat wins. A btco-anchored log whose
+ * anchored sat is not that canonical sat is a non-canonical dupe.
+ *
+ * Fail-closed and NOT opt-in: a btco-anchored did:cel log already requires a
+ * provider, so a provider that cannot enumerate, an empty enumeration, or any
+ * anchoring missing a confirmed block height → `UNIQUENESS_UNVERIFIABLE`. A
+ * same-block tie between two DIFFERENT sats → `AMBIGUOUS_CANONICAL` (no finer
+ * on-chain order is exposed by the provider contract today).
+ *
+ * Returns a coded error string on failure, or null when the anchored sat is
+ * canonical.
+ */
+async function verifyUniqueness(
+  didCel: string,
+  anchoredSat: AnchoredSat,
+  ordinalsProvider: OrdinalsLookup | undefined
+): Promise<string | null> {
+  if (!ordinalsProvider || typeof ordinalsProvider.getAnchoringsForDidCel !== 'function') {
+    return `UNIQUENESS_UNVERIFIABLE: the ordinals provider cannot enumerate anchorings for ${didCel}; a btco-anchored did:cel log requires this to confirm first-anchor-wins canonicality`;
+  }
+
+  let anchorings: Array<{ satoshi: string; inscriptionId: string; blockHeight?: number }>;
+  try {
+    anchorings = await ordinalsProvider.getAnchoringsForDidCel(didCel);
+  } catch (e) {
+    return `UNIQUENESS_UNVERIFIABLE: failed to enumerate anchorings for ${didCel}: ${e instanceof Error ? e.message : String(e)}`;
+  }
+
+  if (!Array.isArray(anchorings) || anchorings.length === 0) {
+    return `UNIQUENESS_UNVERIFIABLE: no on-chain anchorings found for ${didCel}; cannot confirm the anchored sat ${anchoredSat.satoshi} is canonical`;
+  }
+
+  // Every anchoring must carry a confirmed (non-negative integer) block height:
+  // the ordering signal must be provable, or canonicality is undecidable.
+  for (const a of anchorings) {
+    if (typeof a.blockHeight !== 'number' || !Number.isInteger(a.blockHeight) || a.blockHeight < 0) {
+      return `UNIQUENESS_UNVERIFIABLE: anchoring ${a.inscriptionId} on satoshi ${a.satoshi} has no confirmed block height; first-anchor-wins ordering is unprovable`;
+    }
+  }
+
+  // Group by sat; each sat's competitor is its EARLIEST anchoring.
+  const earliestBySat = new Map<string, number>();
+  for (const a of anchorings) {
+    const cur = earliestBySat.get(a.satoshi);
+    if (cur === undefined || a.blockHeight! < cur) earliestBySat.set(a.satoshi, a.blockHeight!);
+  }
+
+  // Lowest earliest-height across DISTINCT sats is canonical.
+  let minHeight = Infinity;
+  for (const h of earliestBySat.values()) if (h < minHeight) minHeight = h;
+  const canonicalSats = [...earliestBySat.entries()].filter(([, h]) => h === minHeight).map(([s]) => s);
+
+  if (canonicalSats.length > 1) {
+    return `AMBIGUOUS_CANONICAL: ${canonicalSats.length} distinct sats (${canonicalSats.join(', ')}) share the earliest block ${minHeight} for ${didCel}; no finer on-chain order is available, so canonicality is undecidable`;
+  }
+
+  const canonicalSat = canonicalSats[0];
+  if (anchoredSat.satoshi !== canonicalSat) {
+    return `NON_CANONICAL_ANCHOR: the log is anchored on satoshi ${anchoredSat.satoshi} for ${didCel}, but the canonical (earliest-anchored) sat is ${canonicalSat}; this is a non-canonical dupe`;
+  }
+
+  return null;
+}
+
+/**
  * The log's current on-sat authority anchor: the satoshi a verified migrate
  * event bound the log to, and the inscription that most recently attested
  * authority on it (the migrate inscription, then each accepted non-cooperative
@@ -1399,6 +1468,16 @@ export async function verifyEventLog(
   if (celController !== undefined) assetDid = deriveDidCelFromGenesis(createEvent);
   else if (legacyDid !== undefined) assetDid = legacyDid;
 
+  // did:cel uniqueness — first-anchor-wins (follow-up spec). Runs whenever a
+  // did:cel log is btco-anchored (`anchoredSat` set by the walk) and a provider
+  // is present. NOT gated on checkHeadFreshness: it is part of the btco
+  // verification contract, not an opt-in extra. Skipped on the custom-verifier
+  // path (which owns proof semantics and never establishes `anchoredSat`).
+  let uniquenessError: string | undefined;
+  if (!options?.verifier && anchoredSat && typeof assetDid === 'string' && assetDid.startsWith('did:cel:')) {
+    uniquenessError = (await verifyUniqueness(assetDid, anchoredSat, options?.ordinalsProvider)) ?? undefined;
+  }
+
   // expectedDid: reject a log that does not back the caller's expected DID.
   // Scoped to the non-custom-verifier path — that path owns proof semantics and
   // the authority binding above is skipped there. did:cel is matched by suffix
@@ -1427,9 +1506,12 @@ export async function verifyEventLog(
   if (staleLogError) {
     errors.push(staleLogError);
   }
+  if (uniquenessError) {
+    errors.push(uniquenessError);
+  }
 
   return {
-    verified: allProofsValid && allChainsValid && !authorityError && !deactivationViolated && !expectedDidError && !staleLogError,
+    verified: allProofsValid && allChainsValid && !authorityError && !deactivationViolated && !expectedDidError && !staleLogError && !uniquenessError,
     errors,
     events: eventVerifications,
     ...(assetDid !== undefined ? { assetDid } : {}),

--- a/packages/sdk/src/cel/types.ts
+++ b/packages/sdk/src/cel/types.ts
@@ -171,6 +171,20 @@ export interface OrdinalsLookup {
    * prove ordering at all: non-cooperative rotations then fail closed.
    */
   getInscriptionsBySatoshi?(satoshi: string): Promise<Array<{ inscriptionId: string }>>;
+  /**
+   * Enumerate every on-chain btco DID-doc anchoring whose `alsoKnownAs`
+   * back-links this did:cel. `blockHeight` is the canonical ordering signal
+   * (first-anchor-wins). Required for btco-anchored did:cel verification: a
+   * btco log already needs a provider, so a provider that cannot enumerate
+   * fails uniqueness CLOSED (`UNIQUENESS_UNVERIFIABLE`). Multiple inscriptions
+   * on the SAME sat (migrate + rotation reinscriptions) are expected and do
+   * not compete — only a different, earlier sat wins.
+   */
+  getAnchoringsForDidCel?(didCel: string): Promise<Array<{
+    satoshi: string;
+    inscriptionId: string;
+    blockHeight?: number;
+  }>>;
 }
 
 /**

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -1894,8 +1894,14 @@ export class LifecycleManager {
       resources: asset.resources.map(res => ({ id: res.id, hash: res.hash, contentType: res.contentType, url: res.url })),
       timestamp: new Date().toISOString()
     };
-    const backLinks = [asset.id, asset.bindings?.['did:webvh']].filter(
-      (d): d is string => typeof d === 'string'
+    // First-anchor-wins uniqueness (#did-cel-uniqueness): the inscribed btco
+    // doc MUST back-link its did:cel so on-chain anchorings are enumerable via
+    // getAnchoringsForDidCel. Derive it from the genesis event (not the mutable
+    // asset.id) and place it first; dedupe so a coincidental asset.id === didCel
+    // does not double-list. The did:webvh predecessor follows.
+    const didCel = asset.celLog ? deriveDidCel(asset.celLog) : asset.id;
+    const backLinks = [didCel, asset.id, asset.bindings?.['did:webvh']].filter(
+      (d, i, arr): d is string => typeof d === 'string' && arr.indexOf(d) === i
     );
 
     // Held locally, not captured into the asset yet: buildContent runs BEFORE

--- a/packages/sdk/tests/unit/adapters/OrdMockProvider.getAnchoringsForDidCel.test.ts
+++ b/packages/sdk/tests/unit/adapters/OrdMockProvider.getAnchoringsForDidCel.test.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect } from 'bun:test';
+import { OrdMockProvider } from '../../../src/adapters/providers/OrdMockProvider';
+
+const DID_CEL = 'did:cel:uZZZ';
+
+function btcoDoc(satoshi: string, alsoKnownAs: string[]) {
+  const id = `did:btco:reg:${satoshi}`;
+  return {
+    '@context': ['https://www.w3.org/ns/did/v1'],
+    id,
+    alsoKnownAs,
+    service: [{ id: `${id}#cel`, type: 'OriginalsCelAnchor', serviceEndpoint: { headDigestMultibase: 'uHEAD' } }],
+  };
+}
+
+async function inscribe(p: OrdMockProvider, satoshi: string, alsoKnownAs: string[]) {
+  const res = await p.createInscription({
+    data: Buffer.from(JSON.stringify(btcoDoc(satoshi, alsoKnownAs))),
+    contentType: 'application/did+json',
+    targetSatoshi: satoshi,
+  });
+  return res.inscriptionId;
+}
+
+describe('OrdMockProvider.getAnchoringsForDidCel', () => {
+  test('returns every inscription whose alsoKnownAs back-links the did:cel', async () => {
+    const p = new OrdMockProvider();
+    const iX = await inscribe(p, '100', [DID_CEL, 'did:webvh:example.com:x']);
+    const iY = await inscribe(p, '200', [DID_CEL]);
+    // Unrelated inscription: different did:cel, must NOT be returned.
+    await inscribe(p, '300', ['did:cel:uOTHER']);
+
+    const anchorings = await p.getAnchoringsForDidCel(DID_CEL);
+    const bySat = new Map(anchorings.map((a) => [a.satoshi, a]));
+
+    expect(anchorings).toHaveLength(2);
+    expect(bySat.get('100')!.inscriptionId).toBe(iX);
+    expect(bySat.get('200')!.inscriptionId).toBe(iY);
+    // OrdMock stamps every inscription with a confirmed block height.
+    expect(typeof bySat.get('100')!.blockHeight).toBe('number');
+  });
+
+  test('returns an empty array when no inscription back-links the did:cel', async () => {
+    const p = new OrdMockProvider();
+    await inscribe(p, '100', ['did:cel:uSOMETHINGELSE']);
+    expect(await p.getAnchoringsForDidCel(DID_CEL)).toEqual([]);
+  });
+
+  test('skips non-JSON / non-DID-document inscriptions', async () => {
+    const p = new OrdMockProvider();
+    await p.createInscription({ data: Buffer.from('not json'), contentType: 'text/plain', targetSatoshi: '100' });
+    expect(await p.getAnchoringsForDidCel(DID_CEL)).toEqual([]);
+  });
+});

--- a/packages/sdk/tests/unit/cel/anchored-sat-identity.test.ts
+++ b/packages/sdk/tests/unit/cel/anchored-sat-identity.test.ts
@@ -9,6 +9,7 @@ import { multikey } from '../../../src/crypto/Multikey';
 import { canonicalizeEvent, canonicalizeEntryForChain } from '../../../src/cel/canonicalize';
 import { computeDigestMultibase } from '../../../src/cel/hash';
 import { verifyEventLog } from '../../../src/cel/algorithms/verifyEventLog';
+import { deriveDidCel } from '../../../src/cel/celDid';
 import { createEventLog } from '../../../src/cel/algorithms/createEventLog';
 import { appendEvent } from '../../../src/cel/algorithms/appendEvent';
 import { OrdMockProvider } from '../../../src/adapters/providers/OrdMockProvider';
@@ -33,17 +34,17 @@ async function makeKey() {
 type Key = Awaited<ReturnType<typeof makeKey>>;
 const chainDigest = (e: LogEntry) => computeDigestMultibase(canonicalizeEntryForChain(e));
 
-function btcoDoc(satoshi: string, headDigestMultibase: string) {
+function btcoDoc(satoshi: string, headDigestMultibase: string, didCel?: string) {
   const id = `did:btco:reg:${satoshi}`;
-  return { '@context': ['https://www.w3.org/ns/did/v1'], id, service: [{ id: `${id}#cel`, type: 'OriginalsCelAnchor', serviceEndpoint: { headDigestMultibase } }] };
+  return { '@context': ['https://www.w3.org/ns/did/v1'], id, ...(didCel ? { alsoKnownAs: [didCel] } : {}), service: [{ id: `${id}#cel`, type: 'OriginalsCelAnchor', serviceEndpoint: { headDigestMultibase } }] };
 }
 function attachWitness(log: EventLog, insc: { inscriptionId: string; txid: string }, satoshi: string): EventLog {
   const last = log.events[log.events.length - 1];
   const witnessProof = { type: 'DataIntegrityProof', cryptosuite: 'bitcoin-ordinals-2024', created: 'x', verificationMethod: 'did:btco:witness', proofPurpose: 'assertionMethod', proofValue: `z${insc.inscriptionId}`, witnessedAt: 'x', txid: insc.txid, satoshi, inscriptionId: insc.inscriptionId };
   return { events: [...log.events.slice(0, -1), { ...last, proof: [...last.proof, witnessProof] }] };
 }
-async function inscribeDoc(provider: OrdMockProvider, satoshi: string, headDigest: string) {
-  const res = await provider.createInscription({ data: Buffer.from(JSON.stringify(btcoDoc(satoshi, headDigest))), contentType: 'application/did+json', targetSatoshi: satoshi });
+async function inscribeDoc(provider: OrdMockProvider, satoshi: string, headDigest: string, didCel?: string) {
+  const res = await provider.createInscription({ data: Buffer.from(JSON.stringify(btcoDoc(satoshi, headDigest, didCel))), contentType: 'application/did+json', targetSatoshi: satoshi });
   return { inscriptionId: res.inscriptionId, txid: res.txid };
 }
 const SAT = '1234567890';
@@ -59,7 +60,7 @@ async function makeAnchoredLog(provider: OrdMockProvider, a: Key, sat = SAT) {
     { sourceDid: 'did:cel:uPlaceholder', layer: 'btco', network: 'regtest', to: `did:btco:reg:${sat}`, migratedAt: '2026-07-13T00:00:00Z' },
     { signer: a.signer, verificationMethod: a.vm }
   );
-  const insc = await inscribeDoc(provider, sat, chainDigest(log.events[log.events.length - 1]));
+  const insc = await inscribeDoc(provider, sat, chainDigest(log.events[log.events.length - 1]), deriveDidCel(log));
   return { log: attachWitness(log, insc, sat), inscriptionId: insc.inscriptionId };
 }
 

--- a/packages/sdk/tests/unit/cel/did-cel-uniqueness.test.ts
+++ b/packages/sdk/tests/unit/cel/did-cel-uniqueness.test.ts
@@ -107,18 +107,27 @@ async function branch(base: EventLog, a: Key, p: OrdMockProvider, sat: string, d
 }
 
 // Wrap a provider to stamp per-inscription block heights onto BOTH
-// getInscriptionById and getAnchoringsForDidCel (OrdMock hardcodes height 1).
+// getInscriptionById and getAnchoringsForDidCel. An UNMAPPED inscription has its
+// blockHeight STRIPPED (not left at OrdMock's hardcoded 1), matching the sibling
+// wrappers in head-freshness/non-cooperative-rotation: an unmapped mock must not
+// silently participate in canonical ordering — it fails uniqueness closed.
 function withHeights(p: OrdMockProvider, heights: Record<string, number>) {
   return {
     getInscriptionById: async (id: string) => {
       const rec = await p.getInscriptionById(id);
       if (!rec) return null;
-      return id in heights ? { ...rec, blockHeight: heights[id] } : rec;
+      if (id in heights) return { ...rec, blockHeight: heights[id] };
+      const { blockHeight: _bh, ...rest } = rec as typeof rec & { blockHeight?: number };
+      return rest as typeof rec;
     },
     getInscriptionsBySatoshi: (s: string) => p.getInscriptionsBySatoshi(s),
     getAnchoringsForDidCel: async (didCel: string) => {
       const anchorings = await p.getAnchoringsForDidCel!(didCel);
-      return anchorings.map((a) => (a.inscriptionId in heights ? { ...a, blockHeight: heights[a.inscriptionId] } : a));
+      return anchorings.map((a) => {
+        if (a.inscriptionId in heights) return { ...a, blockHeight: heights[a.inscriptionId] };
+        const { blockHeight: _bh, ...rest } = a;
+        return rest;
+      });
     },
   };
 }

--- a/packages/sdk/tests/unit/cel/did-cel-uniqueness.test.ts
+++ b/packages/sdk/tests/unit/cel/did-cel-uniqueness.test.ts
@@ -1,0 +1,146 @@
+/**
+ * did:cel uniqueness — first-anchor-wins (follow-up to the signed-anchored-sat
+ * spec). A btco-anchored did:cel log verifies only when its anchored sat is the
+ * canonical one: the sat of the log's earliest on-chain anchoring (lowest
+ * confirmed block height, grouped by sat). Non-canonical → NON_CANONICAL_ANCHOR.
+ *
+ * NOTE: soundness assumes Part A (signed anchored sat) has landed, so the
+ * verifier's anchoredSat is the SIGNED sat, not the attacker-editable witness.
+ * The mechanism below keys off the existing anchoredSat walk-state, so these
+ * fixtures are runnable against the current tree.
+ */
+import { describe, test, expect } from 'bun:test';
+import * as ed25519 from '@noble/ed25519';
+import { multikey } from '../../../src/crypto/Multikey';
+import { canonicalizeEvent, canonicalizeEntryForChain } from '../../../src/cel/canonicalize';
+import { computeDigestMultibase } from '../../../src/cel/hash';
+import { verifyEventLog } from '../../../src/cel/algorithms/verifyEventLog';
+import { createEventLog } from '../../../src/cel/algorithms/createEventLog';
+import { appendEvent } from '../../../src/cel/algorithms/appendEvent';
+import { deriveDidCel } from '../../../src/cel/celDid';
+import { OrdMockProvider } from '../../../src/adapters/providers/OrdMockProvider';
+import type { EventLog, LogEntry } from '../../../src/cel/types';
+
+async function makeKey() {
+  const priv = crypto.getRandomValues(new Uint8Array(32));
+  const pub = await ed25519.getPublicKeyAsync(priv);
+  const pubMb = multikey.encodePublicKey(pub, 'Ed25519');
+  const didKey = `did:key:${pubMb}`;
+  const vm = `${didKey}#${pubMb}`;
+  const signer = async (data: unknown) => ({
+    type: 'DataIntegrityProof',
+    cryptosuite: 'eddsa-jcs-2022',
+    created: '2026-07-13T00:00:00Z',
+    verificationMethod: vm,
+    proofPurpose: 'assertionMethod',
+    proofValue: multikey.encodeMultibase(
+      new Uint8Array(await ed25519.signAsync(canonicalizeEvent(data), priv))
+    ),
+  });
+  return { signer, didKey, vm, pubMb };
+}
+type Key = Awaited<ReturnType<typeof makeKey>>;
+
+const chainDigest = (e: LogEntry) => computeDigestMultibase(canonicalizeEntryForChain(e));
+
+// A btco DID document that back-links the did:cel (Task-2 writer shape).
+function btcoDoc(satoshi: string, headDigestMultibase: string, didCel: string) {
+  const id = `did:btco:reg:${satoshi}`;
+  return {
+    '@context': ['https://www.w3.org/ns/did/v1'],
+    id,
+    alsoKnownAs: [didCel],
+    service: [{ id: `${id}#cel`, type: 'OriginalsCelAnchor', serviceEndpoint: { headDigestMultibase } }],
+  };
+}
+
+function attachWitness(log: EventLog, insc: { inscriptionId: string; txid: string }, satoshi: string): EventLog {
+  const last = log.events[log.events.length - 1];
+  const witnessedAt = '2026-07-13T00:00:01Z';
+  const witnessProof = {
+    type: 'DataIntegrityProof',
+    cryptosuite: 'bitcoin-ordinals-2024',
+    created: witnessedAt,
+    verificationMethod: 'did:btco:witness',
+    proofPurpose: 'assertionMethod',
+    proofValue: `z${insc.inscriptionId}`,
+    witnessedAt,
+    txid: insc.txid,
+    satoshi,
+    inscriptionId: insc.inscriptionId,
+  };
+  return { events: [...log.events.slice(0, -1), { ...last, proof: [...last.proof, witnessProof] }] };
+}
+
+async function inscribeDoc(p: OrdMockProvider, satoshi: string, headDigest: string, didCel: string) {
+  const res = await p.createInscription({
+    data: Buffer.from(JSON.stringify(btcoDoc(satoshi, headDigest, didCel))),
+    contentType: 'application/did+json',
+    targetSatoshi: satoshi,
+  });
+  return { inscriptionId: res.inscriptionId, txid: res.txid };
+}
+
+// Genesis by `a`; returns the shared base log and its derived did:cel.
+async function genesis(a: Key, nonce: string) {
+  const base = await createEventLog(
+    { name: 'Asset', controller: a.didKey, resources: [], createdAt: '2026-07-13T00:00:00Z', nonce },
+    { signer: a.signer, verificationMethod: a.vm }
+  );
+  return { base, didCel: deriveDidCel(base) };
+}
+
+// A controller-signed migrate-to-btco branch onto `sat`, inscribed + witnessed.
+async function branch(base: EventLog, a: Key, p: OrdMockProvider, sat: string, didCel: string) {
+  let log = await appendEvent(
+    base,
+    'migrate',
+    { sourceDid: didCel, layer: 'btco', network: 'regtest', to: `did:btco:reg:${sat}`, migratedAt: '2026-07-13T00:00:00Z' },
+    { signer: a.signer, verificationMethod: a.vm }
+  );
+  const insc = await inscribeDoc(p, sat, chainDigest(log.events[log.events.length - 1]), didCel);
+  log = attachWitness(log, insc, sat);
+  return { log, inscriptionId: insc.inscriptionId };
+}
+
+// Wrap a provider to stamp per-inscription block heights onto BOTH
+// getInscriptionById and getAnchoringsForDidCel (OrdMock hardcodes height 1).
+function withHeights(p: OrdMockProvider, heights: Record<string, number>) {
+  return {
+    getInscriptionById: async (id: string) => {
+      const rec = await p.getInscriptionById(id);
+      if (!rec) return null;
+      return id in heights ? { ...rec, blockHeight: heights[id] } : rec;
+    },
+    getInscriptionsBySatoshi: (s: string) => p.getInscriptionsBySatoshi(s),
+    getAnchoringsForDidCel: async (didCel: string) => {
+      const anchorings = await p.getAnchoringsForDidCel!(didCel);
+      return anchorings.map((a) => (a.inscriptionId in heights ? { ...a, blockHeight: heights[a.inscriptionId] } : a));
+    },
+  };
+}
+
+const hasCode = (r: { errors: string[] }, code: string) => r.errors.some((e) => e.includes(code));
+
+describe('did:cel uniqueness — first-anchor-wins', () => {
+  test('DUPING: two branches of one did:cel on sats X(100) and Y(200); Y-branch → NON_CANONICAL_ANCHOR, X-branch verifies', async () => {
+    const p = new OrdMockProvider();
+    const a = await makeKey();
+    const { base, didCel } = await genesis(a, 'uniq-dupe');
+    const X = '100000001';
+    const Y = '200000002';
+    const bx = await branch(base, a, p, X, didCel);
+    const by = await branch(base, a, p, Y, didCel);
+    const provider = withHeights(p, { [bx.inscriptionId]: 100, [by.inscriptionId]: 200 });
+
+    // Bob holds the Y-branch: X anchored first (block 100) → Y is a dupe.
+    const yResult = await verifyEventLog(by.log, { ordinalsProvider: provider });
+    expect(yResult.verified).toBe(false);
+    expect(hasCode(yResult, 'NON_CANONICAL_ANCHOR')).toBe(true);
+
+    // Alice holds the canonical X-branch → verifies.
+    const xResult = await verifyEventLog(bx.log, { ordinalsProvider: provider });
+    expect(xResult.errors).toEqual([]);
+    expect(xResult.verified).toBe(true);
+  });
+});

--- a/packages/sdk/tests/unit/cel/did-cel-uniqueness.test.ts
+++ b/packages/sdk/tests/unit/cel/did-cel-uniqueness.test.ts
@@ -44,12 +44,15 @@ type Key = Awaited<ReturnType<typeof makeKey>>;
 const chainDigest = (e: LogEntry) => computeDigestMultibase(canonicalizeEntryForChain(e));
 
 // A btco DID document that back-links the did:cel (Task-2 writer shape).
-function btcoDoc(satoshi: string, headDigestMultibase: string, didCel: string) {
+function btcoDoc(satoshi: string, headDigestMultibase: string, didCel: string, publicKeyMultibase?: string) {
   const id = `did:btco:reg:${satoshi}`;
   return {
     '@context': ['https://www.w3.org/ns/did/v1'],
     id,
     alsoKnownAs: [didCel],
+    ...(publicKeyMultibase
+      ? { verificationMethod: [{ id: `${id}#key-0`, type: 'Multikey', controller: id, publicKeyMultibase }] }
+      : {}),
     service: [{ id: `${id}#cel`, type: 'OriginalsCelAnchor', serviceEndpoint: { headDigestMultibase } }],
   };
 }
@@ -72,9 +75,9 @@ function attachWitness(log: EventLog, insc: { inscriptionId: string; txid: strin
   return { events: [...log.events.slice(0, -1), { ...last, proof: [...last.proof, witnessProof] }] };
 }
 
-async function inscribeDoc(p: OrdMockProvider, satoshi: string, headDigest: string, didCel: string) {
+async function inscribeDoc(p: OrdMockProvider, satoshi: string, headDigest: string, didCel: string, publicKeyMultibase?: string) {
   const res = await p.createInscription({
-    data: Buffer.from(JSON.stringify(btcoDoc(satoshi, headDigest, didCel))),
+    data: Buffer.from(JSON.stringify(btcoDoc(satoshi, headDigest, didCel, publicKeyMultibase))),
     contentType: 'application/did+json',
     targetSatoshi: satoshi,
   });
@@ -160,7 +163,7 @@ describe('did:cel uniqueness — first-anchor-wins', () => {
       { newController: b.didKey, rotatedAt: '2026-07-13T00:00:02Z' },
       { signer: b.signer, verificationMethod: b.vm }
     );
-    const rotInsc = await inscribeDoc(p, X, chainDigest(rotated.events[rotated.events.length - 1]), didCel);
+    const rotInsc = await inscribeDoc(p, X, chainDigest(rotated.events[rotated.events.length - 1]), didCel, b.pubMb);
     const full = attachWitness(rotated, rotInsc, X);
 
     // Migrate at block 100, rotation reinscription at block 200 — both on X.

--- a/packages/sdk/tests/unit/cel/did-cel-uniqueness.test.ts
+++ b/packages/sdk/tests/unit/cel/did-cel-uniqueness.test.ts
@@ -143,4 +143,118 @@ describe('did:cel uniqueness — first-anchor-wins', () => {
     expect(xResult.errors).toEqual([]);
     expect(xResult.verified).toBe(true);
   });
+
+  test('ROTATION IS NOT A COMPETITOR: migrate + N reinscriptions on the SAME sat X still verify', async () => {
+    const p = new OrdMockProvider();
+    const a = await makeKey();
+    const b = await makeKey();
+    const { base, didCel } = await genesis(a, 'uniq-rot');
+    const X = '111000111';
+    const bx = await branch(base, a, p, X, didCel);
+
+    // A non-cooperative rotation reinscribes the SAME sat X (a second anchoring
+    // for the same did:cel on the same sat — must NOT count as a rival sat).
+    const rotated = await appendEvent(
+      bx.log,
+      'rotateKey',
+      { newController: b.didKey, rotatedAt: '2026-07-13T00:00:02Z' },
+      { signer: b.signer, verificationMethod: b.vm }
+    );
+    const rotInsc = await inscribeDoc(p, X, chainDigest(rotated.events[rotated.events.length - 1]), didCel);
+    const full = attachWitness(rotated, rotInsc, X);
+
+    // Migrate at block 100, rotation reinscription at block 200 — both on X.
+    const provider = withHeights(p, { [bx.inscriptionId]: 100, [rotInsc.inscriptionId]: 200 });
+    const result = await verifyEventLog(full, { ordinalsProvider: provider });
+    expect(result.errors).toEqual([]);
+    expect(result.verified).toBe(true);
+  });
+
+  test('SAME-BLOCK AMBIGUITY: X and Y both anchored at block 100 → AMBIGUOUS_CANONICAL', async () => {
+    const p = new OrdMockProvider();
+    const a = await makeKey();
+    const { base, didCel } = await genesis(a, 'uniq-tie');
+    const X = '100000001';
+    const Y = '200000002';
+    const bx = await branch(base, a, p, X, didCel);
+    const by = await branch(base, a, p, Y, didCel);
+    const provider = withHeights(p, { [bx.inscriptionId]: 100, [by.inscriptionId]: 100 });
+
+    const result = await verifyEventLog(by.log, { ordinalsProvider: provider });
+    expect(result.verified).toBe(false);
+    expect(hasCode(result, 'AMBIGUOUS_CANONICAL')).toBe(true);
+  });
+
+  test('PROVIDER POSTURE: btco-anchored log + provider WITHOUT getAnchoringsForDidCel → UNIQUENESS_UNVERIFIABLE', async () => {
+    const p = new OrdMockProvider();
+    const a = await makeKey();
+    const { base, didCel } = await genesis(a, 'uniq-noenum');
+    const X = '100000001';
+    const bx = await branch(base, a, p, X, didCel);
+
+    // Enough to verify the migrate witness (getInscriptionById) but NOT to
+    // enumerate anchorings — uniqueness must fail closed.
+    const limited = { getInscriptionById: (id: string) => p.getInscriptionById(id) };
+    const result = await verifyEventLog(bx.log, { ordinalsProvider: limited });
+    expect(result.verified).toBe(false);
+    expect(hasCode(result, 'UNIQUENESS_UNVERIFIABLE')).toBe(true);
+  });
+
+  test('PROVIDER POSTURE: an anchoring missing a blockHeight → UNIQUENESS_UNVERIFIABLE', async () => {
+    const p = new OrdMockProvider();
+    const a = await makeKey();
+    const { base, didCel } = await genesis(a, 'uniq-noheight');
+    const X = '100000001';
+    const bx = await branch(base, a, p, X, didCel);
+
+    // Strip blockHeight from the enumeration only (witness still verifies).
+    const provider = {
+      getInscriptionById: (id: string) => p.getInscriptionById(id),
+      getInscriptionsBySatoshi: (s: string) => p.getInscriptionsBySatoshi(s),
+      getAnchoringsForDidCel: async (dc: string) =>
+        (await p.getAnchoringsForDidCel!(dc)).map(({ blockHeight: _bh, ...rest }) => rest),
+    };
+    const result = await verifyEventLog(bx.log, { ordinalsProvider: provider });
+    expect(result.verified).toBe(false);
+    expect(hasCode(result, 'UNIQUENESS_UNVERIFIABLE')).toBe(true);
+  });
+
+  test('EMPTY ENUMERATION: provider HAS getAnchoringsForDidCel but returns [] → UNIQUENESS_UNVERIFIABLE', async () => {
+    const p = new OrdMockProvider();
+    const a = await makeKey();
+    const { base, didCel } = await genesis(a, 'uniq-empty');
+    const X = '100000001';
+    const bx = await branch(base, a, p, X, didCel);
+
+    // Witness still verifies (getInscriptionById/getInscriptionsBySatoshi delegate
+    // to the real provider); enumeration returns [] — must fail closed, not treat
+    // the anchoring as unopposed/canonical.
+    const provider = {
+      getInscriptionById: (id: string) => p.getInscriptionById(id),
+      getInscriptionsBySatoshi: (s: string) => p.getInscriptionsBySatoshi(s),
+      getAnchoringsForDidCel: async (_dc: string) => [],
+    };
+    const result = await verifyEventLog(bx.log, { ordinalsProvider: provider });
+    expect(result.verified).toBe(false);
+    expect(hasCode(result, 'UNIQUENESS_UNVERIFIABLE')).toBe(true);
+  });
+
+  test('THROWING PROVIDER: getAnchoringsForDidCel throws → UNIQUENESS_UNVERIFIABLE', async () => {
+    const p = new OrdMockProvider();
+    const a = await makeKey();
+    const { base, didCel } = await genesis(a, 'uniq-throw');
+    const X = '100000001';
+    const bx = await branch(base, a, p, X, didCel);
+
+    const provider = {
+      getInscriptionById: (id: string) => p.getInscriptionById(id),
+      getInscriptionsBySatoshi: (s: string) => p.getInscriptionsBySatoshi(s),
+      getAnchoringsForDidCel: async (_dc: string): Promise<never> => {
+        throw new Error('index down');
+      },
+    };
+    const result = await verifyEventLog(bx.log, { ordinalsProvider: provider });
+    expect(result.verified).toBe(false);
+    expect(hasCode(result, 'UNIQUENESS_UNVERIFIABLE')).toBe(true);
+  });
 });

--- a/packages/sdk/tests/unit/cel/event-log-authorization.test.ts
+++ b/packages/sdk/tests/unit/cel/event-log-authorization.test.ts
@@ -20,6 +20,7 @@ import { BtcoCelManager } from '../../../src/cel/layers/BtcoCelManager';
 import { updateEventLog } from '../../../src/cel/algorithms/updateEventLog';
 import { appendEvent } from '../../../src/cel/algorithms/appendEvent';
 import { verifyEventLog } from '../../../src/cel/algorithms/verifyEventLog';
+import { deriveDidCel } from '../../../src/cel/celDid';
 import { computeDigestMultibase } from '../../../src/cel/hash';
 import { canonicalizeEntryForChain } from '../../../src/cel/canonicalize';
 import type { BitcoinManager } from '../../../src/bitcoin/BitcoinManager';
@@ -314,11 +315,20 @@ describe('CEL event-log authorization and btco verifiability', () => {
               satoshi: '123',
             }
           : null,
+      // First-anchor-wins uniqueness: enumerate this content's anchoring iff it
+      // back-links the queried did:cel (mirrors OrdMockProvider.getAnchoringsForDidCel).
+      getAnchoringsForDidCel: async (didCel: string) => {
+        const aka = (content as { alsoKnownAs?: unknown } | null)?.alsoKnownAs;
+        return Array.isArray(aka) && aka.includes(didCel)
+          ? [{ satoshi: '123', inscriptionId: 'insc1', blockHeight: 1 }]
+          : [];
+      },
     });
 
-    const anchorDoc = (headDigestMultibase: string) => ({
+    const anchorDoc = (headDigestMultibase: string, didCel?: string) => ({
       '@context': ['https://www.w3.org/ns/did/v1'],
       id: 'did:btco:reg:123',
+      ...(didCel ? { alsoKnownAs: [didCel] } : {}),
       service: [
         { id: 'did:btco:reg:123#resources', type: 'OriginalsResourceManifest', serviceEndpoint: { resources: [] } },
         { id: 'did:btco:reg:123#cel', type: 'OriginalsCelAnchor', serviceEndpoint: { headDigestMultibase } },
@@ -327,7 +337,7 @@ describe('CEL event-log authorization and btco verifiability', () => {
 
     it('accepts a DID document whose OriginalsCelAnchor commits to the event digest', async () => {
       const { log, digest } = await makeWitnessedLog();
-      const result = await verifyEventLog(log, { ordinalsProvider: providerServing(anchorDoc(digest)) });
+      const result = await verifyEventLog(log, { ordinalsProvider: providerServing(anchorDoc(digest, deriveDidCel(log))) });
       expect(result.verified).toBe(true);
       expect(result.errors).toEqual([]);
     });

--- a/packages/sdk/tests/unit/cel/head-freshness.test.ts
+++ b/packages/sdk/tests/unit/cel/head-freshness.test.ts
@@ -16,6 +16,7 @@ import { multikey } from '../../../src/crypto/Multikey';
 import { canonicalizeEvent, canonicalizeEntryForChain } from '../../../src/cel/canonicalize';
 import { computeDigestMultibase } from '../../../src/cel/hash';
 import { verifyEventLog } from '../../../src/cel/algorithms/verifyEventLog';
+import { deriveDidCel } from '../../../src/cel/celDid';
 import { createEventLog } from '../../../src/cel/algorithms/createEventLog';
 import { appendEvent } from '../../../src/cel/algorithms/appendEvent';
 import { OrdMockProvider } from '../../../src/adapters/providers/OrdMockProvider';
@@ -43,11 +44,12 @@ type Key = Awaited<ReturnType<typeof makeKey>>;
 
 const chainDigest = (event: LogEntry) => computeDigestMultibase(canonicalizeEntryForChain(event));
 
-function btcoDoc(satoshi: string, headDigestMultibase: string, publicKeyMultibase?: string) {
+function btcoDoc(satoshi: string, headDigestMultibase: string, publicKeyMultibase?: string, didCel?: string) {
   const id = `did:btco:reg:${satoshi}`;
   return {
     '@context': ['https://www.w3.org/ns/did/v1'],
     id,
+    ...(didCel ? { alsoKnownAs: [didCel] } : {}),
     ...(publicKeyMultibase
       ? { verificationMethod: [{ id: `${id}#key-0`, type: 'Multikey', controller: id, publicKeyMultibase }] }
       : {}),
@@ -73,9 +75,9 @@ function attachWitness(log: EventLog, insc: { inscriptionId: string; txid: strin
   return { events: [...log.events.slice(0, -1), { ...last, proof: [...last.proof, witnessProof] }] };
 }
 
-async function inscribeDoc(provider: OrdMockProvider, satoshi: string, headDigest: string, publicKeyMultibase?: string) {
+async function inscribeDoc(provider: OrdMockProvider, satoshi: string, headDigest: string, publicKeyMultibase?: string, didCel?: string) {
   const res = await provider.createInscription({
-    data: Buffer.from(JSON.stringify(btcoDoc(satoshi, headDigest, publicKeyMultibase))),
+    data: Buffer.from(JSON.stringify(btcoDoc(satoshi, headDigest, publicKeyMultibase, didCel))),
     contentType: 'application/did+json',
     targetSatoshi: satoshi,
   });
@@ -97,7 +99,7 @@ async function makeAnchoredLog(provider: OrdMockProvider, a: Key, sat = SAT) {
     { signer: a.signer, verificationMethod: a.vm }
   );
   const migrateDigest = chainDigest(log.events[log.events.length - 1]);
-  const insc = await inscribeDoc(provider, sat, migrateDigest);
+  const insc = await inscribeDoc(provider, sat, migrateDigest, undefined, deriveDidCel(log));
   log = attachWitness(log, insc, sat);
   return { log, migrateInscriptionId: insc.inscriptionId, migrateDigest };
 }
@@ -111,7 +113,7 @@ async function addNonCoopRotation(log: EventLog, provider: OrdMockProvider, newC
     { signer: newController.signer, verificationMethod: newController.vm }
   );
   const rotDigest = chainDigest(rotated.events[rotated.events.length - 1]);
-  const insc = await inscribeDoc(provider, SAT, rotDigest, newController.pubMb);
+  const insc = await inscribeDoc(provider, SAT, rotDigest, newController.pubMb, deriveDidCel(log));
   return { log: attachWitness(rotated, insc, SAT), inscriptionId: insc.inscriptionId, rotDigest };
 }
 
@@ -250,6 +252,16 @@ describe('checkHeadFreshness — truncated-log detection', () => {
         async getInscriptionsBySatoshi(satoshi: string) {
           const list = await provider.getInscriptionsBySatoshi(satoshi);
           return [...list].reverse();
+        },
+        // Delegate uniqueness enumeration, remapping blockHeight through `heights`
+        // (unmapped → stripped) exactly as getInscriptionById does.
+        async getAnchoringsForDidCel(didCel: string) {
+          const list = await provider.getAnchoringsForDidCel!(didCel);
+          return list.map((a) => {
+            if (a.inscriptionId in heights) return { ...a, blockHeight: heights[a.inscriptionId] };
+            const { blockHeight: _bh, ...rest } = a;
+            return rest;
+          });
         },
       };
     }

--- a/packages/sdk/tests/unit/cel/non-cooperative-rotation.test.ts
+++ b/packages/sdk/tests/unit/cel/non-cooperative-rotation.test.ts
@@ -25,6 +25,7 @@ import { multikey } from '../../../src/crypto/Multikey';
 import { canonicalizeEvent, canonicalizeEntryForChain } from '../../../src/cel/canonicalize';
 import { computeDigestMultibase } from '../../../src/cel/hash';
 import { verifyEventLog } from '../../../src/cel/algorithms/verifyEventLog';
+import { deriveDidCel } from '../../../src/cel/celDid';
 import { createEventLog } from '../../../src/cel/algorithms/createEventLog';
 import { appendEvent } from '../../../src/cel/algorithms/appendEvent';
 import { OrdMockProvider } from '../../../src/adapters/providers/OrdMockProvider';
@@ -55,11 +56,12 @@ const chainDigest = (event: LogEntry) => computeDigestMultibase(canonicalizeEntr
 
 // The inscribed btco DID document: OriginalsCelAnchor commits to the event's
 // chain digest; verificationMethod announces the (new) controller key.
-function btcoDoc(satoshi: string, headDigestMultibase: string, publicKeyMultibase?: string) {
+function btcoDoc(satoshi: string, headDigestMultibase: string, publicKeyMultibase?: string, didCel?: string) {
   const id = `did:btco:reg:${satoshi}`;
   return {
     '@context': ['https://www.w3.org/ns/did/v1'],
     id,
+    ...(didCel ? { alsoKnownAs: [didCel] } : {}),
     ...(publicKeyMultibase
       ? { verificationMethod: [{ id: `${id}#key-0`, type: 'Multikey', controller: id, publicKeyMultibase }] }
       : {}),
@@ -95,10 +97,11 @@ async function inscribeDoc(
   provider: OrdMockProvider,
   satoshi: string,
   headDigest: string,
-  publicKeyMultibase?: string
+  publicKeyMultibase?: string,
+  didCel?: string
 ) {
   const res = await provider.createInscription({
-    data: Buffer.from(JSON.stringify(btcoDoc(satoshi, headDigest, publicKeyMultibase))),
+    data: Buffer.from(JSON.stringify(btcoDoc(satoshi, headDigest, publicKeyMultibase, didCel))),
     contentType: 'application/did+json',
     targetSatoshi: satoshi,
   });
@@ -120,7 +123,7 @@ async function makeAnchoredLog(provider: OrdMockProvider, a: Key, sat = SAT) {
     { signer: a.signer, verificationMethod: a.vm }
   );
   const migrateDigest = chainDigest(log.events[log.events.length - 1]);
-  const insc = await inscribeDoc(provider, sat, migrateDigest);
+  const insc = await inscribeDoc(provider, sat, migrateDigest, undefined, deriveDidCel(log));
   log = attachWitness(log, insc, sat);
   return { log, migrateInscriptionId: insc.inscriptionId };
 }
@@ -143,7 +146,12 @@ async function addNonCoopRotation(
   );
   const rotDigest = chainDigest(rotated.events[rotated.events.length - 1]);
   const announce = opts.announceMb === null ? undefined : (opts.announceMb ?? newController.pubMb);
-  const insc = await inscribeDoc(provider, opts.inscribeSat ?? SAT, rotDigest, announce);
+  const onSat = opts.inscribeSat ?? SAT;
+  // Only an HONEST anchoring (reinscription on the log's anchored sat) back-links
+  // the did:cel; a foreign-sat attack reinscription must NOT — else uniqueness
+  // sees two block-1 sats and false-flags AMBIGUOUS_CANONICAL.
+  const aka = onSat === SAT ? deriveDidCel(log) : undefined;
+  const insc = await inscribeDoc(provider, onSat, rotDigest, announce, aka);
   return { log: attachWitness(rotated, insc, opts.claimSat ?? opts.inscribeSat ?? SAT), inscriptionId: insc.inscriptionId };
 }
 
@@ -499,6 +507,16 @@ describe('non-cooperative rotation (reinscription-attested hand-off)', () => {
         async getInscriptionsBySatoshi(satoshi: string) {
           const list = await provider.getInscriptionsBySatoshi(satoshi);
           return opts.reverse ? [...list].reverse() : list;
+        },
+        // Delegate uniqueness enumeration, remapping each anchoring's blockHeight
+        // through `heights` exactly as getInscriptionById does (unmapped → stripped).
+        async getAnchoringsForDidCel(didCel: string) {
+          const list = await provider.getAnchoringsForDidCel!(didCel);
+          return list.map((a) => {
+            if (a.inscriptionId in heights) return { ...a, blockHeight: heights[a.inscriptionId] };
+            const { blockHeight: _bh, ...rest } = a;
+            return rest;
+          });
         },
       };
     }

--- a/packages/sdk/tests/unit/lifecycle/LifecycleManager.verifyAsset.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/LifecycleManager.verifyAsset.test.ts
@@ -64,7 +64,8 @@ describe('LifecycleManager.verifyAsset', () => {
         calls += 1;
         return configProvider.getInscriptionById(id);
       },
-      getInscriptionsBySatoshi: (sat: string) => configProvider.getInscriptionsBySatoshi(sat)
+      getInscriptionsBySatoshi: (sat: string) => configProvider.getInscriptionsBySatoshi(sat),
+      getAnchoringsForDidCel: (didCel: string) => configProvider.getAnchoringsForDidCel!(didCel)
     };
     expect(await sdk.lifecycle.verifyAsset(asset, { ordinalsProvider: overrideProvider })).toBe(true);
     expect(calls).toBeGreaterThan(0);

--- a/packages/sdk/tests/unit/lifecycle/inscribe-alsoKnownAs-didcel.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/inscribe-alsoKnownAs-didcel.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from 'bun:test';
+import { OriginalsSDK } from '../../../src';
+import { OrdMockProvider } from '../../../src/adapters/providers/OrdMockProvider';
+import { MockKeyStore } from '../../mocks/MockKeyStore';
+import { deriveDidCel } from '../../../src/cel/celDid';
+
+describe('inscribeOnBitcoin — did:cel back-link in alsoKnownAs', () => {
+  test('inscribed btco doc back-links the did:cel; enumerable via getAnchoringsForDidCel', async () => {
+    const provider = new OrdMockProvider();
+    const sdk = OriginalsSDK.create({
+      network: 'regtest',
+      defaultKeyType: 'Ed25519',
+      ordinalsProvider: provider,
+      keyStore: new MockKeyStore(),
+    });
+    const asset = await sdk.lifecycle.createAsset([
+      { id: 'r', type: 'data', contentType: 'text/plain', hash: '56'.repeat(32) },
+    ]);
+    const didCel = deriveDidCel(asset.celLog!);
+    expect(didCel.startsWith('did:cel:')).toBe(true);
+    expect(asset.id).toBe(didCel);
+
+    await sdk.lifecycle.inscribeOnBitcoin(asset);
+
+    // Round-trip: the anchoring is indexable by the asset's did:cel.
+    const anchorings = await provider.getAnchoringsForDidCel!(didCel);
+    expect(anchorings.length).toBeGreaterThanOrEqual(1);
+    // The anchored sat carries the inscription.
+    const btcoDid = asset.bindings!['did:btco']!;
+    const sat = btcoDid.replace(/^did:btco:(reg:|sig:)?/, '');
+    expect(anchorings.some((a) => a.satoshi === sat)).toBe(true);
+
+    // And the inscribed document literally lists the did:cel first.
+    const resolved = await sdk.did.resolveDID(btcoDid, { skipCache: true });
+    expect(resolved!.alsoKnownAs?.[0]).toBe(didCel);
+  });
+});


### PR DESCRIPTION
## Part B: first-anchor-wins did:cel uniqueness

Closes #396. **Stacked on #398 (Part A, signed anchored-sat identity) — base is `claude/cel-anchored-sat-identity`, not `main`.** Do not merge ahead of Part A.

### What this does
Closes the malicious-controller **duping** case (one `did:cel` signed onto two sats, both sold): a btco-anchored `did:cel` log now verifies only when its anchored sat is the **canonical** one — the sat of the log's earliest on-chain anchoring (lowest confirmed `blockHeight`, **grouped by sat**). Multiple inscriptions on the *same* sat (migrate + rotation reinscriptions) do not compete; only a different, earlier sat wins.

- **Provider capability** `getAnchoringsForDidCel(didCel)` on `OrdinalsLookup` + `OrdinalsProvider` (OrdMock impl): enumerates every on-chain btco DID-doc anchoring whose `alsoKnownAs` back-links the `did:cel`.
- **Writer**: `LifecycleManager.inscribeOnBitcoin` now puts `deriveDidCel(asset.celLog)` first (deduped) in the inscribed btco doc's `alsoKnownAs`, so anchorings are enumerable. (This owns the `alsoKnownAs = backLinks` line Part A deliberately left alone.)
- **Verifier**: `verifyUniqueness` in `verifyEventLog`, a peer of head-freshness.

### Provider posture — fail-closed, NOT opt-in
Uniqueness is part of the btco verification contract. A btco-anchored `did:cel` log already needs a provider; a provider lacking `getAnchoringsForDidCel`, an empty enumeration, or any anchoring missing a `blockHeight` → `UNIQUENESS_UNVERIFIABLE`. A same-block tie between two **different** sats → `AMBIGUOUS_CANONICAL`. A non-canonical sat → `NON_CANONICAL_ANCHOR`. No basic-provider skip path; skipped only on the custom-`verifier` path (which never establishes `anchoredSat`).

### Residuals / follow-ups
- **Same-block tie → `AMBIGUOUS_CANONICAL`** (fail-closed): no finer on-chain order (ordinals inscription number) is exposed by the provider contract today.
- **Third-party denial (griefing) — deny-only, not a theft vector**: enumeration counts *any* inscription that back-links the `did:cel`, without requiring it be controller-signed or head-committing. A non-controller can front-run an earlier/same-block `{alsoKnownAs:["did:cel:Z"]}` inscription on their own sat to permanently deny an honest new mint (→ `NON_CANONICAL_ANCHOR`/`AMBIGUOUS_CANONICAL`). They **cannot steal** (forging the genesis controller's signatures is required to make a rival branch verify), and confirmed anchorings can't be retro-denied. This corrected spec §6's overbroad "a non-controller cannot pre-empt" claim (see §7). Follow-up: require competitor anchorings to be controller-authenticated or head-committing.

### Testing
Full suite green: **3921 pass / 71 skip / 0 fail**. New coverage: uniqueness duping (first-anchor-wins), rotation-not-a-competitor (same-sat), same-block ambiguity, and provider-posture branches (no-method / missing-height / empty-enumeration / throwing). A fixture migration aligns pre-existing btco-anchored `did:cel` CEL fixtures with the writer's back-link shape (attacker/foreign docs deliberately left un-back-linked; no security assertion weakened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce did:cel first-anchor-wins uniqueness in btco-anchored event log verification
> - Adds `verifyUniqueness` in [`verifyEventLog.ts`](https://github.com/onionoriginals/sdk/pull/399/files#diff-aba8e823ef267585b4b8a9603e5b6afe67fce86d0fee4f9ce67bd95b013efedf) that enumerates all btco anchorings for a `did:cel` via the new `getAnchoringsForDidCel` provider method and selects the canonical sat by earliest confirmed block height.
> - `verifyEventLog` now fails with `UNIQUENESS_UNVERIFIABLE`, `AMBIGUOUS_CANONICAL`, or `NON_CANONICAL_ANCHOR` when uniqueness cannot be proven or the log's sat is not canonical; `verified` is set to `false` in all these cases.
> - `LifecycleManager.inscribeOnBitcoin` now writes the `did:cel` as the first entry in `alsoKnownAs` of the inscribed btco DID document, enabling on-chain enumeration of anchorings.
> - `OrdMockProvider` and the `OrdinalsProvider`/`OrdinalsLookup` interfaces gain the optional `getAnchoringsForDidCel` method used by the uniqueness check.
> - Risk: verification is fail-closed — if the provider does not expose `getAnchoringsForDidCel`, returns an empty list, throws, or returns anchorings without confirmed block heights, uniqueness verification fails and the log is marked unverified.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 05defa3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->