### PR TITLE
Content-addressed separation: resource content by reference, not embedded (#407 phase 1)

### DIFF
--- a/.changeset/content-addressed-separation.md
+++ b/.changeset/content-addressed-separation.md
@@ -1,0 +1,7 @@
+---
+"@originals/sdk": minor
+---
+
+Content-addressed separation (epic #407 phase 1): resource-update CEL events now reference content by a signed `toHash` instead of embedding the file bytes. **Breaking to the on-log event shape** — a resource-update `update` event's `data` is now `{ resourceId, contentType, previousVersionHash, toHash, toVersion }` with no `content` field, reversing #401's embed-the-bytes shape.
+
+Content travels as content-addressed blobs alongside a byte-light log: the `serialize()` envelope carries the bytes in its `resources` array (keyed by hash), so offline verification is preserved — `loadAsset` binds `hash(blob) == toHash` (and every envelope resource must match a log-declared hash by resourceId, or it fails closed). The verifier checks only hash-chain continuity on the signed hashes and no longer recomputes `hash(content)` from the event. This shrinks the log so it can be affordably inscribed on Bitcoin in a later phase (#407). Public APIs (`addResourceVersion`, `serialize`, `loadAsset`) are unchanged externally.

--- a/docs/superpowers/plans/2026-07-14-content-addressed-separation.md
+++ b/docs/superpowers/plans/2026-07-14-content-addressed-separation.md
@@ -1,0 +1,62 @@
+# Plan: Content-addressed separation (epic #407, phase 1)
+
+Reworks the just-merged #401. Resource-update CEL events stop embedding file bytes;
+they reference content by a **signed `toHash`** (+ optional `locator`). Content lives
+in the content-addressed store (the `resources` array / `serialize()` envelope blobs).
+Offline verify is preserved: `loadAsset` binds `hash(blob) == toHash` (or genesis digest).
+
+Spec: `docs/superpowers/specs/2026-07-14-content-addressed-separation-design.md`
+
+## Event shape
+
+`update` event `data`:
+- BEFORE (#401): `{ resourceId, content, contentType, previousVersionHash, toVersion }` (toHash derived from content)
+- AFTER: `{ resourceId, contentType, previousVersionHash, toHash, toVersion }` (no bytes; toHash signed)
+
+`toHash` / `previousVersionHash` are hex sha256 (same encoding as `AssetResource.hash`).
+
+## TDD tasks (each: write/convert test → run red → implement → green → commit)
+
+### Task 1 — Writer: `OriginalsAsset.addResourceVersion` appends reference-shaped event
+- Convert `tests/unit/lifecycle/addResourceVersion.celevent.test.ts`: assert the bound
+  appender receives `toHash` (= `hash('v2')`) and NO `content` field.
+- Impl: `#addResourceVersionCritical` calls appender with
+  `{ resourceId, contentType, previousVersionHash: currentResource.hash, toHash: newHash, toVersion: newVersion }`.
+  Bytes stay in `resources` (already pushed). External behavior (async, degrade,
+  UNPROVABLE_BASE, cel:append-skipped) unchanged.
+
+### Task 2 — Verifier: continuity on signed `toHash`, stop hashing content
+- Convert `tests/unit/cel/resource-update-events.test.ts`: all `update` bodies use
+  `toHash: hex('vN')` not `content`. Rework "content-tamper" → tamper `toHash` after
+  signing breaks the controller signature (still rejected).
+- Impl `checkResourceUpdateContinuity`: take `{ resourceId, previousVersionHash, toHash }`;
+  require `toHash` string; chain `previousVersionHash` → last-known (genesis digest / prior
+  toHash); set current = `hexSha256ToDigestMultibase(toHash)`. No `hashResource(content)`.
+- Impl caller in `verifyEventLog`: discriminator still `resourceId` + `previousVersionHash`;
+  pass `toHash` through.
+
+### Task 3 — `loadAsset` content-binding generalization
+- Convert `tests/integration/ResourceUpdateHandoff.e2e.test.ts` "content-tamper" test:
+  tamper the ENVELOPE BLOB (`envelope.resources` v2 content) so `hash(blob) != toHash`
+  → rejected at load. (Log event no longer carries content.)
+- Impl `loadAsset`: for every v≥2 resource, require a matching verified `update` event by
+  `(resourceId, toVersion)` and `hash(content) == match.toHash` DIRECTLY (content integrity
+  vs the SIGNED toHash, not transitively via `res.hash`). Genesis (v1) content binding
+  unchanged (checkGenesisResourceBinding + inline self-consistency). Fail closed.
+
+### Task 4 — Fold: `replayProvenance` reads `toHash` from the field
+- Convert `tests/unit/lifecycle/replayProvenance.test.ts` (line ~245) to `toHash` shape.
+- Impl: discriminator `resourceId && previousVersionHash && toHash`; `toHash: data.toHash`
+  (field, not derived); `fromHash: previousVersionHash`.
+
+### Task 5 — Byte-light log test + serialize confirmation
+- Add e2e assertions: a resource-update event's `data` has NO `content`; serialized log
+  size is (near-)independent of content size. `serialize()` needs no structural change —
+  the log is byte-light by construction once the writer stops embedding.
+
+### Task 6 — fable reviewer on verifier/loadAsset/serialize diff; fix Critical/Important.
+
+### Task 7 — changeset `.changeset/content-addressed-separation.md` (minor/breaking).
+
+## Verify
+`bun run build` → `bun test` (0 fail) → `bunx tsc --noEmit` clean. Commit after every task.

--- a/docs/superpowers/specs/2026-07-14-content-addressed-separation-design.md
+++ b/docs/superpowers/specs/2026-07-14-content-addressed-separation-design.md
@@ -1,0 +1,105 @@
+# Design: Content-addressed separation (epic #407, phase 1)
+
+> First increment of epic #407 ("The CEL lives on the sat"). The log must be
+> **small** before it can be affordably inscribed on Bitcoin (phase 2). Today
+> resource-update events (#401) **embed the file bytes** inline, so the log
+> literally contains content — making it big/expensive to inscribe. This phase
+> moves content **out of the log** into a content-addressed store, so log events
+> carry only hashes. It is a **rework of the just-merged #401**.
+
+## 0. Decision record
+
+- **Separate content from the log:** resource-update events reference content by
+  **hash** (a signed `toHash`), never by embedded bytes. Content lives in the
+  content-addressed store (the asset `resources` array / `serialize()` envelope
+  blobs / webvh host), keyed by hash — exactly where genesis content already
+  lives (genesis references `digestMultibase`, never bytes). This makes updates
+  symmetric with genesis.
+- **Offline verify is preserved:** the `serialize()` envelope still carries the
+  content **blobs alongside** the small log; `loadAsset` binds `hash(blob) ==
+  the event's toHash`. Same guarantee #401 gave, generalized (this IS the
+  content-binding the #401→5/5 fix already added).
+- **No inscription here:** phase 1 changes only the log/event shape and storage.
+  Inscribing the (now-small) log for on-chain provenance is phase 2. The
+  reference `locator` holds a webvh URL now and will upgrade to a
+  `did:btco:<sat>` pointer in the inscription phases.
+- **Hard cutover:** nothing released. #401-shaped logs (content embedded in the
+  event) are regenerated to the reference shape.
+
+## 1. The event-shape change
+
+Resource-update `update` event `data` today (embeds bytes):
+```
+{ resourceId, content, contentType, previousVersionHash, toVersion }   // toHash derived from content
+```
+Becomes (reference only):
+```
+{ resourceId, contentType, previousVersionHash, toHash, toVersion, locator? }
+```
+- `toHash` is now a **stored, signed** field (the content isn't in the event to
+  derive it from). `previousVersionHash` unchanged.
+- `locator?` — optional retrieval hint (a webvh URL now; a `did:btco:<sat>`
+  pointer once inscribed). Advisory: never the root of trust (the hash is).
+- The bytes are removed from the event entirely.
+
+## 2. Where content lives (content-addressed store)
+
+- **In-memory:** the asset's `resources` array (unchanged — `AssetResource.content`).
+- **Interchange:** `serialize()` captures resources as content-addressed blobs
+  keyed by hash, carried **alongside** the small log in the envelope. (Genesis
+  resources already ride this way; resource-update versions now join them
+  instead of living in the log.)
+- **Hosted:** webvh continues to host content by URL (free, live).
+- The log/event holds only `toHash` (+ advisory `locator`).
+
+## 3. Writer — `OriginalsAsset.addResourceVersion`
+
+Unchanged externally (still async, injected signer, `cel:append-skipped` /
+`UNPROVABLE_BASE` degrade). Internally: it appends the **reference-shaped** event
+(no `content` in `data`; `toHash` computed from the new bytes and stored) and
+keeps the new bytes in the `resources` array / content-addressed store. The
+byte-embedding is removed.
+
+## 4. Verifier — `verifyEventLog`
+
+The resource-update branch (`checkResourceUpdateContinuity`) now checks **only
+hash-chain continuity**: `data.previousVersionHash` must equal the last-known
+hash for `resourceId` (genesis digest for the first update, prior `toHash`
+after), and `data.toHash` becomes the new current hash. It no longer recomputes
+`hash(content)` from the event (there is no content in the event). Content
+integrity (does a blob actually hash to `toHash`) moves to `loadAsset`.
+
+## 5. `loadAsset` / envelope
+
+`loadAsset` keeps and generalizes the #401→5/5 content-binding: for every
+envelope resource (genesis AND update versions, all `v≥1`), require it match a
+log-declared hash — `hash(blob) == the event's toHash` (or the genesis digest),
+by `(resourceId, version)` — else `ASSET_LOAD_VERIFICATION_FAILED`. `serialize()`
+emits the content blobs in the envelope; the log it emits is byte-light.
+
+## 6. Deferred (later #407 phases)
+
+- Inscribing the small log on-chain (phase 2) — the payoff this enables.
+- `did:btco:<sat>` content-address upgrade of the `locator` (content inscription
+  phases).
+- The reconstruction resolver (bare sat → rebuild log → verify).
+
+## 7. Testing spine
+
+- **Migration round-trip:** an asset with resource updates → `serialize()` →
+  fresh-SDK `loadAsset` verifies offline with the content blobs (no host); the
+  log carries no bytes.
+- **Content-tamper:** a blob that doesn't hash to the event's `toHash` → rejected
+  at load (`ASSET_LOAD_VERIFICATION_FAILED`).
+- **Chain-continuity:** `previousVersionHash` mismatch → rejected (unchanged).
+- **Byte-light log:** assert a resource-update event's `data` contains no
+  `content` field and the serialized log size is independent of content size.
+- **Authority-after-rotation** and **degrade** (`cel:append-skipped` /
+  `UNPROVABLE_BASE`) still hold.
+
+## 8. Changeset
+
+`@originals/sdk` **minor/breaking** — resource-update CEL events now reference
+content by hash (`toHash`) instead of embedding bytes; content travels as
+content-addressed blobs in the envelope. Reverses #401's embed-the-bytes shape.
+Foundation for on-chain log inscription (#407).

--- a/packages/sdk/src/cel/algorithms/verifyEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/verifyEventLog.ts
@@ -23,7 +23,6 @@ import { multikey } from '../../crypto/Multikey.js';
 import { deriveDidCelFromGenesis, didCelMatchesLog } from '../celDid.js';
 import { parseSatoshiIdentifier } from '../../utils/satoshi-validation.js';
 import { hexSha256ToDigestMultibase } from '../signerAdapter.js';
-import { hashResource } from '../../utils/validation.js';
 
 /**
  * Validates the structural requirements of a DataIntegrityProof (field presence,
@@ -935,7 +934,7 @@ async function resolveControllerKeyHex(
  * @returns EventVerification result
  */
 /**
- * Resource-update continuity + content binding (#Phase-4 resource events).
+ * Resource-update chain continuity (#407 phase 1 — content-addressed separation).
  *
  * A resource-shaped `update` event (`data.resourceId` + `data.previousVersionHash`
  * present) MUST chain forward from the last-known hash of its resourceId:
@@ -943,27 +942,31 @@ async function resolveControllerKeyHex(
  *    (ExternalReference carried an `id`, #401), `previousVersionHash` must match
  *    THAT digest specifically; otherwise (legacy id-less genesis) it may match
  *    ANY genesis digest;
- *  - subsequent updates: it must match the prior update's DERIVED hash.
- * The new current hash is `hashResource(content)` (derived, never stored). All
- * hashes are compared as digestMultibase. On success the per-resourceId map is
- * advanced; on any failure an error string is returned (fail closed) and the map
- * is left untouched.
+ *  - subsequent updates: it must match the prior update's `toHash`.
+ * The new current hash is the SIGNED `data.toHash` field — NOT recomputed from
+ * content, which no longer lives in the event (#407): the bytes travel in the
+ * content-addressed store (resources array / envelope blobs), and CONTENT
+ * INTEGRITY (does a blob actually hash to `toHash`) is bound at load time by
+ * loadAsset. Here we check only the hash chain over the signed hashes. All hashes
+ * are compared as digestMultibase. On success the per-resourceId map is advanced;
+ * on any failure an error string is returned (fail closed) and the map is left
+ * untouched.
  */
 function checkResourceUpdateContinuity(
-  data: { resourceId: unknown; previousVersionHash: unknown; content?: unknown },
+  data: { resourceId: unknown; previousVersionHash: unknown; toHash?: unknown },
   genesisDigests: Set<string>,
   genesisDigestById: Map<string, string>,
   currentResourceHash: Map<string, string>
 ): string | null {
   const resourceId = data.resourceId as string;
-  if (typeof data.content !== 'string') {
-    return `resource update for ${resourceId} has non-string content; cannot verify`;
+  if (typeof data.toHash !== 'string' || data.toHash.length === 0) {
+    return `resource update for ${resourceId} is missing a signed toHash; cannot verify continuity`;
   }
   let prevDigest: string;
   let newDigest: string;
   try {
     prevDigest = hexSha256ToDigestMultibase(data.previousVersionHash as string);
-    newDigest = hexSha256ToDigestMultibase(hashResource(Buffer.from(data.content, 'utf-8')));
+    newDigest = hexSha256ToDigestMultibase(data.toHash);
   } catch (e) {
     return `resource update for ${resourceId} has an unparseable hash: ${e instanceof Error ? e.message : String(e)}`;
   }
@@ -1451,12 +1454,12 @@ export async function verifyEventLog(
     // proof semantics). Only engage for resource-shaped updates that otherwise
     // verified — a failed proof/chain already fails the event.
     if (!options?.verifier && event.type === 'update' && eventResult.proofValid && eventResult.chainValid) {
-      const rd = event.data as { resourceId?: unknown; previousVersionHash?: unknown; content?: unknown } | null;
+      const rd = event.data as { resourceId?: unknown; previousVersionHash?: unknown; toHash?: unknown } | null;
       if (rd && typeof rd.resourceId === 'string' && typeof rd.previousVersionHash === 'string') {
         // Rebuild as a literal: narrowing on rd's optional props doesn't
         // propagate to the whole-object type expected by the helper below.
         const err = checkResourceUpdateContinuity(
-          { resourceId: rd.resourceId, previousVersionHash: rd.previousVersionHash, content: rd.content },
+          { resourceId: rd.resourceId, previousVersionHash: rd.previousVersionHash, toHash: rd.toHash },
           genesisResourceDigests,
           genesisResourceDigestById,
           currentResourceHash

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -31,7 +31,7 @@ import { verifyEventLog } from '../cel/algorithms/verifyEventLog.js';
 import { createDidManagerKeyResolver } from '../cel/keyResolver.js';
 import { PeerCelManager } from '../cel/layers/PeerCelManager.js';
 import { appendEvent } from '../cel/algorithms/appendEvent.js';
-import { computeDigestMultibase } from '../cel/hash.js';
+import { computeDigestMultibase, digestMultibaseEquals } from '../cel/hash.js';
 import { canonicalizeEntryForChain } from '../cel/canonicalize.js';
 import { serializeEventLogJson, parseEventLogJson } from '../cel/serialization/json.js';
 import type { EventLog, LogEntry, ExternalReference, WitnessProof, OrdinalsLookup, VerificationResult } from '../cel/types.js';
@@ -562,6 +562,48 @@ export class LifecycleManager {
         }
       }
 
+      // 4c) EVERY envelope resource must match a LOG-DECLARED hash for its id
+      // (#407 — content integrity now lives at load, so the binding must be
+      // total, not just the v≥2 slice 4b covers). checkGenesisResourceBinding
+      // above is subset-only (genesis ⊆ present) and 4b keys off the
+      // attacker-controlled `res.version`, so an injected resource labeled
+      // `version:1` — or a genuine later blob relabeled to v1 — would otherwise be
+      // restored with ZERO provenance backing and then flow into the buyer's
+      // published/inscribed identity. Bind each resource's declared hash to a
+      // genesis digest (id-bound per #401; id-less genesis falls back to any) OR a
+      // folded update `toHash` for the SAME resourceId — matching NEITHER fails
+      // closed. Skipped only for legacy (data.did) geneses that carry no resources
+      // array (they predate this contract, mirroring checkGenesisResourceBinding).
+      const genesisResources = (log.events[0]?.data as { resources?: unknown } | undefined)?.resources;
+      if (Array.isArray(genesisResources)) {
+        const genesisDigestById = new Map<string, string>();
+        const genesisDigestsIdless = new Set<string>();
+        for (const ref of genesisResources) {
+          const dm = (ref as { digestMultibase?: unknown })?.digestMultibase;
+          if (typeof dm !== 'string' || dm.length === 0) continue;
+          const id = (ref as { id?: unknown })?.id;
+          if (typeof id === 'string' && id.length > 0) genesisDigestById.set(id, dm);
+          else genesisDigestsIdless.add(dm);
+        }
+        for (const res of env.resources) {
+          const resDigest = hexSha256ToDigestMultibase(String(res.hash));
+          const boundGenesis = genesisDigestById.get(res.id);
+          const matchesGenesis = boundGenesis !== undefined
+            ? digestMultibaseEquals(resDigest, boundGenesis)
+            : [...genesisDigestsIdless].some(d => digestMultibaseEquals(resDigest, d));
+          const matchesUpdate = folded.resourceUpdates.some(
+            u => u.resourceId === res.id && u.toHash.toLowerCase() === String(res.hash).toLowerCase()
+          );
+          if (!matchesGenesis && !matchesUpdate) {
+            throw new StructuredError(
+              'ASSET_LOAD_VERIFICATION_FAILED',
+              `Resource ${res.id} (hash ${res.hash}) is not declared by the log — it matches neither a genesis digest nor a signed update toHash for this resourceId; refusing to restore unbacked content.`,
+              { verification }
+            );
+          }
+        }
+      }
+
       // 5) Cross-checks: the fold IS the source of truth for identity/bindings;
       // an envelope's advisory DID docs must not disagree with it — a swapped
       // doc is exactly the attack the envelope invites. did:cel is bound by the
@@ -604,6 +646,26 @@ export class LifecycleManager {
         'Loaded a btco-anchored asset without an ordinals provider: head freshness was NOT checked, so a ' +
         'truncated (pre-rotation) authoring record cannot be ruled out. Re-load with a provider to verify freshness.'
       );
+    }
+    // Missing head blob (#407): the log folds a resource head (latest toHash per
+    // resourceId) that no envelope blob backs. Not a forgery — the signed hash
+    // chain is intact and a substituted blob would fail 4c — but the buyer would
+    // silently carry stale/absent content for the current version. Warn (like the
+    // freshness gap), fetchable-by-hash from the content-addressed store later.
+    if (!opts?.skipVerification) {
+      const headByResource = new Map<string, string>();
+      for (const u of folded.resourceUpdates) headByResource.set(u.resourceId, u.toHash);
+      for (const [resourceId, headHash] of headByResource) {
+        const backed = env.resources.some(
+          r => r.id === resourceId && String(r.hash).toLowerCase() === headHash.toLowerCase()
+        );
+        if (!backed) {
+          warnings.push(
+            `Resource ${resourceId}: the log's current version (toHash ${headHash}) has no backing blob in the ` +
+            `envelope; the loaded asset carries only an older version. Retrieve the current content by hash.`
+          );
+        }
+      }
     }
     const provenance = this.buildRestoredProvenance(log, folded, env, warnings);
 

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -514,15 +514,19 @@ export class LifecycleManager {
         }
       }
 
-      // 4b) Post-genesis resource binding (#401). Genesis (v1) resources are
-      // bound by checkGenesisResourceBinding above; every resource version ≥ 2
-      // MUST instead be backed by a VERIFIED `update` log event with the SAME
-      // resourceId, version, and derived content hash. The step-4 loop only
-      // proves each resource is self-consistent (content ↔ its own hash), NOT
-      // that its content is the one the controller signed. Without this, a
-      // self-consistent forged post-genesis version (or an unprovable degraded
-      // version) in env.resources would load undetected while the fold reports
-      // the genuine hash. Fail closed — the verified log is the source of truth.
+      // 4b) Post-genesis resource binding (#401, generalized for #407). Genesis
+      // (v1) resources are bound by checkGenesisResourceBinding + the step-4
+      // content↔hash check above; every resource version ≥ 2 MUST instead be
+      // backed by a VERIFIED `update` log event with the SAME resourceId and
+      // version, and its blob content MUST hash to that event's SIGNED `toHash`.
+      //
+      // This is where CONTENT INTEGRITY now lives (#407): the verifier no longer
+      // recomputes hash(content) — the bytes are not in the event — so the load
+      // is the sole gate binding a content-addressed blob to the signed hash the
+      // controller committed to. We bind blob→toHash DIRECTLY (not transitively
+      // via the envelope-controlled res.hash): a forged blob (hash(content) ≠
+      // toHash), a self-consistent forgery (content and res.hash both swapped),
+      // and an unprovable degraded version (no backing event) all fail closed.
       for (const res of env.resources) {
         const version = typeof res.version === 'number' ? res.version : 1;
         if (version < 2) continue;
@@ -539,9 +543,22 @@ export class LifecycleManager {
         if (match.toHash.toLowerCase() !== String(res.hash).toLowerCase()) {
           throw new StructuredError(
             'ASSET_LOAD_VERIFICATION_FAILED',
-            `Resource ${res.id} v${version}: envelope hash (${res.hash}) does not match the verified log's derived hash (${match.toHash}).`,
+            `Resource ${res.id} v${version}: envelope hash (${res.hash}) does not match the verified log's signed hash (${match.toHash}).`,
             { verification }
           );
+        }
+        // Bind the actual blob to the signed toHash. The content-addressed store
+        // carries the bytes inline (AssetResource.content); a resource that omits
+        // them is a pure reference and rides on the res.hash↔toHash match above.
+        if (typeof res.content === 'string') {
+          const computed = hashResource(Buffer.from(res.content, 'utf8'));
+          if (computed.toLowerCase() !== match.toHash.toLowerCase()) {
+            throw new StructuredError(
+              'ASSET_LOAD_VERIFICATION_FAILED',
+              `Resource ${res.id} v${version}: blob content hashes to ${computed}, not the log's signed toHash (${match.toHash}).`,
+              { verification }
+            );
+          }
         }
       }
 

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -562,18 +562,17 @@ export class LifecycleManager {
         }
       }
 
-      // 4c) EVERY envelope resource must match a LOG-DECLARED hash for its id
-      // (#407 — content integrity now lives at load, so the binding must be
-      // total, not just the v≥2 slice 4b covers). checkGenesisResourceBinding
-      // above is subset-only (genesis ⊆ present) and 4b keys off the
-      // attacker-controlled `res.version`, so an injected resource labeled
-      // `version:1` — or a genuine later blob relabeled to v1 — would otherwise be
-      // restored with ZERO provenance backing and then flow into the buyer's
-      // published/inscribed identity. Bind each resource's declared hash to a
-      // genesis digest (id-bound per #401; id-less genesis falls back to any) OR a
-      // folded update `toHash` for the SAME resourceId — matching NEITHER fails
-      // closed. Skipped only for legacy (data.did) geneses that carry no resources
-      // array (they predate this contract, mirroring checkGenesisResourceBinding).
+      // 4c) EVERY genesis (version-1) envelope resource must match the LOG's
+      // genesis digest for its id EXACTLY (#407 — content integrity now lives at
+      // load, so the binding must be total AND version-exact). checkGenesisResource
+      // Binding above is subset-only (genesis ⊆ present) and step 4b keys off the
+      // attacker-controlled `res.version`, so a resource labeled `version:1` would
+      // otherwise skip 4b and be restored with zero backing. Version ≥ 2 resources
+      // are bound by 4b to their EXACT `toVersion` update event, so they are left
+      // to 4b here — binding v1 by mere hash-MEMBERSHIP (any update toHash for the
+      // id) would let a genuine higher-version blob be relabeled to v1 and survive
+      // (Greptile P1). Matching neither fails closed. Skipped only for legacy
+      // (data.did) geneses with no resources array (they predate this contract).
       const genesisResources = (log.events[0]?.data as { resources?: unknown } | undefined)?.resources;
       if (Array.isArray(genesisResources)) {
         const genesisDigestById = new Map<string, string>();
@@ -586,18 +585,19 @@ export class LifecycleManager {
           else genesisDigestsIdless.add(dm);
         }
         for (const res of env.resources) {
+          const version = typeof res.version === 'number' ? res.version : 1;
+          if (version >= 2) continue; // bound version-exactly by 4b above
           const resDigest = hexSha256ToDigestMultibase(String(res.hash));
           const boundGenesis = genesisDigestById.get(res.id);
+          // id-bound genesis (#401): only THAT id's digest; id-less legacy genesis
+          // falls back to matching any genesis digest.
           const matchesGenesis = boundGenesis !== undefined
             ? digestMultibaseEquals(resDigest, boundGenesis)
             : [...genesisDigestsIdless].some(d => digestMultibaseEquals(resDigest, d));
-          const matchesUpdate = folded.resourceUpdates.some(
-            u => u.resourceId === res.id && u.toHash.toLowerCase() === String(res.hash).toLowerCase()
-          );
-          if (!matchesGenesis && !matchesUpdate) {
+          if (!matchesGenesis) {
             throw new StructuredError(
               'ASSET_LOAD_VERIFICATION_FAILED',
-              `Resource ${res.id} (hash ${res.hash}) is not declared by the log — it matches neither a genesis digest nor a signed update toHash for this resourceId; refusing to restore unbacked content.`,
+              `Resource ${res.id} v${version} (hash ${res.hash}) is not declared by the log genesis; refusing to restore unbacked content.`,
               { verification }
             );
           }

--- a/packages/sdk/src/lifecycle/OriginalsAsset.ts
+++ b/packages/sdk/src/lifecycle/OriginalsAsset.ts
@@ -679,7 +679,7 @@ export class OriginalsAsset {
     };
 
     // Append a signed `update` CEL event (or degrade). The body is the fixed
-    // resource-update shape; toHash is derived at verify/fold time.
+    // reference-shaped resource-update: it carries the signed toHash, not bytes.
     let appended = false;
     if (this.#celAppender) {
       // Finding 1: the verifier chains continuity from the ON-LOG head, but our
@@ -697,11 +697,15 @@ export class OriginalsAsset {
         });
         // Do NOT also call the appender — exactly one cel:append-skipped per call.
       } else {
+        // Reference-shaped body (#407 phase 1): the event carries the SIGNED
+        // `toHash`, never the bytes. Content lives in the resources array /
+        // serialize() envelope blobs (content-addressed store), keyed by hash.
+        // This keeps the log byte-light so it can be inscribed cheaply (phase 2).
         const digest = await this.#celAppender('update', {
           resourceId,
-          content: newContent,
           contentType,
           previousVersionHash: currentResource.hash,
+          toHash: newHash,
           toVersion: newVersion
         });
         appended = digest !== null; // null ⇒ the manager already emitted cel:append-skipped

--- a/packages/sdk/src/lifecycle/replayProvenance.ts
+++ b/packages/sdk/src/lifecycle/replayProvenance.ts
@@ -99,10 +99,10 @@ export function replayProvenance(log: EventLog): ReplayedProvenance {
       // fields and are skipped.
       const resourceId = typeof data.resourceId === 'string' ? data.resourceId : undefined;
       const previousVersionHash = typeof data.previousVersionHash === 'string' ? data.previousVersionHash : undefined;
-      // An empty-string toHash folds here but is rejected upstream by
-      // checkResourceUpdateContinuity (loadAsset verifies before consuming the
-      // fold), so no unbacked head reaches the resource-binding gate.
-      const toHash = typeof data.toHash === 'string' ? data.toHash : undefined;
+      // Require a NON-EMPTY toHash: replayProvenance is a public export, so a
+      // direct caller must not get an empty-hash resource head folded in (an
+      // empty-string toHash is a malformed update — the verifier rejects it too).
+      const toHash = typeof data.toHash === 'string' && data.toHash.length > 0 ? data.toHash : undefined;
       if (resourceId && previousVersionHash && toHash !== undefined) {
         const toVersion = typeof data.toVersion === 'number' ? data.toVersion : NaN;
         const proofs = event.proof as ReadonlyArray<{ created?: unknown; witnessedAt?: unknown }> | undefined;

--- a/packages/sdk/src/lifecycle/replayProvenance.ts
+++ b/packages/sdk/src/lifecycle/replayProvenance.ts
@@ -99,6 +99,9 @@ export function replayProvenance(log: EventLog): ReplayedProvenance {
       // fields and are skipped.
       const resourceId = typeof data.resourceId === 'string' ? data.resourceId : undefined;
       const previousVersionHash = typeof data.previousVersionHash === 'string' ? data.previousVersionHash : undefined;
+      // An empty-string toHash folds here but is rejected upstream by
+      // checkResourceUpdateContinuity (loadAsset verifies before consuming the
+      // fold), so no unbacked head reaches the resource-binding gate.
       const toHash = typeof data.toHash === 'string' ? data.toHash : undefined;
       if (resourceId && previousVersionHash && toHash !== undefined) {
         const toVersion = typeof data.toVersion === 'number' ? data.toVersion : NaN;

--- a/packages/sdk/src/lifecycle/replayProvenance.ts
+++ b/packages/sdk/src/lifecycle/replayProvenance.ts
@@ -24,7 +24,7 @@
  *    history is the sat's UTXO chain on Bitcoin, not the CEL.
  *  - `rotateKey` / `deactivate` → no provenance entries. Key rotation is
  *    custody, not provenance, for this fold. Resource-shaped `update` events
- *    (`resourceId` + `previousVersionHash` + inline `content`) fold into
+ *    (`resourceId` + `previousVersionHash` + signed `toHash`, #407) fold into
  *    `resourceUpdates`; generic/migration-ish `update` events do not.
  *
  * KNOWN, DOCUMENTED DIVERGENCE from the live in-memory caches
@@ -43,7 +43,6 @@
 import type { EventLog } from '../cel/types.js';
 import { deriveDidCel } from '../cel/celDid.js';
 import { parseSatoshiIdentifier } from '../utils/satoshi-validation.js';
-import { hashResource } from '../utils/validation.js';
 
 /** Honest sentinel: a btco migration whose satoshi cannot be recovered from the log. */
 export const BTCO_SATOSHI_UNKNOWN = 'did:btco:?';
@@ -95,12 +94,13 @@ export function replayProvenance(log: EventLog): ReplayedProvenance {
 
     if (event.type === 'update') {
       // Resource-update events (resourceId + previousVersionHash) fold into the
-      // resource-version history. toHash is DERIVED from inline content, never
-      // stored. Generic/migration-ish updates lack these fields and are skipped.
+      // resource-version history. toHash is the SIGNED field on the event (#407);
+      // content is no longer embedded. Generic/migration-ish updates lack these
+      // fields and are skipped.
       const resourceId = typeof data.resourceId === 'string' ? data.resourceId : undefined;
       const previousVersionHash = typeof data.previousVersionHash === 'string' ? data.previousVersionHash : undefined;
-      const content = typeof data.content === 'string' ? data.content : undefined;
-      if (resourceId && previousVersionHash && content !== undefined) {
+      const toHash = typeof data.toHash === 'string' ? data.toHash : undefined;
+      if (resourceId && previousVersionHash && toHash !== undefined) {
         const toVersion = typeof data.toVersion === 'number' ? data.toVersion : NaN;
         const proofs = event.proof as ReadonlyArray<{ created?: unknown; witnessedAt?: unknown }> | undefined;
         const controllerProof = proofs?.find((p) => !(p && typeof p === 'object' && 'witnessedAt' in p));
@@ -108,7 +108,7 @@ export function replayProvenance(log: EventLog): ReplayedProvenance {
         const entry: ReplayedProvenance['resourceUpdates'][number] = {
           resourceId,
           fromHash: previousVersionHash,
-          toHash: hashResource(Buffer.from(content, 'utf-8')),
+          toHash,
           timestamp,
         };
         // Omit the version fields entirely for foreign logs whose update event

--- a/packages/sdk/tests/integration/ResourceUpdateHandoff.e2e.test.ts
+++ b/packages/sdk/tests/integration/ResourceUpdateHandoff.e2e.test.ts
@@ -28,7 +28,34 @@ describe('Resource-update handoff (e2e)', () => {
     expect(loaded.getProvenance().resourceUpdates.some(u => u.toVersion === 2)).toBe(true);
   });
 
-  test('content-tamper in the envelope is rejected at load', async () => {
+  test('byte-light log: the update event carries no content, and log size is independent of content size', async () => {
+    const mk = async (bytes: number) => {
+      const creator = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
+      const asset = await creator.lifecycle.createAsset([
+        { id: 'note', type: 'text', content: 'v1', contentType: 'text/plain', hash: h('v1') }
+      ]);
+      const big = 'x'.repeat(bytes);
+      await asset.addResourceVersion('note', big, 'text/plain');
+      return asset;
+    };
+
+    const small = await mk(10);
+    const large = await mk(50_000);
+
+    // The signed update event references content by hash only — no bytes.
+    const ev = small.celLog!.events.find(e => e.type === 'update')!;
+    expect((ev.data as Record<string, unknown>).content).toBeUndefined();
+    expect(typeof (ev.data as { toHash?: unknown }).toHash).toBe('string');
+
+    // The log serialization does not grow with content size (bytes live in the
+    // content-addressed store, not the log) — the whole point of #407.
+    const logSize = (a: typeof small) => JSON.stringify(a.serialize().eventLog).length;
+    expect(Math.abs(logSize(large) - logSize(small))).toBeLessThan(200);
+    // The envelope's resource BLOB, by contrast, does carry the large content.
+    expect(large.serialize().resources.some(r => r.content && r.content.length >= 50_000)).toBe(true);
+  });
+
+  test('content-tamper in the envelope blob (hash(blob) != toHash) is rejected at load', async () => {
     const creator = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
     const asset = await creator.lifecycle.createAsset([
       { id: 'note', type: 'text', content: 'v1', contentType: 'text/plain', hash: h('v1') }
@@ -36,9 +63,11 @@ describe('Resource-update handoff (e2e)', () => {
     await asset.addResourceVersion('note', 'v2', 'text/plain');
     const envelope = asset.serialize();
 
-    // Flip the embedded content of the update event.
-    const updateEv = envelope.eventLog.events.find(e => e.type === 'update')!;
-    (updateEv.data as { content: string }).content = 'tampered';
+    // The bytes no longer live in the log event (#407) — they travel as a
+    // content-addressed blob in envelope.resources. Flip that blob (leaving the
+    // signed toHash on the log untouched): hash(blob) != toHash → fail closed.
+    const v2 = envelope.resources.find(r => r.id === 'note' && r.version === 2)!;
+    v2.content = 'tampered';
 
     const buyer = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
     await expect(buyer.lifecycle.loadAsset(envelope)).rejects.toThrow();

--- a/packages/sdk/tests/integration/ResourceUpdateHandoff.e2e.test.ts
+++ b/packages/sdk/tests/integration/ResourceUpdateHandoff.e2e.test.ts
@@ -113,6 +113,26 @@ describe('Resource-update handoff (e2e)', () => {
     await expect(buyer.lifecycle.loadAsset(envelope)).rejects.toThrow(/not declared by the log/);
   });
 
+  test('version-relabel: a GENUINE signed v2 blob relabeled to v1 is rejected at load (#407 version-exact binding)', async () => {
+    // Greptile P1: the v2 blob is genuine (its content IS the signed toVersion:2
+    // content), so a hash-MEMBERSHIP-only 4c would accept it at v1. But (id, v1)
+    // must bind to the genesis digest, not "any update toHash for this id" — a
+    // signed hash placed at the wrong version is a provenance-integrity break.
+    const creator = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
+    const asset = await creator.lifecycle.createAsset([
+      { id: 'note', type: 'text', content: 'v1', contentType: 'text/plain', hash: h('v1') }
+    ]);
+    await asset.addResourceVersion('note', 'v2', 'text/plain');
+    const envelope = asset.serialize();
+
+    // Relabel the genuine v2 blob to version 1 (content and hash untouched).
+    const v2 = envelope.resources.find(r => r.id === 'note' && r.version === 2)!;
+    v2.version = 1;
+
+    const buyer = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
+    await expect(buyer.lifecycle.loadAsset(envelope)).rejects.toThrow(/not declared by the log genesis/);
+  });
+
   test('forged post-genesis env.resource (self-consistent) is rejected at load even though the log verifies', async () => {
     // Greptile #401 gap: the LOG's update event keeps its genuine content (so
     // verifyEventLog passes), but the envelope's CAPTURED resource snapshot for

--- a/packages/sdk/tests/integration/ResourceUpdateHandoff.e2e.test.ts
+++ b/packages/sdk/tests/integration/ResourceUpdateHandoff.e2e.test.ts
@@ -73,6 +73,46 @@ describe('Resource-update handoff (e2e)', () => {
     await expect(buyer.lifecycle.loadAsset(envelope)).rejects.toThrow();
   });
 
+  test('injected never-signed resource (labeled v1) is rejected at load (#407 total binding)', async () => {
+    // An attacker appends a self-consistent, never-signed resource to the
+    // envelope and labels it version 1. The genesis subset-binding passes (the
+    // genuine genesis digest is still present) and the v≥2 gate skips it, so
+    // without a TOTAL resource↔log binding it would restore as genuine content
+    // and flow into the buyer's published/inscribed identity. Must fail closed.
+    const creator = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
+    const asset = await creator.lifecycle.createAsset([
+      { id: 'note', type: 'text', content: 'v1', contentType: 'text/plain', hash: h('v1') }
+    ]);
+    const envelope = asset.serialize();
+    envelope.resources.push({
+      id: 'injected', type: 'text', content: 'attacker-payload',
+      contentType: 'text/plain', hash: h('attacker-payload'), version: 1
+    } as (typeof envelope.resources)[number]);
+
+    const buyer = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
+    await expect(buyer.lifecycle.loadAsset(envelope)).rejects.toThrow(/not declared by the log/);
+  });
+
+  test('downgrade: a genuine v2 blob relabeled to v1 with forged content is rejected at load (#407)', async () => {
+    const creator = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
+    const asset = await creator.lifecycle.createAsset([
+      { id: 'note', type: 'text', content: 'v1', contentType: 'text/plain', hash: h('v1') }
+    ]);
+    await asset.addResourceVersion('note', 'v2', 'text/plain');
+    const envelope = asset.serialize();
+
+    // Take the v2 blob, forge its content self-consistently, and relabel it v1 to
+    // dodge the v≥2 event-backing gate. Its hash matches neither the genesis digest
+    // nor the update toHash → rejected.
+    const v2 = envelope.resources.find(r => r.id === 'note' && r.version === 2)!;
+    v2.version = 1;
+    v2.content = 'forged';
+    v2.hash = h('forged');
+
+    const buyer = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
+    await expect(buyer.lifecycle.loadAsset(envelope)).rejects.toThrow(/not declared by the log/);
+  });
+
   test('forged post-genesis env.resource (self-consistent) is rejected at load even though the log verifies', async () => {
     // Greptile #401 gap: the LOG's update event keeps its genuine content (so
     // verifyEventLog passes), but the envelope's CAPTURED resource snapshot for

--- a/packages/sdk/tests/unit/cel/resource-update-events.test.ts
+++ b/packages/sdk/tests/unit/cel/resource-update-events.test.ts
@@ -52,20 +52,20 @@ describe('verifyEventLog: resource-update events', () => {
     log = await appendEvent(
       log,
       'update',
-      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: hex('v1'), toVersion: 2 },
+      { resourceId: 'r', contentType: 'text/plain', previousVersionHash: hex('v1'), toHash: hex('v2'), toVersion: 2 },
       { signer: a.signer, verificationMethod: a.vm }
     );
     expect((await verifyEventLog(log)).verified).toBe(true);
   });
 
-  test('second update chains from the first derived hash', async () => {
+  test('second update chains from the first toHash', async () => {
     const a = await makeRealSigner();
     let log = await genesisWith('v1', a);
     log = await appendEvent(log, 'update',
-      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: hex('v1'), toVersion: 2 },
+      { resourceId: 'r', contentType: 'text/plain', previousVersionHash: hex('v1'), toHash: hex('v2'), toVersion: 2 },
       { signer: a.signer, verificationMethod: a.vm });
     log = await appendEvent(log, 'update',
-      { resourceId: 'r', content: 'v3', contentType: 'text/plain', previousVersionHash: hex('v2'), toVersion: 3 },
+      { resourceId: 'r', contentType: 'text/plain', previousVersionHash: hex('v2'), toHash: hex('v3'), toVersion: 3 },
       { signer: a.signer, verificationMethod: a.vm });
     expect((await verifyEventLog(log)).verified).toBe(true);
   });
@@ -74,21 +74,23 @@ describe('verifyEventLog: resource-update events', () => {
     const a = await makeRealSigner();
     let log = await genesisWith('v1', a);
     log = await appendEvent(log, 'update',
-      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: hex('not-the-genesis'), toVersion: 2 },
+      { resourceId: 'r', contentType: 'text/plain', previousVersionHash: hex('not-the-genesis'), toHash: hex('v2'), toVersion: 2 },
       { signer: a.signer, verificationMethod: a.vm });
     const result = await verifyEventLog(log);
     expect(result.verified).toBe(false);
     expect(result.errors.join(' ')).toContain('resource');
   });
 
-  test('content-tamper: flipping content after signing breaks the proof', async () => {
+  test('toHash-tamper: flipping the signed toHash after signing breaks the proof', async () => {
     const a = await makeRealSigner();
     let log = await genesisWith('v1', a);
     log = await appendEvent(log, 'update',
-      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: hex('v1'), toVersion: 2 },
+      { resourceId: 'r', contentType: 'text/plain', previousVersionHash: hex('v1'), toHash: hex('v2'), toVersion: 2 },
       { signer: a.signer, verificationMethod: a.vm });
-    // Mutate the embedded content AFTER it was signed.
-    (log.events[1].data as { content: string }).content = 'tampered';
+    // Mutate the SIGNED toHash AFTER it was signed — the controller signature
+    // covers toHash, so the proof no longer verifies. (Content integrity of the
+    // blob itself is bound separately, at loadAsset.)
+    (log.events[1].data as { toHash: string }).toHash = hex('tampered');
     expect((await verifyEventLog(log)).verified).toBe(false);
   });
 
@@ -97,7 +99,7 @@ describe('verifyEventLog: resource-update events', () => {
     const mallory = await makeRealSigner();
     let log = await genesisWith('v1', a);
     log = await appendEvent(log, 'update',
-      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: hex('v1'), toVersion: 2 },
+      { resourceId: 'r', contentType: 'text/plain', previousVersionHash: hex('v1'), toHash: hex('v2'), toVersion: 2 },
       { signer: mallory.signer, verificationMethod: mallory.vm });
     expect((await verifyEventLog(log)).verified).toBe(false);
   });
@@ -121,12 +123,12 @@ describe('verifyEventLog: resource-update events', () => {
       { signer: a.signer, verificationMethod: a.vm });
 
     const good = await appendEvent(base, 'update',
-      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: hex('v1'), toVersion: 2 },
+      { resourceId: 'r', contentType: 'text/plain', previousVersionHash: hex('v1'), toHash: hex('v2'), toVersion: 2 },
       { signer: b.signer, verificationMethod: b.vm });
     expect((await verifyEventLog(good)).verified).toBe(true);
 
     const bad = await appendEvent(base, 'update',
-      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: hex('v1'), toVersion: 2 },
+      { resourceId: 'r', contentType: 'text/plain', previousVersionHash: hex('v1'), toHash: hex('v2'), toVersion: 2 },
       { signer: a.signer, verificationMethod: a.vm });
     expect((await verifyEventLog(bad)).verified).toBe(false);
   });
@@ -158,7 +160,7 @@ describe('verifyEventLog: resource-update events', () => {
     // First update for resourceId 'A', but previousVersionHash = B's genesis hash.
     // With per-id binding, A must chain from A's own genesis digest → rejected.
     log = await appendEvent(log, 'update',
-      { resourceId: 'A', content: 'a2', contentType: 'text/plain', previousVersionHash: hex('b1'), toVersion: 2 },
+      { resourceId: 'A', contentType: 'text/plain', previousVersionHash: hex('b1'), toHash: hex('a2'), toVersion: 2 },
       { signer: s.signer, verificationMethod: s.vm });
     const result = await verifyEventLog(log);
     expect(result.verified).toBe(false);
@@ -169,7 +171,7 @@ describe('verifyEventLog: resource-update events', () => {
     const s = await makeRealSigner();
     let log = await genesisWithTwoIds({ id: 'A', content: 'a1' }, { id: 'B', content: 'b1' }, s);
     log = await appendEvent(log, 'update',
-      { resourceId: 'A', content: 'a2', contentType: 'text/plain', previousVersionHash: hex('a1'), toVersion: 2 },
+      { resourceId: 'A', contentType: 'text/plain', previousVersionHash: hex('a1'), toHash: hex('a2'), toVersion: 2 },
       { signer: s.signer, verificationMethod: s.vm });
     expect((await verifyEventLog(log)).verified).toBe(true);
   });
@@ -179,8 +181,19 @@ describe('verifyEventLog: resource-update events', () => {
     const s = await makeRealSigner();
     let log = await genesisWith('v1', s);
     log = await appendEvent(log, 'update',
-      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: hex('v1'), toVersion: 2 },
+      { resourceId: 'r', contentType: 'text/plain', previousVersionHash: hex('v1'), toHash: hex('v2'), toVersion: 2 },
       { signer: s.signer, verificationMethod: s.vm });
     expect((await verifyEventLog(log)).verified).toBe(true);
+  });
+
+  test('missing toHash: a resource-shaped update with no signed toHash is rejected', async () => {
+    const a = await makeRealSigner();
+    let log = await genesisWith('v1', a);
+    log = await appendEvent(log, 'update',
+      { resourceId: 'r', contentType: 'text/plain', previousVersionHash: hex('v1'), toVersion: 2 },
+      { signer: a.signer, verificationMethod: a.vm });
+    const result = await verifyEventLog(log);
+    expect(result.verified).toBe(false);
+    expect(result.errors.join(' ')).toContain('toHash');
   });
 });

--- a/packages/sdk/tests/unit/lifecycle/addResourceVersion.celevent.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/addResourceVersion.celevent.test.ts
@@ -2,6 +2,9 @@ import { describe, test, expect } from 'bun:test';
 import { OriginalsAsset } from '../../../src/lifecycle/OriginalsAsset';
 import type { AssetResource, DIDDocument } from '../../../src/types';
 import type { CelAppendSkippedEvent } from '../../../src/events/types';
+import { hashResource } from '../../../src/utils/validation';
+
+const h = (s: string) => hashResource(Buffer.from(s, 'utf-8'));
 
 function makeAsset(): OriginalsAsset {
   const did: DIDDocument = { id: 'did:peer:zabc' } as DIDDocument;
@@ -29,9 +32,11 @@ describe('addResourceVersion: injected CEL appender', () => {
     expect(calls.length).toBe(1);
     expect(calls[0].type).toBe('update');
     expect(calls[0].data.resourceId).toBe('r');
-    expect(calls[0].data.content).toBe('v2');
+    // Reference-shaped event (#407 phase 1): the signed body carries toHash, NOT bytes.
+    expect(calls[0].data.content).toBeUndefined();
+    expect(calls[0].data.toHash).toBe(h('v2'));
+    expect(calls[0].data.previousVersionHash).toBe(h('v1'));
     expect(calls[0].data.contentType).toBe('text/plain');
-    expect(typeof calls[0].data.previousVersionHash).toBe('string');
     expect(calls[0].data.toVersion).toBe(2);
     // In-memory resources updated.
     expect(asset.getResourceVersion('r', 2)?.content).toBe('v2');

--- a/packages/sdk/tests/unit/lifecycle/replayProvenance.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/replayProvenance.test.ts
@@ -235,14 +235,14 @@ async function makeReplaySigner() {
 const rhex = (s: string) => hashResource(Buffer.from(s, 'utf-8'));
 
 describe('replayProvenance: resourceUpdates fold', () => {
-  test('folds update events into resourceUpdates with derived toHash', async () => {
+  test('folds update events into resourceUpdates with the signed toHash', async () => {
     const a = await makeReplaySigner();
     let log = await createEventLog(
       { name: 'r', controller: a.didKey, resources: [{ digestMultibase: hexSha256ToDigestMultibase(rhex('v1')) }], createdAt: 'x', nonce: 'z1' },
       { signer: a.signer, verificationMethod: a.vm }
     );
     log = await appendEvent(log, 'update',
-      { resourceId: 'r', content: 'v2', contentType: 'text/plain', previousVersionHash: rhex('v1'), toVersion: 2 },
+      { resourceId: 'r', contentType: 'text/plain', previousVersionHash: rhex('v1'), toHash: rhex('v2'), toVersion: 2 },
       { signer: a.signer, verificationMethod: a.vm });
 
     const folded = replayProvenance(log);


### PR DESCRIPTION
## What & why

Epic **#407 phase 1** ("the CEL lives on the sat"). The Cryptographic Event Log must be **small** before it can be affordably inscribed on Bitcoin (phase 2). Today's resource-update events (#401) **embed the file bytes** inline, so the log literally carries content — big and expensive to inscribe. This phase moves content **out of the log** into a content-addressed store; events carry only a signed hash. It **reworks the just-merged #401**.

## The change

- **Event shape (breaking, on-log):** a resource-update `update` event's `data` is now `{ resourceId, contentType, previousVersionHash, toHash, toVersion }` — no `content`. `toHash` is a **stored, signed** field; the bytes are gone from the event.
- **Content-addressed store:** bytes live in the asset `resources` array / the `serialize()` envelope blobs (keyed by hash) — exactly where genesis content already lives. The log becomes **byte-light** (its serialized size is independent of content size).
- **Verifier** (`checkResourceUpdateContinuity`): checks **only hash-chain continuity** on the signed hashes (`previousVersionHash` → prior `toHash` / genesis digest); it no longer recomputes `hash(content)` (there is none in the event).
- **`loadAsset`** is where **content integrity now lives**. Offline verify is preserved: the envelope carries the blobs alongside the small log, and load binds `hash(blob) == the log's signed toHash`. Generalized so **every** envelope resource must match a log-declared hash by `(resourceId, version)` — genesis digest or a folded update `toHash` — else `ASSET_LOAD_VERIFICATION_FAILED`.
- **`replayProvenance`** folds `toHash` from the field (not derived from content).
- Public APIs (`addResourceVersion`, `serialize`, `loadAsset`) are **unchanged externally** — same async/degrade contract (`cel:append-skipped` / `UNPROVABLE_BASE`).

## Security review

A **fable** reviewer audited the verifier / `loadAsset` / `serialize` diff and confirmed the fail-closed properties (content-tamper rejected at load, chain-continuity intact, log carries no bytes, degraded/unbacked v≥2 rejected). It surfaced one **Important** pre-existing fail-open (a resource labeled `version:1` could be restored with zero provenance backing — inject or downgrade), now closed by the total resource↔log binding above. Tests cover both attack variants plus content-tamper, missing-`toHash`, and byte-light assertions.

## Verification

- `bun run build` + `bunx tsc --noEmit`: clean
- `bun test` (packages/sdk): **3957 pass, 70 skip, 0 fail**

Foundation for on-chain log inscription (**#407**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace embedded content bytes with `toHash` references in resource-update events
> - Resource-update events in the CEL log no longer carry raw content bytes; they now carry a signed `toHash` (hex SHA-256 multibase digest), keeping logs byte-light regardless of asset size.
> - `checkResourceUpdateContinuity` in [`verifyEventLog.ts`](https://github.com/onionoriginals/sdk/pull/409/files#diff-f56ca3bb283b365d27038f7e7abd753c4f031cf30069d3ba78e70eec8010d9b2) now validates and chains `toHash` instead of hashing inline content.
> - `replayProvenance` folds the signed `toHash` directly from each update event rather than recomputing it from content.
> - `loadAsset` in [`LifecycleManager.ts`](https://github.com/onionoriginals/sdk/pull/409/files#diff-f7ee48c88de9ace2f72662a51534f0bbb19607128b3c2178416d1b28c87fc9e8) now enforces content-integrity at load time: v≥2 blobs must hash to the event's signed `toHash`, and v1 blobs must match the genesis declaration.
> - Risk: Breaking change to on-log event shape — existing logs with embedded `content` in resource-update events will fail verification.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 80580d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->