### PR TITLE
Resource-update events on the CEL log (did:cel Phase 4 · 1/5)

### DIFF
--- a/.changeset/resource-update-events-on-log.md
+++ b/.changeset/resource-update-events-on-log.md
@@ -1,0 +1,16 @@
+---
+"@originals/sdk": minor
+---
+
+Resource versions are now signed CEL `update` log events instead of advisory
+envelope metadata. `OriginalsAsset.addResourceVersion` is now **async** and
+appends a signed `update` event (via a controller signer bound by
+`LifecycleManager`), degrading with `cel:append-skipped` when no signing key is
+available. `verifyEventLog` gains a resource-update branch that checks
+per-resourceId hash continuity (seeded from genesis) and derives the new content
+hash inline, so a buyer can verify every post-genesis version offline.
+
+**BREAKING:** `addResourceVersion` returns a `Promise<AssetResource>` (await it),
+and the advisory `AssetEnvelope.unverified.resourceUpdates` field is removed —
+`serialize()` no longer emits it and `loadAsset` folds resource versions from the
+verified log. Regenerate any persisted envelopes that carried it.

--- a/docs/LLM_AGENT_GUIDE.md
+++ b/docs/LLM_AGENT_GUIDE.md
@@ -772,12 +772,16 @@ asset.queryProvenance(): ProvenanceQuery  // Fluent API for queries
 // newContent must be a string: AssetResource stores inline content as a string,
 // so Buffer input throws StructuredError('BINARY_CONTENT_UNSUPPORTED') rather
 // than silently dropping the bytes. Encode binary content (e.g. base64) first.
-asset.addResourceVersion(
+// Async: appends a signed `update` CEL event via the bound controller appender
+// (must `await`). When no signer is available (no keyStore / key absent) it
+// degrades — advances the in-memory version but emits `cel:append-skipped` and
+// writes no provable event. Concurrent calls are serialized per asset.
+await asset.addResourceVersion(
   resourceId: string,
   newContent: string,
   contentType: string,
   changes?: string
-): AssetResource
+): Promise<AssetResource>
 
 asset.getResourceVersion(resourceId: string, version: number): AssetResource | null
 asset.getAllVersions(resourceId: string): AssetResource[]

--- a/docs/superpowers/plans/2026-07-13-resource-update-events-on-log.md
+++ b/docs/superpowers/plans/2026-07-13-resource-update-events-on-log.md
@@ -1,0 +1,1073 @@
+# Resource-update Events on the CEL Log — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn post-genesis resource versions from advisory, unverifiable envelope metadata into signed `update` CEL log events, so provenance for every authorship op — not just genesis — is cryptographically verifiable offline.
+
+**Architecture:** `OriginalsAsset.addResourceVersion` becomes async and appends a signed `'update'` CEL event (via a controller signer/appender injected by `LifecycleManager`) instead of pushing to a local `provenance.resourceUpdates` array. The verifier (`verifyEventLog`) gains a resource-update branch that checks per-`resourceId` hash continuity (seeded from genesis) and derives the new content hash inline. Hard cutover: `serialize()` stops emitting `unverified.resourceUpdates`, `loadAsset` folds versions from the verified log, and the envelope type drops the field.
+
+**Tech Stack:** TypeScript, Bun runtime + test runner (`bun test`), `@noble/hashes` (sha256), `@noble/ed25519` / `@noble/curves` (eddsa-jcs-2022 CEL signing), multibase Multikey encoding. CEL primitives live in `packages/sdk/src/cel/`.
+
+## Global Constraints
+
+- **Runtime:** Bun. Run tests with `bun test <path>` from `packages/sdk/` (or repo root). `bun run build` compiles `packages/sdk/src` → `dist`.
+- **Green gate:** `bun test` must be fully green at the end of every task. Never commit red.
+- **Commits:** use `git commit --no-verify` (the commitlint hook binary is missing in this environment; a plain `git commit` will fail).
+- **Imports:** CLAUDE.md prefers absolute-from-`src/` imports, but the CEL/lifecycle source files use **relative, `.js`-suffixed ESM specifiers** (e.g. `import { hexSha256ToDigestMultibase } from '../signerAdapter.js'`). Match the import style of the file you are editing — do NOT drop the `.js` suffix.
+- **Noble hashes import style:** use `@noble/hashes/sha2.js`, never `@noble/hashes/sha256`. (Already routed through `hashResource` in `src/utils/validation.ts` — reuse that helper rather than importing sha256 directly.)
+- **CEL is Ed25519-only** end-to-end; controller proofs are `eddsa-jcs-2022` DataIntegrityProofs. Never introduce JWK.
+- **Branch independence:** this branch (`claude/cel-resource-update-events`, off `main`) is independent of the anchored-sat Part A work. Do not depend on or merge anything from that line.
+- **Hard cutover, no back-compat:** nothing is released and there are no external consumers. Do not preserve `unverified.resourceUpdates`; regenerate any fixtures/tests that used it.
+
+---
+
+## File Map
+
+**Modified source:**
+- `packages/sdk/src/cel/algorithms/verifyEventLog.ts` — add the resource-update continuity/content-binding branch to the main event walk. (Task 1)
+- `packages/sdk/src/lifecycle/replayProvenance.ts` — fold `resourceUpdates` out of `'update'` events. (Task 2)
+- `packages/sdk/src/lifecycle/OriginalsAsset.ts` — `addResourceVersion` async + injected `#celAppender`; stop writing `provenance.resourceUpdates` locally; drop `unverified.resourceUpdates` from `serialize()`. (Tasks 3, 4)
+- `packages/sdk/src/lifecycle/LifecycleManager.ts` — bind the appender in `createAsset` and `loadAsset`; fold `resourceUpdates` in `buildRestoredProvenance`. (Task 4)
+- `packages/sdk/src/lifecycle/assetEnvelope.ts` — remove `unverified.resourceUpdates`. (Task 4)
+
+**Modified/created tests:**
+- `packages/sdk/tests/unit/cel/resource-update-events.test.ts` — NEW, verifier branch. (Task 1)
+- `packages/sdk/tests/unit/lifecycle/replayProvenance.test.ts` — add fold coverage. (Task 2)
+- `packages/sdk/tests/unit/lifecycle/ResourceVersioning.test.ts` — await + degrade rework. (Task 3)
+- `packages/sdk/tests/unit/lifecycle/addResourceVersion.celevent.test.ts` — NEW, injection contract. (Task 3)
+- `packages/sdk/tests/unit/lifecycle/assetEnvelope.test.ts` — drop `unverified.resourceUpdates` assertions. (Task 4)
+- `packages/sdk/tests/integration/ResourceUpdateHandoff.e2e.test.ts` — NEW, honest round-trip + rotation + degrade. (Task 5)
+- `.changeset/resource-update-events-on-log.md` — NEW. (Task 6)
+
+## Design contract (read once, applies across tasks)
+
+The signed resource-update event (produced by `addResourceVersion`, checked by `verifyEventLog`):
+
+```
+{
+  type: 'update',
+  data: {
+    resourceId:          string,   // logical resource id (AssetResource.id)
+    content:             string,   // the NEW file content, inline (AssetResource.content is a string)
+    contentType:         string,
+    previousVersionHash: string,   // hex sha256 of the prior version (AssetResource.hash format)
+    toVersion:           number,   // new version number
+  },
+  previousEvent: <chain link>,
+  proof: [ controllerProof ],      // eddsa-jcs-2022, current authorized controller key
+}
+```
+
+- **`toHash` is NEVER stored.** It is derived as `hashResource(Buffer.from(content, 'utf-8'))` (hex) at fold/verify time. The chain digest + controller signature already cover `data`, so `content` (and therefore the derived hash) is tamper-evident.
+- **Hash encodings:** `AssetResource.hash` and `previousVersionHash` are **hex sha256** (64 lowercase hex chars). Genesis resources in the log are `ExternalReference[]` carrying **`digestMultibase`** (multibase base64url multihash). The verifier converts hex → digestMultibase with `hexSha256ToDigestMultibase` (from `src/cel/signerAdapter.ts`) before comparing, and `digestMultibaseEquals` for the comparison.
+- **Discriminator (no heuristic collision):** an `'update'` event is resource-shaped iff `typeof data.resourceId === 'string' && typeof data.previousVersionHash === 'string'`. Legacy/generic updates (`{ note }`) and migration-ish updates (`{ sourceDid, layer, migratedAt }`) carry neither `resourceId` nor `previousVersionHash`, so the branch skips them. Genesis resources carry no `resourceId`, so continuity for a resource's FIRST update matches against the whole genesis digest set.
+- **Authority:** resource updates ride the SAME controller-authorization walk (`authorizedKeyIds`, evolving across `rotateKey`) every other post-genesis event uses. No new authority code is needed — an update signed by a non-controller or a pre-rotation key already fails the existing walk at `verifyEvent`.
+
+---
+
+### Task 1: Verifier — resource-update continuity + content binding
+
+**Files:**
+- Modify: `packages/sdk/src/cel/algorithms/verifyEventLog.ts` (add imports near top ~L20-23; add a helper function; wire it into the main loop ~L1293-1364; seed the genesis digest set near the create-event extraction ~L1177-1190)
+- Test: `packages/sdk/tests/unit/cel/resource-update-events.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `hexSha256ToDigestMultibase(hexHash: string): string` from `../signerAdapter.js`; `hashResource(content: Uint8Array): string` from `../../utils/validation.js`; existing `digestMultibaseEquals`, `verifyEventLog`.
+- Produces: no new exports. `verifyEventLog` now fails closed on a resource-shaped `'update'` whose `previousVersionHash` does not chain from the last-known hash of its `resourceId` (or genesis for the first update), or whose `content` is not a string.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/sdk/tests/unit/cel/resource-update-events.test.ts`:
+
+```typescript
+import { describe, test, expect } from 'bun:test';
+import * as ed25519 from '@noble/ed25519';
+import { multikey } from '../../../src/crypto/Multikey';
+import { canonicalizeEvent } from '../../../src/cel/canonicalize';
+import { verifyEventLog } from '../../../src/cel/algorithms/verifyEventLog';
+import { createEventLog } from '../../../src/cel/algorithms/createEventLog';
+import { appendEvent } from '../../../src/cel/algorithms/appendEvent';
+import { hashResource } from '../../../src/utils/validation';
+import { hexSha256ToDigestMultibase } from '../../../src/cel/signerAdapter';
+
+// A real eddsa-jcs-2022 signer exposing its holder did:key + canonical VM.
+// (Mirrors makeRealSigner in key-rotation-authority.test.ts.)
+async function makeRealSigner() {
+  const priv = crypto.getRandomValues(new Uint8Array(32));
+  const pub = await ed25519.getPublicKeyAsync(priv);
+  const pubMb = multikey.encodePublicKey(pub, 'Ed25519');
+  const didKey = `did:key:${pubMb}`;
+  const vm = `${didKey}#${pubMb}`;
+  const signer = async (data: unknown) => ({
+    type: 'DataIntegrityProof',
+    cryptosuite: 'eddsa-jcs-2022',
+    created: '2020-01-01T00:00:00Z',
+    verificationMethod: vm,
+    proofPurpose: 'assertionMethod',
+    proofValue: multikey.encodeMultibase(
+      new Uint8Array(await ed25519.signAsync(canonicalizeEvent(data), priv))
+    ),
+  });
+  return { signer, didKey, vm };
+}
+
+const hex = (s: string) => hashResource(Buffer.from(s, 'utf-8'));
+
+// Genesis carrying ONE resource whose content is `content`.
+async function genesisWith(content: string, signer: Awaited<ReturnType<typeof makeRealSigner>>) {
+  return createEventLog(
+    {
+      name: 'r',
+      controller: signer.didKey,
+      resources: [{ digestMultibase: hexSha256ToDigestMultibase(hex(content)) }],
+      createdAt: 'x',
+      nonce: 'n-' + Math.random(),
+    },
+    { signer: signer.signer, verificationMethod: signer.vm }
+  );
+}
+
+describe('verifyEventLog: resource-update events', () => {
+  test('honest first update (prev=genesis hash) verifies', async () => {
+    const a = await makeRealSigner();
+    let log = await genesisWith('v1', a);
+    log = await appendEvent(
+      log,
+      'update',
+      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: hex('v1'), toVersion: 2 },
+      { signer: a.signer, verificationMethod: a.vm }
+    );
+    expect((await verifyEventLog(log)).verified).toBe(true);
+  });
+
+  test('second update chains from the first derived hash', async () => {
+    const a = await makeRealSigner();
+    let log = await genesisWith('v1', a);
+    log = await appendEvent(log, 'update',
+      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: hex('v1'), toVersion: 2 },
+      { signer: a.signer, verificationMethod: a.vm });
+    log = await appendEvent(log, 'update',
+      { resourceId: 'r', content: 'v3', contentType: 'text/plain', previousVersionHash: hex('v2'), toVersion: 3 },
+      { signer: a.signer, verificationMethod: a.vm });
+    expect((await verifyEventLog(log)).verified).toBe(true);
+  });
+
+  test('chain-continuity attack: wrong previousVersionHash is rejected', async () => {
+    const a = await makeRealSigner();
+    let log = await genesisWith('v1', a);
+    log = await appendEvent(log, 'update',
+      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: hex('not-the-genesis'), toVersion: 2 },
+      { signer: a.signer, verificationMethod: a.vm });
+    const result = await verifyEventLog(log);
+    expect(result.verified).toBe(false);
+    expect(result.errors.join(' ')).toContain('resource');
+  });
+
+  test('content-tamper: flipping content after signing breaks the proof', async () => {
+    const a = await makeRealSigner();
+    let log = await genesisWith('v1', a);
+    log = await appendEvent(log, 'update',
+      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: hex('v1'), toVersion: 2 },
+      { signer: a.signer, verificationMethod: a.vm });
+    // Mutate the embedded content AFTER it was signed.
+    (log.events[1].data as { content: string }).content = 'tampered';
+    expect((await verifyEventLog(log)).verified).toBe(false);
+  });
+
+  test('unauthorized signer: an update from a non-controller is rejected', async () => {
+    const a = await makeRealSigner();
+    const mallory = await makeRealSigner();
+    let log = await genesisWith('v1', a);
+    log = await appendEvent(log, 'update',
+      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: hex('v1'), toVersion: 2 },
+      { signer: mallory.signer, verificationMethod: mallory.vm });
+    expect((await verifyEventLog(log)).verified).toBe(false);
+  });
+
+  test('no heuristic collision: generic and migration-ish updates are ignored by the branch', async () => {
+    const a = await makeRealSigner();
+    let log = await genesisWith('v1', a);
+    log = await appendEvent(log, 'update', { note: 'generic' }, { signer: a.signer, verificationMethod: a.vm });
+    log = await appendEvent(log, 'update',
+      { sourceDid: 'did:cel:x', layer: 'webvh', migratedAt: 'x' },
+      { signer: a.signer, verificationMethod: a.vm });
+    // Neither carries resourceId+previousVersionHash, so continuity never engages.
+    expect((await verifyEventLog(log)).verified).toBe(true);
+  });
+
+  test('authority-after-rotation: update by the NEW key verifies, by the OLD key fails', async () => {
+    const a = await makeRealSigner();
+    const b = await makeRealSigner();
+    let base = await genesisWith('v1', a);
+    base = await appendEvent(base, 'rotateKey', { newController: b.didKey, rotatedAt: 'x' },
+      { signer: a.signer, verificationMethod: a.vm });
+
+    const good = await appendEvent(base, 'update',
+      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: hex('v1'), toVersion: 2 },
+      { signer: b.signer, verificationMethod: b.vm });
+    expect((await verifyEventLog(good)).verified).toBe(true);
+
+    const bad = await appendEvent(base, 'update',
+      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: hex('v1'), toVersion: 2 },
+      { signer: a.signer, verificationMethod: a.vm });
+    expect((await verifyEventLog(bad)).verified).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/sdk && bun test tests/unit/cel/resource-update-events.test.ts`
+Expected: FAIL — the chain-continuity attack test still reports `verified: true` (no branch yet rejects a mismatched `previousVersionHash`). Other tests may pass already.
+
+- [ ] **Step 3: Add imports and the continuity helper**
+
+In `packages/sdk/src/cel/algorithms/verifyEventLog.ts`, add to the import block (after the existing `import { deriveDidCelFromGenesis, didCelMatchesLog } from '../celDid.js';` line):
+
+```typescript
+import { hexSha256ToDigestMultibase } from '../signerAdapter.js';
+import { hashResource } from '../../utils/validation.js';
+```
+
+Then add this helper function (place it just above `async function verifyEvent(` ~L858):
+
+```typescript
+/**
+ * Resource-update continuity + content binding (#Phase-4 resource events).
+ *
+ * A resource-shaped `update` event (`data.resourceId` + `data.previousVersionHash`
+ * present) MUST chain forward from the last-known hash of its resourceId:
+ *  - first update for a resourceId: `previousVersionHash` must match SOME genesis
+ *    resource digest (genesis ExternalReferences carry no resourceId);
+ *  - subsequent updates: it must match the prior update's DERIVED hash.
+ * The new current hash is `hashResource(content)` (derived, never stored). All
+ * hashes are compared as digestMultibase. On success the per-resourceId map is
+ * advanced; on any failure an error string is returned (fail closed) and the map
+ * is left untouched.
+ */
+function checkResourceUpdateContinuity(
+  data: { resourceId: unknown; previousVersionHash: unknown; content?: unknown },
+  genesisDigests: Set<string>,
+  currentResourceHash: Map<string, string>
+): string | null {
+  const resourceId = data.resourceId as string;
+  if (typeof data.content !== 'string') {
+    return `resource update for ${resourceId} has non-string content; cannot verify`;
+  }
+  let prevDigest: string;
+  let newDigest: string;
+  try {
+    prevDigest = hexSha256ToDigestMultibase(data.previousVersionHash as string);
+    newDigest = hexSha256ToDigestMultibase(hashResource(Buffer.from(data.content, 'utf-8')));
+  } catch (e) {
+    return `resource update for ${resourceId} has an unparseable hash: ${e instanceof Error ? e.message : String(e)}`;
+  }
+
+  const known = currentResourceHash.get(resourceId);
+  const matches = known !== undefined
+    ? digestMultibaseEquals(prevDigest, known)
+    : [...genesisDigests].some((d) => digestMultibaseEquals(prevDigest, d));
+  if (!matches) {
+    return `resource update for ${resourceId}: previousVersionHash does not match the last-known hash (chain-continuity broken)`;
+  }
+
+  currentResourceHash.set(resourceId, newDigest);
+  return null;
+}
+```
+
+- [ ] **Step 4: Seed the genesis digest set and declare walk state**
+
+In `verifyEventLog`, find the create-event extraction (`const createEvent = log.events[0];` ~L1177). Immediately AFTER the `const celController = ...` block (~L1188), add:
+
+```typescript
+  // Seed for resource-update continuity: the genesis resource digests
+  // (ExternalReference.digestMultibase). A resource's FIRST update must chain
+  // from one of these; subsequent updates chain from the prior derived hash.
+  const genesisResourceDigests = new Set<string>();
+  {
+    const genesisResources = (createEvent.data as { resources?: unknown } | null | undefined)?.resources;
+    if (Array.isArray(genesisResources)) {
+      for (const r of genesisResources) {
+        const dm = (r as { digestMultibase?: unknown })?.digestMultibase;
+        if (typeof dm === 'string' && dm.length > 0) genesisResourceDigests.add(dm);
+      }
+    }
+  }
+  const currentResourceHash = new Map<string, string>();
+```
+
+- [ ] **Step 5: Wire the check into the main event walk**
+
+In `verifyEventLog`'s event loop, find where `eventResult` is produced:
+
+```typescript
+    const eventResult = await verifyEvent(event, i, options?.verifier, previousEvent, options?.resolveKey, authorizedKeyIds, options?.ordinalsProvider, anchoredSat);
+```
+
+Immediately AFTER that line (before the `// rotateKey hand-off.` comment), insert:
+
+```typescript
+    // Resource-update continuity (default path only; a custom verifier owns
+    // proof semantics). Only engage for resource-shaped updates that otherwise
+    // verified — a failed proof/chain already fails the event.
+    if (!options?.verifier && event.type === 'update' && eventResult.proofValid && eventResult.chainValid) {
+      const rd = event.data as { resourceId?: unknown; previousVersionHash?: unknown; content?: unknown } | null;
+      if (rd && typeof rd.resourceId === 'string' && typeof rd.previousVersionHash === 'string') {
+        const err = checkResourceUpdateContinuity(rd, genesisResourceDigests, currentResourceHash);
+        if (err) {
+          eventResult.proofValid = false;
+          eventResult.errors.push(`Event ${i}: ${err}`);
+        }
+      }
+    }
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cd packages/sdk && bun test tests/unit/cel/resource-update-events.test.ts`
+Expected: PASS (all 7 tests).
+
+- [ ] **Step 7: Guard against regressions in the existing CEL verifier suite**
+
+Run: `cd packages/sdk && bun test tests/unit/cel/verifyEventLog.test.ts tests/unit/cel/key-rotation-authority.test.ts tests/unit/cel/event-log-authorization.test.ts tests/unit/cel/updateEventLog.test.ts`
+Expected: PASS (generic `{ note }` updates still verify — they lack `resourceId`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/sdk/src/cel/algorithms/verifyEventLog.ts packages/sdk/tests/unit/cel/resource-update-events.test.ts
+git commit --no-verify -m "feat(cel): verify resource-update events (continuity + content binding)"
+```
+
+---
+
+### Task 2: Fold — derive `resourceUpdates` from `update` events in `replayProvenance`
+
+**Files:**
+- Modify: `packages/sdk/src/lifecycle/replayProvenance.ts` (extend `ReplayedProvenance`; add the update-fold in the loop ~L90-127; update the header doc ~L30-31)
+- Test: `packages/sdk/tests/unit/lifecycle/replayProvenance.test.ts` (add a describe block)
+
+**Interfaces:**
+- Consumes: `hashResource` from `../utils/validation.js`.
+- Produces: `ReplayedProvenance.resourceUpdates: Array<{ resourceId: string; fromVersion: number; toVersion: number; fromHash: string; toHash: string; timestamp: string; changes?: string }>` — the folded resource-version history (hex hashes, `timestamp` from the controller proof's `created`, `changes` always undefined). `buildRestoredProvenance` (Task 4) consumes this.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/sdk/tests/unit/lifecycle/replayProvenance.test.ts` (append a new `describe` at the end, before the final closing lines if the file wraps everything; otherwise just append). It uses the same real-signer + genesis helpers as Task 1 — copy them into this file's imports/top if not already present:
+
+```typescript
+import { hashResource } from '../../../src/utils/validation';
+import { hexSha256ToDigestMultibase } from '../../../src/cel/signerAdapter';
+import { createEventLog } from '../../../src/cel/algorithms/createEventLog';
+import { appendEvent } from '../../../src/cel/algorithms/appendEvent';
+import { multikey } from '../../../src/crypto/Multikey';
+import { canonicalizeEvent } from '../../../src/cel/canonicalize';
+import * as ed25519 from '@noble/ed25519';
+
+async function makeReplaySigner() {
+  const priv = crypto.getRandomValues(new Uint8Array(32));
+  const pub = await ed25519.getPublicKeyAsync(priv);
+  const pubMb = multikey.encodePublicKey(pub, 'Ed25519');
+  const didKey = `did:key:${pubMb}`;
+  const vm = `${didKey}#${pubMb}`;
+  const signer = async (data: unknown) => ({
+    type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', created: '2021-05-05T00:00:00Z',
+    verificationMethod: vm, proofPurpose: 'assertionMethod',
+    proofValue: multikey.encodeMultibase(new Uint8Array(await ed25519.signAsync(canonicalizeEvent(data), priv))),
+  });
+  return { signer, didKey, vm };
+}
+const rhex = (s: string) => hashResource(Buffer.from(s, 'utf-8'));
+
+describe('replayProvenance: resourceUpdates fold', () => {
+  test('folds update events into resourceUpdates with derived toHash', async () => {
+    const a = await makeReplaySigner();
+    let log = await createEventLog(
+      { name: 'r', controller: a.didKey, resources: [{ digestMultibase: hexSha256ToDigestMultibase(rhex('v1')) }], createdAt: 'x', nonce: 'z1' },
+      { signer: a.signer, verificationMethod: a.vm }
+    );
+    log = await appendEvent(log, 'update',
+      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: rhex('v1'), toVersion: 2 },
+      { signer: a.signer, verificationMethod: a.vm });
+
+    const folded = replayProvenance(log);
+    expect(folded.resourceUpdates.length).toBe(1);
+    const u = folded.resourceUpdates[0];
+    expect(u.resourceId).toBe('r');
+    expect(u.fromVersion).toBe(1);
+    expect(u.toVersion).toBe(2);
+    expect(u.fromHash).toBe(rhex('v1'));
+    expect(u.toHash).toBe(rhex('v2'));
+    expect(u.timestamp).toBe('2021-05-05T00:00:00Z');
+  });
+
+  test('generic and migration-ish updates do NOT fold into resourceUpdates', async () => {
+    const a = await makeReplaySigner();
+    let log = await createEventLog(
+      { name: 'r', controller: a.didKey, resources: [{ digestMultibase: hexSha256ToDigestMultibase(rhex('v1')) }], createdAt: 'x', nonce: 'z2' },
+      { signer: a.signer, verificationMethod: a.vm }
+    );
+    log = await appendEvent(log, 'update', { note: 'generic' }, { signer: a.signer, verificationMethod: a.vm });
+    expect(replayProvenance(log).resourceUpdates.length).toBe(0);
+  });
+});
+```
+
+(If `replayProvenance` is not already imported at the top of the file, add `import { replayProvenance } from '../../../src/lifecycle/replayProvenance';`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/sdk && bun test tests/unit/lifecycle/replayProvenance.test.ts`
+Expected: FAIL — `folded.resourceUpdates` is `undefined` (property does not exist yet).
+
+- [ ] **Step 3: Extend the interface and fold**
+
+In `packages/sdk/src/lifecycle/replayProvenance.ts`:
+
+Add the import near the top (after the existing `import { btcoDidFromSatoshi } from '../cel/btcoDid.js';`):
+
+```typescript
+import { hashResource } from '../utils/validation.js';
+```
+
+Extend `ReplayedProvenance`:
+
+```typescript
+export interface ReplayedProvenance {
+  currentLayer: 'did:peer' | 'did:webvh' | 'did:btco';
+  bindings: Record<string, string>;
+  migrations: Array<{ from: string; to: string; timestamp: string }>;
+  resourceUpdates: Array<{
+    resourceId: string;
+    fromVersion: number;
+    toVersion: number;
+    fromHash: string;
+    toHash: string;
+    timestamp: string;
+    changes?: string;
+  }>;
+}
+```
+
+Initialize it in the `result` literal:
+
+```typescript
+  const result: ReplayedProvenance = {
+    currentLayer: 'did:peer',
+    bindings: {},
+    migrations: [],
+    resourceUpdates: [],
+  };
+```
+
+In the event loop, replace the non-migrate `continue` block. The current code is:
+
+```typescript
+    if (event.type !== 'migrate') {
+      // transfer (legacy) / rotateKey / update / deactivate: not provenance.
+      // Ownership history is the sat's UTXO chain, not the CEL.
+      continue;
+    }
+```
+
+Replace it with:
+
+```typescript
+    if (event.type === 'update') {
+      // Resource-update events (resourceId + previousVersionHash) fold into the
+      // resource-version history. toHash is DERIVED from inline content, never
+      // stored. Generic/migration-ish updates lack these fields and are skipped.
+      const resourceId = typeof data.resourceId === 'string' ? data.resourceId : undefined;
+      const previousVersionHash = typeof data.previousVersionHash === 'string' ? data.previousVersionHash : undefined;
+      const content = typeof data.content === 'string' ? data.content : undefined;
+      if (resourceId && previousVersionHash && content !== undefined) {
+        const toVersion = typeof data.toVersion === 'number' ? data.toVersion : NaN;
+        const proofs = event.proof as ReadonlyArray<{ created?: unknown; witnessedAt?: unknown }> | undefined;
+        const controllerProof = proofs?.find((p) => !(p && typeof p === 'object' && 'witnessedAt' in p));
+        const timestamp = typeof controllerProof?.created === 'string' ? controllerProof.created : '';
+        result.resourceUpdates.push({
+          resourceId,
+          fromVersion: Number.isFinite(toVersion) ? toVersion - 1 : NaN,
+          toVersion,
+          fromHash: previousVersionHash,
+          toHash: hashResource(Buffer.from(content, 'utf-8')),
+          timestamp,
+        });
+      }
+      continue;
+    }
+
+    if (event.type !== 'migrate') {
+      // transfer (legacy) / rotateKey / deactivate: not provenance.
+      // Ownership history is the sat's UTXO chain, not the CEL.
+      continue;
+    }
+```
+
+Also update the header doc bullet (~L30) from `rotateKey / update / deactivate → no provenance entries` to note that resource-shaped `update` events now fold into `resourceUpdates`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/sdk && bun test tests/unit/lifecycle/replayProvenance.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/sdk/src/lifecycle/replayProvenance.ts packages/sdk/tests/unit/lifecycle/replayProvenance.test.ts
+git commit --no-verify -m "feat(lifecycle): fold resourceUpdates from update events in replayProvenance"
+```
+
+---
+
+### Task 3: Writer — `addResourceVersion` async + injected controller appender
+
+**Files:**
+- Modify: `packages/sdk/src/lifecycle/OriginalsAsset.ts` (add `#celAppender` field + `_bindCelAppender`; make `addResourceVersion` async ~L549-653; stop writing `provenance.resourceUpdates` locally, fold it instead)
+- Modify: `packages/sdk/tests/unit/lifecycle/ResourceVersioning.test.ts` (await all `addResourceVersion` calls; rework the provenance-tracking test into a degrade assertion)
+- Test: `packages/sdk/tests/unit/lifecycle/addResourceVersion.celevent.test.ts` (create — injection contract)
+
+**Interfaces:**
+- Consumes: `replayProvenance` (already imported in OriginalsAsset); the appender contract `(type: 'migrate' | 'rotateKey' | 'update', data: unknown) => Promise<string | null>` (returns the appended event's head digest, or `null` when the append was skipped/degraded).
+- Produces:
+  - `OriginalsAsset._bindCelAppender(fn: (type: 'migrate' | 'rotateKey' | 'update', data: unknown) => Promise<string | null>): void` — `@internal`, called by `LifecycleManager` (Task 4).
+  - `OriginalsAsset.addResourceVersion(resourceId, newContent, contentType, changes?): Promise<AssetResource>` — now async.
+
+- [ ] **Step 1: Write the failing test (injection contract)**
+
+Create `packages/sdk/tests/unit/lifecycle/addResourceVersion.celevent.test.ts`:
+
+```typescript
+import { describe, test, expect } from 'bun:test';
+import { OriginalsAsset } from '../../../src/lifecycle/OriginalsAsset';
+import type { AssetResource, DIDDocument } from '../../../src/types';
+import type { CelAppendSkippedEvent } from '../../../src/events/types';
+
+function makeAsset(): OriginalsAsset {
+  const did: DIDDocument = { id: 'did:peer:zabc' } as DIDDocument;
+  const resources: AssetResource[] = [
+    { id: 'r', type: 'text', content: 'v1', contentType: 'text/plain', hash: '', version: 1 } as AssetResource,
+  ];
+  // Fix the hash to match content so continuity checks elsewhere line up.
+  const { hashResource } = require('../../../src/utils/validation');
+  resources[0].hash = hashResource(Buffer.from('v1', 'utf-8'));
+  return new OriginalsAsset(resources, did, []);
+}
+
+describe('addResourceVersion: injected CEL appender', () => {
+  test('calls the bound appender with the resource-update body and updates resources', async () => {
+    const asset = makeAsset();
+    const calls: Array<{ type: string; data: any }> = [];
+    asset._bindCelAppender(async (type, data) => {
+      calls.push({ type, data });
+      return 'zHeadDigest'; // pretend the append committed
+    });
+
+    const created = await asset.addResourceVersion('r', 'v2', 'text/plain', 'edit');
+
+    expect(created.version).toBe(2);
+    expect(calls.length).toBe(1);
+    expect(calls[0].type).toBe('update');
+    expect(calls[0].data.resourceId).toBe('r');
+    expect(calls[0].data.content).toBe('v2');
+    expect(calls[0].data.contentType).toBe('text/plain');
+    expect(typeof calls[0].data.previousVersionHash).toBe('string');
+    expect(calls[0].data.toVersion).toBe(2);
+    // In-memory resources updated.
+    expect(asset.getResourceVersion('r', 2)?.content).toBe('v2');
+  });
+
+  test('degrades: no appender bound emits cel:append-skipped and does NOT record provenance', async () => {
+    const asset = makeAsset();
+    const skipped: CelAppendSkippedEvent[] = [];
+    asset.on('cel:append-skipped', (e) => skipped.push(e as CelAppendSkippedEvent));
+
+    const created = await asset.addResourceVersion('r', 'v2', 'text/plain');
+
+    expect(created.version).toBe(2);                       // in-memory still versioned
+    expect(asset.getProvenance().resourceUpdates.length).toBe(0); // not provable
+    expect(skipped.length).toBe(1);
+  });
+
+  test('appender returning null (skip) updates resources but not provenance', async () => {
+    const asset = makeAsset();
+    asset._bindCelAppender(async () => null); // signer unavailable
+    await asset.addResourceVersion('r', 'v2', 'text/plain');
+    expect(asset.getResourceVersion('r', 2)?.content).toBe('v2');
+    expect(asset.getProvenance().resourceUpdates.length).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/sdk && bun test tests/unit/lifecycle/addResourceVersion.celevent.test.ts`
+Expected: FAIL — `asset._bindCelAppender is not a function` (and `addResourceVersion` is still sync).
+
+- [ ] **Step 3: Add the appender field and setter**
+
+In `packages/sdk/src/lifecycle/OriginalsAsset.ts`, add a private field near the other private fields (after `#didDocuments` ~L68):
+
+```typescript
+  // Injected by LifecycleManager (createAsset / loadAsset). Appends a signed CEL
+  // event via the manager's degrade-aware path and returns the new head digest,
+  // or null when the append was skipped (no keyStore / no signing key). Undefined
+  // for assets constructed outside the lifecycle (they degrade in-memory only).
+  #celAppender?: (type: 'migrate' | 'rotateKey' | 'update', data: unknown) => Promise<string | null>;
+```
+
+Add the setter (place it near `_replaceCelLog` ~L162):
+
+```typescript
+  /**
+   * @internal — LifecycleManager binds the controller append path so
+   * addResourceVersion can write signed `update` events with the same degrade
+   * contract (cel:append-skipped) as the other authorship ops.
+   */
+  _bindCelAppender(
+    fn: (type: 'migrate' | 'rotateKey' | 'update', data: unknown) => Promise<string | null>
+  ): void {
+    this.#celAppender = fn;
+  }
+```
+
+- [ ] **Step 4: Rewrite `addResourceVersion` as async, appending the signed event**
+
+Replace the whole `addResourceVersion(...)` method (~L549-653) with:
+
+```typescript
+  /**
+   * Add a new version of a resource (immutable versioning) as a signed CEL
+   * `update` event.
+   *
+   * Async: the new version is appended to the CEL log via the injected
+   * controller appender (bound by LifecycleManager). On success the in-memory
+   * resources advance and `provenance.resourceUpdates` is re-folded from the log.
+   * Degraded mode (no appender bound, or the appender skips because no signing
+   * key is available): the in-memory resources still advance so the object is
+   * usable, but NO event is appended (the version is not provable) and a
+   * `cel:append-skipped` is emitted.
+   *
+   * `changes` is retained for the emitted `resource:version:created` event only;
+   * it is NOT part of the signed CEL body (the log is the source of truth and its
+   * body is fixed — see the design contract).
+   *
+   * @throws StructuredError('BINARY_CONTENT_UNSUPPORTED') for Buffer content (#276)
+   * @throws Error if content is unchanged or the resource is not found
+   */
+  async addResourceVersion(
+    resourceId: string,
+    newContent: string,
+    contentType: string,
+    changes?: string
+  ): Promise<AssetResource> {
+    if (typeof newContent !== 'string') {
+      throw new StructuredError(
+        'BINARY_CONTENT_UNSUPPORTED',
+        'addResourceVersion cannot store binary (Buffer) content inline: AssetResource.content is a string. ' +
+        'Encode the content as a string (e.g. base64) and handle decoding at publish time, ' +
+        'or host the bytes externally and reference them by hash.'
+      );
+    }
+    const currentResources = this.resources.filter(r => r.id === resourceId);
+    if (currentResources.length === 0) {
+      throw new Error(`Resource with id ${resourceId} not found`);
+    }
+    const currentResource = currentResources.sort((a, b) => {
+      const versionA = a.version || 1;
+      const versionB = b.version || 1;
+      return versionB - versionA;
+    })[0];
+
+    const contentBuffer = Buffer.from(newContent, 'utf-8');
+    const newHash = hashResource(contentBuffer);
+    if (newHash === currentResource.hash) {
+      throw new Error('Content unchanged - new version would be identical to current version');
+    }
+
+    const newVersion = (currentResource.version || 1) + 1;
+    const newResource: AssetResource = {
+      id: resourceId,
+      type: currentResource.type,
+      content: newContent,
+      contentType,
+      hash: newHash,
+      size: contentBuffer.length,
+      version: newVersion,
+      previousVersionHash: currentResource.hash,
+      createdAt: new Date().toISOString()
+    };
+
+    // Append a signed `update` CEL event (or degrade). The body is the fixed
+    // resource-update shape; toHash is derived at verify/fold time.
+    let appended = false;
+    if (this.#celAppender) {
+      const digest = await this.#celAppender('update', {
+        resourceId,
+        content: newContent,
+        contentType,
+        previousVersionHash: currentResource.hash,
+        toVersion: newVersion
+      });
+      appended = digest !== null; // null ⇒ the manager already emitted cel:append-skipped
+    } else {
+      // No manager bound: degrade in-memory only. Surface the honesty signal on
+      // the asset emitter (the manager path uses its own emitter).
+      await this.eventEmitter.emit({
+        type: 'cel:append-skipped',
+        timestamp: new Date().toISOString(),
+        asset: { id: this.id },
+        reason: this.#celLog ? 'NO_SIGNING_KEY' : 'NO_CEL_LOG'
+      });
+    }
+
+    // In-memory resources advance in BOTH the appended and degraded cases.
+    this.resources.push(newResource);
+    this.versionManager.addVersion(
+      resourceId,
+      newHash,
+      contentType,
+      currentResource.hash,
+      changes,
+      newVersion
+    );
+
+    // Provenance.resourceUpdates is the source-of-truth fold of the log — only
+    // populated when the event actually landed (provable). Re-fold from the log.
+    if (appended && this.#celLog) {
+      this.provenance.resourceUpdates = replayProvenance(this.#celLog).resourceUpdates;
+    }
+
+    const timestamp = new Date().toISOString();
+    const event = {
+      type: 'resource:version:created' as const,
+      timestamp,
+      asset: { id: this.id },
+      resource: {
+        id: resourceId,
+        fromVersion: currentResource.version || 1,
+        toVersion: newVersion,
+        fromHash: currentResource.hash,
+        toHash: newHash
+      },
+      changes
+    };
+    queueMicrotask(() => {
+      void this.eventEmitter.emit(event);
+    });
+
+    return newResource;
+  }
+```
+
+- [ ] **Step 5: Run the injection test to verify it passes**
+
+Run: `cd packages/sdk && bun test tests/unit/lifecycle/addResourceVersion.celevent.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Update the existing ResourceVersioning test suite (await + degrade rework)**
+
+In `packages/sdk/tests/unit/lifecycle/ResourceVersioning.test.ts`:
+
+1. Add `await` to every `asset.addResourceVersion(...)` call, and make each enclosing `test(...)` callback `async` if it is not already. (Lines ~169, 196, 214, 230-231, 252, 273-274, 308, 336-337, 374, 397, 415, 433, 451, 475-477, 500.) The rejection tests at ~196 and ~214 use `expect(() => ...).toThrow(...)`; convert them to `await expect(asset.addResourceVersion(...)).rejects.toThrow(...)`. The Buffer-rejection test at ~397 similarly becomes `await expect(asset.addResourceVersion('res1', buffer2 as unknown as string, 'application/octet-stream')).rejects.toThrow(...)`.
+
+2. Rework the provenance-tracking test (~L332-352, "tracks resourceUpdates in provenance"). A directly-constructed asset has no bound appender, so it degrades and records NO provenance. Replace that test body with a degrade assertion:
+
+```typescript
+  test('directly-constructed asset degrades: no appender ⇒ no provenance, emits cel:append-skipped', async () => {
+    const asset = createTestAsset(); // whatever the file's existing factory is named
+    const skipped: unknown[] = [];
+    asset.on('cel:append-skipped', (e) => skipped.push(e));
+
+    await asset.addResourceVersion('res1', 'v2', 'text/plain', 'First update');
+    await asset.addResourceVersion('res1', 'v3', 'text/plain', 'Second update');
+
+    // In-memory versions advanced, but nothing provable was recorded.
+    expect(asset.getAllVersions('res1').map(r => r.version)).toEqual([1, 2, 3]);
+    expect(asset.getProvenance().resourceUpdates.length).toBe(0);
+    expect(skipped.length).toBe(2);
+  });
+```
+
+(Use the same asset-construction helper the surrounding tests use; if they build inline via `new OriginalsAsset(...)`, replicate that here. The folded-provenance behavior is covered end-to-end in Task 5, where a real lifecycle asset with a keyStore signs the events.)
+
+- [ ] **Step 7: Run the full lifecycle unit suite**
+
+Run: `cd packages/sdk && bun test tests/unit/lifecycle/ResourceVersioning.test.ts tests/unit/lifecycle/addResourceVersion.celevent.test.ts`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/sdk/src/lifecycle/OriginalsAsset.ts packages/sdk/tests/unit/lifecycle/ResourceVersioning.test.ts packages/sdk/tests/unit/lifecycle/addResourceVersion.celevent.test.ts
+git commit --no-verify -m "feat(lifecycle): addResourceVersion appends signed update CEL events (async)"
+```
+
+---
+
+### Task 4: Hard cutover — bind the appender, drop `unverified.resourceUpdates`
+
+**Files:**
+- Modify: `packages/sdk/src/lifecycle/LifecycleManager.ts` (bind appender in `createAsset` ~L323 and `loadAsset` ~L608-614; fold `resourceUpdates` in `buildRestoredProvenance` ~L741)
+- Modify: `packages/sdk/src/lifecycle/OriginalsAsset.ts` (`serialize()` — remove the `unverified.resourceUpdates` emit ~L222-224)
+- Modify: `packages/sdk/src/lifecycle/assetEnvelope.ts` (remove `unverified.resourceUpdates` field ~L38-46)
+- Modify: `packages/sdk/tests/unit/lifecycle/assetEnvelope.test.ts` (drop the `unverified.resourceUpdates` roundtrip assertion ~L81; await the `addResourceVersion` at ~L50)
+
+**Interfaces:**
+- Consumes: `OriginalsAsset._bindCelAppender` (Task 3); `LifecycleManager.appendCelEventOrSkip(asset, type, data): Promise<string | null>` (existing private, ~L1793 — already accepts `'update'`); `replayProvenance(...).resourceUpdates` (Task 2).
+- Produces: assets returned by `createAsset` / `loadAsset` carry a bound appender, so `addResourceVersion` on them writes signed events. `AssetEnvelope.unverified` no longer has a `resourceUpdates` field.
+
+- [ ] **Step 1: Write the failing test (envelope cutover + folded provenance)**
+
+Add to `packages/sdk/tests/unit/lifecycle/assetEnvelope.test.ts` a new test (alongside the existing ones), and fix the existing one:
+
+New test:
+
+```typescript
+  test('serialize no longer emits unverified.resourceUpdates; loadAsset folds versions from the log', async () => {
+    const sdk = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
+    const asset = await sdk.lifecycle.createAsset([
+      { id: 'note', type: 'text', content: 'hello v1', contentType: 'text/plain', hash: require('../../../src/utils/validation').hashResource(Buffer.from('hello v1', 'utf-8')) }
+    ]);
+    await asset.addResourceVersion('note', 'hello v2', 'text/plain', 'edit');
+
+    const env = asset.serialize();
+    // Cutover: the advisory array is gone.
+    expect((env.unverified as any)?.resourceUpdates).toBeUndefined();
+    // The update event is on the log.
+    expect(env.eventLog.events.some(e => e.type === 'update')).toBe(true);
+    // A fresh SDK (no keys) loads and the folded provenance shows the version.
+    const fresh = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
+    const { asset: loaded } = await fresh.lifecycle.loadAsset(env);
+    expect(loaded.getProvenance().resourceUpdates.some(u => u.resourceId === 'note' && u.toVersion === 2)).toBe(true);
+  });
+```
+
+Fix the existing test at ~L50/L81: add `await` to `asset.addResourceVersion('note', ...)`, and DELETE the assertion `expect(env.unverified?.resourceUpdates?.some(...)).toBe(true);` (the field no longer exists — this is the hard cutover).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/sdk && bun test tests/unit/lifecycle/assetEnvelope.test.ts`
+Expected: FAIL — `createAsset`-minted assets have no appender bound yet, so `addResourceVersion` degrades (`update` event absent from the log), and `loaded.getProvenance().resourceUpdates` is empty.
+
+- [ ] **Step 3: Bind the appender in `createAsset`**
+
+In `LifecycleManager.ts`, find `const asset = new OriginalsAsset(resources, didDoc, [], log);` (~L323). Immediately after it, add:
+
+```typescript
+    // Bind the controller append path so addResourceVersion can write signed
+    // `update` events with the same degrade contract as the other authorship ops.
+    asset._bindCelAppender((type, data) => this.appendCelEventOrSkip(asset, type, data));
+```
+
+- [ ] **Step 4: Bind the appender in `loadAsset`**
+
+In `LifecycleManager.ts` `loadAsset`, find `const asset = OriginalsAsset.restore(...)` (~L608-614). Immediately after that statement (before the `// Repopulate captured DID docs` loop ~L616), add:
+
+```typescript
+    asset._bindCelAppender((type, data) => this.appendCelEventOrSkip(asset, type, data));
+```
+
+- [ ] **Step 5: Fold `resourceUpdates` in `buildRestoredProvenance`**
+
+In `LifecycleManager.ts` `buildRestoredProvenance` (~L741), replace:
+
+```typescript
+    const resourceUpdates = (env.unverified?.resourceUpdates ?? []).map(u => ({ ...u }));
+```
+
+with:
+
+```typescript
+    // Resource versions are now signed `update` log events — fold them from the
+    // (verified) log, never from the advisory envelope section (removed).
+    const resourceUpdates = folded.resourceUpdates.map(u => ({ ...u }));
+```
+
+- [ ] **Step 6: Remove the `serialize()` emit and the envelope field**
+
+In `OriginalsAsset.ts` `serialize()` (~L222-224), delete:
+
+```typescript
+    if (this.provenance.resourceUpdates.length > 0) {
+      unverified.resourceUpdates = this.provenance.resourceUpdates.map(u => ({ ...u }));
+    }
+```
+
+In `assetEnvelope.ts`, delete the `resourceUpdates?: Array<...>` block from the `unverified` object (~L38-46), leaving `commitTxId`, `feeRate`, and `bindings`.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `cd packages/sdk && bun test tests/unit/lifecycle/assetEnvelope.test.ts`
+Expected: PASS.
+
+- [ ] **Step 8: Full regression sweep of lifecycle + cel**
+
+Run: `cd packages/sdk && bun test tests/unit/lifecycle tests/unit/cel`
+Expected: PASS. (If any other test referenced `unverified.resourceUpdates`, update it to the hard-cutover behavior — the field is gone.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/sdk/src/lifecycle/LifecycleManager.ts packages/sdk/src/lifecycle/OriginalsAsset.ts packages/sdk/src/lifecycle/assetEnvelope.ts packages/sdk/tests/unit/lifecycle/assetEnvelope.test.ts
+git commit --no-verify -m "feat(lifecycle): hard cutover to on-log resource updates; drop unverified.resourceUpdates"
+```
+
+---
+
+### Task 5: End-to-end — honest round-trip, rotation authority, degrade
+
+**Files:**
+- Test: `packages/sdk/tests/integration/ResourceUpdateHandoff.e2e.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `OriginalsSDK.create`, `MockKeyStore`, `sdk.lifecycle.createAsset/loadAsset/rotateBtcoKeys`, `asset.addResourceVersion/serialize/verify`. No production changes — this task only proves the spec's testing spine end-to-end.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/sdk/tests/integration/ResourceUpdateHandoff.e2e.test.ts`:
+
+```typescript
+import { describe, test, expect } from 'bun:test';
+import { OriginalsSDK } from '../../src';
+import { MockKeyStore } from '../mocks/MockKeyStore';
+import { hashResource } from '../../src/utils/validation';
+import type { CelAppendSkippedEvent } from '../../src/events/types';
+
+const h = (s: string) => hashResource(Buffer.from(s, 'utf-8'));
+
+describe('Resource-update handoff (e2e)', () => {
+  test('honest round-trip: creator updates, buyer verifies offline with no keys', async () => {
+    const creator = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
+    const asset = await creator.lifecycle.createAsset([
+      { id: 'note', type: 'text', content: 'v1', contentType: 'text/plain', hash: h('v1') }
+    ]);
+    await asset.addResourceVersion('note', 'v2', 'text/plain', 'edit');
+
+    // The signed update landed on the log.
+    expect(asset.celLog!.events.some(e => e.type === 'update')).toBe(true);
+
+    const envelope = asset.serialize();
+
+    // Buyer loads with a FRESH, keyless SDK — verification is public-key-only.
+    const buyer = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
+    const { asset: loaded, verification } = await buyer.lifecycle.loadAsset(envelope);
+    expect(verification?.verified).toBe(true);
+    // The folded current resource is v2.
+    expect(loaded.getResourceVersion('note', 2)?.content).toBe('v2');
+    expect(loaded.getProvenance().resourceUpdates.some(u => u.toVersion === 2)).toBe(true);
+  });
+
+  test('content-tamper in the envelope is rejected at load', async () => {
+    const creator = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
+    const asset = await creator.lifecycle.createAsset([
+      { id: 'note', type: 'text', content: 'v1', contentType: 'text/plain', hash: h('v1') }
+    ]);
+    await asset.addResourceVersion('note', 'v2', 'text/plain');
+    const envelope = asset.serialize();
+
+    // Flip the embedded content of the update event.
+    const updateEv = envelope.eventLog.events.find(e => e.type === 'update')!;
+    (updateEv.data as { content: string }).content = 'tampered';
+
+    const buyer = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
+    await expect(buyer.lifecycle.loadAsset(envelope)).rejects.toThrow();
+  });
+
+  test('degrade: keyless creator emits cel:append-skipped and the update is not on the log', async () => {
+    // No keyStore ⇒ createAsset drops the controller key ⇒ appends degrade.
+    const creator = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519' });
+    const asset = await creator.lifecycle.createAsset([
+      { id: 'note', type: 'text', content: 'v1', contentType: 'text/plain', hash: h('v1') }
+    ]);
+    const skipped: CelAppendSkippedEvent[] = [];
+    creator.lifecycle.on('cel:append-skipped', (e) => skipped.push(e as CelAppendSkippedEvent));
+
+    await asset.addResourceVersion('note', 'v2', 'text/plain');
+
+    expect(asset.getResourceVersion('note', 2)?.content).toBe('v2'); // usable in-memory
+    expect(asset.celLog!.events.some(e => e.type === 'update')).toBe(false); // not provable
+    expect(skipped.length).toBe(1);
+    expect(asset.getProvenance().resourceUpdates.length).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `cd packages/sdk && bun test tests/integration/ResourceUpdateHandoff.e2e.test.ts`
+Expected: PASS. (If the honest round-trip fails at load verification, confirm Task 4 bound the appender in BOTH `createAsset` and `loadAsset`, and that the `update` event is present in `asset.celLog`.)
+
+- [ ] **Step 3: Full suite sweep**
+
+Run: `cd packages/sdk && bun test`
+Expected: PASS across integration, unit, security, stress. Investigate and fix any test that assumed the old advisory `resourceUpdates` (hard cutover).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/sdk/tests/integration/ResourceUpdateHandoff.e2e.test.ts
+git commit --no-verify -m "test(lifecycle): e2e resource-update handoff (round-trip, tamper, degrade)"
+```
+
+---
+
+### Task 6: Changeset
+
+**Files:**
+- Create: `.changeset/resource-update-events-on-log.md`
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Write the changeset**
+
+Create `.changeset/resource-update-events-on-log.md` (match the frontmatter style of existing changesets, e.g. `.changeset/ownership-is-the-sat.md`):
+
+```markdown
+---
+"@originals/sdk": minor
+---
+
+Resource versions are now signed CEL `update` log events instead of advisory
+envelope metadata. `OriginalsAsset.addResourceVersion` is now **async** and
+appends a signed `update` event (via a controller signer bound by
+`LifecycleManager`), degrading with `cel:append-skipped` when no signing key is
+available. `verifyEventLog` gains a resource-update branch that checks
+per-resourceId hash continuity (seeded from genesis) and derives the new content
+hash inline, so a buyer can verify every post-genesis version offline.
+
+**BREAKING:** `addResourceVersion` returns a `Promise<AssetResource>` (await it),
+and the advisory `AssetEnvelope.unverified.resourceUpdates` field is removed —
+`serialize()` no longer emits it and `loadAsset` folds resource versions from the
+verified log. Regenerate any persisted envelopes that carried it.
+```
+
+- [ ] **Step 2: Verify the changeset is picked up**
+
+Run: `cd /Users/brian/Projects/onionoriginals/sdk/.claude/worktrees/phase4-ownership-is-sat && ls .changeset/resource-update-events-on-log.md`
+Expected: the path prints (file exists). The repo's "Changeset present" gate is satisfied.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .changeset/resource-update-events-on-log.md
+git commit --no-verify -m "chore: changeset for on-log resource-update events"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §2 signed `update` model (resourceId/content/contentType/previousVersionHash/toVersion; derived toHash) → Task 1 (verify) + Task 3 (write).
+- §3 async writer + injected signer + degrade → Task 3 + Task 4 (binding).
+- §4 verifier continuity/content-binding/authority (per-resourceId map seeded from genesis; current-controller authority via existing walk) → Task 1.
+- §5 fold + envelope hard cutover (`replayProvenance` derives; `serialize()` stops emitting; `loadAsset` folds; envelope field removed) → Task 2 + Task 4.
+- §6 unchanged (did:cel derivation, genesis binding, legacy `update` uses) → discriminator in Task 1; genesis binding untouched.
+- §7 testing spine (honest round-trip, chain-continuity, content-tamper, unauthorized signer, degrade, no heuristic collision, authority-after-rotation) → Tasks 1 + 5.
+- Changeset → Task 6.
+
+**Type consistency:** the appender contract `(type: 'migrate'|'rotateKey'|'update', data: unknown) => Promise<string | null>` matches `LifecycleManager.appendCelEventOrSkip`'s existing signature. `ReplayedProvenance.resourceUpdates` (Task 2) matches the fields `buildRestoredProvenance` maps (Task 4) and the `ProvenanceChain.resourceUpdates` shape in `OriginalsAsset.ts`. Hashes: hex on `AssetResource.hash`/`previousVersionHash`/fold output; digestMultibase only inside the verifier comparison (converted via `hexSha256ToDigestMultibase`).
+
+**Known residual:** the folded `resourceUpdates.timestamp` derives from the controller proof's (unsigned) `created` field and `changes` is dropped from the signed body — both are advisory display metadata at the same trust level as the removed `unverified.resourceUpdates`, never gating verification.

--- a/docs/superpowers/specs/2026-07-13-resource-update-events-on-log-design.md
+++ b/docs/superpowers/specs/2026-07-13-resource-update-events-on-log-design.md
@@ -1,0 +1,163 @@
+# Design: Resource-update events on the CEL log
+
+> did:cel epic — Phase 4, sub-project 1 of 5 (design spec
+> `2026-07-10-cel-backbone-did-cel-design.md` §7 "Phase 4"). Turns post-genesis
+> resource versions from advisory, unverifiable envelope metadata into signed
+> CEL log events, so provenance for *every* authorship op — not just genesis —
+> is cryptographically verifiable.
+
+## 0. Decision record
+
+- **Event type:** reuse the existing generic `'update'` CEL event type. A
+  resource-update `update` is discriminated by carrying `resourceId` +
+  `previousVersionHash`; the legacy migration-sniff heuristic keys off
+  `sourceDid`/`layer`/`migratedAt`, which a resource update never carries — no
+  collision in either direction.
+- **Payload = the new file itself.** The `update` event embeds the new content;
+  `toHash` is *derived* (`hashResource(content)`), never stored, so it cannot
+  lie. This keeps a buyer verifying **offline** in possession of the actual file
+  and does NOT touch the Bitcoin inscription byte-cap (#378) — a resource update
+  is a log append; on-chain only ever commits to the log *head digest* via the
+  `#cel` anchor.
+- **Authoring stays on `OriginalsAsset.addResourceVersion`**, which gains an
+  injected controller signer (bound by `LifecycleManager`); it becomes async and
+  degrades with `cel:append-skipped` when no signer is available. `OriginalsAsset`
+  becomes key-aware for this one op.
+- **Hard cutover:** resource versions now MUST be signed `update` log events.
+  `serialize()` stops emitting the advisory `unverified.resourceUpdates`;
+  `loadAsset` folds versions from the log. Consistent with the project's
+  hard-cutover stance (nothing released, no external consumers). Old test
+  envelopes/fixtures regenerated.
+- **Authority:** a resource update is authorship — signed by the **currently
+  authorized** controller key (post-`rotateKey` authority), the same walk every
+  other authorship event uses.
+
+## 1. The gap today
+
+`OriginalsAsset.addResourceVersion` (`src/lifecycle/OriginalsAsset.ts:549`) is
+synchronous: it validates (Buffer rejected #276, content-unchanged rejected,
+resource-exists), pushes the new version to the in-memory `this.resources`
+array, and records a `this.provenance.resourceUpdates` entry — a **local array,
+no CEL event**. `serialize()` emits those entries under
+`unverified.resourceUpdates` (`OriginalsAsset.ts:222-223`), and `loadAsset`
+reads them back as advisory, **unverifiable** metadata
+(`LifecycleManager.ts:748`). So a post-genesis resource version has no
+cryptographic backing: a buyer cannot prove the creator authored it.
+
+## 2. Model — the signed `update` event
+
+```
+event: {
+  type: 'update',
+  data: {
+    resourceId,
+    content,               // the new file (string; AssetResource.content is a string)
+    contentType,
+    previousVersionHash,   // link: the prior version's hash (genesis hash for the 1st update)
+    toVersion,             // the new version number (advisory/among the signed body)
+  },
+  previousEvent,           // CEL hash-chain link (as every event)
+  proof: [ controllerProof ],
+}
+```
+
+- `toHash` is not stored; it is `hashResource(Buffer.from(content, 'utf-8'))`,
+  derived at verify/fold time. The signed event commits to `content` (the chain
+  digest covers `data`), so `toHash` is tamper-evident.
+- `previousVersionHash` is the continuity link: it MUST equal the last-known hash
+  of `resourceId` at this point in the log (the genesis resource hash for the
+  first update, or the prior update's derived `toHash` for subsequent ones).
+
+## 3. Writer — `OriginalsAsset.addResourceVersion` (now async)
+
+Signature becomes `addResourceVersion(...): Promise<AssetResource>`. It keeps its
+current guards, then instead of pushing to `provenance.resourceUpdates`:
+
+1. Computes `newHash`/`newVersion` as today.
+2. Appends a signed `'update'` CEL event with the §2 body, via the **injected
+   controller signer** (bound by `LifecycleManager` when a keyStore is present),
+   using the shared signer-adapter path (`celSignerFromKeyPair` /
+   `createKeyStoreCelSigner`) that every other authorship append uses.
+3. On success, updates the in-memory `this.resources` (so live use sees the new
+   version) — the log is the source of truth; `provenance.resourceUpdates` is no
+   longer written locally (it is folded from the log, §5).
+
+**Degraded mode (no signer):** the in-memory `this.resources` still updates so
+the object is usable, but no `update` event is appended and the manager emits
+`cel:append-skipped` — the version is NOT provable, exactly the honesty pattern
+`createAsset`/`inscribeOnBitcoin` already follow when keyless.
+
+**Signer injection:** `LifecycleManager` binds a controller signer into the
+`OriginalsAsset` it constructs (in `createAsset` and `loadAsset`) when a keyStore
+is configured; `addResourceVersion` reads it. No key material is passed by
+callers; `OriginalsAsset` holds a reference to the signer for its lifetime.
+
+## 4. Verifier — `verifyEventLog` resource-`update` branch
+
+When an `update` event is resource-shaped (`data.resourceId` +
+`data.previousVersionHash` present, and NOT migration-shaped):
+
+1. **Continuity:** `data.previousVersionHash` MUST equal the last-known hash for
+   `data.resourceId` — the genesis resource hash on the first update, or the
+   prior resource-update's derived `toHash` thereafter. A mismatch fails the log.
+2. **Content binding:** `hashResource(data.content)` becomes the new current hash
+   for `resourceId` (fed to the next continuity check). Because the chain digest
+   already covers `data`, tampering with `content` breaks the hash chain / proof.
+3. **Authority:** the event's controller proof MUST be the currently authorized
+   controller key (the same authorized-key-set walk migrate/rotateKey/update use)
+   — an update signed by a non-controller or a pre-rotation key fails the log.
+
+The verifier tracks a per-`resourceId` "current hash" map across the walk,
+seeded from the genesis resources, so continuity is checkable with no external
+input (content is inline).
+
+## 5. Fold + envelope (hard cutover)
+
+- `replayProvenance` / `getCurrentState` reconstruct current resource versions
+  **from the `update` events**; `ProvenanceChain.resourceUpdates` is derived from
+  the log, not a local array.
+- `serialize()` **stops emitting `unverified.resourceUpdates`**
+  (`OriginalsAsset.ts:222-223` removed); the resources it captures are the folded
+  current versions.
+- `loadAsset` folds resource versions from the verified log; the
+  `unverified.resourceUpdates` read (`LifecycleManager.ts:748`) is removed.
+- Old test envelopes/fixtures carrying `unverified.resourceUpdates` are
+  regenerated to append real `update` events.
+
+## 6. Unchanged
+
+`did:cel` derivation, the migration/rotation/ownership machinery, genesis
+resource binding (`checkGenesisResourceBinding` still gates genesis; updates
+chain forward from it). The `'update'` event type keeps working for its existing
+(legacy migration-sniff) uses — the discriminator separates the two.
+
+## 7. Testing spine
+
+- **Honest round-trip:** genesis → `addResourceVersion` → `serialize()` → a
+  FRESH SDK `loadAsset` verifies the new version with NO keys (content is inline);
+  the folded current resource matches.
+- **Chain-continuity attack:** an `update` whose `previousVersionHash` does not
+  match the prior known hash → rejected.
+- **Content-tamper:** flip a byte of the embedded `content` after signing → the
+  chain digest / proof breaks → rejected.
+- **Unauthorized signer:** an `update` signed by a non-controller (or a
+  pre-`rotateKey` key) → rejected.
+- **Degrade:** no signer → `cel:append-skipped`, in-memory version present but
+  NOT in the log (not provable), asserted explicitly.
+- **No heuristic collision:** a resource `update` is not mistaken for a legacy
+  migration, and a legacy migration `update` is not mistaken for a resource
+  version.
+- **Authority-after-rotation:** an `update` signed by the NEW controller after a
+  `rotateKey` verifies; one signed by the retired key does not.
+
+## 8. Out of scope / deferred
+
+- Inline-vs-referenced storage + size caps for large resource content — the
+  default is inline (like genesis today); an opt-in reference-by-hash for big
+  blobs is a later refinement, and on-chain inline-content mechanics are the
+  separate #378 sub-project.
+- VC/credential derivation from these events (Phase 4 sub-project 2) — builds on
+  this once resource authorship is on-log.
+- Re-inscribing an updated `#cel` head on Bitcoin after a resource update
+  (freshness of the on-chain anchor) — orthogonal; today only migrate/rotate
+  re-embed `#cel`.

--- a/packages/sdk/src/cel/algorithms/verifyEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/verifyEventLog.ts
@@ -22,6 +22,8 @@ import { canonicalizeEvent, canonicalizeEntryForChain } from '../canonicalize.js
 import { multikey } from '../../crypto/Multikey.js';
 import { deriveDidCelFromGenesis, didCelMatchesLog } from '../celDid.js';
 import { parseSatoshiIdentifier } from '../../utils/satoshi-validation.js';
+import { hexSha256ToDigestMultibase } from '../signerAdapter.js';
+import { hashResource } from '../../utils/validation.js';
 
 /**
  * Validates the structural requirements of a DataIntegrityProof (field presence,
@@ -856,6 +858,49 @@ async function resolveControllerKeyHex(
  * @param resolveKey - Optional key resolver for non-did:key proofs
  * @returns EventVerification result
  */
+/**
+ * Resource-update continuity + content binding (#Phase-4 resource events).
+ *
+ * A resource-shaped `update` event (`data.resourceId` + `data.previousVersionHash`
+ * present) MUST chain forward from the last-known hash of its resourceId:
+ *  - first update for a resourceId: `previousVersionHash` must match SOME genesis
+ *    resource digest (genesis ExternalReferences carry no resourceId);
+ *  - subsequent updates: it must match the prior update's DERIVED hash.
+ * The new current hash is `hashResource(content)` (derived, never stored). All
+ * hashes are compared as digestMultibase. On success the per-resourceId map is
+ * advanced; on any failure an error string is returned (fail closed) and the map
+ * is left untouched.
+ */
+function checkResourceUpdateContinuity(
+  data: { resourceId: unknown; previousVersionHash: unknown; content?: unknown },
+  genesisDigests: Set<string>,
+  currentResourceHash: Map<string, string>
+): string | null {
+  const resourceId = data.resourceId as string;
+  if (typeof data.content !== 'string') {
+    return `resource update for ${resourceId} has non-string content; cannot verify`;
+  }
+  let prevDigest: string;
+  let newDigest: string;
+  try {
+    prevDigest = hexSha256ToDigestMultibase(data.previousVersionHash as string);
+    newDigest = hexSha256ToDigestMultibase(hashResource(Buffer.from(data.content, 'utf-8')));
+  } catch (e) {
+    return `resource update for ${resourceId} has an unparseable hash: ${e instanceof Error ? e.message : String(e)}`;
+  }
+
+  const known = currentResourceHash.get(resourceId);
+  const matches = known !== undefined
+    ? digestMultibaseEquals(prevDigest, known)
+    : [...genesisDigests].some((d) => digestMultibaseEquals(prevDigest, d));
+  if (!matches) {
+    return `resource update for ${resourceId}: previousVersionHash does not match the last-known hash (chain-continuity broken)`;
+  }
+
+  currentResourceHash.set(resourceId, newDigest);
+  return null;
+}
+
 async function verifyEvent(
   event: LogEntry,
   index: number,
@@ -1188,6 +1233,21 @@ export async function verifyEventLog(
     ? genesisData.controller
     : undefined;
 
+  // Seed for resource-update continuity: the genesis resource digests
+  // (ExternalReference.digestMultibase). A resource's FIRST update must chain
+  // from one of these; subsequent updates chain from the prior derived hash.
+  const genesisResourceDigests = new Set<string>();
+  {
+    const genesisResources = (createEvent.data as { resources?: unknown } | null | undefined)?.resources;
+    if (Array.isArray(genesisResources)) {
+      for (const r of genesisResources) {
+        const dm = (r as { digestMultibase?: unknown })?.digestMultibase;
+        if (typeof dm === 'string' && dm.length > 0) genesisResourceDigests.add(dm);
+      }
+    }
+  }
+  const currentResourceHash = new Map<string, string>();
+
   let authorizedKeyIds = new Set<string>();
   let authorityError: string | undefined;
   if (!options?.verifier) {
@@ -1288,6 +1348,26 @@ export async function verifyEventLog(
     const event = log.events[i];
     const previousEvent = i > 0 ? log.events[i - 1] : undefined;
     const eventResult = await verifyEvent(event, i, options?.verifier, previousEvent, options?.resolveKey, authorizedKeyIds, options?.ordinalsProvider, anchoredSat);
+
+    // Resource-update continuity (default path only; a custom verifier owns
+    // proof semantics). Only engage for resource-shaped updates that otherwise
+    // verified — a failed proof/chain already fails the event.
+    if (!options?.verifier && event.type === 'update' && eventResult.proofValid && eventResult.chainValid) {
+      const rd = event.data as { resourceId?: unknown; previousVersionHash?: unknown; content?: unknown } | null;
+      if (rd && typeof rd.resourceId === 'string' && typeof rd.previousVersionHash === 'string') {
+        // Rebuild as a literal: narrowing on rd's optional props doesn't
+        // propagate to the whole-object type expected by the helper below.
+        const err = checkResourceUpdateContinuity(
+          { resourceId: rd.resourceId, previousVersionHash: rd.previousVersionHash, content: rd.content },
+          genesisResourceDigests,
+          currentResourceHash
+        );
+        if (err) {
+          eventResult.proofValid = false;
+          eventResult.errors.push(`Event ${i}: ${err}`);
+        }
+      }
+    }
 
     // rotateKey hand-off. Order matters: the rotation event must pass ALL its
     // checks (chain link, signature, CURRENT-set authorization, gating witness

--- a/packages/sdk/src/cel/algorithms/verifyEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/verifyEventLog.ts
@@ -863,8 +863,10 @@ async function resolveControllerKeyHex(
  *
  * A resource-shaped `update` event (`data.resourceId` + `data.previousVersionHash`
  * present) MUST chain forward from the last-known hash of its resourceId:
- *  - first update for a resourceId: `previousVersionHash` must match SOME genesis
- *    resource digest (genesis ExternalReferences carry no resourceId);
+ *  - first update for a resourceId: if genesis BOUND that resourceId to a digest
+ *    (ExternalReference carried an `id`, #401), `previousVersionHash` must match
+ *    THAT digest specifically; otherwise (legacy id-less genesis) it may match
+ *    ANY genesis digest;
  *  - subsequent updates: it must match the prior update's DERIVED hash.
  * The new current hash is `hashResource(content)` (derived, never stored). All
  * hashes are compared as digestMultibase. On success the per-resourceId map is
@@ -874,6 +876,7 @@ async function resolveControllerKeyHex(
 function checkResourceUpdateContinuity(
   data: { resourceId: unknown; previousVersionHash: unknown; content?: unknown },
   genesisDigests: Set<string>,
+  genesisDigestById: Map<string, string>,
   currentResourceHash: Map<string, string>
 ): string | null {
   const resourceId = data.resourceId as string;
@@ -890,9 +893,20 @@ function checkResourceUpdateContinuity(
   }
 
   const known = currentResourceHash.get(resourceId);
-  const matches = known !== undefined
-    ? digestMultibaseEquals(prevDigest, known)
-    : [...genesisDigests].some((d) => digestMultibaseEquals(prevDigest, d));
+  let matches: boolean;
+  if (known !== undefined) {
+    // Subsequent update: chain from this resource's prior derived hash.
+    matches = digestMultibaseEquals(prevDigest, known);
+  } else {
+    // First update. If genesis bound this resourceId (#401), it MUST chain from
+    // that specific digest — not any genesis resource's digest (which would let
+    // a fabricated/mismatched resourceId anchor off an unrelated resource). Only
+    // an id-less legacy genesis falls back to matching any genesis digest.
+    const boundDigest = genesisDigestById.get(resourceId);
+    matches = boundDigest !== undefined
+      ? digestMultibaseEquals(prevDigest, boundDigest)
+      : [...genesisDigests].some((d) => digestMultibaseEquals(prevDigest, d));
+  }
   if (!matches) {
     return `resource update for ${resourceId}: previousVersionHash does not match the last-known hash (chain-continuity broken)`;
   }
@@ -1233,16 +1247,24 @@ export async function verifyEventLog(
     ? genesisData.controller
     : undefined;
 
-  // Seed for resource-update continuity: the genesis resource digests
-  // (ExternalReference.digestMultibase). A resource's FIRST update must chain
-  // from one of these; subsequent updates chain from the prior derived hash.
+  // Seed for resource-update continuity from the genesis resource digests
+  // (ExternalReference.digestMultibase). Two seeds (#401):
+  //  - `genesisResourceDigestById`: when a genesis ref carries its resource `id`,
+  //    that resource's FIRST update MUST chain from ITS OWN genesis digest.
+  //  - `genesisResourceDigests` (flat): legacy/hand-built geneses whose refs have
+  //    no `id` fall back to matching ANY genesis digest (the pre-#401 behavior).
+  // Subsequent updates always chain from the prior derived hash.
   const genesisResourceDigests = new Set<string>();
+  const genesisResourceDigestById = new Map<string, string>();
   {
     const genesisResources = (createEvent.data as { resources?: unknown } | null | undefined)?.resources;
     if (Array.isArray(genesisResources)) {
       for (const r of genesisResources) {
         const dm = (r as { digestMultibase?: unknown })?.digestMultibase;
-        if (typeof dm === 'string' && dm.length > 0) genesisResourceDigests.add(dm);
+        if (typeof dm !== 'string' || dm.length === 0) continue;
+        genesisResourceDigests.add(dm);
+        const id = (r as { id?: unknown })?.id;
+        if (typeof id === 'string' && id.length > 0) genesisResourceDigestById.set(id, dm);
       }
     }
   }
@@ -1360,6 +1382,7 @@ export async function verifyEventLog(
         const err = checkResourceUpdateContinuity(
           { resourceId: rd.resourceId, previousVersionHash: rd.previousVersionHash, content: rd.content },
           genesisResourceDigests,
+          genesisResourceDigestById,
           currentResourceHash
         );
         if (err) {

--- a/packages/sdk/src/cel/types.ts
+++ b/packages/sdk/src/cel/types.ts
@@ -23,6 +23,15 @@ export interface WitnessProof extends DataIntegrityProof {
  * Used for large resources that shouldn't be embedded in the log
  */
 export interface ExternalReference {
+  /**
+   * Optional logical resource id (AssetResource.id). When present at genesis it
+   * BINDS this digest to a specific resourceId, so a resource's first on-log
+   * `update` must chain from ITS OWN genesis digest — not any genesis digest
+   * (#401). Omitted by legacy/hand-built geneses, which fall back to unkeyed
+   * matching. Additive: it does not affect the digest, only the did:cel
+   * derivation of assets that include it.
+   */
+  id?: string;
   /** Optional URLs where the data can be retrieved */
   url?: string[];
   /** Optional MIME type of the data */

--- a/packages/sdk/src/events/types.ts
+++ b/packages/sdk/src/events/types.ts
@@ -347,8 +347,11 @@ export interface CelAppendSkippedEvent extends BaseEvent {
    * NO_KEYSTORE: no keyStore configured. NO_CEL_LOG: legacy asset with no CEL
    * log. NO_SIGNING_KEY: keyStore present but the current controller's key is
    * absent (e.g. asset minted by a different, keyStore-less manager).
+   * UNPROVABLE_BASE: the in-memory resource head diverged from the on-log head
+   * (a prior update degraded/skipped), so appending now would chain from an
+   * un-logged base and be permanently unverifiable — degrade instead of poison.
    */
-  reason: 'NO_KEYSTORE' | 'NO_CEL_LOG' | 'NO_SIGNING_KEY';
+  reason: 'NO_KEYSTORE' | 'NO_CEL_LOG' | 'NO_SIGNING_KEY' | 'UNPROVABLE_BASE';
 }
 
 /**

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -509,6 +509,37 @@ export class LifecycleManager {
         }
       }
 
+      // 4b) Post-genesis resource binding (#401). Genesis (v1) resources are
+      // bound by checkGenesisResourceBinding above; every resource version ≥ 2
+      // MUST instead be backed by a VERIFIED `update` log event with the SAME
+      // resourceId, version, and derived content hash. The step-4 loop only
+      // proves each resource is self-consistent (content ↔ its own hash), NOT
+      // that its content is the one the controller signed. Without this, a
+      // self-consistent forged post-genesis version (or an unprovable degraded
+      // version) in env.resources would load undetected while the fold reports
+      // the genuine hash. Fail closed — the verified log is the source of truth.
+      for (const res of env.resources) {
+        const version = typeof res.version === 'number' ? res.version : 1;
+        if (version < 2) continue;
+        const match = folded.resourceUpdates.find(
+          u => u.resourceId === res.id && u.toVersion === version
+        );
+        if (!match) {
+          throw new StructuredError(
+            'ASSET_LOAD_VERIFICATION_FAILED',
+            `Resource ${res.id} v${version} is not backed by a verified update event on the log (unprovable or forged post-genesis version).`,
+            { verification }
+          );
+        }
+        if (match.toHash.toLowerCase() !== String(res.hash).toLowerCase()) {
+          throw new StructuredError(
+            'ASSET_LOAD_VERIFICATION_FAILED',
+            `Resource ${res.id} v${version}: envelope hash (${res.hash}) does not match the verified log's derived hash (${match.toHash}).`,
+            { verification }
+          );
+        }
+      }
+
       // 5) Cross-checks: the fold IS the source of truth for identity/bindings;
       // an envelope's advisory DID docs must not disagree with it — a swapped
       // doc is exactly the attack the envelope invites. did:cel is bound by the

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -287,8 +287,13 @@ export class LifecycleManager {
     const controllerKp = await new KeyManager().generateKeyPair('Ed25519');
     const { signer, verificationMethod } = celSignerFromKeyPair(controllerKp);
 
-    // Bridge AssetResource hashes (hex sha256) to CEL ExternalReferences.
+    // Bridge AssetResource hashes (hex sha256) to CEL ExternalReferences. The
+    // resource id is bound into the genesis reference (#401) so the verifier can
+    // require a resource's first `update` to chain from ITS OWN genesis digest,
+    // not any genesis digest. (resource.id is validated as a non-empty string
+    // above.)
     const externalRefs: ExternalReference[] = resources.map((r) => ({
+      id: r.id,
       digestMultibase: hexSha256ToDigestMultibase(r.hash),
       ...(r.contentType ? { mediaType: r.contentType } : {})
     }));

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -321,6 +321,9 @@ export class LifecycleManager {
     }
 
     const asset = new OriginalsAsset(resources, didDoc, [], log);
+    // Bind the controller append path so addResourceVersion can write signed
+    // `update` events with the same degrade contract as the other authorship ops.
+    asset._bindCelAppender((type, data) => this.appendCelEventOrSkip(asset, type, data));
 
     // Persist the genesis CEL at the conventional cel/<suffix>.json key so
     // the did:cel resolves from storage immediately (best-effort, never gates).
@@ -612,6 +615,7 @@ export class LifecycleManager {
       log,
       { currentLayer: folded.currentLayer, bindings: folded.bindings, provenance }
     );
+    asset._bindCelAppender((type, data) => this.appendCelEventOrSkip(asset, type, data));
 
     // Repopulate captured DID docs so re-serializing a loaded asset is
     // lossless. Only for layers cross-checked against the fold in step 5
@@ -745,7 +749,9 @@ export class LifecycleManager {
       }
     }
 
-    const resourceUpdates = (env.unverified?.resourceUpdates ?? []).map(u => ({ ...u }));
+    // Resource versions are now signed `update` log events — fold them from the
+    // (verified) log, never from the advisory envelope section (removed).
+    const resourceUpdates = folded.resourceUpdates.map(u => ({ ...u }));
 
     // txid: the btco migration's witnessed reveal txid (ownership moves live on
     // the sat's UTXO chain, not the CEL — no transfers to derive a txid from).

--- a/packages/sdk/src/lifecycle/OriginalsAsset.ts
+++ b/packages/sdk/src/lifecycle/OriginalsAsset.ts
@@ -235,9 +235,6 @@ export class OriginalsAsset {
     const btcoMigration = this.provenance.migrations.find(m => m.to === 'did:btco');
     if (btcoMigration?.commitTxId) unverified.commitTxId = btcoMigration.commitTxId;
     if (typeof btcoMigration?.feeRate === 'number') unverified.feeRate = btcoMigration.feeRate;
-    if (this.provenance.resourceUpdates.length > 0) {
-      unverified.resourceUpdates = this.provenance.resourceUpdates.map(u => ({ ...u }));
-    }
     // Degraded binding: the fold can't derive did:btco (no witness proof in the
     // log) but the live cache holds it — surface the whole live binding snapshot
     // as advisory. Do NOT promote it: loadAsset must not trust it.

--- a/packages/sdk/src/lifecycle/OriginalsAsset.ts
+++ b/packages/sdk/src/lifecycle/OriginalsAsset.ts
@@ -66,6 +66,11 @@ export class OriginalsAsset {
   // Per-layer DID documents captured at operation time (publish/inscribe/rotate).
   // These are discarded by the live flow otherwise; serialize() needs them.
   #didDocuments: Map<'did:webvh' | 'did:btco', DIDDocument> = new Map();
+  // Injected by LifecycleManager (createAsset / loadAsset). Appends a signed CEL
+  // event via the manager's degrade-aware path and returns the new head digest,
+  // or null when the append was skipped (no keyStore / no signing key). Undefined
+  // for assets constructed outside the lifecycle (they degrade in-memory only).
+  #celAppender?: (type: 'migrate' | 'rotateKey' | 'update', data: unknown) => Promise<string | null>;
 
   constructor(
     resources: AssetResource[],
@@ -161,6 +166,17 @@ export class OriginalsAsset {
    */
   _replaceCelLog(log: EventLog): void {
     this.#celLog = log;
+  }
+
+  /**
+   * @internal — LifecycleManager binds the controller append path so
+   * addResourceVersion can write signed `update` events with the same degrade
+   * contract (cel:append-skipped) as the other authorship ops.
+   */
+  _bindCelAppender(
+    fn: (type: 'migrate' | 'rotateKey' | 'update', data: unknown) => Promise<string | null>
+  ): void {
+    this.#celAppender = fn;
   }
 
   /**
@@ -532,9 +548,21 @@ export class OriginalsAsset {
   }
 
   /**
-   * Add a new version of a resource (immutable versioning).
-   * Creates a new AssetResource with incremented version number and links it to the previous version.
-   * 
+   * Add a new version of a resource (immutable versioning) as a signed CEL
+   * `update` event.
+   *
+   * Async: the new version is appended to the CEL log via the injected
+   * controller appender (bound by LifecycleManager). On success the in-memory
+   * resources advance and `provenance.resourceUpdates` is re-folded from the log.
+   * Degraded mode (no appender bound, or the appender skips because no signing
+   * key is available): the in-memory resources still advance so the object is
+   * usable, but NO event is appended (the version is not provable) and a
+   * `cel:append-skipped` is emitted.
+   *
+   * `changes` is retained for the emitted `resource:version:created` event only;
+   * it is NOT part of the signed CEL body (the log is the source of truth and its
+   * body is fixed — see the design contract).
+   *
    * @param resourceId - The logical resource ID
    * @param newContent - The new content. Must be a string: AssetResource can
    *   only carry inline string content, so Buffer input is rejected rather
@@ -544,14 +572,15 @@ export class OriginalsAsset {
    * @param contentType - The content type
    * @param changes - Optional description of changes
    * @returns The newly created AssetResource
-   * @throws Error if content is unchanged, resource not found, or newContent is a Buffer
+   * @throws StructuredError('BINARY_CONTENT_UNSUPPORTED') for Buffer content (#276)
+   * @throws Error if content is unchanged or the resource is not found
    */
-  addResourceVersion(
+  async addResourceVersion(
     resourceId: string,
     newContent: string,
     contentType: string,
     changes?: string
-  ): AssetResource {
+  ): Promise<AssetResource> {
     // AssetResource.content is a string; a Buffer used to be silently dropped
     // (only its hash was stored), unrecoverably losing the binary content
     // while the caller believed it was versioned (issue #276). The parameter
@@ -570,23 +599,23 @@ export class OriginalsAsset {
     if (currentResources.length === 0) {
       throw new Error(`Resource with id ${resourceId} not found`);
     }
-    
+
     // Get the latest version
     const currentResource = currentResources.sort((a, b) => {
       const versionA = a.version || 1;
       const versionB = b.version || 1;
       return versionB - versionA;
     })[0];
-    
+
     // Compute new hash
     const contentBuffer = Buffer.from(newContent, 'utf-8');
     const newHash = hashResource(contentBuffer);
-    
+
     // Check if content has actually changed
     if (newHash === currentResource.hash) {
       throw new Error('Content unchanged - new version would be identical to current version');
     }
-    
+
     // Create new resource version
     const newVersion = (currentResource.version || 1) + 1;
     const newResource: AssetResource = {
@@ -600,12 +629,32 @@ export class OriginalsAsset {
       previousVersionHash: currentResource.hash,
       createdAt: new Date().toISOString()
     };
-    
-    // Add to resources array (immutable - don't modify old resource)
+
+    // Append a signed `update` CEL event (or degrade). The body is the fixed
+    // resource-update shape; toHash is derived at verify/fold time.
+    let appended = false;
+    if (this.#celAppender) {
+      const digest = await this.#celAppender('update', {
+        resourceId,
+        content: newContent,
+        contentType,
+        previousVersionHash: currentResource.hash,
+        toVersion: newVersion
+      });
+      appended = digest !== null; // null ⇒ the manager already emitted cel:append-skipped
+    } else {
+      // No manager bound: degrade in-memory only. Surface the honesty signal on
+      // the asset emitter (the manager path uses its own emitter).
+      await this.eventEmitter.emit({
+        type: 'cel:append-skipped',
+        timestamp: new Date().toISOString(),
+        asset: { id: this.id },
+        reason: this.#celLog ? 'NO_SIGNING_KEY' : 'NO_CEL_LOG'
+      });
+    }
+
+    // In-memory resources advance in BOTH the appended and degraded cases.
     this.resources.push(newResource);
-    
-    // Track in version manager, using the resource's own next version number so
-    // the manager numbering matches getResourceVersion(id, newVersion).
     this.versionManager.addVersion(
       resourceId,
       newHash,
@@ -614,26 +663,18 @@ export class OriginalsAsset {
       changes,
       newVersion
     );
-    
-    // Update provenance
+
+    // Provenance.resourceUpdates is the source-of-truth fold of the log — only
+    // populated when the event actually landed (provable). Re-fold from the log.
+    if (appended && this.#celLog) {
+      this.provenance.resourceUpdates = replayProvenance(this.#celLog).resourceUpdates;
+    }
+
     const timestamp = new Date().toISOString();
-    this.provenance.resourceUpdates.push({
-      resourceId,
-      fromVersion: currentResource.version || 1,
-      toVersion: newVersion,
-      fromHash: currentResource.hash,
-      toHash: newHash,
-      timestamp,
-      changes
-    });
-    
-    // Emit version-created event
     const event = {
       type: 'resource:version:created' as const,
       timestamp,
-      asset: {
-        id: this.id
-      },
+      asset: { id: this.id },
       resource: {
         id: resourceId,
         fromVersion: currentResource.version || 1,
@@ -643,12 +684,10 @@ export class OriginalsAsset {
       },
       changes
     };
-    
-    // Emit asynchronously (don't block)
     queueMicrotask(() => {
       void this.eventEmitter.emit(event);
     });
-    
+
     return newResource;
   }
 

--- a/packages/sdk/src/lifecycle/OriginalsAsset.ts
+++ b/packages/sdk/src/lifecycle/OriginalsAsset.ts
@@ -41,8 +41,10 @@ export interface ProvenanceChain {
   }>;
   resourceUpdates: Array<{
     resourceId: string;
-    fromVersion: number;
-    toVersion: number;
+    // Optional: foreign/legacy update events may carry no numeric version (see
+    // replayProvenance — omitted rather than folded as NaN).
+    fromVersion?: number;
+    toVersion?: number;
     fromHash: string;
     toHash: string;
     timestamp: string;
@@ -71,6 +73,13 @@ export class OriginalsAsset {
   // or null when the append was skipped (no keyStore / no signing key). Undefined
   // for assets constructed outside the lifecycle (they degrade in-memory only).
   #celAppender?: (type: 'migrate' | 'rotateKey' | 'update', data: unknown) => Promise<string | null>;
+  // Per-asset serialization for addResourceVersion: the sync→async cutover made
+  // the shared #celLog read-modify-write span await points, so concurrent calls
+  // raced (a later _replaceCelLog clobbered an earlier signed append, or landed
+  // a stale-chained unverifiable event). A promise-chain mutex forces each call
+  // to run its critical section — re-read head, base-check, append — to
+  // completion before the next begins.
+  #appendChain: Promise<unknown> = Promise.resolve();
 
   constructor(
     resources: AssetResource[],
@@ -591,7 +600,47 @@ export class OriginalsAsset {
         'or host the bytes externally and reference them by hash.'
       );
     }
-    // Find the current version of the resource by id
+    // Serialize the whole read-modify-write of #celLog per asset: acquire this
+    // asset's append turn, run the critical section to completion, release. A
+    // second queued call re-reads the head INSIDE its turn, so it chains from
+    // the first call's committed result rather than a stale snapshot (Finding 2).
+    const run = this.#appendChain.then(() =>
+      this.#addResourceVersionCritical(resourceId, newContent, contentType, changes)
+    );
+    // Keep the chain alive across a rejected turn without swallowing it for the caller.
+    this.#appendChain = run.catch(() => {});
+    return run;
+  }
+
+  /**
+   * The on-log provable head hex hash for a resourceId — the base the verifier
+   * will chain the next update from: the last on-log update's derived `toHash`,
+   * or (no on-log update yet) the genesis version-1 resource's `.hash`. Returns
+   * undefined when there is no CEL log (nothing to prove against). Used to
+   * detect an in-memory head that has diverged from the log (Finding 1).
+   */
+  #onLogProvableHead(resourceId: string): string | undefined {
+    if (!this.#celLog) return undefined;
+    const updates = replayProvenance(this.#celLog).resourceUpdates.filter(
+      u => u.resourceId === resourceId
+    );
+    if (updates.length > 0) return updates[updates.length - 1].toHash;
+    // Genesis entries are never removed, only appended — the lowest version is v1.
+    const genesis = this.resources
+      .filter(r => r.id === resourceId)
+      .sort((a, b) => (a.version || 1) - (b.version || 1))[0];
+    return genesis?.hash;
+  }
+
+  /** Critical section of addResourceVersion — runs one-at-a-time via #appendChain. */
+  async #addResourceVersionCritical(
+    resourceId: string,
+    newContent: string,
+    contentType: string,
+    changes?: string
+  ): Promise<AssetResource> {
+    // RE-READ the current head inside the turn (a prior queued call may have
+    // just committed a new version).
     const currentResources = this.resources.filter(r => r.id === resourceId);
     if (currentResources.length === 0) {
       throw new Error(`Resource with id ${resourceId} not found`);
@@ -631,14 +680,30 @@ export class OriginalsAsset {
     // resource-update shape; toHash is derived at verify/fold time.
     let appended = false;
     if (this.#celAppender) {
-      const digest = await this.#celAppender('update', {
-        resourceId,
-        content: newContent,
-        contentType,
-        previousVersionHash: currentResource.hash,
-        toVersion: newVersion
-      });
-      appended = digest !== null; // null ⇒ the manager already emitted cel:append-skipped
+      // Finding 1: the verifier chains continuity from the ON-LOG head, but our
+      // base is the IN-MEMORY head. They diverge once a prior update degraded
+      // (in-memory advanced, log did not). Appending now would chain from a base
+      // that isn't on the log → the event (and every later one) is permanently
+      // unverifiable. Detect the divergence and degrade instead of poisoning.
+      const onLogHead = this.#onLogProvableHead(resourceId);
+      if (onLogHead !== undefined && onLogHead !== currentResource.hash) {
+        await this.eventEmitter.emit({
+          type: 'cel:append-skipped',
+          timestamp: new Date().toISOString(),
+          asset: { id: this.id },
+          reason: 'UNPROVABLE_BASE'
+        });
+        // Do NOT also call the appender — exactly one cel:append-skipped per call.
+      } else {
+        const digest = await this.#celAppender('update', {
+          resourceId,
+          content: newContent,
+          contentType,
+          previousVersionHash: currentResource.hash,
+          toVersion: newVersion
+        });
+        appended = digest !== null; // null ⇒ the manager already emitted cel:append-skipped
+      }
     } else {
       // No manager bound: degrade in-memory only. Surface the honesty signal on
       // the asset emitter (the manager path uses its own emitter).

--- a/packages/sdk/src/lifecycle/assetEnvelope.ts
+++ b/packages/sdk/src/lifecycle/assetEnvelope.ts
@@ -5,9 +5,10 @@
  * and `bindings` / `currentLayer` / `migrations` are deliberately NOT
  * first-class fields — they are folds over the log (see replayProvenance).
  * Ownership history is the sat's UTXO chain on Bitcoin, never the envelope.
- * Anything the log cannot derive (commitTxId, feeRate, post-genesis resource
- * updates, a btco binding not yet anchored by a witness proof) rides in the
- * `unverified` HONESTY SECTION: advisory-only, never trusted at load/verify time.
+ * Anything the log cannot derive (commitTxId, feeRate, a btco binding not yet
+ * anchored by a witness proof) rides in the `unverified` HONESTY SECTION:
+ * advisory-only, never trusted at load/verify time. Post-genesis resource
+ * updates are signed `update` log events (#Phase 4) — folded from the log, not advisory.
  */
 import type { AssetResource, DIDDocument, VerifiableCredential } from '../types/index.js';
 import type { EventLog } from '../cel/types.js';
@@ -35,15 +36,6 @@ export interface AssetEnvelope {
   unverified?: {
     commitTxId?: string;
     feeRate?: number;
-    resourceUpdates?: Array<{
-      resourceId: string;
-      fromVersion: number;
-      toVersion: number;
-      fromHash: string;
-      toHash: string;
-      timestamp: string;
-      changes?: string;
-    }>;
     /** Live-cache btco binding, present ONLY when the fold can't derive it from the log. */
     bindings?: Record<string, string>;
   };

--- a/packages/sdk/src/lifecycle/replayProvenance.ts
+++ b/packages/sdk/src/lifecycle/replayProvenance.ts
@@ -110,8 +110,9 @@ export function replayProvenance(log: EventLog): ReplayedProvenance {
           timestamp,
         };
         // Omit the version fields entirely for foreign logs whose update event
-        // carries no numeric toVersion (rather than fold them as NaN → null).
-        if (Number.isFinite(toVersion)) {
+        // carries no numeric toVersion (rather than fold them as NaN → null), or
+        // whose toVersion is < 2 (would yield a nonsensical fromVersion:0).
+        if (Number.isFinite(toVersion) && toVersion >= 2) {
           entry.fromVersion = toVersion - 1;
           entry.toVersion = toVersion;
         }

--- a/packages/sdk/src/lifecycle/replayProvenance.ts
+++ b/packages/sdk/src/lifecycle/replayProvenance.ts
@@ -22,8 +22,10 @@
  *    is the honest sentinel `'did:btco:?'` rather than a fabricated DID.
  *  - `transfer` (legacy, no longer written) → no provenance entries. Ownership
  *    history is the sat's UTXO chain on Bitcoin, not the CEL.
- *  - `rotateKey` / `update` / `deactivate` → no provenance entries. Key
- *    rotation is custody, not provenance, for this fold.
+ *  - `rotateKey` / `deactivate` → no provenance entries. Key rotation is
+ *    custody, not provenance, for this fold. Resource-shaped `update` events
+ *    (`resourceId` + `previousVersionHash` + inline `content`) fold into
+ *    `resourceUpdates`; generic/migration-ish `update` events do not.
  *
  * KNOWN, DOCUMENTED DIVERGENCE from the live in-memory caches
  * (`OriginalsAsset.getProvenance()` / `asset.bindings`):
@@ -41,6 +43,7 @@
 import type { EventLog } from '../cel/types.js';
 import { deriveDidCel } from '../cel/celDid.js';
 import { parseSatoshiIdentifier } from '../utils/satoshi-validation.js';
+import { hashResource } from '../utils/validation.js';
 
 /** Honest sentinel: a btco migration whose satoshi cannot be recovered from the log. */
 export const BTCO_SATOSHI_UNKNOWN = 'did:btco:?';
@@ -49,6 +52,15 @@ export interface ReplayedProvenance {
   currentLayer: 'did:peer' | 'did:webvh' | 'did:btco';
   bindings: Record<string, string>;
   migrations: Array<{ from: string; to: string; timestamp: string }>;
+  resourceUpdates: Array<{
+    resourceId: string;
+    fromVersion: number;
+    toVersion: number;
+    fromHash: string;
+    toHash: string;
+    timestamp: string;
+    changes?: string;
+  }>;
 }
 
 export function replayProvenance(log: EventLog): ReplayedProvenance {
@@ -65,6 +77,7 @@ export function replayProvenance(log: EventLog): ReplayedProvenance {
     currentLayer: 'did:peer',
     bindings: {},
     migrations: [],
+    resourceUpdates: [],
   };
 
   const genesisData = genesis.data as Record<string, unknown>;
@@ -76,8 +89,32 @@ export function replayProvenance(log: EventLog): ReplayedProvenance {
     const event = log.events[i];
     const data = (event.data ?? {}) as Record<string, unknown>;
 
+    if (event.type === 'update') {
+      // Resource-update events (resourceId + previousVersionHash) fold into the
+      // resource-version history. toHash is DERIVED from inline content, never
+      // stored. Generic/migration-ish updates lack these fields and are skipped.
+      const resourceId = typeof data.resourceId === 'string' ? data.resourceId : undefined;
+      const previousVersionHash = typeof data.previousVersionHash === 'string' ? data.previousVersionHash : undefined;
+      const content = typeof data.content === 'string' ? data.content : undefined;
+      if (resourceId && previousVersionHash && content !== undefined) {
+        const toVersion = typeof data.toVersion === 'number' ? data.toVersion : NaN;
+        const proofs = event.proof as ReadonlyArray<{ created?: unknown; witnessedAt?: unknown }> | undefined;
+        const controllerProof = proofs?.find((p) => !(p && typeof p === 'object' && 'witnessedAt' in p));
+        const timestamp = typeof controllerProof?.created === 'string' ? controllerProof.created : '';
+        result.resourceUpdates.push({
+          resourceId,
+          fromVersion: Number.isFinite(toVersion) ? toVersion - 1 : NaN,
+          toVersion,
+          fromHash: previousVersionHash,
+          toHash: hashResource(Buffer.from(content, 'utf-8')),
+          timestamp,
+        });
+      }
+      continue;
+    }
+
     if (event.type !== 'migrate') {
-      // transfer (legacy) / rotateKey / update / deactivate: not provenance.
+      // transfer (legacy) / rotateKey / deactivate: not provenance.
       // Ownership history is the sat's UTXO chain, not the CEL.
       continue;
     }

--- a/packages/sdk/src/lifecycle/replayProvenance.ts
+++ b/packages/sdk/src/lifecycle/replayProvenance.ts
@@ -54,8 +54,10 @@ export interface ReplayedProvenance {
   migrations: Array<{ from: string; to: string; timestamp: string }>;
   resourceUpdates: Array<{
     resourceId: string;
-    fromVersion: number;
-    toVersion: number;
+    // Omitted for foreign/legacy update events that carry no numeric toVersion
+    // (folding them as NaN serialized to null, poisoning the interchange shape).
+    fromVersion?: number;
+    toVersion?: number;
     fromHash: string;
     toHash: string;
     timestamp: string;
@@ -101,14 +103,19 @@ export function replayProvenance(log: EventLog): ReplayedProvenance {
         const proofs = event.proof as ReadonlyArray<{ created?: unknown; witnessedAt?: unknown }> | undefined;
         const controllerProof = proofs?.find((p) => !(p && typeof p === 'object' && 'witnessedAt' in p));
         const timestamp = typeof controllerProof?.created === 'string' ? controllerProof.created : '';
-        result.resourceUpdates.push({
+        const entry: ReplayedProvenance['resourceUpdates'][number] = {
           resourceId,
-          fromVersion: Number.isFinite(toVersion) ? toVersion - 1 : NaN,
-          toVersion,
           fromHash: previousVersionHash,
           toHash: hashResource(Buffer.from(content, 'utf-8')),
           timestamp,
-        });
+        };
+        // Omit the version fields entirely for foreign logs whose update event
+        // carries no numeric toVersion (rather than fold them as NaN → null).
+        if (Number.isFinite(toVersion)) {
+          entry.fromVersion = toVersion - 1;
+          entry.toVersion = toVersion;
+        }
+        result.resourceUpdates.push(entry);
       }
       continue;
     }

--- a/packages/sdk/tests/integration/ResourceUpdateHandoff.e2e.test.ts
+++ b/packages/sdk/tests/integration/ResourceUpdateHandoff.e2e.test.ts
@@ -60,4 +60,85 @@ describe('Resource-update handoff (e2e)', () => {
     expect(skipped.length).toBe(1);
     expect(asset.getProvenance().resourceUpdates.length).toBe(0);
   });
+
+  test('degrade-then-provable does NOT poison the log (Finding 1)', async () => {
+    // Real Finding-1 repro: a skipped update advances the in-memory head to v2
+    // while the log stays at genesis; when the key becomes available and a
+    // second update is attempted, chaining from the un-logged v2 would make the
+    // log permanently unverifiable. The fix must degrade instead of poison.
+    const ks = new MockKeyStore();
+    const creator = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: ks });
+    const asset = await creator.lifecycle.createAsset([
+      { id: 'note', type: 'text', content: 'v1', contentType: 'text/plain', hash: h('v1') }
+    ]);
+
+    // 1) Key temporarily unavailable → this update degrades (in-memory only).
+    const saved = ks.getAllKeys();
+    ks.clear();
+    await asset.addResourceVersion('note', 'v2', 'text/plain');
+    expect(asset.getResourceVersion('note', 2)?.content).toBe('v2'); // in-memory advanced
+    expect(asset.celLog!.events.some(e => e.type === 'update')).toBe(false); // nothing on log
+
+    // 2) Key becomes available again; attempting a provable update now would
+    //    chain from the un-logged v2. The base-check must catch the divergence.
+    for (const [vm, sk] of saved) await ks.setPrivateKey(vm, sk);
+    const skipped: CelAppendSkippedEvent[] = [];
+    asset.on('cel:append-skipped', (e) => skipped.push(e as CelAppendSkippedEvent));
+    await asset.addResourceVersion('note', 'v3', 'text/plain');
+
+    // Degraded (not appended): exactly one skip with the new reason, no update event.
+    expect(skipped.length).toBe(1);
+    expect(skipped[0].reason).toBe('UNPROVABLE_BASE');
+    expect(asset.celLog!.events.some(e => e.type === 'update')).toBe(false);
+
+    // The log is still verifiable — no unverifiable event was ever appended.
+    expect(await asset.verify()).toBe(true);
+    const buyer = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
+    const { verification } = await buyer.lifecycle.loadAsset(asset.serialize());
+    expect(verification?.verified).toBe(true);
+  });
+
+  test('concurrent same-resource updates serialize into a valid chain (Finding 2)', async () => {
+    const creator = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
+    const asset = await creator.lifecycle.createAsset([
+      { id: 'note', type: 'text', content: 'v1', contentType: 'text/plain', hash: h('v1') }
+    ]);
+
+    await Promise.all([
+      asset.addResourceVersion('note', 'v2a', 'text/plain'),
+      asset.addResourceVersion('note', 'v2b', 'text/plain')
+    ]);
+
+    // Both signed appends landed — neither was lost/clobbered.
+    const updates = asset.celLog!.events.filter(e => e.type === 'update');
+    expect(updates.length).toBe(2);
+    const contents = asset.getAllVersions('note').map(r => r.content);
+    expect(contents).toContain('v2a');
+    expect(contents).toContain('v2b');
+
+    // The resulting chain verifies (genesis → v2a → v2b, correctly serialized).
+    expect(await asset.verify()).toBe(true);
+    const buyer = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
+    const { verification } = await buyer.lifecycle.loadAsset(asset.serialize());
+    expect(verification?.verified).toBe(true);
+  });
+
+  test('concurrent updates to different resources both land (Finding 2)', async () => {
+    const creator = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
+    const asset = await creator.lifecycle.createAsset([
+      { id: 'a', type: 'text', content: 'a1', contentType: 'text/plain', hash: h('a1') },
+      { id: 'b', type: 'text', content: 'b1', contentType: 'text/plain', hash: h('b1') }
+    ]);
+
+    await Promise.all([
+      asset.addResourceVersion('a', 'a2', 'text/plain'),
+      asset.addResourceVersion('b', 'b2', 'text/plain')
+    ]);
+
+    const updates = asset.celLog!.events.filter(e => e.type === 'update');
+    expect(updates.length).toBe(2);
+    expect(asset.getResourceVersion('a', 2)?.content).toBe('a2');
+    expect(asset.getResourceVersion('b', 2)?.content).toBe('b2');
+    expect(await asset.verify()).toBe(true);
+  });
 });

--- a/packages/sdk/tests/integration/ResourceUpdateHandoff.e2e.test.ts
+++ b/packages/sdk/tests/integration/ResourceUpdateHandoff.e2e.test.ts
@@ -44,6 +44,46 @@ describe('Resource-update handoff (e2e)', () => {
     await expect(buyer.lifecycle.loadAsset(envelope)).rejects.toThrow();
   });
 
+  test('forged post-genesis env.resource (self-consistent) is rejected at load even though the log verifies', async () => {
+    // Greptile #401 gap: the LOG's update event keeps its genuine content (so
+    // verifyEventLog passes), but the envelope's CAPTURED resource snapshot for
+    // v2 is swapped for self-consistent forged content (content AND its own hash
+    // both changed). Step-4 self-consistency passes; without the 4b post-genesis
+    // binding, the buyer would restore forged content while the fold reports the
+    // genuine hash. Must fail closed.
+    const creator = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
+    const asset = await creator.lifecycle.createAsset([
+      { id: 'note', type: 'text', content: 'v1', contentType: 'text/plain', hash: h('v1') }
+    ]);
+    await asset.addResourceVersion('note', 'v2', 'text/plain');
+    const envelope = asset.serialize();
+
+    // Log update event is UNTOUCHED (still genuine → verifyEventLog passes).
+    // Tamper ONLY the captured v2 resource snapshot, self-consistently.
+    const v2 = envelope.resources.find(r => r.id === 'note' && r.version === 2)!;
+    v2.content = 'forged-v2';
+    v2.hash = h('forged-v2'); // self-consistent: content matches its own hash
+
+    const buyer = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
+    await expect(buyer.lifecycle.loadAsset(envelope)).rejects.toThrow(/does not match the verified log/);
+  });
+
+  test('unprovable (degraded) post-genesis version in an envelope is rejected at load', async () => {
+    // A keyless creator advances v2 in-memory but appends NO update event. If it
+    // serializes and hands off, that v2 is unprovable — indistinguishable from a
+    // forgery. The buyer must not silently accept it (fail closed on a v≥2
+    // resource with no backing verified update event).
+    const creator = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519' });
+    const asset = await creator.lifecycle.createAsset([
+      { id: 'note', type: 'text', content: 'v1', contentType: 'text/plain', hash: h('v1') }
+    ]);
+    await asset.addResourceVersion('note', 'v2', 'text/plain'); // degrades (no signer)
+    expect(asset.celLog!.events.some(e => e.type === 'update')).toBe(false);
+
+    const buyer = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
+    await expect(buyer.lifecycle.loadAsset(asset.serialize())).rejects.toThrow(/not backed by a verified update event/);
+  });
+
   test('degrade: keyless creator emits cel:append-skipped and the update is not on the log', async () => {
     // No keyStore ⇒ createAsset drops the controller key ⇒ appends degrade.
     const creator = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519' });
@@ -93,9 +133,11 @@ describe('Resource-update handoff (e2e)', () => {
 
     // The log is still verifiable — no unverifiable event was ever appended.
     expect(await asset.verify()).toBe(true);
+    // But the envelope now carries UNPROVABLE in-memory v2/v3 (degraded, never
+    // logged); a buyer must fail closed rather than restore unverifiable
+    // versions (#401 post-genesis binding). The log soundness is proven above.
     const buyer = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
-    const { verification } = await buyer.lifecycle.loadAsset(asset.serialize());
-    expect(verification?.verified).toBe(true);
+    await expect(buyer.lifecycle.loadAsset(asset.serialize())).rejects.toThrow(/not backed by a verified update event/);
   });
 
   test('concurrent same-resource updates serialize into a valid chain (Finding 2)', async () => {

--- a/packages/sdk/tests/integration/ResourceUpdateHandoff.e2e.test.ts
+++ b/packages/sdk/tests/integration/ResourceUpdateHandoff.e2e.test.ts
@@ -1,0 +1,63 @@
+import { describe, test, expect } from 'bun:test';
+import { OriginalsSDK } from '../../src';
+import { MockKeyStore } from '../mocks/MockKeyStore';
+import { hashResource } from '../../src/utils/validation';
+import type { CelAppendSkippedEvent } from '../../src/events/types';
+
+const h = (s: string) => hashResource(Buffer.from(s, 'utf-8'));
+
+describe('Resource-update handoff (e2e)', () => {
+  test('honest round-trip: creator updates, buyer verifies offline with no keys', async () => {
+    const creator = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
+    const asset = await creator.lifecycle.createAsset([
+      { id: 'note', type: 'text', content: 'v1', contentType: 'text/plain', hash: h('v1') }
+    ]);
+    await asset.addResourceVersion('note', 'v2', 'text/plain', 'edit');
+
+    // The signed update landed on the log.
+    expect(asset.celLog!.events.some(e => e.type === 'update')).toBe(true);
+
+    const envelope = asset.serialize();
+
+    // Buyer loads with a FRESH, keyless SDK — verification is public-key-only.
+    const buyer = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
+    const { asset: loaded, verification } = await buyer.lifecycle.loadAsset(envelope);
+    expect(verification?.verified).toBe(true);
+    // The folded current resource is v2.
+    expect(loaded.getResourceVersion('note', 2)?.content).toBe('v2');
+    expect(loaded.getProvenance().resourceUpdates.some(u => u.toVersion === 2)).toBe(true);
+  });
+
+  test('content-tamper in the envelope is rejected at load', async () => {
+    const creator = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
+    const asset = await creator.lifecycle.createAsset([
+      { id: 'note', type: 'text', content: 'v1', contentType: 'text/plain', hash: h('v1') }
+    ]);
+    await asset.addResourceVersion('note', 'v2', 'text/plain');
+    const envelope = asset.serialize();
+
+    // Flip the embedded content of the update event.
+    const updateEv = envelope.eventLog.events.find(e => e.type === 'update')!;
+    (updateEv.data as { content: string }).content = 'tampered';
+
+    const buyer = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
+    await expect(buyer.lifecycle.loadAsset(envelope)).rejects.toThrow();
+  });
+
+  test('degrade: keyless creator emits cel:append-skipped and the update is not on the log', async () => {
+    // No keyStore ⇒ createAsset drops the controller key ⇒ appends degrade.
+    const creator = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519' });
+    const asset = await creator.lifecycle.createAsset([
+      { id: 'note', type: 'text', content: 'v1', contentType: 'text/plain', hash: h('v1') }
+    ]);
+    const skipped: CelAppendSkippedEvent[] = [];
+    creator.lifecycle.on('cel:append-skipped', (e) => skipped.push(e as CelAppendSkippedEvent));
+
+    await asset.addResourceVersion('note', 'v2', 'text/plain');
+
+    expect(asset.getResourceVersion('note', 2)?.content).toBe('v2'); // usable in-memory
+    expect(asset.celLog!.events.some(e => e.type === 'update')).toBe(false); // not provable
+    expect(skipped.length).toBe(1);
+    expect(asset.getProvenance().resourceUpdates.length).toBe(0);
+  });
+});

--- a/packages/sdk/tests/unit/cel/resource-update-events.test.ts
+++ b/packages/sdk/tests/unit/cel/resource-update-events.test.ts
@@ -130,4 +130,57 @@ describe('verifyEventLog: resource-update events', () => {
       { signer: a.signer, verificationMethod: a.vm });
     expect((await verifyEventLog(bad)).verified).toBe(false);
   });
+
+  // Genesis carrying TWO resources, each ExternalReference BOUND to its own id (#401).
+  async function genesisWithTwoIds(
+    a: { id: string; content: string },
+    b: { id: string; content: string },
+    signer: Awaited<ReturnType<typeof makeRealSigner>>
+  ) {
+    return createEventLog(
+      {
+        name: 'r',
+        controller: signer.didKey,
+        resources: [
+          { id: a.id, digestMultibase: hexSha256ToDigestMultibase(hex(a.content)) },
+          { id: b.id, digestMultibase: hexSha256ToDigestMultibase(hex(b.content)) },
+        ],
+        createdAt: 'x',
+        nonce: 'n-' + Math.random(),
+      },
+      { signer: signer.signer, verificationMethod: signer.vm }
+    );
+  }
+
+  test('id-bound genesis: a first update for A chaining from B\'s genesis digest is REJECTED (#401)', async () => {
+    const s = await makeRealSigner();
+    let log = await genesisWithTwoIds({ id: 'A', content: 'a1' }, { id: 'B', content: 'b1' }, s);
+    // First update for resourceId 'A', but previousVersionHash = B's genesis hash.
+    // With per-id binding, A must chain from A's own genesis digest → rejected.
+    log = await appendEvent(log, 'update',
+      { resourceId: 'A', content: 'a2', contentType: 'text/plain', previousVersionHash: hex('b1'), toVersion: 2 },
+      { signer: s.signer, verificationMethod: s.vm });
+    const result = await verifyEventLog(log);
+    expect(result.verified).toBe(false);
+    expect(result.errors.join(' ')).toContain('resource');
+  });
+
+  test('id-bound genesis: a first update for A chaining from A\'s OWN genesis digest verifies (#401)', async () => {
+    const s = await makeRealSigner();
+    let log = await genesisWithTwoIds({ id: 'A', content: 'a1' }, { id: 'B', content: 'b1' }, s);
+    log = await appendEvent(log, 'update',
+      { resourceId: 'A', content: 'a2', contentType: 'text/plain', previousVersionHash: hex('a1'), toVersion: 2 },
+      { signer: s.signer, verificationMethod: s.vm });
+    expect((await verifyEventLog(log)).verified).toBe(true);
+  });
+
+  test('legacy id-less genesis still falls back to matching any genesis digest', async () => {
+    // genesisWith emits an ExternalReference WITHOUT an id → flat-set fallback.
+    const s = await makeRealSigner();
+    let log = await genesisWith('v1', s);
+    log = await appendEvent(log, 'update',
+      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: hex('v1'), toVersion: 2 },
+      { signer: s.signer, verificationMethod: s.vm });
+    expect((await verifyEventLog(log)).verified).toBe(true);
+  });
 });

--- a/packages/sdk/tests/unit/cel/resource-update-events.test.ts
+++ b/packages/sdk/tests/unit/cel/resource-update-events.test.ts
@@ -1,0 +1,133 @@
+import { describe, test, expect } from 'bun:test';
+import * as ed25519 from '@noble/ed25519';
+import { multikey } from '../../../src/crypto/Multikey';
+import { canonicalizeEvent } from '../../../src/cel/canonicalize';
+import { verifyEventLog } from '../../../src/cel/algorithms/verifyEventLog';
+import { createEventLog } from '../../../src/cel/algorithms/createEventLog';
+import { appendEvent } from '../../../src/cel/algorithms/appendEvent';
+import { hashResource } from '../../../src/utils/validation';
+import { hexSha256ToDigestMultibase } from '../../../src/cel/signerAdapter';
+
+// A real eddsa-jcs-2022 signer exposing its holder did:key + canonical VM.
+// (Mirrors makeRealSigner in key-rotation-authority.test.ts.)
+async function makeRealSigner() {
+  const priv = crypto.getRandomValues(new Uint8Array(32));
+  const pub = await ed25519.getPublicKeyAsync(priv);
+  const pubMb = multikey.encodePublicKey(pub, 'Ed25519');
+  const didKey = `did:key:${pubMb}`;
+  const vm = `${didKey}#${pubMb}`;
+  const signer = async (data: unknown) => ({
+    type: 'DataIntegrityProof',
+    cryptosuite: 'eddsa-jcs-2022',
+    created: '2020-01-01T00:00:00Z',
+    verificationMethod: vm,
+    proofPurpose: 'assertionMethod',
+    proofValue: multikey.encodeMultibase(
+      new Uint8Array(await ed25519.signAsync(canonicalizeEvent(data), priv))
+    ),
+  });
+  return { signer, didKey, vm };
+}
+
+const hex = (s: string) => hashResource(Buffer.from(s, 'utf-8'));
+
+// Genesis carrying ONE resource whose content is `content`.
+async function genesisWith(content: string, signer: Awaited<ReturnType<typeof makeRealSigner>>) {
+  return createEventLog(
+    {
+      name: 'r',
+      controller: signer.didKey,
+      resources: [{ digestMultibase: hexSha256ToDigestMultibase(hex(content)) }],
+      createdAt: 'x',
+      nonce: 'n-' + Math.random(),
+    },
+    { signer: signer.signer, verificationMethod: signer.vm }
+  );
+}
+
+describe('verifyEventLog: resource-update events', () => {
+  test('honest first update (prev=genesis hash) verifies', async () => {
+    const a = await makeRealSigner();
+    let log = await genesisWith('v1', a);
+    log = await appendEvent(
+      log,
+      'update',
+      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: hex('v1'), toVersion: 2 },
+      { signer: a.signer, verificationMethod: a.vm }
+    );
+    expect((await verifyEventLog(log)).verified).toBe(true);
+  });
+
+  test('second update chains from the first derived hash', async () => {
+    const a = await makeRealSigner();
+    let log = await genesisWith('v1', a);
+    log = await appendEvent(log, 'update',
+      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: hex('v1'), toVersion: 2 },
+      { signer: a.signer, verificationMethod: a.vm });
+    log = await appendEvent(log, 'update',
+      { resourceId: 'r', content: 'v3', contentType: 'text/plain', previousVersionHash: hex('v2'), toVersion: 3 },
+      { signer: a.signer, verificationMethod: a.vm });
+    expect((await verifyEventLog(log)).verified).toBe(true);
+  });
+
+  test('chain-continuity attack: wrong previousVersionHash is rejected', async () => {
+    const a = await makeRealSigner();
+    let log = await genesisWith('v1', a);
+    log = await appendEvent(log, 'update',
+      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: hex('not-the-genesis'), toVersion: 2 },
+      { signer: a.signer, verificationMethod: a.vm });
+    const result = await verifyEventLog(log);
+    expect(result.verified).toBe(false);
+    expect(result.errors.join(' ')).toContain('resource');
+  });
+
+  test('content-tamper: flipping content after signing breaks the proof', async () => {
+    const a = await makeRealSigner();
+    let log = await genesisWith('v1', a);
+    log = await appendEvent(log, 'update',
+      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: hex('v1'), toVersion: 2 },
+      { signer: a.signer, verificationMethod: a.vm });
+    // Mutate the embedded content AFTER it was signed.
+    (log.events[1].data as { content: string }).content = 'tampered';
+    expect((await verifyEventLog(log)).verified).toBe(false);
+  });
+
+  test('unauthorized signer: an update from a non-controller is rejected', async () => {
+    const a = await makeRealSigner();
+    const mallory = await makeRealSigner();
+    let log = await genesisWith('v1', a);
+    log = await appendEvent(log, 'update',
+      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: hex('v1'), toVersion: 2 },
+      { signer: mallory.signer, verificationMethod: mallory.vm });
+    expect((await verifyEventLog(log)).verified).toBe(false);
+  });
+
+  test('no heuristic collision: generic and migration-ish updates are ignored by the branch', async () => {
+    const a = await makeRealSigner();
+    let log = await genesisWith('v1', a);
+    log = await appendEvent(log, 'update', { note: 'generic' }, { signer: a.signer, verificationMethod: a.vm });
+    log = await appendEvent(log, 'update',
+      { sourceDid: 'did:cel:x', layer: 'webvh', migratedAt: 'x' },
+      { signer: a.signer, verificationMethod: a.vm });
+    // Neither carries resourceId+previousVersionHash, so continuity never engages.
+    expect((await verifyEventLog(log)).verified).toBe(true);
+  });
+
+  test('authority-after-rotation: update by the NEW key verifies, by the OLD key fails', async () => {
+    const a = await makeRealSigner();
+    const b = await makeRealSigner();
+    let base = await genesisWith('v1', a);
+    base = await appendEvent(base, 'rotateKey', { newController: b.didKey, rotatedAt: 'x' },
+      { signer: a.signer, verificationMethod: a.vm });
+
+    const good = await appendEvent(base, 'update',
+      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: hex('v1'), toVersion: 2 },
+      { signer: b.signer, verificationMethod: b.vm });
+    expect((await verifyEventLog(good)).verified).toBe(true);
+
+    const bad = await appendEvent(base, 'update',
+      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: hex('v1'), toVersion: 2 },
+      { signer: a.signer, verificationMethod: a.vm });
+    expect((await verifyEventLog(bad)).verified).toBe(false);
+  });
+});

--- a/packages/sdk/tests/unit/lifecycle/ResourceVersioning.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/ResourceVersioning.test.ts
@@ -154,7 +154,7 @@ describe('OriginalsAsset - Resource Versioning', () => {
     expect(asset.resources[0].previousVersionHash).toBeUndefined();
   });
 
-  test('addResourceVersion creates new version and preserves old', () => {
+  test('addResourceVersion creates new version and preserves old', async () => {
     const resources: AssetResource[] = [
       {
         id: 'res1',
@@ -164,9 +164,9 @@ describe('OriginalsAsset - Resource Versioning', () => {
         hash: hashResource(Buffer.from('hello', 'utf-8'))
       }
     ];
-    
+
     const asset = new OriginalsAsset(resources, buildDid('did:peer:xyz'), emptyCreds);
-    const newResource = asset.addResourceVersion('res1', 'hello world', 'text/plain', 'Added world');
+    const newResource = await asset.addResourceVersion('res1', 'hello world', 'text/plain', 'Added world');
     
     expect(asset.resources.length).toBe(2);
     expect(newResource.version).toBe(2);
@@ -179,7 +179,7 @@ describe('OriginalsAsset - Resource Versioning', () => {
     expect(v1!.content).toBe('hello');
   });
 
-  test('addResourceVersion throws error if content unchanged', () => {
+  test('addResourceVersion throws error if content unchanged', async () => {
     const resources: AssetResource[] = [
       {
         id: 'res1',
@@ -189,15 +189,13 @@ describe('OriginalsAsset - Resource Versioning', () => {
         hash: hashResource(Buffer.from('hello', 'utf-8'))
       }
     ];
-    
+
     const asset = new OriginalsAsset(resources, buildDid('did:peer:xyz'), emptyCreds);
-    
-    expect(() => {
-      asset.addResourceVersion('res1', 'hello', 'text/plain');
-    }).toThrow('Content unchanged');
+
+    await expect(asset.addResourceVersion('res1', 'hello', 'text/plain')).rejects.toThrow('Content unchanged');
   });
 
-  test('addResourceVersion throws error if resource not found', () => {
+  test('addResourceVersion throws error if resource not found', async () => {
     const resources: AssetResource[] = [
       {
         id: 'res1',
@@ -207,15 +205,13 @@ describe('OriginalsAsset - Resource Versioning', () => {
         hash: hashResource(Buffer.from('hello', 'utf-8'))
       }
     ];
-    
+
     const asset = new OriginalsAsset(resources, buildDid('did:peer:xyz'), emptyCreds);
-    
-    expect(() => {
-      asset.addResourceVersion('nonexistent', 'content', 'text/plain');
-    }).toThrow('Resource with id nonexistent not found');
+
+    await expect(asset.addResourceVersion('nonexistent', 'content', 'text/plain')).rejects.toThrow('Resource with id nonexistent not found');
   });
 
-  test('getAllVersions returns all versions sorted', () => {
+  test('getAllVersions returns all versions sorted', async () => {
     const resources: AssetResource[] = [
       {
         id: 'res1',
@@ -225,11 +221,11 @@ describe('OriginalsAsset - Resource Versioning', () => {
         hash: hashResource(Buffer.from('v1', 'utf-8'))
       }
     ];
-    
+
     const asset = new OriginalsAsset(resources, buildDid('did:peer:xyz'), emptyCreds);
-    asset.addResourceVersion('res1', 'v2', 'text/plain');
-    asset.addResourceVersion('res1', 'v3', 'text/plain');
-    
+    await asset.addResourceVersion('res1', 'v2', 'text/plain');
+    await asset.addResourceVersion('res1', 'v3', 'text/plain');
+
     const versions = asset.getAllVersions('res1');
     expect(versions.length).toBe(3);
     expect(versions[0].version || 1).toBe(1);
@@ -237,7 +233,7 @@ describe('OriginalsAsset - Resource Versioning', () => {
     expect(versions[2].version).toBe(3);
   });
 
-  test('getResourceHistory returns complete history', () => {
+  test('getResourceHistory returns complete history', async () => {
     const resources: AssetResource[] = [
       {
         id: 'res1',
@@ -247,10 +243,10 @@ describe('OriginalsAsset - Resource Versioning', () => {
         hash: hashResource(Buffer.from('v1', 'utf-8'))
       }
     ];
-    
+
     const asset = new OriginalsAsset(resources, buildDid('did:peer:xyz'), emptyCreds);
-    asset.addResourceVersion('res1', 'v2', 'text/plain');
-    
+    await asset.addResourceVersion('res1', 'v2', 'text/plain');
+
     const history = asset.getResourceHistory('res1');
     expect(history).not.toBeNull();
     expect(history!.resourceId).toBe('res1');
@@ -258,7 +254,7 @@ describe('OriginalsAsset - Resource Versioning', () => {
     expect(history!.currentVersion.version).toBe(2);
   });
 
-  test('version chain integrity is verifiable', () => {
+  test('version chain integrity is verifiable', async () => {
     const resources: AssetResource[] = [
       {
         id: 'res1',
@@ -268,11 +264,11 @@ describe('OriginalsAsset - Resource Versioning', () => {
         hash: hashResource(Buffer.from('v1', 'utf-8'))
       }
     ];
-    
+
     const asset = new OriginalsAsset(resources, buildDid('did:peer:xyz'), emptyCreds);
-    asset.addResourceVersion('res1', 'v2', 'text/plain');
-    asset.addResourceVersion('res1', 'v3', 'text/plain');
-    
+    await asset.addResourceVersion('res1', 'v2', 'text/plain');
+    await asset.addResourceVersion('res1', 'v3', 'text/plain');
+
     // Access internal version manager for testing
     const history = asset.getResourceHistory('res1');
     expect(history).not.toBeNull();
@@ -305,8 +301,8 @@ describe('OriginalsAsset - Resource Versioning', () => {
       capturedEvent = event;
     });
     
-    asset.addResourceVersion('res1', 'v2', 'text/plain', 'Test changes');
-    
+    await asset.addResourceVersion('res1', 'v2', 'text/plain', 'Test changes');
+
     // Wait for microtask to complete
     await new Promise(resolve => setImmediate(resolve));
     
@@ -319,40 +315,32 @@ describe('OriginalsAsset - Resource Versioning', () => {
     expect(capturedEvent.changes).toBe('Test changes');
   });
 
-  test('provenance tracks resource updates', () => {
+  test('directly-constructed asset degrades: no appender ⇒ no provenance, emits cel:append-skipped', async () => {
     const resources: AssetResource[] = [
       {
         id: 'res1',
         type: 'text',
         content: 'v1',
         contentType: 'text/plain',
-        hash: hashResource(Buffer.from('v1', 'utf-8'))
+        hash: hashResource(Buffer.from('v1', 'utf-8')),
+        version: 1
       }
     ];
-    
+
     const asset = new OriginalsAsset(resources, buildDid('did:peer:xyz'), emptyCreds);
-    const v1Hash = resources[0].hash;
-    
-    asset.addResourceVersion('res1', 'v2', 'text/plain', 'First update');
-    asset.addResourceVersion('res1', 'v3', 'text/plain', 'Second update');
-    
-    const provenance = asset.getProvenance();
-    expect(provenance.resourceUpdates.length).toBe(2);
-    
-    const update1 = provenance.resourceUpdates[0];
-    expect(update1.resourceId).toBe('res1');
-    expect(update1.fromVersion).toBe(1);
-    expect(update1.toVersion).toBe(2);
-    expect(update1.fromHash).toBe(v1Hash);
-    expect(update1.changes).toBe('First update');
-    
-    const update2 = provenance.resourceUpdates[1];
-    expect(update2.fromVersion).toBe(2);
-    expect(update2.toVersion).toBe(3);
-    expect(update2.changes).toBe('Second update');
+    const skipped: unknown[] = [];
+    asset.on('cel:append-skipped', (e) => skipped.push(e));
+
+    await asset.addResourceVersion('res1', 'v2', 'text/plain', 'First update');
+    await asset.addResourceVersion('res1', 'v3', 'text/plain', 'Second update');
+
+    // In-memory versions advanced, but nothing provable was recorded.
+    expect(asset.getAllVersions('res1').map(r => r.version)).toEqual([1, 2, 3]);
+    expect(asset.getProvenance().resourceUpdates.length).toBe(0);
+    expect(skipped.length).toBe(2);
   });
 
-  test('hash-based content addressing validated', () => {
+  test('hash-based content addressing validated', async () => {
     const content1 = 'content 1';
     const content2 = 'content 2';
     const hash1 = hashResource(Buffer.from(content1, 'utf-8'));
@@ -371,13 +359,13 @@ describe('OriginalsAsset - Resource Versioning', () => {
     ];
     
     const asset = new OriginalsAsset(resources, buildDid('did:peer:xyz'), emptyCreds);
-    const newResource = asset.addResourceVersion('res1', content2, 'text/plain');
-    
+    const newResource = await asset.addResourceVersion('res1', content2, 'text/plain');
+
     expect(newResource.hash).toBe(hash2);
     expect(newResource.hash).not.toBe(hash1);
   });
 
-  test('addResourceVersion rejects Buffer content instead of silently dropping it (issue #276)', () => {
+  test('addResourceVersion rejects Buffer content instead of silently dropping it (issue #276)', async () => {
     const buffer1 = Buffer.from('binary content 1', 'utf-8');
     const resources: AssetResource[] = [
       {
@@ -394,11 +382,11 @@ describe('OriginalsAsset - Resource Versioning', () => {
     // bytes were unrecoverably lost. It now throws so the loss is impossible.
     // The parameter is declared `string` since issue #311, so JS callers
     // (modelled with the cast) still hit the runtime guard.
-    expect(() => asset.addResourceVersion('res1', buffer2 as unknown as string, 'application/octet-stream'))
-      .toThrow(/binary \(Buffer\) content/);
+    await expect(asset.addResourceVersion('res1', buffer2 as unknown as string, 'application/octet-stream'))
+      .rejects.toThrow(/binary \(Buffer\) content/);
   });
 
-  test('versioning works across all layers (did:peer)', () => {
+  test('versioning works across all layers (did:peer)', async () => {
     const resources: AssetResource[] = [
       {
         id: 'res1',
@@ -408,15 +396,15 @@ describe('OriginalsAsset - Resource Versioning', () => {
         hash: hashResource(Buffer.from('v1', 'utf-8'))
       }
     ];
-    
+
     const asset = new OriginalsAsset(resources, buildDid('did:peer:xyz'), emptyCreds);
     expect(asset.currentLayer).toBe('did:peer');
-    
-    const newResource = asset.addResourceVersion('res1', 'v2', 'text/plain');
+
+    const newResource = await asset.addResourceVersion('res1', 'v2', 'text/plain');
     expect(newResource.version).toBe(2);
   });
 
-  test('versioning works across all layers (did:webvh)', () => {
+  test('versioning works across all layers (did:webvh)', async () => {
     const resources: AssetResource[] = [
       {
         id: 'res1',
@@ -426,15 +414,15 @@ describe('OriginalsAsset - Resource Versioning', () => {
         hash: hashResource(Buffer.from('v1', 'utf-8'))
       }
     ];
-    
+
     const asset = new OriginalsAsset(resources, buildDid('did:webvh:example.com:xyz'), emptyCreds);
     expect(asset.currentLayer).toBe('did:webvh');
-    
-    const newResource = asset.addResourceVersion('res1', 'v2', 'text/plain');
+
+    const newResource = await asset.addResourceVersion('res1', 'v2', 'text/plain');
     expect(newResource.version).toBe(2);
   });
 
-  test('versioning works across all layers (did:btco)', () => {
+  test('versioning works across all layers (did:btco)', async () => {
     const resources: AssetResource[] = [
       {
         id: 'res1',
@@ -444,15 +432,15 @@ describe('OriginalsAsset - Resource Versioning', () => {
         hash: hashResource(Buffer.from('v1', 'utf-8'))
       }
     ];
-    
+
     const asset = new OriginalsAsset(resources, buildDid('did:btco:123'), emptyCreds);
     expect(asset.currentLayer).toBe('did:btco');
-    
-    const newResource = asset.addResourceVersion('res1', 'v2', 'text/plain');
+
+    const newResource = await asset.addResourceVersion('res1', 'v2', 'text/plain');
     expect(newResource.version).toBe(2);
   });
 
-  test('multiple resources can be versioned independently', () => {
+  test('multiple resources can be versioned independently', async () => {
     const resources: AssetResource[] = [
       {
         id: 'res1',
@@ -469,21 +457,21 @@ describe('OriginalsAsset - Resource Versioning', () => {
         hash: hashResource(Buffer.from('res2-v1', 'utf-8'))
       }
     ];
-    
+
     const asset = new OriginalsAsset(resources, buildDid('did:peer:xyz'), emptyCreds);
-    
-    asset.addResourceVersion('res1', 'res1-v2', 'text/plain');
-    asset.addResourceVersion('res2', 'res2-v2', 'text/plain');
-    asset.addResourceVersion('res1', 'res1-v3', 'text/plain');
-    
+
+    await asset.addResourceVersion('res1', 'res1-v2', 'text/plain');
+    await asset.addResourceVersion('res2', 'res2-v2', 'text/plain');
+    await asset.addResourceVersion('res1', 'res1-v3', 'text/plain');
+
     const res1Versions = asset.getAllVersions('res1');
     const res2Versions = asset.getAllVersions('res2');
-    
+
     expect(res1Versions.length).toBe(3);
     expect(res2Versions.length).toBe(2);
   });
 
-  test('timestamp is recorded for each version', () => {
+  test('timestamp is recorded for each version', async () => {
     const resources: AssetResource[] = [
       {
         id: 'res1',
@@ -493,11 +481,11 @@ describe('OriginalsAsset - Resource Versioning', () => {
         hash: hashResource(Buffer.from('v1', 'utf-8'))
       }
     ];
-    
+
     const asset = new OriginalsAsset(resources, buildDid('did:peer:xyz'), emptyCreds);
     const beforeTime = new Date().toISOString();
-    
-    const newResource = asset.addResourceVersion('res1', 'v2', 'text/plain');
+
+    const newResource = await asset.addResourceVersion('res1', 'v2', 'text/plain');
     const afterTime = new Date().toISOString();
     
     expect(newResource.createdAt).toBeDefined();

--- a/packages/sdk/tests/unit/lifecycle/addResourceVersion.celevent.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/addResourceVersion.celevent.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, expect } from 'bun:test';
+import { OriginalsAsset } from '../../../src/lifecycle/OriginalsAsset';
+import type { AssetResource, DIDDocument } from '../../../src/types';
+import type { CelAppendSkippedEvent } from '../../../src/events/types';
+
+function makeAsset(): OriginalsAsset {
+  const did: DIDDocument = { id: 'did:peer:zabc' } as DIDDocument;
+  const resources: AssetResource[] = [
+    { id: 'r', type: 'text', content: 'v1', contentType: 'text/plain', hash: '', version: 1 } as AssetResource,
+  ];
+  // Fix the hash to match content so continuity checks elsewhere line up.
+  const { hashResource } = require('../../../src/utils/validation');
+  resources[0].hash = hashResource(Buffer.from('v1', 'utf-8'));
+  return new OriginalsAsset(resources, did, []);
+}
+
+describe('addResourceVersion: injected CEL appender', () => {
+  test('calls the bound appender with the resource-update body and updates resources', async () => {
+    const asset = makeAsset();
+    const calls: Array<{ type: string; data: any }> = [];
+    asset._bindCelAppender(async (type, data) => {
+      calls.push({ type, data });
+      return 'zHeadDigest'; // pretend the append committed
+    });
+
+    const created = await asset.addResourceVersion('r', 'v2', 'text/plain', 'edit');
+
+    expect(created.version).toBe(2);
+    expect(calls.length).toBe(1);
+    expect(calls[0].type).toBe('update');
+    expect(calls[0].data.resourceId).toBe('r');
+    expect(calls[0].data.content).toBe('v2');
+    expect(calls[0].data.contentType).toBe('text/plain');
+    expect(typeof calls[0].data.previousVersionHash).toBe('string');
+    expect(calls[0].data.toVersion).toBe(2);
+    // In-memory resources updated.
+    expect(asset.getResourceVersion('r', 2)?.content).toBe('v2');
+  });
+
+  test('degrades: no appender bound emits cel:append-skipped and does NOT record provenance', async () => {
+    const asset = makeAsset();
+    const skipped: CelAppendSkippedEvent[] = [];
+    asset.on('cel:append-skipped', (e) => skipped.push(e as CelAppendSkippedEvent));
+
+    const created = await asset.addResourceVersion('r', 'v2', 'text/plain');
+
+    expect(created.version).toBe(2);                       // in-memory still versioned
+    expect(asset.getProvenance().resourceUpdates.length).toBe(0); // not provable
+    expect(skipped.length).toBe(1);
+  });
+
+  test('appender returning null (skip) updates resources but not provenance', async () => {
+    const asset = makeAsset();
+    asset._bindCelAppender(async () => null); // signer unavailable
+    await asset.addResourceVersion('r', 'v2', 'text/plain');
+    expect(asset.getResourceVersion('r', 2)?.content).toBe('v2');
+    expect(asset.getProvenance().resourceUpdates.length).toBe(0);
+  });
+});

--- a/packages/sdk/tests/unit/lifecycle/assetEnvelope.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/assetEnvelope.test.ts
@@ -46,7 +46,7 @@ describe('AssetEnvelope + serialize() (#377)', () => {
     await sdk.lifecycle.inscribeOnBitcoin(asset);
     const btcoBinding = asset.bindings!['did:btco'];
 
-    // A post-genesis resource version → rides envelope-only (no CEL event until Phase 4).
+    // A post-genesis resource version → appends a signed `update` CEL event.
     await asset.addResourceVersion('note', 'hello originals v2', 'text/plain', 'edit');
 
     const env = asset.serialize();
@@ -57,8 +57,9 @@ describe('AssetEnvelope + serialize() (#377)', () => {
     expect(env.assetDid).toBe(didCel);
 
     // eventLog is THE provenance encoding, embedded as a parsed object. The
-    // trailing update is the btco migrate's acknowledgeWitness (map §5.1).
-    expect(env.eventLog.events.map(e => e.type)).toEqual(['create', 'migrate', 'migrate', 'update']);
+    // first update is the btco migrate's acknowledgeWitness (map §5.1); the
+    // second is the signed resource-version update appended above.
+    expect(env.eventLog.events.map(e => e.type)).toEqual(['create', 'migrate', 'migrate', 'update', 'update']);
     const folded = replayProvenance(env.eventLog);
     expect(folded.bindings['did:cel']).toBe(didCel);
     expect(folded.bindings['did:webvh']).toBe(webvhBinding);
@@ -74,11 +75,30 @@ describe('AssetEnvelope + serialize() (#377)', () => {
     expect(note.some(r => r.content === content)).toBe(true);
     expect(note.some(r => r.content === 'hello originals v2')).toBe(true);
 
-    // Honesty section: btco IS log-derivable → no advisory bindings. feeRate +
-    // resourceUpdates ride from the provenance cache.
+    // Honesty section: btco IS log-derivable → no advisory bindings. feeRate
+    // rides the provenance cache; resourceUpdates is no longer advisory (hard
+    // cutover — it's folded from the signed `update` log event instead).
     expect(env.unverified?.bindings).toBeUndefined();
     expect(typeof env.unverified?.feeRate).toBe('number');
-    expect(env.unverified?.resourceUpdates?.some(u => u.resourceId === 'note' && u.toVersion === 2)).toBe(true);
+    expect(folded.resourceUpdates.some(u => u.resourceId === 'note' && u.toVersion === 2)).toBe(true);
+  });
+
+  test('serialize no longer emits unverified.resourceUpdates; loadAsset folds versions from the log', async () => {
+    const sdk = makeSDK();
+    const asset = await sdk.lifecycle.createAsset([
+      { id: 'note', type: 'text', content: 'hello v1', contentType: 'text/plain', hash: hashResource(Buffer.from('hello v1', 'utf-8')) }
+    ]);
+    await asset.addResourceVersion('note', 'hello v2', 'text/plain', 'edit');
+
+    const env = asset.serialize();
+    // Cutover: the advisory array is gone.
+    expect((env.unverified as any)?.resourceUpdates).toBeUndefined();
+    // The update event is on the log.
+    expect(env.eventLog.events.some(e => e.type === 'update')).toBe(true);
+    // A fresh SDK (no keys) loads and the folded provenance shows the version.
+    const fresh = makeSDK(false);
+    const { asset: loaded } = await fresh.lifecycle.loadAsset(env);
+    expect(loaded.getProvenance().resourceUpdates.some(u => u.resourceId === 'note' && u.toVersion === 2)).toBe(true);
   });
 
   test('serialize is JSON-safe: JSON.parse(JSON.stringify(env)) deep-equals', async () => {

--- a/packages/sdk/tests/unit/lifecycle/assetEnvelope.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/assetEnvelope.test.ts
@@ -47,7 +47,7 @@ describe('AssetEnvelope + serialize() (#377)', () => {
     const btcoBinding = asset.bindings!['did:btco'];
 
     // A post-genesis resource version → rides envelope-only (no CEL event until Phase 4).
-    asset.addResourceVersion('note', 'hello originals v2', 'text/plain', 'edit');
+    await asset.addResourceVersion('note', 'hello originals v2', 'text/plain', 'edit');
 
     const env = asset.serialize();
 

--- a/packages/sdk/tests/unit/lifecycle/replayProvenance.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/replayProvenance.test.ts
@@ -21,8 +21,13 @@ import { MemoryStorageAdapter } from '../../../src/storage/MemoryStorageAdapter'
 import { OrdMockProvider } from '../../../src/adapters/providers/OrdMockProvider';
 import { deriveDidCel } from '../../../src/cel/celDid';
 import { appendEvent } from '../../../src/cel/algorithms/appendEvent';
-import { createKeyStoreCelSigner, currentControllerVm } from '../../../src/cel/signerAdapter';
+import { createKeyStoreCelSigner, currentControllerVm, hexSha256ToDigestMultibase } from '../../../src/cel/signerAdapter';
 import { replayProvenance } from '../../../src/lifecycle/replayProvenance';
+import { hashResource } from '../../../src/utils/validation';
+import { createEventLog } from '../../../src/cel/algorithms/createEventLog';
+import { multikey } from '../../../src/crypto/Multikey';
+import { canonicalizeEvent } from '../../../src/cel/canonicalize';
+import * as ed25519 from '@noble/ed25519';
 
 const VALID_ADDR = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx';
 
@@ -211,5 +216,53 @@ describe('replayProvenance pure fold (#Phase2 Task7)', () => {
     const folded = replayProvenance(log);
     expect(folded.currentLayer).toBe('did:btco');
     expect(folded.bindings['did:btco']).toBe('did:btco:reg:111'); // signed, not the witness 999
+  });
+});
+
+async function makeReplaySigner() {
+  const priv = crypto.getRandomValues(new Uint8Array(32));
+  const pub = await ed25519.getPublicKeyAsync(priv);
+  const pubMb = multikey.encodePublicKey(pub, 'Ed25519');
+  const didKey = `did:key:${pubMb}`;
+  const vm = `${didKey}#${pubMb}`;
+  const signer = async (data: unknown) => ({
+    type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', created: '2021-05-05T00:00:00Z',
+    verificationMethod: vm, proofPurpose: 'assertionMethod',
+    proofValue: multikey.encodeMultibase(new Uint8Array(await ed25519.signAsync(canonicalizeEvent(data), priv))),
+  });
+  return { signer, didKey, vm };
+}
+const rhex = (s: string) => hashResource(Buffer.from(s, 'utf-8'));
+
+describe('replayProvenance: resourceUpdates fold', () => {
+  test('folds update events into resourceUpdates with derived toHash', async () => {
+    const a = await makeReplaySigner();
+    let log = await createEventLog(
+      { name: 'r', controller: a.didKey, resources: [{ digestMultibase: hexSha256ToDigestMultibase(rhex('v1')) }], createdAt: 'x', nonce: 'z1' },
+      { signer: a.signer, verificationMethod: a.vm }
+    );
+    log = await appendEvent(log, 'update',
+      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: rhex('v1'), toVersion: 2 },
+      { signer: a.signer, verificationMethod: a.vm });
+
+    const folded = replayProvenance(log);
+    expect(folded.resourceUpdates.length).toBe(1);
+    const u = folded.resourceUpdates[0];
+    expect(u.resourceId).toBe('r');
+    expect(u.fromVersion).toBe(1);
+    expect(u.toVersion).toBe(2);
+    expect(u.fromHash).toBe(rhex('v1'));
+    expect(u.toHash).toBe(rhex('v2'));
+    expect(u.timestamp).toBe('2021-05-05T00:00:00Z');
+  });
+
+  test('generic and migration-ish updates do NOT fold into resourceUpdates', async () => {
+    const a = await makeReplaySigner();
+    let log = await createEventLog(
+      { name: 'r', controller: a.didKey, resources: [{ digestMultibase: hexSha256ToDigestMultibase(rhex('v1')) }], createdAt: 'x', nonce: 'z2' },
+      { signer: a.signer, verificationMethod: a.vm }
+    );
+    log = await appendEvent(log, 'update', { note: 'generic' }, { signer: a.signer, verificationMethod: a.vm });
+    expect(replayProvenance(log).resourceUpdates.length).toBe(0);
   });
 });


### PR DESCRIPTION
Turns post-genesis resource versions from advisory, unverifiable envelope metadata into **signed `update` CEL events** — so provenance for every authorship op, not just genesis, is cryptographically verifiable. Design: `docs/superpowers/specs/2026-07-13-resource-update-events-on-log-design.md`.

## What changes
- `addResourceVersion` now appends a signed `'update'` CEL event that **embeds the new file**; `toHash` is derived (`hashResource(content)`), `previousVersionHash` chains from the genesis resource digest. A buyer verifying **offline** has the actual file in hand.
- **`addResourceVersion` becomes async** with an injected controller appender; it degrades with `cel:append-skipped` when no signer (and `UNPROVABLE_BASE` when the in-memory head has diverged from the on-log head — fail-closed, never poisons the log).
- Verifier: a resource-shaped `update` must chain `previousVersionHash` to the last on-log hash for that `resourceId` (seeded from the genesis digest set) and be signed by the **current** controller (post-rotation authority). Reuses the existing authority walk; only the continuity link is new.
- **Hard cutover:** `serialize()` and the `AssetEnvelope` type drop `unverified.resourceUpdates`; `loadAsset` folds versions from the log.

## Reviews
6 tasks, each per-task reviewed (fable on the verifier task); final whole-branch review (fable) found 2 Important seam bugs — **off-log continuity-base poisoning** and a **concurrent-append race** — both fixed and **re-reviewed (fable): FIX SOUND**, both proven fail-closed. Full suite: **3925 pass / 0 fail / 70 skip** (after `bun run build`; the transient 16 are the known stale-`dist` CEL-CLI subprocess tests).

## Follow-ups (all fail-closed, non-blocking)
- **#400:** unify append serialization — the per-asset mutex covers `addResourceVersion` but not a concurrent migrate/rotate append (feature-created surface). Plus minor residuals (re-entrancy, emitter split, multi-version-genesis false-close) noted there.

Phase 4 sub-project 1 of 5 in the did:cel epic; independent of the anchored-sat work (off main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move resource versioning from advisory envelope metadata to signed CEL `update` events
> - `addResourceVersion` is now async and appends a signed CEL `update` event via a manager-bound signer, with per-asset mutex serialization to prevent concurrent append races.
> - `verifyEventLog` now enforces per-resource continuity and content binding for `update` events, rejecting those whose `previousVersionHash` does not chain from the last-known hash or genesis digest.
> - `replayProvenance` folds resource-shaped `update` events into `resourceUpdates` with derived hashes; `loadAsset` rejects envelopes whose post-genesis resource versions are not backed by verified log events.
> - When no signer is bound, `addResourceVersion` degrades gracefully: in-memory versions still advance and a `cel:append-skipped` event is emitted with reason `NO_SIGNING_KEY`, `NO_CEL_LOG`, or `UNPROVABLE_BASE`.
> - Risk: Breaking changes — `addResourceVersion` is now async (callers must `await` it) and `AssetEnvelope.unverified.resourceUpdates` is removed; consumers must fold resource versions from the event log.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e43aaf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->