### PR TITLE
Layer-label rename: did:cel genesis reports 'did:cel' (Phase 4 · 4/5)

### DIFF
--- a/.changeset/layer-label-rename.md
+++ b/.changeset/layer-label-rename.md
@@ -1,0 +1,7 @@
+---
+"@originals/sdk": patch
+---
+
+Correct the misleading lifecycle layer label: a did:cel genesis asset now reports `currentLayer: 'did:cel'` instead of `'did:peer'`. `LayerType` gains `'did:cel'` (`'did:peer' | 'did:cel' | 'did:webvh' | 'did:btco'`), and `OriginalsAsset.determineCurrentLayer` maps a `did:cel:` id to `'did:cel'`. The migrate transition table, the publish/inscribe genesis-layer gates, `replayProvenance`, and envelope restore all accept `'did:cel'` as the genesis layer (same migration targets as legacy `'did:peer'`).
+
+Legacy `did:peer` assets are unchanged — they still report `'did:peer'` and migrate identically. The `ResourceMigrated` publication credential's `fromLayer` is unchanged (spec non-goal: credentials are untouched). did:cel derivation, verification, ownership, and credentials are all unaffected.

--- a/docs/superpowers/plans/2026-07-14-layer-label-rename.md
+++ b/docs/superpowers/plans/2026-07-14-layer-label-rename.md
@@ -1,0 +1,53 @@
+# Plan: layer-label rename — did:cel genesis reports `'did:cel'`
+
+Spec: `docs/superpowers/specs/2026-07-14-layer-label-rename-design.md`
+(did:cel epic — Phase 4, sub-project 4 of 5).
+
+## Task 1 — type + `determineCurrentLayer` + `validTransitions` (+ test)
+
+- **Test first** (`tests/unit/lifecycle/`): a `createAsset` (did:cel genesis) asset
+  reports `currentLayer === 'did:cel'`; a legacy `did:peer`-constructed asset still
+  reports `'did:peer'`; `migrate('did:webvh')` from a did:cel asset does NOT throw
+  (validTransitions has the key).
+- `src/types/common.ts` — `LayerType` gains `'did:cel'`.
+- `src/lifecycle/OriginalsAsset.ts`
+  - `determineCurrentLayer`: `did:cel:` → `'did:cel'` (was `'did:peer'`); drop stale
+    "synonym" comment; keep `did:peer:` → `'did:peer'`.
+  - `validTransitions` (in `migrate`): add `'did:cel': ['did:webvh','did:btco']`.
+- Adding `'did:cel'` to `LayerType` makes every `Record<LayerType, LayerType[]>`
+  literal a compile error until it gets the key — so the second `validTransitions`
+  copy in `LifecycleManager.validateMigration` (~3328) also gains the key.
+
+## Task 2 — forced ripples from the flipped genesis label
+
+A freshly `createAsset`'d asset now reports `'did:cel'`, so genesis-layer gates that
+hard-coded `'did:peer'` must also accept `'did:cel'` (spec §4: publish + inscribe must
+succeed from a did:cel asset):
+- `LifecycleManager.publishToWeb` gate (~1052) — accept `'did:cel'` OR legacy `'did:peer'`.
+- `LifecycleManager.inscribeOnBitcoin` gate (~1904) — accept `'did:cel'` alongside
+  `'did:webvh'`/`'did:peer'`.
+- `LifecycleManager.recordMigration` from-layer (~1201) — use the dynamic `priorLayer`
+  (already captured) so the metric matches the `asset:migrated` event + provenance.
+
+Fold / restore (spec touch points):
+- `src/lifecycle/replayProvenance.ts` — genesis-with-controller folds
+  `currentLayer: 'did:cel'`; widen `ReplayedProvenance.currentLayer` union; fix JSDoc.
+- `src/lifecycle/LifecycleManager.buildRestoredProvenance` — layer seed `'did:peer'` → `'did:cel'`.
+- `src/playground/repl.ts` — publish gate accepts either genesis form; fix message.
+
+**Frozen by spec §3 non-goals ("No change to … credentials"):** the `ResourceMigrated`
+credential's `fromLayer: 'did:peer' as const` (~1672) and its test stay as-is.
+
+**Fixtures:** run the full suite + grep; flip only assertions that describe a
+*did:cel-genesis* asset's layer / migration-from (e.g. `currentLayer).toBe('did:peer')`,
+`migrations[0].from).toBe('did:peer')`, `asset:migrated` `fromLayer`). Do NOT touch
+did:peer-as-DID-method parsing, hand-built did:peer assets, credential assertions, or
+direct `MetricsCollector` unit tests.
+
+## Task 3 — changeset
+
+`.changeset/layer-label-rename.md` (`@originals/sdk` patch).
+
+## Verify
+`bun run build` → `bun test` (0 fail) → `bunx tsc --noEmit` clean. One opus reviewer
+pass over the whole diff before PR.

--- a/docs/superpowers/specs/2026-07-14-layer-label-rename-design.md
+++ b/docs/superpowers/specs/2026-07-14-layer-label-rename-design.md
@@ -1,0 +1,79 @@
+# Design: layer-label rename — a did:cel genesis reports `'did:cel'`
+
+> did:cel epic — Phase 4, sub-project 4 of 5. Fixes the misleading lifecycle
+> layer label: a did:cel genesis asset currently reports `currentLayer:
+> 'did:peer'` (`OriginalsAsset.determineCurrentLayer`, line ~691), a leftover
+> from before did:cel replaced did:peer as the genesis layer.
+
+## 0. Decision record
+
+- **Vocabulary:** keep the existing DID-method-named convention (the other
+  layers are already `'did:webvh'` / `'did:btco'`). A did:cel genesis reports
+  `currentLayer: 'did:cel'`; legacy did:peer assets keep reporting
+  `'did:peer'`. No switch to lifecycle-stage names.
+- **Legacy:** `'did:peer'` stays a valid layer — did:peer assets still exist and
+  must keep working. Its full deprecation is a separate sub-project (5).
+- **Back-compat:** hard cutover (nothing released). Fixtures/tests asserting
+  `currentLayer === 'did:peer'` for a *did:cel-genesis* asset flip to `'did:cel'`.
+
+## 1. The change
+
+`LayerType` gains `'did:cel'`:
+
+```ts
+// src/types/common.ts
+export type LayerType = 'did:peer' | 'did:cel' | 'did:webvh' | 'did:btco';
+```
+
+A did:cel genesis asset reports `currentLayer: 'did:cel'` instead of the
+misleading `'did:peer'`. The label stays method-named, so the axis is
+self-describing and consistent across all four values.
+
+## 2. Touch points
+
+- **`src/types/common.ts`** — add `'did:cel'` to the `LayerType` union.
+- **`src/lifecycle/OriginalsAsset.ts`**
+  - `determineCurrentLayer(didId)` — `did:cel:` → `'did:cel'` (was `'did:peer'`);
+    keep `did:peer:` → `'did:peer'`; other branches unchanged. Drop the stale
+    "did:cel is the genesis-layer synonym for did:peer" comment (line ~690) — it
+    is now a real dedicated layer.
+  - `validTransitions` (used by `migrate`) — add
+    `'did:cel': ['did:webvh', 'did:btco']`. **Required:** without this key, a
+    did:cel asset's `migrate()` throws on an undefined lookup
+    (`validTransitions[this.currentLayer]`). Keep the `'did:peer'` entry for
+    legacy assets (same targets).
+- **`src/lifecycle/replayProvenance.ts`** — the genesis branch (a `create` event
+  with `data.controller`) folds `currentLayer: 'did:cel'` (was `'did:peer'`);
+  update the `ReplayedProvenance.currentLayer` union to include `'did:cel'`.
+- **`src/lifecycle/LifecycleManager.ts`** — `buildRestoredProvenance`'s layer
+  seed (`let layer: LayerType = 'did:peer'` ~line 715) becomes `'did:cel'` for
+  the did:cel-genesis restore path, so a loaded/folded asset reports `'did:cel'`.
+- **`src/playground/repl.ts`** — the publish gate (`if (asset.currentLayer !==
+  'did:peer')`) accepts **either** genesis form: allow publish when
+  `currentLayer` is `'did:cel'` or legacy `'did:peer'`; adjust the message text.
+
+## 3. Non-goals / unchanged
+
+- No lifecycle-stage renaming of the other layers (`'did:webvh'`/`'did:btco'`
+  stay).
+- No did:peer removal — legacy did:peer support is untouched here (sub-project 5).
+- No change to did:cel derivation, verification, ownership, or credentials.
+
+## 4. Testing spine
+
+- A `createAsset` (did:cel genesis) asset reports `currentLayer === 'did:cel'`.
+- A legacy did:peer-constructed asset still reports `currentLayer === 'did:peer'`.
+- `migrate('did:webvh')` and the inscribe path succeed from a `'did:cel'` asset
+  (validTransitions has the key — no undefined-key throw).
+- `loadAsset` / `replayProvenance` of a did:cel genesis yields
+  `currentLayer === 'did:cel'`.
+- The publish gate accepts a `'did:cel'` asset (and still a legacy `'did:peer'`
+  one).
+- Regenerate any fixtures/tests asserting `'did:peer'` for a did:cel-genesis
+  asset.
+
+## 5. Changeset
+
+`@originals/sdk` **patch** — note the corrected label: `OriginalsAsset.currentLayer`
+now returns `'did:cel'` for a did:cel genesis (was `'did:peer'`); `LayerType`
+gains `'did:cel'`; legacy did:peer assets unchanged.

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -1084,8 +1084,8 @@ export class LifecycleManager {
       }));
       const writtenObjects: Array<{ domain: string; relativePath: string }> = [];
 
-      // Capture the layer before migration (always 'did:peer' here due to the
-      // guard above, but captured dynamically for correctness).
+      // Capture the layer before migration (the genesis layer — 'did:cel', or
+      // legacy 'did:peer' — per the guard above; captured dynamically).
       const priorLayer = asset.currentLayer;
 
       // Snapshot the CEL log so a mid-publish failure after the migrate append

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -1670,6 +1670,10 @@ export class LifecycleManager {
         id: asset.id,
         migratedTo,
         resourceId: asset.resources[0].id,
+        // TODO(did:cel sub-project 5): frozen at 'did:peer' by the layer-label-rename
+        // spec non-goal (credentials untouched). For a did:cel genesis this now
+        // disagrees with the asset:migrated event / getProvenance().from ('did:cel');
+        // reconcile when credentials are unfrozen.
         fromLayer: 'did:peer' as const,
         toLayer: 'did:webvh' as const,
         migratedAt: new Date().toISOString()

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -750,9 +750,10 @@ export class LifecycleManager {
         ? genesisData.creator
         : env.assetDid;
 
-    // Re-materialize migrations layer-to-layer by walking the log.
+    // Re-materialize migrations layer-to-layer by walking the log. Genesis is a
+    // did:cel (the derived genesis identity), so the first migration folds from it.
     const migrations: ProvenanceChain['migrations'] = [];
-    let layer: LayerType = 'did:peer';
+    let layer: LayerType = 'did:cel';
     for (let i = 1; i < log.events.length; i++) {
       const ev = log.events[i];
       if (ev.type !== 'migrate') continue;
@@ -1049,8 +1050,8 @@ export class LifecycleManager {
     const metricsStart = performance.now();
 
     try {
-      if (asset.currentLayer !== 'did:peer') {
-        throw new StructuredError('INVALID_STATE', 'Asset must be in did:peer layer to publish to web. Assets can only be published from the did:peer layer.');
+      if (asset.currentLayer !== 'did:cel' && asset.currentLayer !== 'did:peer') {
+        throw new StructuredError('INVALID_STATE', 'Asset must be in the genesis layer (did:cel, or legacy did:peer) to publish to web.');
       }
 
       // Concurrency guard (issue #255): the layer check above is
@@ -1198,7 +1199,7 @@ export class LifecycleManager {
         resourceCount: asset.resources.length 
       });
       this.metrics.recordOperation('lifecycle.publishToWeb', performance.now() - metricsStart, true);
-      this.metrics.recordMigration('did:peer', 'did:webvh');
+      this.metrics.recordMigration(priorLayer, 'did:webvh');
 
       return asset;
       } finally {
@@ -1901,8 +1902,8 @@ export class LifecycleManager {
     if (typeof asset.migrate !== 'function') {
       throw new StructuredError('NOT_IMPLEMENTED', 'Asset inscription is not yet implemented for this asset type. Use a standard OriginalsAsset created via lifecycle.createAsset().');
     }
-    if (asset.currentLayer !== 'did:webvh' && asset.currentLayer !== 'did:peer') {
-      throw new StructuredError('NOT_IMPLEMENTED', 'Asset inscription is not yet implemented for this layer. Assets must be in did:peer or did:webvh layer to inscribe.');
+    if (asset.currentLayer !== 'did:webvh' && asset.currentLayer !== 'did:cel' && asset.currentLayer !== 'did:peer') {
+      throw new StructuredError('NOT_IMPLEMENTED', 'Asset inscription is not yet implemented for this layer. Assets must be in the genesis layer (did:cel, or legacy did:peer) or did:webvh layer to inscribe.');
     }
     // Concurrency guard (issue #255): the layer check above is check-then-act
     // across the awaits below — two overlapping calls would both pass it,
@@ -3327,10 +3328,11 @@ export class LifecycleManager {
     // Check layer transition validity
     const validTransitions: Record<LayerType, LayerType[]> = {
       'did:peer': ['did:webvh', 'did:btco'],
+      'did:cel': ['did:webvh', 'did:btco'],
       'did:webvh': ['did:btco'],
       'did:btco': []
     };
-    
+
     if (validTransitions[asset.currentLayer].includes(targetLayer)) {
       checks.layerTransition = true;
     } else {

--- a/packages/sdk/src/lifecycle/OriginalsAsset.ts
+++ b/packages/sdk/src/lifecycle/OriginalsAsset.ts
@@ -140,7 +140,8 @@ export class OriginalsAsset {
    * @internal — reconstruct an asset from a persisted envelope (loadAsset, #377).
    *
    * The public constructor FIGHTS restoration: `determineCurrentLayer` derives
-   * `'did:peer'` for a published did:cel asset (wrong layer), and it fabricates
+   * `'did:cel'` for a published did:cel asset (the genesis layer, not the
+   * current `'did:webvh'`/`'did:btco'`), and it fabricates
    * `provenance.createdAt = new Date()`. restore() constructs, then OVERWRITES
    * `currentLayer` / `bindings` / `#provenance` with values the caller folded
    * from the (already-verified) log + genesis data. It emits NO events and its
@@ -284,6 +285,7 @@ export class OriginalsAsset {
     // Handle migration between layers
     const validTransitions: Record<LayerType, LayerType[]> = {
       'did:peer': ['did:webvh', 'did:btco'],
+      'did:cel': ['did:webvh', 'did:btco'], // did:cel genesis (same targets as legacy did:peer)
       'did:webvh': ['did:btco'],
       'did:btco': [] // No further migrations possible
     };
@@ -788,8 +790,7 @@ export class OriginalsAsset {
 
   private determineCurrentLayer(didId: string): LayerType {
     if (didId.startsWith('did:peer:')) return 'did:peer';
-    // did:cel is the genesis-layer synonym for did:peer (Phase-4 may introduce a dedicated layer).
-    if (didId.startsWith('did:cel:')) return 'did:peer';
+    if (didId.startsWith('did:cel:')) return 'did:cel';
     if (didId.startsWith('did:webvh:')) return 'did:webvh';
     if (didId.startsWith('did:btco:')) return 'did:btco';
     throw new Error('Unknown DID method');

--- a/packages/sdk/src/lifecycle/replayProvenance.ts
+++ b/packages/sdk/src/lifecycle/replayProvenance.ts
@@ -6,7 +6,7 @@
  * live-cache parity tests below).
  *
  * Fold rules:
- *  - Genesis (`create` with `data.controller`) → `currentLayer: 'did:peer'`,
+ *  - Genesis (`create` with `data.controller`) → `currentLayer: 'did:cel'`,
  *    `bindings['did:cel'] = deriveDidCel(log)`.
  *  - `migrate` with `data.layer === 'webvh'` → `currentLayer: 'did:webvh'`,
  *    `bindings['did:webvh'] = data.targetDid`, and a migrations entry
@@ -49,7 +49,7 @@ import { hashResource } from '../utils/validation.js';
 export const BTCO_SATOSHI_UNKNOWN = 'did:btco:?';
 
 export interface ReplayedProvenance {
-  currentLayer: 'did:peer' | 'did:webvh' | 'did:btco';
+  currentLayer: 'did:peer' | 'did:cel' | 'did:webvh' | 'did:btco';
   bindings: Record<string, string>;
   migrations: Array<{ from: string; to: string; timestamp: string }>;
   resourceUpdates: Array<{
@@ -84,6 +84,8 @@ export function replayProvenance(log: EventLog): ReplayedProvenance {
 
   const genesisData = genesis.data as Record<string, unknown>;
   if (typeof genesisData.controller === 'string') {
+    // A signed did:cel genesis — the genesis layer is did:cel, not did:peer.
+    result.currentLayer = 'did:cel';
     result.bindings['did:cel'] = deriveDidCel(log);
   }
 

--- a/packages/sdk/src/playground/repl.ts
+++ b/packages/sdk/src/playground/repl.ts
@@ -98,8 +98,8 @@ async function handlePublish(state: SessionState, args: string[]): Promise<void>
     return;
   }
 
-  if (asset.currentLayer !== 'did:peer') {
-    console.log(`  Asset is already at layer "${asset.currentLayer}". Can only publish from did:peer.`);
+  if (asset.currentLayer !== 'did:cel' && asset.currentLayer !== 'did:peer') {
+    console.log(`  Asset is already at layer "${asset.currentLayer}". Can only publish from the genesis layer (did:cel, or legacy did:peer).`);
     return;
   }
 

--- a/packages/sdk/src/types/common.ts
+++ b/packages/sdk/src/types/common.ts
@@ -7,7 +7,7 @@ import type { DIDCacheConfig } from '../did/DIDCache.js';
 import type { OperationLock } from '../utils/OperationLock.js';
 
 // Base types for the Originals protocol
-export type LayerType = 'did:peer' | 'did:webvh' | 'did:btco';
+export type LayerType = 'did:peer' | 'did:cel' | 'did:webvh' | 'did:btco';
 
 export interface OriginalsConfig {
   network: 'mainnet' | 'regtest' | 'signet';

--- a/packages/sdk/tests/integration/BatchOperations.test.ts
+++ b/packages/sdk/tests/integration/BatchOperations.test.ts
@@ -117,7 +117,7 @@ describe('Batch Operations Integration', () => {
       // Verify each asset
       for (const item of result.successful) {
         expect(item.result).toBeInstanceOf(OriginalsAsset);
-        expect(item.result.currentLayer).toBe('did:peer');
+        expect(item.result.currentLayer).toBe('did:cel');
         expect(item.result.id).toMatch(/^did:cel:/);
       }
     });
@@ -386,7 +386,7 @@ describe('Batch Operations Integration', () => {
       for (const asset of inscribedAssets) {
         const provenance = asset.getProvenance();
         expect(provenance.migrations).toHaveLength(2); // peer -> webvh -> btco
-        expect(provenance.migrations[0].from).toBe('did:peer');
+        expect(provenance.migrations[0].from).toBe('did:cel');
         expect(provenance.migrations[0].to).toBe('did:webvh');
         expect(provenance.migrations[1].from).toBe('did:webvh');
         expect(provenance.migrations[1].to).toBe('did:btco');

--- a/packages/sdk/tests/integration/BatchOperations.test.ts
+++ b/packages/sdk/tests/integration/BatchOperations.test.ts
@@ -385,7 +385,7 @@ describe('Batch Operations Integration', () => {
       // Verify complete provenance chain
       for (const asset of inscribedAssets) {
         const provenance = asset.getProvenance();
-        expect(provenance.migrations).toHaveLength(2); // peer -> webvh -> btco
+        expect(provenance.migrations).toHaveLength(2); // cel -> webvh -> btco
         expect(provenance.migrations[0].from).toBe('did:cel');
         expect(provenance.migrations[0].to).toBe('did:webvh');
         expect(provenance.migrations[1].from).toBe('did:webvh');

--- a/packages/sdk/tests/integration/BtcoRoundTrip.test.ts
+++ b/packages/sdk/tests/integration/BtcoRoundTrip.test.ts
@@ -166,6 +166,6 @@ describe('inscribeOnBitcoin commits to the CEL head digest (#365)', () => {
     await expect(sdk.lifecycle.inscribeOnBitcoin(asset)).rejects.toThrow('broadcast failed');
     // Pure in-memory restore — nothing was paid before broadcast failed.
     expect(asset.celLog).toBe(logBefore);
-    expect(asset.currentLayer).toBe('did:peer');
+    expect(asset.currentLayer).toBe('did:cel');
   });
 });

--- a/packages/sdk/tests/integration/CelConvergence.e2e.test.ts
+++ b/packages/sdk/tests/integration/CelConvergence.e2e.test.ts
@@ -38,14 +38,14 @@ describe('CEL convergence end-to-end (#Phase2 Task9)', () => {
       keyStore: new MockKeyStore()
     });
 
-    // create — mints did:cel genesis; currentLayer label stays 'did:peer'.
+    // create — mints did:cel genesis; currentLayer label is 'did:cel'.
     const asset = await sdk.lifecycle.createAsset([
       { id: 'art', type: 'image', contentType: 'image/png', hash: 'ab'.repeat(32) }
     ]);
     const didCel = asset.id;
     expect(didCel.startsWith('did:cel:u')).toBe(true);
     expect(deriveDidCel(asset.celLog!)).toBe(didCel);
-    expect(asset.currentLayer).toBe('did:peer');
+    expect(asset.currentLayer).toBe('did:cel');
 
     // publish — appends the webvh migrate event.
     await sdk.lifecycle.publishToWeb(asset, 'example.com');

--- a/packages/sdk/tests/integration/CompleteLifecycle.e2e.test.ts
+++ b/packages/sdk/tests/integration/CompleteLifecycle.e2e.test.ts
@@ -149,7 +149,7 @@ describe('E2E Integration: Complete Lifecycle Flow', () => {
 
       // Verify asset creation
       expect(asset).toBeInstanceOf(OriginalsAsset);
-      expect(asset.currentLayer).toBe('did:peer');
+      expect(asset.currentLayer).toBe('did:cel');
       expect(asset.id).toMatch(/^did:cel:/);
       expect(asset.resources).toHaveLength(2);
       expect(asset.resources[0].id).toBe('resource-1');
@@ -196,7 +196,7 @@ describe('E2E Integration: Complete Lifecycle Flow', () => {
       // Verify provenance after web migration
       const webProvenance = webAsset.getProvenance();
       expect(webProvenance.migrations).toHaveLength(1);
-      expect(webProvenance.migrations[0].from).toBe('did:peer');
+      expect(webProvenance.migrations[0].from).toBe('did:cel');
       expect(webProvenance.migrations[0].to).toBe('did:webvh');
       expect(webProvenance.migrations[0].timestamp).toBeDefined();
 
@@ -276,7 +276,7 @@ describe('E2E Integration: Complete Lifecycle Flow', () => {
       expect(finalProvenance.migrations).toHaveLength(2);
 
       // Verify migration chain
-      expect(finalProvenance.migrations[0].from).toBe('did:peer');
+      expect(finalProvenance.migrations[0].from).toBe('did:cel');
       expect(finalProvenance.migrations[0].to).toBe('did:webvh');
       expect(finalProvenance.migrations[1].from).toBe('did:webvh');
       expect(finalProvenance.migrations[1].to).toBe('did:btco');
@@ -303,7 +303,7 @@ describe('E2E Integration: Complete Lifecycle Flow', () => {
       ];
 
       const asset = await sdk.lifecycle.createAsset(resources);
-      expect(asset.currentLayer).toBe('did:peer');
+      expect(asset.currentLayer).toBe('did:cel');
 
       // Inscribe directly to Bitcoin (skip webvh)
       const requestedFeeRate = 10;
@@ -314,7 +314,7 @@ describe('E2E Integration: Complete Lifecycle Flow', () => {
       
       const provenance = btcoAsset.getProvenance();
       expect(provenance.migrations).toHaveLength(1);
-      expect(provenance.migrations[0].from).toBe('did:peer');
+      expect(provenance.migrations[0].from).toBe('did:cel');
       expect(provenance.migrations[0].to).toBe('did:btco');
       expect(provenance.migrations[0].feeRate).toBe(10); // Explicit rate wins over the oracle
 
@@ -685,7 +685,7 @@ describe('E2E Integration: Complete Lifecycle Flow', () => {
       expect(provenance.migrations).toHaveLength(2);
       
       const webMigration = provenance.migrations[0];
-      expect(webMigration.from).toBe('did:peer');
+      expect(webMigration.from).toBe('did:cel');
       expect(webMigration.to).toBe('did:webvh');
       expect(webMigration.timestamp).toBeDefined();
       expect(new Date(webMigration.timestamp).getTime()).toBeGreaterThanOrEqual(startTime);

--- a/packages/sdk/tests/integration/DidPeerToWebVhFlow.test.ts
+++ b/packages/sdk/tests/integration/DidPeerToWebVhFlow.test.ts
@@ -66,7 +66,7 @@ describe('DID Peer to WebVH Publication Flow', () => {
     
     expect(asset).toBeDefined();
     expect(asset.id).toMatch(/^did:cel:/);
-    expect(asset.currentLayer).toBe('did:peer');
+    expect(asset.currentLayer).toBe('did:cel');
     expect(asset.resources).toHaveLength(2);
     
     console.log(`✅ Asset created: ${asset.id}`);
@@ -118,7 +118,7 @@ describe('DID Peer to WebVH Publication Flow', () => {
     
     const webvhMigration = provenance.migrations.find((m: any) => m.to === 'did:webvh');
     expect(webvhMigration).toBeDefined();
-    expect(webvhMigration.from).toBe('did:peer');
+    expect(webvhMigration.from).toBe('did:cel');
     expect(webvhMigration.to).toBe('did:webvh');
     expect(webvhMigration.timestamp).toBeDefined();
     
@@ -337,7 +337,7 @@ describe('DID Peer to WebVH Publication Flow', () => {
     
     // Verify layer changed
     expect(published.currentLayer).toBe('did:webvh');
-    expect(originalLayer).toBe('did:peer');
+    expect(originalLayer).toBe('did:cel');
     
     // Verify bindings preserve original ID
     const bindings = (published as any).bindings;

--- a/packages/sdk/tests/integration/Events.test.ts
+++ b/packages/sdk/tests/integration/Events.test.ts
@@ -116,7 +116,7 @@ describe('Integration: Event System', () => {
 
       // Events should have been emitted during creation
       expect(asset.id).toMatch(/^did:cel:/);
-      expect(asset.currentLayer).toBe('did:peer');
+      expect(asset.currentLayer).toBe('did:cel');
     });
 
     test('asset:created reaches pre-subscribed lifecycle handlers; asset-level post-await does not (#293)', async () => {
@@ -167,7 +167,7 @@ describe('Integration: Event System', () => {
 
       // The event was emitted during creation, verify asset state
       expect(asset.id).toMatch(/^did:cel:/);
-      expect(asset.currentLayer).toBe('did:peer');
+      expect(asset.currentLayer).toBe('did:cel');
       expect(asset.resources).toHaveLength(2);
     });
   });
@@ -199,7 +199,7 @@ describe('Integration: Event System', () => {
       expect(eventReceived).toBe(true);
       expect(capturedEvent).not.toBeNull();
       expect(capturedEvent?.type).toBe('asset:migrated');
-      expect(capturedEvent?.asset.fromLayer).toBe('did:peer');
+      expect(capturedEvent?.asset.fromLayer).toBe('did:cel');
       expect(capturedEvent?.asset.toLayer).toBe('did:webvh');
       expect(capturedEvent?.asset.id).toBe(asset.id);
     });

--- a/packages/sdk/tests/integration/createTypedOriginal.test.ts
+++ b/packages/sdk/tests/integration/createTypedOriginal.test.ts
@@ -57,7 +57,7 @@ describe('LifecycleManager.createTypedOriginal', () => {
       
       expect(asset).toBeDefined();
       expect(asset.id).toMatch(/^did:cel:/);
-      expect(asset.currentLayer).toBe('did:peer');
+      expect(asset.currentLayer).toBe('did:cel');
       expect(asset.resources.length).toBe(1);
       expect(asset.resources[0].id).toBe('index.js');
     });

--- a/packages/sdk/tests/unit/events/ManagerEventMirroring.test.ts
+++ b/packages/sdk/tests/unit/events/ManagerEventMirroring.test.ts
@@ -42,7 +42,7 @@ describe('manager-level asset:migrated / asset:transferred (issue #346)', () => 
     await sdk.lifecycle.publishToWeb(asset, 'example.com');
 
     expect(events.length).toBe(1);
-    expect(events[0].asset.fromLayer).toBe('did:peer');
+    expect(events[0].asset.fromLayer).toBe('did:cel');
     expect(events[0].asset.toLayer).toBe('did:webvh');
     expect(events[0].asset.id).toBe(asset.id);
   });

--- a/packages/sdk/tests/unit/lifecycle/LifecycleManager.atomicRollback.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/LifecycleManager.atomicRollback.test.ts
@@ -56,7 +56,7 @@ function makeFailingAdapter(failOnCall: number) {
 }
 
 describe('publishToWeb atomicRollback', () => {
-  test('default (atomicRollback on): a mid-publish failure reverts resource.url mutations and stays on did:peer', async () => {
+  test('default (atomicRollback on): a mid-publish failure reverts resource.url mutations and stays on did:cel', async () => {
     // Fail on the SECOND resource write (call 1 = genesis cel persist).
     const { adapter, deleted } = makeFailingAdapter(3);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -70,7 +70,7 @@ describe('publishToWeb atomicRollback', () => {
     for (const resource of asset.resources) {
       expect((resource as { url?: string }).url).toBeUndefined();
     }
-    expect(asset.currentLayer).toBe('did:peer');
+    expect(asset.currentLayer).toBe('did:cel');
     // The successfully-written first object was best-effort deleted
     // (the adapter supports deleteObject).
     expect(deleted.length).toBe(1);
@@ -119,7 +119,7 @@ describe('publishToWeb atomicRollback', () => {
     for (const resource of asset.resources) {
       expect((resource as { url?: string }).url).toBeUndefined();
     }
-    expect(asset.currentLayer).toBe('did:peer');
+    expect(asset.currentLayer).toBe('did:cel');
   });
 
   test('a successful publish is unaffected by the rollback machinery', async () => {

--- a/packages/sdk/tests/unit/lifecycle/LifecycleManager.celgenesis.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/LifecycleManager.celgenesis.test.ts
@@ -30,7 +30,7 @@ function makeSdkWithKeyStore() {
 }
 
 describe('createAsset mints did:cel genesis (#Phase2)', () => {
-  test('asset.id is the derived did:cel; log verifies; layer label is did:peer', async () => {
+  test('asset.id is the derived did:cel; log verifies; layer label is did:cel', async () => {
     const sdk = makeSdkWithKeyStore();
     const asset = await sdk.lifecycle.createAsset([
       { id: 'res-1', type: 'data', contentType: 'text/plain', hash: 'ab'.repeat(32) }
@@ -38,7 +38,7 @@ describe('createAsset mints did:cel genesis (#Phase2)', () => {
     expect(asset.id.startsWith('did:cel:u')).toBe(true);
     expect(asset.celLog).toBeDefined();
     expect(deriveDidCel(asset.celLog!)).toBe(asset.id);
-    expect(asset.currentLayer).toBe('did:peer');
+    expect(asset.currentLayer).toBe('did:cel');
     const result = await verifyEventLog(asset.celLog!, { expectedDid: asset.id });
     expect(result.verified).toBe(true);
     // genesis resource digest matches the AssetResource hash (bridged)

--- a/packages/sdk/tests/unit/lifecycle/LifecycleManager.cleanapi.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/LifecycleManager.cleanapi.test.ts
@@ -17,7 +17,7 @@ const resources = [
 
 describe('LifecycleManager - Clean API', () => {
   describe('createDraft', () => {
-    test('creates a peer-layer asset', async () => {
+    test('creates a did:cel-layer asset', async () => {
       const sdk = OriginalsSDK.create({ storageAdapter: new MemoryStorageAdapter(), network: 'regtest' });
       const asset = await sdk.lifecycle.createDraft(resources);
       expect(asset.currentLayer).toBe('did:cel');

--- a/packages/sdk/tests/unit/lifecycle/LifecycleManager.cleanapi.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/LifecycleManager.cleanapi.test.ts
@@ -20,7 +20,7 @@ describe('LifecycleManager - Clean API', () => {
     test('creates a peer-layer asset', async () => {
       const sdk = OriginalsSDK.create({ storageAdapter: new MemoryStorageAdapter(), network: 'regtest' });
       const asset = await sdk.lifecycle.createDraft(resources);
-      expect(asset.currentLayer).toBe('did:peer');
+      expect(asset.currentLayer).toBe('did:cel');
       expect(asset.id.startsWith('did:cel:')).toBe(true);
     });
 
@@ -32,7 +32,7 @@ describe('LifecycleManager - Clean API', () => {
         onProgress: (p) => progressEvents.push({ ...p })
       });
       
-      expect(asset.currentLayer).toBe('did:peer');
+      expect(asset.currentLayer).toBe('did:cel');
       expect(progressEvents.length).toBeGreaterThan(0);
       expect(progressEvents[0].phase).toBe('preparing');
       expect(progressEvents[progressEvents.length - 1].phase).toBe('complete');
@@ -280,7 +280,7 @@ describe('LifecycleManager - Migration Validation', () => {
       
       expect(validation.valid).toBe(true);
       expect(validation.errors).toHaveLength(0);
-      expect(validation.currentLayer).toBe('did:peer');
+      expect(validation.currentLayer).toBe('did:cel');
       expect(validation.targetLayer).toBe('did:webvh');
       expect(validation.checks.layerTransition).toBe(true);
       expect(validation.checks.resourcesValid).toBe(true);

--- a/packages/sdk/tests/unit/lifecycle/LifecycleManager.keymanagement.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/LifecycleManager.keymanagement.test.ts
@@ -113,7 +113,7 @@ describe('LifecycleManager Key Management', () => {
     test('should automatically register key when keyStore is provided', async () => {
       const asset = await lifecycleManager.createAsset(resources);
 
-      expect(asset.currentLayer).toBe('did:peer');
+      expect(asset.currentLayer).toBe('did:cel');
       expect(asset.did.verificationMethod).toBeDefined();
       expect(asset.did.verificationMethod!.length).toBeGreaterThan(0);
 
@@ -132,7 +132,7 @@ describe('LifecycleManager Key Management', () => {
       const lifecycleWithoutKeyStore = new LifecycleManager(config, didManager, credentialManager);
       const asset = await lifecycleWithoutKeyStore.createAsset(resources);
 
-      expect(asset.currentLayer).toBe('did:peer');
+      expect(asset.currentLayer).toBe('did:cel');
       expect(asset.did.verificationMethod).toBeDefined();
     });
   });

--- a/packages/sdk/tests/unit/lifecycle/LifecycleManager.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/LifecycleManager.test.ts
@@ -13,10 +13,10 @@ const resources = [
 ];
 
 describe('LifecycleManager', () => {
-  test('createAsset creates a peer-layer asset', async () => {
+  test('createAsset creates a did:cel-layer asset', async () => {
     const sdk = OriginalsSDK.create({ storageAdapter: new MemoryStorageAdapter(), network: 'regtest' });
     const asset = await sdk.lifecycle.createAsset(resources);
-    expect(asset.currentLayer).toBe('did:peer');
+    expect(asset.currentLayer).toBe('did:cel');
     expect(asset.id.startsWith('did:cel:')).toBe(true);
   });
 
@@ -138,7 +138,7 @@ describe('Bitcoin inscription MVP - dry run', () => {
     const latest = prov.migrations[prov.migrations.length - 1];
     expect(latest.feeRate).toBe(feeRate);
     expect(latest.transactionId).toEqual(expect.any(String));
-    expect(before).toBe('did:peer');
+    expect(before).toBe('did:cel');
   });
 });
 
@@ -244,7 +244,7 @@ describe('publishToWeb storage requirement (issue #244)', () => {
     await expect(sdk.lifecycle.publishToWeb(asset, 'example.com'))
       .rejects.toThrow(/storageAdapter must be configured/);
     // The asset must NOT have migrated
-    expect(asset.currentLayer).toBe('did:peer');
+    expect(asset.currentLayer).toBe('did:cel');
   });
 
   test('throws STORAGE_REQUIRED when the adapter implements neither put nor putObject', async () => {
@@ -254,7 +254,7 @@ describe('publishToWeb storage requirement (issue #244)', () => {
     ] as any);
     await expect(sdk.lifecycle.publishToWeb(asset, 'example.com'))
       .rejects.toThrow(/neither put\(\) nor putObject\(\)/);
-    expect(asset.currentLayer).toBe('did:peer');
+    expect(asset.currentLayer).toBe('did:cel');
   });
 });
 

--- a/packages/sdk/tests/unit/lifecycle/OriginalsAsset.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/OriginalsAsset.test.ts
@@ -33,8 +33,8 @@ describe('OriginalsAsset', () => {
     expect(new OriginalsAsset(resources, buildDid('did:btco:123'), emptyCreds).currentLayer).toBe('did:btco');
   });
 
-  test('treats did:cel as the genesis-layer synonym for did:peer', () => {
-    expect(new OriginalsAsset(resources, buildDid('did:cel:uEiAabc'), emptyCreds).currentLayer).toBe('did:peer');
+  test('maps a did:cel genesis to the did:cel layer', () => {
+    expect(new OriginalsAsset(resources, buildDid('did:cel:uEiAabc'), emptyCreds).currentLayer).toBe('did:cel');
   });
 
   test('rejects invalid migration path', async () => {

--- a/packages/sdk/tests/unit/lifecycle/lifecycle-coverage.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/lifecycle-coverage.test.ts
@@ -193,7 +193,7 @@ describe('LIFECYCLE-005/error – publishToWeb from wrong layer', () => {
 
     await expect(
       sdk.lifecycle.publishToWeb(asset, 'example.com')
-    ).rejects.toThrow(/did:peer layer/);
+    ).rejects.toThrow(/genesis layer/);
   });
 
   test('asset on did:btco also throws', async () => {
@@ -204,7 +204,7 @@ describe('LIFECYCLE-005/error – publishToWeb from wrong layer', () => {
 
     await expect(
       sdk.lifecycle.publishToWeb(asset, 'example.com')
-    ).rejects.toThrow(/did:peer layer/);
+    ).rejects.toThrow(/genesis layer/);
   });
 });
 

--- a/packages/sdk/tests/unit/lifecycle/loadAsset.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/loadAsset.test.ts
@@ -87,13 +87,13 @@ describe('loadAsset — round-trip', () => {
     expect(await loaded.verify({ ordinalsProvider: (sdk as any).config?.ordinalsProvider })).toBe(true);
   });
 
-  test('genesis-only asset round-trips (currentLayer did:peer)', async () => {
+  test('genesis-only asset round-trips (currentLayer did:cel)', async () => {
     const { sdk } = makeSDK();
     const asset = await createGenesisAsset(sdk);
     const envelope = asset.serialize();
     const { asset: loaded, verification } = await sdk.lifecycle.loadAsset(envelope);
     expect(verification?.verified).toBe(true);
-    expect(loaded.currentLayer).toBe('did:peer');
+    expect(loaded.currentLayer).toBe('did:cel');
     expect(loaded.id).toBe(asset.id);
     expect(loaded.bindings).toEqual({ 'did:cel': asset.id });
   });

--- a/packages/sdk/tests/unit/lifecycle/loadAsset.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/loadAsset.test.ts
@@ -59,7 +59,8 @@ describe('loadAsset — round-trip', () => {
     expect(verification?.verified).toBe(true);
     expect(warnings).toEqual([]);
 
-    // Identity + layer restored (ctor would have derived 'did:peer' for did:cel).
+    // Identity + layer restored (ctor derives the genesis 'did:cel'; restore()
+    // overrides it with the folded post-migration layer 'did:btco').
     expect(loaded.id).toBe(asset.id);
     expect(loaded.currentLayer).toBe('did:btco');
     expect(loaded.currentLayer).toBe(asset.currentLayer);

--- a/packages/sdk/tests/unit/lifecycle/replayProvenance.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/replayProvenance.test.ts
@@ -50,7 +50,7 @@ function makeLifecycle() {
 }
 
 describe('replayProvenance pure fold (#Phase2 Task7)', () => {
-  test('genesis-only log: did:peer layer, did:cel binding, no migrations', async () => {
+  test('genesis-only log: did:cel layer, did:cel binding, no migrations', async () => {
     const { lifecycle } = makeLifecycle();
     const asset = await lifecycle.createAsset([
       { id: 'r', type: 'data', contentType: 'text/plain', hash: 'cd'.repeat(32) }
@@ -58,7 +58,7 @@ describe('replayProvenance pure fold (#Phase2 Task7)', () => {
 
     const folded = replayProvenance(asset.celLog!);
 
-    expect(folded.currentLayer).toBe('did:peer');
+    expect(folded.currentLayer).toBe('did:cel');
     expect(folded.bindings['did:cel']).toBe(asset.id);
     expect(folded.bindings['did:cel']).toBe(deriveDidCel(asset.celLog!));
     expect(folded.migrations).toEqual([]);

--- a/packages/sdk/tests/unit/lifecycle/resource-hash-verification.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/resource-hash-verification.test.ts
@@ -38,7 +38,7 @@ describe('issue #347: content/hash verification', () => {
     const sdk = makeSdk();
     const upper = { ...goodResource(), hash: contentHash('authentic bytes').toUpperCase() };
     const asset = await sdk.lifecycle.createAsset([upper]);
-    expect(asset.currentLayer).toBe('did:peer');
+    expect(asset.currentLayer).toBe('did:cel');
   });
 
   test('createAsset still accepts hash-only resources (no inline content to check)', async () => {
@@ -50,7 +50,7 @@ describe('issue #347: content/hash verification', () => {
       hash: contentHash('content hosted elsewhere')
     };
     const asset = await sdk.lifecycle.createAsset([hashOnly]);
-    expect(asset.currentLayer).toBe('did:peer');
+    expect(asset.currentLayer).toBe('did:cel');
   });
 
   test('publishToWeb rejects content tampered with after creation, BEFORE writing or attesting', async () => {
@@ -75,7 +75,7 @@ describe('issue #347: content/hash verification', () => {
     expect(asset.credentials.length).toBe(0);
     expect(asset.resources[0].url).toBeUndefined();
     // The asset did not migrate.
-    expect(asset.currentLayer).toBe('did:peer');
+    expect(asset.currentLayer).toBe('did:cel');
   });
 
   test('publishToWeb succeeds when content matches its declared hash', async () => {

--- a/packages/sdk/tests/unit/migration/migration-scenarios.test.ts
+++ b/packages/sdk/tests/unit/migration/migration-scenarios.test.ts
@@ -897,14 +897,14 @@ describe('CORE-MIG-EVENTS-041: Peer→Bitcoin direct migration', () => {
     } as any);
 
     const asset = await sdk.lifecycle.createAsset(sampleResources);
-    expect(asset.currentLayer).toBe('did:peer');
+    expect(asset.currentLayer).toBe('did:cel');
 
     const inscribed = await sdk.lifecycle.inscribeOnBitcoin(asset, 10);
 
     expect(inscribed.currentLayer).toBe('did:btco');
     const prov = inscribed.getProvenance();
     const lastMig = prov.migrations[prov.migrations.length - 1];
-    expect(lastMig.from).toBe('did:peer');
+    expect(lastMig.from).toBe('did:cel');
     expect(lastMig.to).toBe('did:btco');
   });
 

--- a/packages/sdk/tests/unit/playground/repl.test.ts
+++ b/packages/sdk/tests/unit/playground/repl.test.ts
@@ -44,7 +44,7 @@ describe('Playground REPL', () => {
     expect(output).toContain('Created "Asset 1"');
     expect(output).toContain('Alias:  a1');
     expect(output).toContain('did:cel:');
-    expect(output).toContain('Layer:  did:peer');
+    expect(output).toContain('Layer:  did:cel');
   });
 
   test('creates an asset with custom name', async () => {
@@ -65,7 +65,7 @@ describe('Playground REPL', () => {
     expect(output).toContain('Session Assets:');
     expect(output).toContain('a1');
     expect(output).toContain('a2');
-    expect(output).toContain('did:peer');
+    expect(output).toContain('did:cel');
   });
 
   test('shows empty assets message', async () => {
@@ -76,7 +76,7 @@ describe('Playground REPL', () => {
   test('inspects an asset', async () => {
     const output = await runRepl(['create InspectMe', 'inspect a1', 'exit']);
     expect(output).toContain('Asset: a1');
-    expect(output).toContain('Layer:         did:peer');
+    expect(output).toContain('Layer:         did:cel');
     expect(output).toContain('Resources:     1');
     expect(output).toContain('Provenance:');
     expect(output).toContain('Migrations:  0');


### PR DESCRIPTION
## Summary

Fixes the misleading lifecycle **layer label**: a `did:cel` genesis asset now reports `currentLayer: 'did:cel'` instead of the leftover `'did:peer'`. did:cel epic — **Phase 4, sub-project 4 of 5**.

Spec: `docs/superpowers/specs/2026-07-14-layer-label-rename-design.md`.

## What changed

- **`LayerType`** gains `'did:cel'` → `'did:peer' | 'did:cel' | 'did:webvh' | 'did:btco'`.
- **`OriginalsAsset.determineCurrentLayer`** maps a `did:cel:` id to `'did:cel'` (was `'did:peer'`); `did:peer:` still maps to `'did:peer'`.
- **Migrate transition tables** (both `OriginalsAsset.migrate` and `LifecycleManager.validateMigration`) get the `'did:cel': ['did:webvh','did:btco']` key — required so a did:cel asset's `migrate()` has valid targets (and to keep the exhaustive `Record<LayerType, …>` type-complete).
- **Genesis-layer gates** `publishToWeb` / `inscribeOnBitcoin` (plus the playground REPL publish gate and `validateMigration`) accept `'did:cel'` as the genesis layer — required by the spec's testing spine so publish + inscribe still succeed from a freshly created did:cel asset. They still reject non-genesis layers (`did:webvh`/`did:btco` for publish).
- **Fold / restore**: `replayProvenance` folds a controller-genesis to `currentLayer: 'did:cel'`; `buildRestoredProvenance` seeds the genesis migration layer as `'did:cel'`; the migration metric/event `fromLayer` now report the dynamic genesis layer.

## Legacy did:peer is unchanged

Legacy `did:peer` assets still report `'did:peer'` and migrate identically (`'did:peer'` remains a valid layer; its deprecation is sub-project 5). did:peer-as-DID-method parsing, hand-built did:peer assets, and — per the spec's non-goals — the `ResourceMigrated` publication credential's `fromLayer` are all untouched. No change to did:cel derivation, verification, ownership, or credentials.

## Fixtures

Flipped only the assertions describing a **did:cel-genesis** asset's layer / migration-from (created via `createAsset`/`createDraft` or a `did:cel:` id) to `'did:cel'`; genuine did:peer assets left as-is.

## Verification

- `bun test` (packages/sdk): **3953 pass, 0 fail**, 70 skip.
- `bunx tsc --noEmit`: clean. `bun run build`: clean.
- Reviewed by an independent opus pass against the spec — verdict: correct and faithful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename genesis layer label from 'did:peer' to 'did:cel' across lifecycle and replay
> - Adds `'did:cel'` to the `LayerType` union in [common.ts](https://github.com/onionoriginals/sdk/pull/406/files#diff-9781751bea79b2a3158cfa00e25358ad0ad33e973edf0a24b0cc24b3b5342632) and updates `determineCurrentLayer` so assets with a `did:cel:` DID report `currentLayer: 'did:cel'` instead of `'did:peer'`.
> - Extends valid transitions in `OriginalsAsset.migrate` and `LifecycleManager.validateMigration` to include `'did:cel' → 'did:webvh' | 'did:btco'`.
> - Updates `replayProvenance` to set `currentLayer: 'did:cel'` on genesis for signed did:cel logs, and fixes `buildRestoredProvenance` to seed migration replay from `'did:cel'` instead of `'did:peer'`.
> - Relaxes layer guards in `publishToWeb` and `inscribeOnBitcoin` to accept `'did:cel'` as a valid starting layer; migration metrics now record the actual from-layer dynamically.
> - Updates all unit and integration test assertions to expect `'did:cel'` as the initial layer after asset creation.
> - Behavioral Change: any code or consumers comparing `currentLayer === 'did:peer'` for genesis assets will no longer match; the genesis layer is now exclusively `'did:cel'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d6419f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->