### PR TITLE
fix(cel): BtcoCelManager.migrate signs the anchoring sat (pin-sat-first, #397)

### DIFF
--- a/.changeset/btcocel-sign-sat.md
+++ b/.changeset/btcocel-sign-sat.md
@@ -1,0 +1,22 @@
+---
+"@originals/sdk": patch
+---
+
+Sign the anchoring sat on the secondary btco writer (`BtcoCelManager.migrate` /
+`cel migrate` → btco), completing the anchored-sat binding for every btco path
+and closing the known follow-up (#397) from the Part A cutover. The migrate-to-btco
+CEL event now uses a pin-sat-first inscribe: `bitcoinManager.inscribeData({ buildContent })`
+pins the satoshi before the reveal, so the event body can sign
+`data.to = did:btco:<network>:<sat>` and inscribe the asset's btco DID document
+(whose `#cel` OriginalsCelAnchor commits to that event's chain digest and IS the
+Bitcoin witness artifact, with the `did:cel` back-linked in `alsoKnownAs`). This
+un-quarantines the `BtcoCelManager` btco verifiability path — logs it produces now
+pass `verifyEventLog` instead of failing `UNBOUND_ANCHOR`.
+
+Fails closed: the sat signed into `data.to`, the sat the inscription landed on, and
+the sat the witness proof carries must all agree, or `migrate` throws rather than
+emitting a mis-anchored log. The witness proof satoshi is normalised to a string
+(the verifier only recognises string sats), and a `lockKey` is passed to
+`inscribeData` so a concurrent inscription of the same asset is rejected before
+broadcast rather than double-paying. The verifier and the production
+`LifecycleManager.inscribeOnBitcoin` path are unchanged.

--- a/packages/sdk/src/cel/cli/migrate.ts
+++ b/packages/sdk/src/cel/cli/migrate.ts
@@ -273,12 +273,20 @@ function createMockBitcoinManager(): any {
   // For CLI use, we create a minimal mock that satisfies the interface
   // Real Bitcoin integration requires additional configuration
   return {
-    // eslint-disable-next-line @typescript-eslint/require-await
-    inscribeData: async (_data: unknown) => {
+    network: 'mainnet',
+    inscribeData: async (data: unknown) => {
       // Generate mock Bitcoin transaction details
       const timestamp = Date.now();
       const mockTxid = `cli_mock_tx_${timestamp.toString(16)}`;
       const mockInscriptionId = `cli_mock_inscription_${timestamp.toString(16)}i0`;
+      const satoshi = 10000;
+
+      // BtcoCelManager pins the sat first: it inscribes via a buildContent(satoshi)
+      // callback so the migrate body can sign `to: did:btco:<sat>`. Invoke it with
+      // the satoshi we will return (mirrors OrdMockProvider/BitcoinManager).
+      if (typeof data === 'function') {
+        await (data as (s: string) => Buffer | Promise<Buffer>)(String(satoshi));
+      }
 
       console.error('\n⚠️  Note: Using mock Bitcoin manager for CLI migration.');
       console.error('    For real Bitcoin inscriptions, use the SDK programmatically.\n');
@@ -286,7 +294,7 @@ function createMockBitcoinManager(): any {
       return {
         txid: mockTxid,
         inscriptionId: mockInscriptionId,
-        satoshi: 10000,
+        satoshi,
         blockHeight: 0, // Will be set when confirmed
       };
     },

--- a/packages/sdk/src/cel/layers/BtcoCelManager.ts
+++ b/packages/sdk/src/cel/layers/BtcoCelManager.ts
@@ -516,15 +516,16 @@ export class BtcoCelManager {
           }
         }
         
-        // Store other fields in metadata. `network` is consumed (and stored)
-        // explicitly only for btco migration events, so exclude it here for
-        // those events alone — for an ordinary update, an application-defined
-        // `network` field must still flow through to metadata.
-        const excludedKeys = ['name', 'resources', 'updatedAt', 'did', 'layer', 'creator', 'createdAt', 'sourceDid', 'targetDid', 'to', 'domain', 'migratedAt', 'txid', 'inscriptionId'];
+        // Store other fields in metadata. `network` and `to` are the SIGNED
+        // btco-anchor fields, consumed (and stored) explicitly only for btco
+        // migration events, so exclude them here for those events alone — for an
+        // ordinary update, an application-defined `network`/`to` field must still
+        // flow through to metadata rather than being silently stripped.
+        const excludedKeys = ['name', 'resources', 'updatedAt', 'did', 'layer', 'creator', 'createdAt', 'sourceDid', 'targetDid', 'domain', 'migratedAt', 'txid', 'inscriptionId'];
         const isBtcoMigration = updateData.layer === 'btco' &&
           (event.type === 'migrate' || (updateData.sourceDid && updateData.migratedAt));
         if (isBtcoMigration) {
-          excludedKeys.push('network');
+          excludedKeys.push('network', 'to');
         }
         for (const [key, value] of Object.entries(updateData)) {
           if (!excludedKeys.includes(key)) {

--- a/packages/sdk/src/cel/layers/BtcoCelManager.ts
+++ b/packages/sdk/src/cel/layers/BtcoCelManager.ts
@@ -11,14 +11,14 @@
  * @see https://github.com/aviarytech/did-btco
  */
 
-import type { EventLog, ExternalReference, UpdateOptions, AssetState } from '../types.js';
+import type { EventLog, ExternalReference, UpdateOptions, AssetState, WitnessProof } from '../types.js';
 import { appendEvent } from '../algorithms/appendEvent.js';
-import { witnessEvent } from '../algorithms/witnessEvent.js';
-import { BitcoinWitness } from '../witnesses/BitcoinWitness.js';
 import type { BitcoinManager } from '../../bitcoin/BitcoinManager.js';
 import type { CelSigner } from './PeerCelManager.js';
-import { btcoDidPrefix } from '../btcoDid.js';
+import { btcoDidPrefix, btcoDidFromSatoshi } from '../btcoDid.js';
 import { deriveDidCel } from '../celDid.js';
+import { computeDigestMultibase } from '../hash.js';
+import { canonicalizeEntryForChain } from '../canonicalize.js';
 
 /**
  * Configuration options for BtcoCelManager
@@ -52,6 +52,15 @@ export interface BtcoMigrationData {
    * derivation rather than being embedded in (and signed as part of) the data.
    */
   targetDid?: string;
+  /**
+   * The resolvable `did:btco:<network>:<sat>` anchor, SIGNED into the migrate
+   * body (#397, design 2026-07-13). Unlike targetDid this is required by the
+   * anchored-sat verifier: the sat is pinned before the reveal (via
+   * inscribeData's buildContent callback) so it can be signed here, and the
+   * verifier derives the anchoring sat from THIS signed field — not the
+   * unsigned witness proof. Absent only on legacy logs written before #397.
+   */
+  to?: string;
   /** The target layer */
   layer: 'btco';
   /**
@@ -96,7 +105,6 @@ export interface BtcoMigrationData {
 export class BtcoCelManager {
   private signer: CelSigner;
   private bitcoinManager?: BitcoinManager;
-  private _bitcoinWitness?: BitcoinWitness;
   private config: BtcoCelConfig;
 
   /**
@@ -146,17 +154,6 @@ export class BtcoCelManager {
       throw new Error('BTCO operations require a BitcoinManager. Provide it in config.btco.bitcoinManager');
     }
     return this.bitcoinManager;
-  }
-
-  /** Lazily-created Bitcoin witness service (requires a BitcoinManager). */
-  private get bitcoinWitness(): BitcoinWitness {
-    if (!this._bitcoinWitness) {
-      this._bitcoinWitness = new BitcoinWitness(this.requireBitcoinManager(), {
-        feeRate: this.config.feeRate,
-        verificationMethod: this.config.verificationMethod,
-      });
-    }
-    return this._bitcoinWitness;
   }
 
   /**
@@ -241,28 +238,16 @@ export class BtcoCelManager {
       throw new Error('Cannot migrate a deactivated event log');
     }
 
-    // Finalize the migration data BEFORE signing. The controller signature and
-    // the witness digest both commit to {type, data, previousEvent}; mutating
-    // `data` after signing (as this code previously did to splice in
-    // txid/inscriptionId) invalidates both, so every btco log failed
-    // verification. The Bitcoin details cannot be known before the inscription
-    // (chicken-and-egg): txid, inscriptionId AND the satoshi that forms the
-    // canonical did:btco:<sat> identifier all come from the inscription. They
-    // are therefore NOT part of the signed data — they live in the bitcoin
-    // witness proof (added after signing, excluded from the chain digest) and
-    // the resolvable targetDid is derived from the proof's satoshi at
-    // state-derivation time.
-    const migrationData: BtcoMigrationData = {
-      sourceDid: currentDid,
-      layer: 'btco',
-      // Record the network in the SIGNED data. The satoshi is not yet known
-      // (it comes from the inscription, via the witness proof), but the network
-      // is known now — recording it here keeps state derivation deterministic:
-      // replaying the log yields the same network-scoped did:btco identifier
-      // regardless of the SDK's configured network.
-      network: bitcoinManager.network,
-      migratedAt: new Date().toISOString(),
-    };
+    const network = bitcoinManager.network;
+
+    // The did:cel back-link so on-chain anchorings are enumerable for the
+    // first-anchor-wins uniqueness check: new-shape genesis derives its did:cel;
+    // a legacy genesis embeds `did` (uniqueness is not run for those, but the
+    // back-link is harmless). Placed in the inscribed doc's alsoKnownAs.
+    const genesisData = createEvent.data as Record<string, unknown>;
+    const didCel = genesisData.controller !== undefined
+      ? deriveDidCel(webvhLog)
+      : (genesisData.did as string | undefined);
 
     // Build update options
     const updateOptions: UpdateOptions = {
@@ -271,22 +256,110 @@ export class BtcoCelManager {
       proofPurpose: this.config.proofPurpose,
     };
 
-    // Append the (final, signed) first-class migrate event with the migration data.
-    const updatedLog = await appendEvent(webvhLog, 'migrate', migrationData, updateOptions);
-
-    // Add the Bitcoin witness proof (REQUIRED at btco layer). This attests the
-    // already-signed event content and appends the txid/inscriptionId; it does
-    // not — and must not — alter the signed `data`.
-    const lastEventIndex = updatedLog.events.length - 1;
-    const witnessedEvent = await witnessEvent(updatedLog.events[lastEventIndex], this.bitcoinWitness);
-
-    return {
-      ...updatedLog,
-      events: [
-        ...updatedLog.events.slice(0, lastEventIndex),
-        witnessedEvent,
-      ],
+    // Pin-sat-first (#397, design 2026-07-13). The anchored-sat verifier requires
+    // the migrate body to SIGN its anchoring sat as `to: did:btco:<network>:<sat>`,
+    // but the sat is only known after the reveal. inscribeData's buildContent
+    // callback pins the sat BEFORE the reveal, so we sign the migrate event —
+    // carrying the resolvable `to` — inside it, then inscribe the asset's btco DID
+    // document, which IS the witness artifact: its #cel OriginalsCelAnchor commits
+    // to that event's chain digest. Mirrors LifecycleManager.inscribeOnBitcoin.
+    // (Replaces the old digest-first appendEvent→witnessEvent path, which emitted a
+    // bare migrate the verifier now rejects with UNBOUND_ANCHOR.)
+    let signedLog: EventLog | undefined;
+    let signedTo: string | undefined;
+    const inscription = await bitcoinManager.inscribeData(
+      async (satoshi: string) => {
+        const migrationData: BtcoMigrationData = {
+          sourceDid: currentDid!,
+          layer: 'btco',
+          // The network lives in the SIGNED data so replaying the log is
+          // deterministic; the sat completes the resolvable `to` anchor.
+          network,
+          to: btcoDidFromSatoshi(satoshi, network),
+          migratedAt: new Date().toISOString(),
+        };
+        signedTo = migrationData.to;
+        signedLog = await appendEvent(webvhLog, 'migrate', migrationData, updateOptions);
+        // The DID doc's #cel anchor commits to THIS migrate event's chain digest
+        // (proof-excluded), so the append must precede doc construction.
+        const migrateEvent = signedLog.events[signedLog.events.length - 1];
+        const headDigestMultibase = computeDigestMultibase(canonicalizeEntryForChain(migrateEvent));
+        const btcoDid = btcoDidFromSatoshi(satoshi, network);
+        const btcoDoc = {
+          '@context': ['https://www.w3.org/ns/did/v1'],
+          id: btcoDid,
+          // Back-link the did:cel so on-chain anchorings are enumerable (uniqueness).
+          ...(didCel ? { alsoKnownAs: [didCel] } : {}),
+          service: [
+            {
+              id: `${btcoDid}#cel`,
+              type: 'OriginalsCelAnchor',
+              serviceEndpoint: { headDigestMultibase },
+            },
+          ],
+        };
+        return Buffer.from(JSON.stringify(btcoDoc));
+      },
+      'application/did+json',
+      this.config.feeRate
+    ) as {
+      txid: string;
+      inscriptionId: string;
+      satoshi?: string;
+      blockHeight?: number;
     };
+
+    if (!signedLog || signedTo === undefined) {
+      throw new Error('Bitcoin inscription did not invoke the buildContent callback to sign the migrate event');
+    }
+    if (!inscription.inscriptionId || !inscription.txid) {
+      throw new Error('Bitcoin inscription did not return a valid inscription id or transaction id');
+    }
+    // The satoshi anchors the did:btco identity. Fail closed if absent, and —
+    // critically — if it diverges from the sat signed into `data.to`: the sat
+    // signed, the sat the witness proof carries, and the sat the inscription
+    // landed on MUST all agree, or the log would anchor to the wrong sat.
+    const satoshi = inscription.satoshi;
+    if (!satoshi) {
+      throw new Error('Bitcoin inscription did not return a satoshi ordinal (required for the did:btco anchor)');
+    }
+    if (signedTo !== btcoDidFromSatoshi(satoshi, network)) {
+      throw new Error(
+        `Anchoring sat mismatch: migrate event signed ${signedTo} but the inscription landed on satoshi ${satoshi}`
+      );
+    }
+
+    // Attach the bitcoin witness proof carrying that SAME sat. Chain digests
+    // exclude the proof array, so this post-hoc attach cannot alter the signed
+    // body or the anchored head digest (mirrors witnessEvent / LifecycleManager).
+    const now = new Date().toISOString();
+    const witnessProof: WitnessProof & {
+      txid: string;
+      satoshi: string;
+      inscriptionId: string;
+      blockHeight?: number;
+    } = {
+      type: 'DataIntegrityProof',
+      cryptosuite: 'bitcoin-ordinals-2024',
+      created: now,
+      verificationMethod: this.config.verificationMethod ?? 'did:btco:witness',
+      proofPurpose: 'assertionMethod',
+      proofValue: `z${inscription.inscriptionId}`,
+      witnessedAt: now,
+      txid: inscription.txid,
+      satoshi,
+      inscriptionId: inscription.inscriptionId,
+      ...(inscription.blockHeight !== undefined ? { blockHeight: inscription.blockHeight } : {}),
+    };
+
+    const migrateIdx = signedLog.events.length - 1;
+    const events = signedLog.events.slice();
+    events[migrateIdx] = {
+      ...events[migrateIdx],
+      proof: [...events[migrateIdx].proof, witnessProof],
+    };
+
+    return { ...signedLog, events };
   }
 
   /**
@@ -440,7 +513,7 @@ export class BtcoCelManager {
         // explicitly only for btco migration events, so exclude it here for
         // those events alone — for an ordinary update, an application-defined
         // `network` field must still flow through to metadata.
-        const excludedKeys = ['name', 'resources', 'updatedAt', 'did', 'layer', 'creator', 'createdAt', 'sourceDid', 'targetDid', 'domain', 'migratedAt', 'txid', 'inscriptionId'];
+        const excludedKeys = ['name', 'resources', 'updatedAt', 'did', 'layer', 'creator', 'createdAt', 'sourceDid', 'targetDid', 'to', 'domain', 'migratedAt', 'txid', 'inscriptionId'];
         const isBtcoMigration = updateData.layer === 'btco' &&
           (event.type === 'migrate' || (updateData.sourceDid && updateData.migratedAt));
         if (isBtcoMigration) {

--- a/packages/sdk/src/cel/layers/BtcoCelManager.ts
+++ b/packages/sdk/src/cel/layers/BtcoCelManager.ts
@@ -301,7 +301,11 @@ export class BtcoCelManager {
         return Buffer.from(JSON.stringify(btcoDoc));
       },
       'application/did+json',
-      this.config.feeRate
+      this.config.feeRate,
+      // Key the shared money-lock by the asset's stable identity so a concurrent
+      // inscription of the same asset (even from another manager) is rejected
+      // before broadcast rather than double-paying (mirrors LifecycleManager, #303).
+      { lockKey: didCel ?? currentDid }
     ) as {
       txid: string;
       inscriptionId: string;
@@ -319,10 +323,13 @@ export class BtcoCelManager {
     // critically — if it diverges from the sat signed into `data.to`: the sat
     // signed, the sat the witness proof carries, and the sat the inscription
     // landed on MUST all agree, or the log would anchor to the wrong sat.
-    const satoshi = inscription.satoshi;
-    if (!satoshi) {
+    // Normalise to a string: the verifier only recognises bitcoin witness proofs
+    // whose `satoshi` is a string, so a provider that returns a numeric sat would
+    // otherwise produce a paid-for but permanently unverifiable log.
+    if (inscription.satoshi === undefined || inscription.satoshi === null || (inscription.satoshi as unknown) === '') {
       throw new Error('Bitcoin inscription did not return a satoshi ordinal (required for the did:btco anchor)');
     }
+    const satoshi = String(inscription.satoshi);
     if (signedTo !== btcoDidFromSatoshi(satoshi, network)) {
       throw new Error(
         `Anchoring sat mismatch: migrate event signed ${signedTo} but the inscription landed on satoshi ${satoshi}`

--- a/packages/sdk/tests/unit/cel/BtcoCelManager.test.ts
+++ b/packages/sdk/tests/unit/cel/BtcoCelManager.test.ts
@@ -522,6 +522,33 @@ describe('BtcoCelManager', () => {
       expect(state.name).toBe('B');
     });
 
+    it('preserves an application-defined `to` field on an ordinary update', async () => {
+      // Regression (#397 greptile P2): `to` is the SIGNED btco-anchor field, so it
+      // must be stripped from metadata only on btco migration events — not globally.
+      // An ordinary update carrying an application-defined `to` must keep it.
+      const log = {
+        events: [
+          { type: 'create', data: { did: 'did:peer:abc', name: 'A', layer: 'peer', resources: [] } },
+          { type: 'update', data: { name: 'B', to: 'application-defined-target', updatedAt: '2020-01-01T00:00:00.000Z' } },
+        ],
+      } as unknown as EventLog;
+
+      const state = manager.getCurrentState(log);
+      expect(state.metadata?.to).toBe('application-defined-target');
+      expect(state.name).toBe('B');
+    });
+
+    it('strips the signed `to` anchor from metadata on a btco migration event', async () => {
+      // The complement: on a real btco migration, `to` is consumed to derive the
+      // did:btco identity and must NOT leak into metadata.
+      const webvhLog = await createWebvhLog();
+      const btcoLog = await manager.migrate(webvhLog);
+      const migrationData = btcoLog.events[2].data as Record<string, unknown>;
+      expect(migrationData.to).toBe('did:btco:1234567890'); // signed into the body
+      const state = manager.getCurrentState(btcoLog);
+      expect(state.metadata?.to).toBeUndefined(); // but not surfaced as metadata
+    });
+
     it('should not be deactivated after migration', async () => {
       const webvhLog = await createWebvhLog();
       const btcoLog = await manager.migrate(webvhLog);

--- a/packages/sdk/tests/unit/cel/BtcoCelManager.test.ts
+++ b/packages/sdk/tests/unit/cel/BtcoCelManager.test.ts
@@ -23,9 +23,20 @@ const createMockSigner = () => {
   });
 };
 
+// BtcoCelManager now pins the sat first: it inscribes via a buildContent(satoshi)
+// callback (so the migrate body can sign `to: did:btco:<sat>`). A mock inscribeData
+// must therefore invoke the callback with the returned satoshi, mirroring OrdMockProvider.
+const mockInscribeData = (result: { txid: string; inscriptionId: string; satoshi: string; blockHeight?: number }) =>
+  vi.fn(async (data: unknown) => {
+    if (typeof data === 'function') {
+      await (data as (s: string) => Buffer | Promise<Buffer>)(result.satoshi);
+    }
+    return result;
+  });
+
 // Mock BitcoinManager
 const createMockBitcoinManager = (): BitcoinManager => ({
-  inscribeData: vi.fn().mockResolvedValue({
+  inscribeData: mockInscribeData({
     txid: 'abc123def456',
     inscriptionId: 'abc123def456i0',
     satoshi: '1234567890',
@@ -220,7 +231,7 @@ describe('BtcoCelManager', () => {
       // createBtcoDidDocument — otherwise a regtest/signet asset resolves
       // against the mainnet ordinals namespace.
       const regtestBitcoin = {
-        inscribeData: vi.fn().mockResolvedValue({
+        inscribeData: mockInscribeData({
           txid: 'abc123def456',
           inscriptionId: 'abc123def456i0',
           satoshi: '1234567890',
@@ -247,7 +258,7 @@ describe('BtcoCelManager', () => {
       // the mainnet form. The network is recorded in the signed data, so replay
       // must be deterministic regardless of the replaying manager's network.
       const regtestBitcoin = {
-        inscribeData: vi.fn().mockResolvedValue({
+        inscribeData: mockInscribeData({
           txid: 'abc123def456',
           inscriptionId: 'abc123def456i0',
           satoshi: '1234567890',

--- a/packages/sdk/tests/unit/cel/OriginalsCel.test.ts
+++ b/packages/sdk/tests/unit/cel/OriginalsCel.test.ts
@@ -61,12 +61,21 @@ function createMockSigner(): CelSigner {
  */
 function createMockBitcoinManager() {
   return {
-    inscribeData: vi.fn(async () => ({
-      txid: 'mock-txid-' + Math.random().toString(36).substring(7),
-      inscriptionId: 'mock-inscription-' + Math.random().toString(36).substring(7),
-      satoshi: 1000,
-      blockHeight: 800000,
-    })),
+    network: 'mainnet',
+    // BtcoCelManager pins the sat first via a buildContent(satoshi) callback;
+    // invoke it (mirrors OrdMockProvider) so the migrate body can sign `to`.
+    inscribeData: vi.fn(async (data: unknown) => {
+      const satoshi = 1000;
+      if (typeof data === 'function') {
+        await (data as (s: string) => Buffer | Promise<Buffer>)(String(satoshi));
+      }
+      return {
+        txid: 'mock-txid-' + Math.random().toString(36).substring(7),
+        inscriptionId: 'mock-inscription-' + Math.random().toString(36).substring(7),
+        satoshi,
+        blockHeight: 800000,
+      };
+    }),
   } as any;
 }
 

--- a/packages/sdk/tests/unit/cel/cel-core-coverage.test.ts
+++ b/packages/sdk/tests/unit/cel/cel-core-coverage.test.ts
@@ -61,12 +61,19 @@ const createMockSigner = () =>
 /** BitcoinManager mock that returns deterministic inscription data. */
 const createMockBitcoinManager = (): BitcoinManager =>
   ({
-    inscribeData: async () => ({
-      txid: 'deadbeef01020304',
-      inscriptionId: 'deadbeef01020304i0',
-      satoshi: '9876543210',
-      blockHeight: 840000,
-    }),
+    network: 'mainnet',
+    // BtcoCelManager pins the sat first: invoke the buildContent(satoshi) callback.
+    inscribeData: async (data: unknown) => {
+      if (typeof data === 'function') {
+        await (data as (s: string) => Buffer | Promise<Buffer>)('9876543210');
+      }
+      return {
+        txid: 'deadbeef01020304',
+        inscriptionId: 'deadbeef01020304i0',
+        satoshi: '9876543210',
+        blockHeight: 840000,
+      };
+    },
   } as unknown as BitcoinManager);
 
 /** Build a webvh-layer event log (peer → webvh migration). */

--- a/packages/sdk/tests/unit/cel/event-log-authorization.test.ts
+++ b/packages/sdk/tests/unit/cel/event-log-authorization.test.ts
@@ -50,40 +50,49 @@ function makeSigner() {
 // the inscription exists, sits on the claimed satoshi, and commits to the
 // event digest.
 const mockBitcoin = (): { manager: BitcoinManager; ordinalsProvider: any } => {
-  let lastPayload: unknown;
+  const satoshi = '1234567890';
+  const inscriptionId = 'abc123def456i0';
+  const txid = 'abc123def456';
+  const blockHeight = 800000;
+  // BtcoCelManager pins the sat first: it inscribes via a buildContent(satoshi)
+  // callback, so capture what that callback produced (the btco DID document that
+  // IS the witness artifact) and serve it back from the ordinals lookup.
+  let lastContent: Buffer | undefined;
   const manager = {
     network: 'mainnet',
     inscribeData: async (data: unknown) => {
-      lastPayload = data;
-      return {
-        txid: 'abc123def456',
-        inscriptionId: 'abc123def456i0',
-        satoshi: '1234567890',
-        blockHeight: 800000,
-      };
+      lastContent = typeof data === 'function'
+        ? Buffer.from(await (data as (s: string) => Buffer | Promise<Buffer>)(satoshi))
+        : Buffer.from(JSON.stringify(data));
+      return { txid, inscriptionId, satoshi, blockHeight };
     },
   } as unknown as BitcoinManager;
   const ordinalsProvider = {
     getInscriptionById: async (id: string) =>
-      id === 'abc123def456i0'
+      id === inscriptionId
         ? {
             inscriptionId: id,
-            content: Buffer.from(JSON.stringify(lastPayload)),
-            contentType: 'application/json',
-            txid: 'abc123def456',
-            satoshi: '1234567890',
+            content: lastContent,
+            contentType: 'application/did+json',
+            txid,
+            satoshi,
           }
         : null,
+    // First-anchor-wins uniqueness: enumerate this sat's anchoring iff the
+    // inscribed doc back-links the queried did:cel (mirrors OrdMockProvider).
+    getAnchoringsForDidCel: async (didCel: string) => {
+      const parsed = lastContent ? JSON.parse(lastContent.toString()) : null;
+      const aka = (parsed as { alsoKnownAs?: unknown } | null)?.alsoKnownAs;
+      return Array.isArray(aka) && aka.includes(didCel)
+        ? [{ satoshi, inscriptionId, blockHeight }]
+        : [];
+    },
   };
   return { manager, ordinalsProvider };
 };
 
 describe('CEL event-log authorization and btco verifiability', () => {
-  // QUARANTINED (#397): BtcoCelManager.migrate (via the WitnessService digest-first
-  // path) cannot yet sign the anchoring sat into the migrate body, so the anchored-sat
-  // verifier (design 2026-07-13, Part A) rejects its logs with UNBOUND_ANCHOR. Re-enable
-  // once BtcoCelManager gains a pin-sat-first inscribe / converges with LifecycleManager.
-  it.skip('a real webvh→btco migration produces a verifiable log', async () => {
+  it('a real webvh→btco migration produces a verifiable log', async () => {
     const signer = makeSigner();
     const peer = new PeerCelManager(signer as any);
     let { log } = await peer.create('Asset', [{ digestMultibase: 'uHash', mediaType: 'image/png' }]);
@@ -109,6 +118,51 @@ describe('CEL event-log authorization and btco verifiability', () => {
     expect((last.data as any).targetDid).toBeUndefined();
     const state = new BtcoCelManager(makeSigner() as any, mockBitcoin().manager).getCurrentState(btcoLog);
     expect(/^did:btco:[0-9]+$/.test(state.did)).toBe(true);
+  });
+
+  it('signs the anchoring sat into data.to and the witness proof carries the same sat (#397)', async () => {
+    // The sat signed into the migrate body, the sat the bitcoin witness proof
+    // carries, and the sat the inscription landed on must all agree — this is
+    // the anchored-sat binding the Part A verifier enforces.
+    const signer = makeSigner();
+    let { log } = await new PeerCelManager(signer as any).create('Asset', []);
+    log = await new WebVHCelManager(signer as any, 'example.com').migrate(log);
+    const { manager } = mockBitcoin(); // network 'mainnet', satoshi '1234567890'
+    const btcoLog = await new BtcoCelManager(signer as any, manager).migrate(log);
+
+    const last = btcoLog.events[btcoLog.events.length - 1];
+    expect(last.type).toBe('migrate');
+    // The SIGNED body carries the resolvable did:btco anchor (mainnet is bare).
+    expect((last.data as any).to).toBe('did:btco:1234567890');
+    // The bitcoin witness proof carries the SAME sat.
+    const bp = (last.proof as any[]).find(p => p.cryptosuite === 'bitcoin-ordinals-2024');
+    expect(bp).toBeDefined();
+    expect(bp.satoshi).toBe('1234567890');
+    // `to` is a signed field (covered by the controller proof over {type,data,previousEvent}).
+    const controllerProof = (last.proof as any[]).find(p => p.cryptosuite === 'eddsa-jcs-2022');
+    const reverified = await ed25519.verifyAsync(
+      multikey.decodeMultibase(controllerProof.proofValue),
+      canonicalizeEvent({ type: last.type, data: last.data, previousEvent: (last as any).previousEvent }),
+      multikey.decodePublicKey(controllerProof.verificationMethod.split('#')[0].slice('did:key:'.length)).key
+    );
+    expect(reverified).toBe(true);
+  });
+
+  it('fails closed if the inscription lands on a different sat than was signed (#397)', async () => {
+    // If the reveal returns a sat that disagrees with the one signed into
+    // data.to, the migrate must throw rather than emit a mis-anchored log.
+    const signer = makeSigner();
+    let { log } = await new PeerCelManager(signer as any).create('Asset', []);
+    log = await new WebVHCelManager(signer as any, 'example.com').migrate(log);
+    // Manager whose buildContent pins one sat but whose reveal returns another.
+    const treacherous = {
+      network: 'mainnet',
+      inscribeData: async (data: unknown) => {
+        if (typeof data === 'function') await (data as (s: string) => any)('1111111111');
+        return { txid: 'tx', inscriptionId: 'txi0', satoshi: '9999999999', blockHeight: 1 };
+      },
+    } as unknown as BitcoinManager;
+    await expect(new BtcoCelManager(signer as any, treacherous).migrate(log)).rejects.toThrow(/Anchoring sat mismatch/);
   });
 
   it('reports a clear "content is missing" diagnostic when the witness inscription has no content', async () => {


### PR DESCRIPTION
## Summary

Part A's anchored-sat verifier (`verifyEventLog`, already on main) requires **every** btco `migrate` event to sign its anchoring sat as `data.to = did:btco:<network>:<sat>`, deriving the anchor from that **signed** body. `LifecycleManager.inscribeOnBitcoin` (the production path) already does this. But the second btco writer — `BtcoCelManager.migrate` (the `cel migrate` CLI / `OriginalsCel` path) — could not: it reached Bitcoin through the **digest-first** `WitnessService` path (`witnessEvent` inscribes the digest of the already-signed event), so the sat was only known *after* signing. It emitted a bare migrate whose logs now fail `UNBOUND_ANCHOR`. Its verifiability test was quarantined.

This gives `BtcoCelManager.migrate` the same **pin-sat-first** flow as the reference implementation.

## The fix

- Inscribe via `bitcoinManager.inscribeData({ buildContent })`. Inside `buildContent(satoshi)` — where the sat is pinned *before* the reveal — sign the migrate event with `to: btcoDidFromSatoshi(satoshi, network)`, then inscribe the asset's btco **DID document** whose `#cel` `OriginalsCelAnchor` commits to that event's chain digest (the DID-doc inscription **IS** the witness artifact, #367). `alsoKnownAs` back-links the `did:cel` so first-anchor-wins uniqueness enumeration works.
- Attach the bitcoin witness proof carrying the **same** sat (chain digests exclude the proof array, so this cannot alter the signed body or the anchored head digest).
- **Fails closed**: the sat signed into `data.to`, the sat the inscription landed on, and the sat the witness proof carries must all agree, or `migrate` throws rather than emitting a mis-anchored log.
- Verifier and `LifecycleManager` are unchanged.

## TDD / test changes

- Un-quarantines the acceptance test `a real webvh→btco migration produces a verifiable log` (confirmed RED with `UNBOUND_ANCHOR` first, then GREEN).
- Adds focused coverage: signed `data.to` == `did:btco:<sat>` and the witness proof carries the same sat (with the `to` field re-verified under the controller signature), plus a fail-closed test for a provider whose reveal lands on a different sat than was signed.
- Updates the `BtcoCelManager` / `OriginalsCel` / cel-core test mocks and the CLI mock `BitcoinManager` to invoke the `buildContent(satoshi)` callback (mirrors `OrdMockProvider`).

## Review follow-ups (fable, both fail-closed Minor nits)

- Normalise `inscription.satoshi` to a string before building the witness proof (the verifier only recognises string sats), so numeric-returning providers still yield verifiable logs.
- Pass `{ lockKey }` to `inscribeData` so a concurrent inscription of the same asset is rejected before broadcast rather than double-paying (mirrors `LifecycleManager`, #303).

## Verification

- `bun run build` clean, `bunx tsc --noEmit` clean.
- Full `bun test` (packages/sdk): **3927 pass, 70 skip, 0 fail** (3997 tests).

This is release-gating.

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sign the anchoring sat into `BtcoCelManager.migrate` using a pin-sat-first flow
> - `BtcoCelManager.migrate` now passes a `buildContent(satoshi)` callback to `bitcoinManager.inscribeData`, constructing the DID document (including the `data.to = did:btco:<network>:<sat>` anchor) inside the callback so the satoshi is known before signing.
> - After inscription, the returned satoshi is normalized to a string and validated against the signed `to` field; a mismatch throws an error.
> - A `bitcoin-ordinals-2024` `DataIntegrityProof` carrying `txid`, `satoshi`, `inscriptionId`, and optional `blockHeight` is appended to the migrate event's proof array without mutating the signed body.
> - `getCurrentState` no longer surfaces the signed `to` field in `state.metadata` for btco migration events.
> - Test mocks across `BtcoCelManager`, `OriginalsCel`, and `event-log-authorization` suites are updated to invoke the `buildContent(satoshi)` callback and reflect `application/did+json` content type.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a19716d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->