### PR TITLE
Content-as-ordinal + provenance-in-metadata: provenance recoverable from a bare sat (#407 phase 2)

### DIFF
--- a/.changeset/log-on-chain-phase2.md
+++ b/.changeset/log-on-chain-phase2.md
@@ -1,0 +1,18 @@
+---
+"@originals/sdk": minor
+---
+
+Content-as-ordinal, provenance-in-metadata (#407 phase 2). The did:btco
+anchoring inscription now BECOMES the asset: its content is the asset's current
+media (the most-recent resource's bytes) and its CBOR metadata carries the
+byte-light provenance (the did:btco DID document with its `#cel` anchor + the
+full CEL log). The verifier reads the `#cel`/witness commitment from inscription
+metadata (falling back to content for phase-1 inscriptions) and adds a
+content-as-ordinal gate binding the on-chain media to the log's most-recent
+resource hash. A new `LifecycleManager.resolveAssetFromSat(satoshi)` reconstructs
+and fully verifies an asset — provenance and current media — from a bare
+satoshi, with no envelope and no host. Provenance is now recoverable from
+Bitcoin alone. Pure-reference assets (no inline media) inscribe the DID document
+as content and carry no media on-chain. `OrdinalsProvider.createInscription`
+gains a `metadata` parameter (and a `{ content, metadata }` deferred-builder
+return), and `getInscriptionById` surfaces inscription metadata.

--- a/docs/superpowers/plans/2026-07-14-log-on-chain-phase2.md
+++ b/docs/superpowers/plans/2026-07-14-log-on-chain-phase2.md
@@ -1,0 +1,77 @@
+# Plan: Content-as-ordinal, provenance-in-metadata (#407 phase 2)
+
+Implements `docs/superpowers/specs/2026-07-14-log-on-chain-phase2-design.md`.
+Stacks on #409 (byte-light log). The anchoring inscription BECOMES the asset:
+its **content** = the current media (most-recent resource bytes), its
+**metadata** (CBOR) = `{ didDocument, celLog }`, and a new resolver rebuilds +
+verifies the whole asset from a bare sat.
+
+## Chunks (commit after each)
+
+### 1. Provider metadata plumbing
+- `OrdinalsProvider.createInscription` (adapters/types.ts): add static
+  `metadata?: Record<string,unknown>` param; widen `buildContent` return to
+  `Buffer | { content: Buffer; metadata?: Record<string,unknown> }`; add
+  `metadata?` to the return shape.
+- `getInscriptionById` return (adapters/types.ts AND cel/types.ts OrdinalsLookup):
+  add `metadata?: Record<string,unknown>`.
+- `OrdMockProvider`: normalize deferred `{content,metadata}`; static-metadata
+  fallback; store metadata on the record; echo it from `getInscriptionById` and
+  `createInscription`; `getAnchoringsForDidCel` reads `alsoKnownAs` from
+  `metadata.didDocument` (fallback: content JSON).
+- `BitcoinManager.inscribeData`: accept `options.metadata`; thread to
+  `createInscription`; support the deferred builder returning `{content,metadata}`;
+  return `metadata` on the `OrdinalsInscription`. `OrdinalsInscription` type gains
+  `metadata?`.
+- `commit.ts` already threads the metadata CBOR tag — no change.
+- Tests: OrdMock round-trip; BitcoinManager deferred+metadata.
+
+### 2. Writer
+- Shared helper `mostRecentResourceHash(log)` (hex): last `update` event's toHash,
+  else genesis primary resource[0] digest → hex. Used by writer AND verifier.
+- `inscribeOnBitcoin`: before inscribe, resolve head resource
+  (`asset.resources.find(hash === mostRecentResourceHash)`), its bytes + contentType
+  (fail closed if missing/no inline content). Deferred builder now returns
+  `{ content: mediaBytes, metadata: { didDocument: btcoDoc, celLog: <byte-light
+  snapshot after migrate append> } }`; contentType arg = media type. Integrity
+  cross-check reads `inscription.metadata.didDocument.id` (was `content`).
+- `rotateBtcoKeys` / `authorizeSigner` (via `reinscribeRotatedDoc`): content =
+  head media, static metadata `{ didDocument: rotatedDoc, celLog: snapshot }`.
+- Tests: content == media bytes; metadata carries didDocument+celLog; celLog head
+  == #cel anchor; point-in-time; most-recent selection.
+
+### 3. Verifier
+- Helper `didDocumentFromInscription(insc)`: prefer `metadata.didDocument`, fall
+  back to parsing `content` as JSON (phase-1 back-compat).
+- `verifyBitcoinWitnessProof` shape (b): read DID doc via helper (was content).
+  Shape (a) standalone witness attestation (`content.digestMultibase`) unchanged.
+- `verifyHeadFreshness` + `evaluateNonCooperativeRotation`: read the anchor DID
+  doc via the helper.
+- Content-hash gate: when the anchor inscription carries metadata (phase-2),
+  `hashResource(content)` MUST equal `mostRecentResourceHash(log)` — new
+  fail-closed error included in `verified`.
+- Tests: metadata source; tampered metadata celLog rejected; content-hash mismatch
+  rejected.
+
+### 4. Resolver
+- `LifecycleManager.resolveAssetFromSat(satoshi, opts?)`:
+  1. `getInscriptionsBySatoshi` → newest by confirmed block height (fail closed on
+     missing height / ties).
+  2. `getInscriptionById` → metadata `{didDocument, celLog}` + content.
+  3. Assert `metadata.celLog` head digest == `#cel` anchor headDigestMultibase.
+  4. Reconstruct byte-light envelope: eventLog = celLog (with a reconstructed
+     bitcoin witness proof attached to HEAD pointing at this inscription);
+     resources rebuilt from genesis + update events, head resource gets the
+     content blob (verify hash == head hash first); didDocuments {did:cel derived,
+     did:btco = metadata.didDocument}; assetDid = deriveDidCel(celLog).
+  5. `loadAsset(envelope, { ordinalsProvider })` → verified asset.
+- Tests: bare-sat round-trip (create→addResourceVersion→publish→inscribe→resolve);
+  tampered metadata; content mismatch; newest-selection fail-closed.
+
+### 5. Changeset + docs
+- `.changeset/log-on-chain-phase2.md` (minor).
+
+## Security (fable review before PR)
+Fail-closed invariants: celLog head ≠ #cel → reject; tampered metadata log →
+verifyEventLog rejects; content ≠ most-recent hash → reject; newest pick fails
+closed on missing height/ties; resolver path never weaker than envelope-load.

--- a/docs/superpowers/specs/2026-07-14-log-on-chain-phase2-design.md
+++ b/docs/superpowers/specs/2026-07-14-log-on-chain-phase2-design.md
@@ -1,0 +1,122 @@
+# Design: Content-as-ordinal, provenance-in-metadata (epic #407, phase 2)
+
+> Second increment of epic #407 ("The CEL lives on the sat"). Phase 1 (#409)
+> made the log **byte-light** (content referenced by `toHash`, no embedded
+> bytes). Phase 2 makes the anchoring inscription **be the asset**: its
+> **content** is the asset's current media, its **metadata** carries the full
+> provenance (DID doc + byte-light CEL log), and a resolver reconstructs +
+> verifies the whole asset from a **bare sat** — no envelope, no host.
+>
+> **Stacks on #409** (needs the byte-light log). Branch off #409 /
+> main-after-#409.
+
+## 0. Decision record
+
+- **The inscription IS the asset.** Content = the asset's **most recent
+  resource** (current/latest version) as raw bytes + its real `contentType` — a
+  real, viewable ordinal. Metadata (CBOR) = the byte-light provenance: the
+  did:btco DID doc (with `#cel` anchor) + the full CEL log.
+- **Always inscribe the content.** No size cap / no referenced fallback for the
+  primary media — the current media is always on-chain. Older versions and
+  secondary resources stay **referenced** (phase 1); their content inscription
+  is a later, opt-in phase.
+- **Provenance moves to metadata.** The DID doc + `#cel` commitment + log live in
+  the inscription's metadata, not its content. The `#cel`/witness verification
+  reads metadata; the content is verified separately (hash vs the log's
+  most-recent-resource hash).
+- **Point-in-time.** The metadata snapshot is the log as-of-inscription;
+  `rotateBtcoKeys`/re-inscription re-embeds the current provenance + re-inscribes
+  the current media (recoverable-as-of-last-inscription, per the #407 tiers).
+- **Scope = write + read.** Phase 2 ships both the inscribe path and the
+  reconstruction resolver, so "recoverable from a bare sat" is demonstrable.
+
+## 1. Provider metadata plumbing
+
+`commit.ts` already builds the inscription envelope with a `metadata` (CBOR) tag,
+but the provider abstraction doesn't surface it. Add:
+- `OrdinalsProvider.createInscription({ …, metadata?: Record<string, unknown> })`
+  (write) — thread it to the existing `commit.ts` `metadata` tag.
+- `getInscriptionById(id)` return gains `metadata?: Record<string, unknown>`
+  (read) — so the SDK/verifier can read inscription metadata.
+- `OrdMockProvider` echoes metadata round-trip for tests.
+
+## 2. Writer — `LifecycleManager.inscribeOnBitcoin` / `rotateBtcoKeys`
+
+Inside the existing `buildContent(satoshi)` window:
+- **Content** = the most-recent resource's bytes (decoded from
+  `AssetResource.content`), `contentType` = its media type. (Most-recent = the
+  current head of the resource timeline: the latest `addResourceVersion` result,
+  or the genesis resource if none.)
+- **Metadata** = `{ didDocument: <did:btco doc with #cel anchor>, celLog:
+  <byte-light log snapshot> }`.
+- The `#cel` anchor still commits to the log head; the embedded `celLog` head
+  MUST equal it.
+Re-inscription (`rotateBtcoKeys`) re-embeds the then-current provenance + media.
+
+## 3. Verifier — read provenance from metadata
+
+`verifyBitcoinWitnessProof` / the `#cel` anchor check currently parse
+`inscription.content` as the DID doc (`verifyEventLog.ts:395-418`). Under this
+model they parse `inscription.metadata` instead: locate `didDocument` +
+`#cel`/`digestMultibase` there; the commitment logic (`didDocumentCommitsToDigest`
+/ `extractCelAnchorHeadDigest`) is unchanged, only its source moves
+content→metadata. The inscription **content** is the media, verified by
+`hashResource(content) == the log's most-recent-resource hash`.
+
+## 4. Resolver — bare sat → verified asset
+
+New resolution path (reuses #377 `loadAsset` for the provenance half):
+1. `getInscriptionsBySatoshi(sat)` → pick the newest DID-doc/provenance-bearing
+   inscription by confirmed block height (fail-closed on ambiguity, like
+   head-freshness).
+2. `getInscriptionById(id)` → read its `metadata` (provenance) + `content` (media).
+3. Reconstruct the byte-light `AssetEnvelope` from the metadata's `didDocument` +
+   `celLog`, plus the content as the most-recent resource blob → run `loadAsset`
+   (which runs `verifyEventLog` + anchor + resource-binding).
+4. Confirm the content hashes to the log's most-recent-resource `toHash`.
+Returns the verified asset (log + folded state + current media) — from chain
+alone.
+
+## 5. Integrity / security
+
+- Embedded `celLog` head digest MUST equal the `#cel` anchor `headDigestMultibase`
+  (else reject — inconsistent inscription).
+- `verifyEventLog` gates the reconstructed log identically to any log (chain
+  origin never relaxes verification — anchored-sat, uniqueness, continuity all
+  apply).
+- Content hash-check fails closed: media not matching the log's most-recent hash
+  → reject.
+- Newest-inscription selection by block height, fail-closed on missing height /
+  ties (mirrors head-freshness).
+
+## 6. Boundaries / deferred (later #407 phases)
+
+- Secondary resources + older versions: still referenced (phase 1); their content
+  inscription is a later opt-in phase.
+- Per-event inscription (the log as an inscription chain), the checkpoint/squash
+  tier, and the fee/economics model.
+- Real-time chain-recoverability of every append (this phase is point-in-time).
+
+## 7. Testing spine
+
+- **Bare-sat round-trip:** create → addResourceVersion → publish → inscribe; a
+  resolver with ONLY the sat + provider reconstructs provenance (from metadata)
+  AND the current media (from content), verified, with NO envelope/host.
+- **Content hash-check:** an inscription whose content ≠ the log's most-recent
+  resource hash → reject.
+- **Provenance-in-metadata tamper:** a tampered metadata `celLog` →
+  `verifyEventLog` rejects; embedded head ≠ `#cel` → reject.
+- **Metadata plumbing:** createInscription metadata round-trips through
+  getInscriptionById (OrdMock).
+- **Point-in-time:** a resource update AFTER inscription is absent from the
+  on-chain snapshot until re-inscription; `rotateBtcoKeys` re-embeds the updated
+  provenance + media.
+- **Most-recent selection:** with several resource versions, the inscribed
+  content is the latest.
+
+## 8. Changeset
+
+`@originals/sdk` **minor** — the btco anchoring inscription now carries the
+asset's current media as content and the full provenance (DID doc + byte-light
+CEL log) in metadata; a new resolver reconstructs + verifies the asset from a
+bare sat. Provenance is now recoverable from Bitcoin alone (#407).

--- a/packages/sdk/src/adapters/providers/OrdHttpProvider.ts
+++ b/packages/sdk/src/adapters/providers/OrdHttpProvider.ts
@@ -1,5 +1,5 @@
 /* istanbul ignore file */
-import type { OrdinalsProvider } from '../types.js';
+import type { OrdinalsProvider, InscriptionParts } from '../types.js';
 import { StructuredError } from '../../utils/telemetry.js';
 
 interface HttpProviderOptions {
@@ -172,9 +172,10 @@ export class OrdHttpProvider implements OrdinalsProvider {
 
   createInscription(params: {
     data?: Buffer;
-    buildContent?: (satoshi: string) => Buffer | Promise<Buffer>;
+    buildContent?: (satoshi: string) => InscriptionParts | Promise<InscriptionParts>;
     contentType: string;
     feeRate?: number;
+    metadata?: Record<string, unknown>;
     targetSatoshi?: string;
   }): Promise<{
     inscriptionId: string;
@@ -187,6 +188,7 @@ export class OrdHttpProvider implements OrdinalsProvider {
     content?: Buffer;
     contentType?: string;
     feeRate?: number;
+    metadata?: Record<string, unknown>;
   }> {
     if (params.buildContent || params.targetSatoshi) {
       return Promise.reject(new StructuredError(

--- a/packages/sdk/src/adapters/providers/OrdMockProvider.ts
+++ b/packages/sdk/src/adapters/providers/OrdMockProvider.ts
@@ -1,4 +1,4 @@
-import { OrdinalsProvider } from '../types.js';
+import { OrdinalsProvider, InscriptionParts } from '../types.js';
 
 export interface OrdMockState {
   inscriptionsById: Map<string, {
@@ -9,6 +9,7 @@ export interface OrdMockState {
     vout: number;
     satoshi?: string;
     blockHeight?: number;
+    metadata?: Record<string, unknown>;
   }>;
   inscriptionsBySatoshi: Map<string, string[]>;
   ownershipBySatoshi: Map<string, { address: string; outpoint: string }>;
@@ -31,7 +32,14 @@ export class OrdMockProvider implements OrdinalsProvider {
   // eslint-disable-next-line @typescript-eslint/require-await
   async getInscriptionById(id: string) {
     const rec = this.state.inscriptionsById.get(id);
-    return rec ? { ...rec } : null;
+    if (!rec) return null;
+    // Clone metadata so a reader mutating the result cannot corrupt stored state.
+    return {
+      ...rec,
+      ...(rec.metadata !== undefined
+        ? { metadata: structuredClone(rec.metadata) as Record<string, unknown> }
+        : {})
+    };
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await
@@ -57,9 +65,10 @@ export class OrdMockProvider implements OrdinalsProvider {
 
   async createInscription(params: {
     data?: Buffer;
-    buildContent?: (satoshi: string) => Buffer | Promise<Buffer>;
+    buildContent?: (satoshi: string) => InscriptionParts | Promise<InscriptionParts>;
     contentType: string;
     feeRate?: number;
+    metadata?: Record<string, unknown>;
     targetSatoshi?: string;
   }) {
     if ((params.data === undefined) === (params.buildContent === undefined)) {
@@ -70,10 +79,30 @@ export class OrdMockProvider implements OrdinalsProvider {
     // Pin the sat FIRST (mirrors real commit-phase sat assignment), then let
     // deferred content embed it.
     const satoshi = params.targetSatoshi ?? `${Math.floor(Math.random() * 1e12)}`;
-    const content = params.buildContent
-      ? Buffer.from(await params.buildContent(satoshi))
-      : params.data!;
+    // Normalize the deferred build result: a bare Buffer (content only) or
+    // `{ content, metadata }` (#407 phase 2). Deferred metadata wins over the
+    // static `metadata` param.
+    let content: Buffer;
+    let deferredMetadata: Record<string, unknown> | undefined;
+    if (params.buildContent) {
+      const built = await params.buildContent(satoshi);
+      if (Buffer.isBuffer(built)) {
+        content = Buffer.from(built);
+      } else {
+        content = Buffer.from(built.content);
+        deferredMetadata = built.metadata;
+      }
+    } else {
+      content = params.data!;
+    }
+    const metadata = deferredMetadata ?? params.metadata;
     const vout = 0;
+    // Round-trip metadata as a structural clone so a caller mutating its input
+    // object after inscription cannot retroactively change the stored copy
+    // (mirrors a real CBOR encode/decode boundary).
+    const storedMetadata = metadata !== undefined
+      ? (structuredClone(metadata) as Record<string, unknown>)
+      : undefined;
     const record = {
       inscriptionId,
       content,
@@ -81,7 +110,8 @@ export class OrdMockProvider implements OrdinalsProvider {
       txid,
       vout,
       satoshi,
-      blockHeight: 1
+      blockHeight: 1,
+      ...(storedMetadata !== undefined ? { metadata: storedMetadata } : {})
     };
     this.state.inscriptionsById.set(inscriptionId, record);
     const list = this.state.inscriptionsBySatoshi.get(satoshi) || [];
@@ -98,7 +128,8 @@ export class OrdMockProvider implements OrdinalsProvider {
       blockHeight: 1,
       content,
       contentType: params.contentType,
-      feeRate: params.feeRate
+      feeRate: params.feeRate,
+      ...(storedMetadata !== undefined ? { metadata: structuredClone(storedMetadata) as Record<string, unknown> } : {})
     };
   }
 
@@ -116,13 +147,18 @@ export class OrdMockProvider implements OrdinalsProvider {
     const out: Array<{ satoshi: string; inscriptionId: string; blockHeight?: number }> = [];
     for (const rec of this.state.inscriptionsById.values()) {
       if (rec.satoshi === undefined) continue;
-      let content: unknown;
-      try {
-        content = JSON.parse(rec.content.toString('utf8'));
-      } catch {
-        continue; // non-JSON inscription — not a DID document
+      // #407 phase 2: the DID document rides in inscription METADATA (content is
+      // the asset media). Prefer metadata.didDocument; fall back to parsing the
+      // content as a DID document JSON (phase-1 content-as-DID-doc inscriptions).
+      let doc: unknown = (rec.metadata as { didDocument?: unknown } | undefined)?.didDocument;
+      if (doc === undefined) {
+        try {
+          doc = JSON.parse(rec.content.toString('utf8'));
+        } catch {
+          continue; // non-JSON, no metadata DID doc — not an anchoring inscription
+        }
       }
-      const aka = (content as { alsoKnownAs?: unknown } | null)?.alsoKnownAs;
+      const aka = (doc as { alsoKnownAs?: unknown } | null)?.alsoKnownAs;
       if (Array.isArray(aka) && aka.includes(didCel)) {
         out.push({ satoshi: rec.satoshi, inscriptionId: rec.inscriptionId, blockHeight: rec.blockHeight });
       }

--- a/packages/sdk/src/adapters/providers/QuickNodeProvider.ts
+++ b/packages/sdk/src/adapters/providers/QuickNodeProvider.ts
@@ -1,4 +1,4 @@
-import type { OrdinalsProvider } from '../types.js';
+import type { OrdinalsProvider, InscriptionParts } from '../types.js';
 import { StructuredError } from '../../utils/telemetry.js';
 import { validateSatoshiNumber } from '../../utils/satoshi-validation.js';
 
@@ -522,9 +522,10 @@ export class QuickNodeProvider implements OrdinalsProvider {
 
   createInscription(params: {
     data?: Buffer;
-    buildContent?: (satoshi: string) => Buffer | Promise<Buffer>;
+    buildContent?: (satoshi: string) => InscriptionParts | Promise<InscriptionParts>;
     contentType: string;
     feeRate?: number;
+    metadata?: Record<string, unknown>;
     targetSatoshi?: string;
   }): Promise<{
     inscriptionId: string;
@@ -537,6 +538,7 @@ export class QuickNodeProvider implements OrdinalsProvider {
     content?: Buffer;
     contentType?: string;
     feeRate?: number;
+    metadata?: Record<string, unknown>;
   }> {
     if (params.buildContent || params.targetSatoshi) {
       return Promise.reject(new StructuredError(

--- a/packages/sdk/src/adapters/types.ts
+++ b/packages/sdk/src/adapters/types.ts
@@ -1,3 +1,10 @@
+/**
+ * Deferred inscription build result (#407 phase 2): either bare content bytes,
+ * or content plus the CBOR metadata to attach (the anchoring inscription's
+ * `{ didDocument, celLog }` provenance).
+ */
+export type InscriptionParts = Buffer | { content: Buffer; metadata?: Record<string, unknown> };
+
 export interface StoragePutOptions {
   contentType?: string;
   cacheControl?: string;
@@ -29,6 +36,10 @@ export interface OrdinalsProvider {
     vout: number;
     satoshi?: string;
     blockHeight?: number;
+    // Inscription CBOR metadata (#407 phase 2): the anchoring inscription's
+    // content is the asset media, and its metadata carries the byte-light
+    // provenance (`{ didDocument, celLog }`). Absent for content-only inscriptions.
+    metadata?: Record<string, unknown>;
   } | null>;
   /**
    * MUST return inscription ids oldest-first (on-chain inscription order).
@@ -45,12 +56,20 @@ export interface OrdinalsProvider {
     data?: Buffer;
     /**
      * Deferred content: called with the pinned satoshi between commit and
-     * reveal, so content that must embed its own sat (a did:btco DID
-     * document) can be constructed. Provide exactly one of data / buildContent.
+     * reveal, so content (and metadata) that must embed its own sat (a did:btco
+     * DID document / the byte-light celLog) can be constructed. Provide exactly
+     * one of data / buildContent. May return a bare Buffer (content only) or
+     * `{ content, metadata }` — the returned metadata wins over the static
+     * `metadata` param below (#407 phase 2).
      */
-    buildContent?: (satoshi: string) => Buffer | Promise<Buffer>;
+    buildContent?: (satoshi: string) => InscriptionParts | Promise<InscriptionParts>;
     contentType: string;
     feeRate?: number;
+    /**
+     * Inscription CBOR metadata (#407 phase 2). Threaded to the `metadata`
+     * envelope tag. Ignored when `buildContent` returns its own metadata.
+     */
+    metadata?: Record<string, unknown>;
     /** Reinscribe on an existing sat (key rotation / DID update). */
     targetSatoshi?: string;
   }): Promise<{
@@ -64,6 +83,7 @@ export interface OrdinalsProvider {
     content?: Buffer;
     contentType?: string;
     feeRate?: number;
+    metadata?: Record<string, unknown>;
   }>;
   /**
    * Current ownership of the UTXO carrying this satoshi. Optional: providers

--- a/packages/sdk/src/bitcoin/BitcoinManager.ts
+++ b/packages/sdk/src/bitcoin/BitcoinManager.ts
@@ -3,7 +3,7 @@ import {
   OrdinalsInscription,
   BitcoinTransaction
 } from '../types/index.js';
-import type { FeeOracleAdapter, OrdinalsProvider } from '../adapters/index.js';
+import type { FeeOracleAdapter, OrdinalsProvider, InscriptionParts } from '../adapters/index.js';
 import type { OperationLock } from '../utils/OperationLock.js';
 import { emitTelemetry, StructuredError } from '../utils/telemetry.js';
 import { validateBitcoinAddress } from '../utils/bitcoin-address.js';
@@ -127,6 +127,12 @@ export class BitcoinManager {
        * different manager — is rejected rather than double-paying (issue #303).
        */
       lockKey?: string;
+      /**
+       * Static CBOR metadata to attach to the inscription (#407 phase 2). On the
+       * deferred (`buildContent`) path, a `{ content, metadata }` result from the
+       * builder takes precedence over this.
+       */
+      metadata?: Record<string, unknown>;
     }
   ): Promise<OrdinalsInscription> {
     // Input validation
@@ -172,15 +178,17 @@ export class BitcoinManager {
     const performInscription = async (): Promise<OrdinalsInscription> => {
     const creation = typeof data === 'function'
       ? await ord.createInscription({
-          buildContent: data as (satoshi: string) => Buffer | Promise<Buffer>,
+          buildContent: data as (satoshi: string) => InscriptionParts | Promise<InscriptionParts>,
           contentType,
           feeRate: effectiveFeeRate,
+          ...(options?.metadata ? { metadata: options.metadata } : {}),
           ...(options?.targetSatoshi ? { targetSatoshi: options.targetSatoshi } : {})
         })
       : await ord.createInscription({
           data,
           contentType,
           feeRate: effectiveFeeRate,
+          ...(options?.metadata ? { metadata: options.metadata } : {}),
           ...(options?.targetSatoshi ? { targetSatoshi: options.targetSatoshi } : {})
         });
     const txid = creation.txid ?? creation.revealTxId;
@@ -247,7 +255,8 @@ export class BitcoinManager {
       blockHeight: creation.blockHeight,
       revealTxId: creation.revealTxId,
       commitTxId: creation.commitTxId,
-      feeRate: recordedFeeRate
+      feeRate: recordedFeeRate,
+      ...(creation.metadata !== undefined ? { metadata: creation.metadata } : {})
     };
 
     return inscription;
@@ -271,7 +280,8 @@ export class BitcoinManager {
         contentType: info.contentType,
         txid: info.txid,
         vout: info.vout,
-        blockHeight: info.blockHeight
+        blockHeight: info.blockHeight,
+        ...(info.metadata !== undefined ? { metadata: info.metadata } : {})
       };
     }
     return null;

--- a/packages/sdk/src/cel/algorithms/index.ts
+++ b/packages/sdk/src/cel/algorithms/index.ts
@@ -8,5 +8,5 @@ export { createEventLog } from './createEventLog.js';
 export { appendEvent } from './appendEvent.js';
 export { updateEventLog } from './updateEventLog.js';
 export { deactivateEventLog } from './deactivateEventLog.js';
-export { verifyEventLog, verifyDidKeyEd25519Proof } from './verifyEventLog.js';
+export { verifyEventLog, verifyDidKeyEd25519Proof, selectNewestAnchorInscription } from './verifyEventLog.js';
 export { witnessEvent } from './witnessEvent.js';

--- a/packages/sdk/src/cel/algorithms/verifyEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/verifyEventLog.ts
@@ -522,73 +522,81 @@ function extractCelAnchorHeadDigest(content: unknown): string | undefined {
  *
  * Returns a `STALE_LOG`-coded error string on failure, or null when fresh.
  */
+/**
+ * Selects the NEWEST OriginalsCelAnchor-bearing inscription on a satoshi, chosen
+ * by per-inscription block HEIGHT (via getInscriptionById), NOT list-tail
+ * position — otherwise a provider violating the oldest-first contract (returning
+ * newest-first) could make a tail-walk pick the OLDEST anchor (#395). Fail-closed
+ * throughout: no enumeration capability, an enumeration/fetch that throws, no
+ * anchor on the sat, or any anchor candidate missing a confirmed block height all
+ * return `{ error }`. Same-block ties fall back to list-tail order (the
+ * documented oldest-first residual, unprovable intra-block).
+ *
+ * Under #407 phase 2 the anchor DID document rides in inscription metadata
+ * (content is the asset media); phase-1 inscriptions carried it as content —
+ * didDocumentFromInscription handles both.
+ *
+ * Shared by head-freshness and the content-as-ordinal gate so BOTH agree on which
+ * inscription is the current anchor (a cooperative rotation leaves `anchoredSat`
+ * pointing at the migrate inscription, so neither may rely on it).
+ */
+export async function selectNewestAnchorInscription(
+  satoshi: string,
+  ordinalsProvider: OrdinalsLookup | undefined
+): Promise<{ inscription: NonNullable<FetchedInscription>; digest: string } | { error: string }> {
+  if (!ordinalsProvider || typeof ordinalsProvider.getInscriptionsBySatoshi !== 'function') {
+    return { error: `the ordinals provider cannot enumerate inscriptions on satoshi ${satoshi}` };
+  }
+  let onSat: Array<{ inscriptionId: string }>;
+  try {
+    onSat = await ordinalsProvider.getInscriptionsBySatoshi(satoshi);
+  } catch (e) {
+    return { error: `failed to enumerate inscriptions on satoshi ${satoshi}: ${e instanceof Error ? e.message : String(e)}` };
+  }
+  const anchors: Array<{ height: number | undefined; listIdx: number; digest: string; inscription: NonNullable<FetchedInscription> }> = [];
+  for (let idx = 0; idx < onSat.length; idx++) {
+    const inscriptionId = onSat[idx].inscriptionId;
+    let inscription: FetchedInscription;
+    try {
+      inscription = await ordinalsProvider.getInscriptionById(inscriptionId);
+    } catch (e) {
+      return { error: `failed to fetch inscription ${inscriptionId} on satoshi ${satoshi}: ${e instanceof Error ? e.message : String(e)}` };
+    }
+    if (!inscription) continue;
+    const doc = didDocumentFromInscription(inscription);
+    const digest = extractCelAnchorHeadDigest(doc);
+    if (digest !== undefined) {
+      anchors.push({ height: inscriptionBlockHeight(inscription), listIdx: idx, digest, inscription });
+    }
+  }
+  if (anchors.length === 0) {
+    return { error: `no OriginalsCelAnchor DID document found on satoshi ${satoshi}` };
+  }
+  if (anchors.some((c) => c.height === undefined)) {
+    return { error: `an OriginalsCelAnchor inscription on satoshi ${satoshi} has no confirmed block height; the newest anchor is unprovable` };
+  }
+  let head = anchors[0];
+  for (const c of anchors) {
+    if (c.height! > head.height! || (c.height! === head.height! && c.listIdx > head.listIdx)) head = c;
+  }
+  return { inscription: head.inscription, digest: head.digest };
+}
+
 async function verifyHeadFreshness(
   log: EventLog,
   anchoredSat: AnchoredSat,
   ordinalsProvider: OrdinalsLookup | undefined
 ): Promise<string | null> {
-  if (!ordinalsProvider || typeof ordinalsProvider.getInscriptionsBySatoshi !== 'function') {
-    return `STALE_LOG: head freshness was requested but the ordinals provider cannot enumerate inscriptions on satoshi ${anchoredSat.satoshi}; cannot confirm the log is not truncated`;
+  const newest = await selectNewestAnchorInscription(anchoredSat.satoshi, ordinalsProvider);
+  if ('error' in newest) {
+    return `STALE_LOG: ${newest.error}; cannot confirm the presented log is not truncated`;
   }
-
-  let onSat: Array<{ inscriptionId: string }>;
-  try {
-    onSat = await ordinalsProvider.getInscriptionsBySatoshi(anchoredSat.satoshi);
-  } catch (e) {
-    return `STALE_LOG: failed to enumerate inscriptions on satoshi ${anchoredSat.satoshi} for the head-freshness check: ${e instanceof Error ? e.message : String(e)}`;
-  }
-
-  // The "newest" anchor is chosen by per-inscription block HEIGHT (via
-  // getInscriptionById), NOT by list-tail position — otherwise a provider
-  // violating the oldest-first contract (returning newest-first) would make a
-  // tail-walk pick the OLDEST anchor, present even in a truncated prefix →
-  // fail-open (#395 sibling of the non-cooperative-rotation ordering fix).
-  // So collect EVERY anchor-carrying inscription with its height + list index.
-  // Non-anchor / non-JSON inscriptions are skipped; a genuine FETCH failure
-  // fails closed rather than silently skipping a real head.
-  const anchors: Array<{ height: number | undefined; listIdx: number; digest: string }> = [];
-  for (let idx = 0; idx < onSat.length; idx++) {
-    const inscriptionId = onSat[idx].inscriptionId;
-    let inscription: Awaited<ReturnType<OrdinalsLookup['getInscriptionById']>>;
-    try {
-      inscription = await ordinalsProvider.getInscriptionById(inscriptionId);
-    } catch (e) {
-      return `STALE_LOG: failed to fetch inscription ${inscriptionId} on satoshi ${anchoredSat.satoshi} during the head-freshness check: ${e instanceof Error ? e.message : String(e)}`;
-    }
-    if (!inscription) continue;
-    // #407 phase 2: the anchor DID document rides in inscription metadata
-    // (content is the asset media); phase-1 inscriptions carried it as content.
-    const doc = didDocumentFromInscription(inscription);
-    const digest = extractCelAnchorHeadDigest(doc);
-    if (digest !== undefined) {
-      anchors.push({ height: inscriptionBlockHeight(inscription), listIdx: idx, digest });
-    }
-  }
-
-  if (anchors.length === 0) {
-    return `STALE_LOG: no OriginalsCelAnchor DID document found on satoshi ${anchoredSat.satoshi}; cannot confirm the presented log is current`;
-  }
-  // Ordering must be provable: if any anchor candidate lacks a block height, we
-  // cannot identify the genuinely-newest one — fail closed (consistent with the
-  // non-cooperative rotation ordering check).
-  if (anchors.some((c) => c.height === undefined)) {
-    return `STALE_LOG: an OriginalsCelAnchor inscription on satoshi ${anchoredSat.satoshi} has no confirmed block height; the newest anchor is unprovable, so head freshness cannot be confirmed`;
-  }
-  // Highest block wins; same-block ties fall back to list-tail order (highest
-  // list index) — the documented oldest-first residual, unprovable intra-block.
-  let head = anchors[0];
-  for (const c of anchors) {
-    if (c.height! > head.height! || (c.height! === head.height! && c.listIdx > head.listIdx)) head = c;
-  }
-  const headDigest = head.digest;
-
   const present = log.events.some(
-    (ev) => digestMultibaseEquals(headDigest, computeDigestMultibase(canonicalizeEntryForChain(ev)))
+    (ev) => digestMultibaseEquals(newest.digest, computeDigestMultibase(canonicalizeEntryForChain(ev)))
   );
   if (!present) {
-    return `STALE_LOG: the newest on-chain anchor on satoshi ${anchoredSat.satoshi} commits to head digest ${headDigest}, which is absent from the presented log; the log is truncated or stale`;
+    return `STALE_LOG: the newest on-chain anchor on satoshi ${anchoredSat.satoshi} commits to head digest ${newest.digest}, which is absent from the presented log; the log is truncated or stale`;
   }
-
   return null;
 }
 
@@ -697,20 +705,22 @@ async function verifyAnchorContentMatchesHead(
   ordinalsProvider: OrdinalsLookup | undefined
 ): Promise<string | null> {
   if (!ordinalsProvider) return null;
-  let inscription: FetchedInscription;
-  try {
-    inscription = await ordinalsProvider.getInscriptionById(anchoredSat.inscriptionId);
-  } catch (e) {
-    return `CONTENT_MISMATCH: failed to fetch anchor inscription ${anchoredSat.inscriptionId} to verify its media content: ${e instanceof Error ? e.message : String(e)}`;
+  // Check the CURRENT anchor — the newest anchor inscription on the sat, not
+  // `anchoredSat` (a cooperative rotation leaves that at the migrate inscription,
+  // whose media predates any later resource update / reinscription).
+  const newest = await selectNewestAnchorInscription(anchoredSat.satoshi, ordinalsProvider);
+  if ('error' in newest) {
+    // No enumerable anchor to check the media against. Not a content mismatch —
+    // the witness-proof path already gated the anchor's DID document, and the
+    // resolver (which needs the bytes) gates media strictly on its own path.
+    return null;
   }
-  if (!inscription) {
-    return `CONTENT_MISMATCH: anchor inscription ${anchoredSat.inscriptionId} not found on chain`;
-  }
+  const inscription = newest.inscription;
+  const inscriptionId = inscription.inscriptionId;
   // Only phase-2 inscriptions (DID document in metadata) bind media as content.
   const metaDoc = (inscription.metadata as { didDocument?: { id?: unknown } } | undefined)?.didDocument;
   if (!metaDoc) return null;
-  // Provider omitted content → availability gap, not a mismatch (the witness
-  // proof already gated the metadata DID doc). The resolver gates media strictly.
+  // Provider omitted content → availability gap, not a mismatch.
   if (inscription.content === undefined) return null;
   const head = mostRecentResourceHead(log);
   // Media match: content hashes to the log's current resource head.
@@ -730,7 +740,7 @@ async function verifyAnchorContentMatchesHead(
     return null;
   }
   const contentHash = hashResource(inscription.content);
-  return `CONTENT_MISMATCH: anchor inscription ${anchoredSat.inscriptionId} content hashes to ${contentHash}, which is neither the log's most-recent-resource hash ${head ? head.hash : '(none)'} nor the anchor's own DID document`;
+  return `CONTENT_MISMATCH: anchor inscription ${inscriptionId} content hashes to ${contentHash}, which is neither the log's most-recent-resource hash ${head ? head.hash : '(none)'} nor the anchor's own DID document`;
 }
 
 /**

--- a/packages/sdk/src/cel/algorithms/verifyEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/verifyEventLog.ts
@@ -23,6 +23,30 @@ import { multikey } from '../../crypto/Multikey.js';
 import { deriveDidCelFromGenesis, didCelMatchesLog } from '../celDid.js';
 import { parseSatoshiIdentifier } from '../../utils/satoshi-validation.js';
 import { hexSha256ToDigestMultibase } from '../signerAdapter.js';
+import { hashResource } from '../../utils/validation.js';
+import { mostRecentResourceHead } from '../resourceHead.js';
+
+/** getInscriptionById result shape (narrowed for reuse). */
+type FetchedInscription = Awaited<ReturnType<OrdinalsLookup['getInscriptionById']>>;
+
+/**
+ * Extracts the asset DID document an anchoring inscription carries. Under #407
+ * phase 2 the DID document rides in the inscription's CBOR METADATA
+ * (`metadata.didDocument`) — its content is the asset media. Legacy phase-1
+ * inscriptions carried the DID document as JSON CONTENT, so this falls back to
+ * parsing content when no metadata document is present. Returns undefined when
+ * neither source yields an object.
+ */
+function didDocumentFromInscription(inscription: FetchedInscription): unknown {
+  const metaDoc = (inscription?.metadata as { didDocument?: unknown } | undefined)?.didDocument;
+  if (metaDoc && typeof metaDoc === 'object') return metaDoc;
+  if (inscription?.content === undefined) return undefined;
+  try {
+    return JSON.parse(inscription.content.toString('utf8'));
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Validates the structural requirements of a DataIntegrityProof (field presence,
@@ -391,30 +415,38 @@ async function verifyBitcoinWitnessProof(
     return `bitcoin witness proof txid (${record.txid}) does not match the inscription's txid (${inscription.txid})`;
   }
 
-  // The inscription content must commit to the event's digest — the exact
-  // digest witnessEvent computed over the committed fields (computed once by
-  // the caller and shared with ordinary witness verification).
-  if (inscription.content === undefined) {
+  // The inscription must commit to the event's digest — the exact digest
+  // witnessEvent computed over the committed fields (computed once by the caller
+  // and shared with ordinary witness verification). Two accepted shapes:
+  //  (a) a witness ATTESTATION with a top-level `digestMultibase` inscribed as
+  //      JSON CONTENT (BitcoinWitness / BtcoCelManager), or
+  //  (b) the asset's own inscribed DID document carrying an OriginalsCelAnchor
+  //      service whose headDigestMultibase is this event's chain digest — under
+  //      #407 phase 2 that document rides in inscription METADATA (content is
+  //      the asset media); phase-1 inscriptions carried it as content.
+  //      (LifecycleManager.inscribeOnBitcoin — the anchoring inscription IS the
+  //      witness artifact, #367.)
+  // Anything else fails closed.
+  const metaDoc = (inscription.metadata as { didDocument?: unknown } | undefined)?.didDocument;
+  // No commitment source at all (no content AND no metadata DID doc): a clear,
+  // non-alarming diagnostic (distinct from "content is not valid JSON", which
+  // implies tampering).
+  if (inscription.content === undefined && !metaDoc) {
     return `bitcoin witness inscription ${inscriptionId} content is missing`;
   }
-  let content: unknown;
-  try {
-    content = JSON.parse(inscription.content.toString('utf8'));
-  } catch {
-    return `bitcoin witness inscription ${inscriptionId} content is not valid JSON`;
+  let attestation: unknown;
+  if (inscription.content !== undefined) {
+    try {
+      attestation = JSON.parse(inscription.content.toString('utf8'));
+    } catch {
+      attestation = undefined; // content is media (phase 2) — shape (a) N/A
+    }
   }
-  // Two accepted commitment shapes, each requiring an exact digest match:
-  //  (a) witness attestation JSON with a top-level `digestMultibase`
-  //      (BitcoinWitness / BtcoCelManager inscribe this), or
-  //  (b) the asset's own inscribed DID document carrying an OriginalsCelAnchor
-  //      service whose headDigestMultibase is this event's chain digest
-  //      (LifecycleManager.inscribeOnBitcoin — the DID-doc inscription IS the
-  //      witness artifact, #367).
-  // Anything else fails closed.
-  const attested = (content as { digestMultibase?: unknown } | null)?.digestMultibase;
+  const attested = (attestation as { digestMultibase?: unknown } | null)?.digestMultibase;
+  const didDoc = didDocumentFromInscription(inscription);
   const commits =
     (typeof attested === 'string' && digestMultibaseEquals(attested, expectedDigest)) ||
-    didDocumentCommitsToDigest(content, expectedDigest);
+    didDocumentCommitsToDigest(didDoc, expectedDigest);
   if (!commits) {
     return `bitcoin witness inscription ${inscriptionId} does not commit to this event's digest`;
   }
@@ -523,14 +555,11 @@ async function verifyHeadFreshness(
     } catch (e) {
       return `STALE_LOG: failed to fetch inscription ${inscriptionId} on satoshi ${anchoredSat.satoshi} during the head-freshness check: ${e instanceof Error ? e.message : String(e)}`;
     }
-    if (!inscription || inscription.content === undefined) continue;
-    let content: unknown;
-    try {
-      content = JSON.parse(inscription.content.toString('utf8'));
-    } catch {
-      continue;
-    }
-    const digest = extractCelAnchorHeadDigest(content);
+    if (!inscription) continue;
+    // #407 phase 2: the anchor DID document rides in inscription metadata
+    // (content is the asset media); phase-1 inscriptions carried it as content.
+    const doc = didDocumentFromInscription(inscription);
+    const digest = extractCelAnchorHeadDigest(doc);
     if (digest !== undefined) {
       anchors.push({ height: inscriptionBlockHeight(inscription), listIdx: idx, digest });
     }
@@ -637,6 +666,71 @@ async function verifyUniqueness(
   }
 
   return null;
+}
+
+/**
+ * Content-as-ordinal integrity (#407 phase 2). The anchoring inscription IS the
+ * asset: its CONTENT is the asset's current media. When the anchor inscription
+ * carries media, its content MUST hash to the log's most-recent-resource hash —
+ * so a chain-reconstructed asset cannot present media that disagrees with its
+ * signed provenance. A tampered/wrong-media content fails closed.
+ *
+ * The single legitimate non-media shape: a pure-reference asset (the head
+ * resource has no inline bytes) whose writer inscribed the DID document itself
+ * as content (no media on-chain). That is accepted iff the content parses as the
+ * anchor's OWN DID document (id == metadata.didDocument.id) — anything else is a
+ * mismatch. It cannot be abused to forge media: fake media never hashes to the
+ * head, and substituting the DID document only DECLINES to prove media (which
+ * only the sat holder, re-inscribing, could do — an honest owner choice).
+ *
+ * Skipped for phase-1 inscriptions (no metadata DID document) and when the
+ * provider omits content (availability gap, not a mismatch; the resolver, which
+ * needs the bytes, gates that separately). Runs only once an `anchoredSat` is
+ * established (which already required a verified bitcoin witness proof → a
+ * provider).
+ *
+ * Returns a `CONTENT_MISMATCH`-coded error string on failure, or null.
+ */
+async function verifyAnchorContentMatchesHead(
+  log: EventLog,
+  anchoredSat: AnchoredSat,
+  ordinalsProvider: OrdinalsLookup | undefined
+): Promise<string | null> {
+  if (!ordinalsProvider) return null;
+  let inscription: FetchedInscription;
+  try {
+    inscription = await ordinalsProvider.getInscriptionById(anchoredSat.inscriptionId);
+  } catch (e) {
+    return `CONTENT_MISMATCH: failed to fetch anchor inscription ${anchoredSat.inscriptionId} to verify its media content: ${e instanceof Error ? e.message : String(e)}`;
+  }
+  if (!inscription) {
+    return `CONTENT_MISMATCH: anchor inscription ${anchoredSat.inscriptionId} not found on chain`;
+  }
+  // Only phase-2 inscriptions (DID document in metadata) bind media as content.
+  const metaDoc = (inscription.metadata as { didDocument?: { id?: unknown } } | undefined)?.didDocument;
+  if (!metaDoc) return null;
+  // Provider omitted content → availability gap, not a mismatch (the witness
+  // proof already gated the metadata DID doc). The resolver gates media strictly.
+  if (inscription.content === undefined) return null;
+  const head = mostRecentResourceHead(log);
+  // Media match: content hashes to the log's current resource head.
+  if (head && hashResource(inscription.content).toLowerCase() === head.hash.toLowerCase()) {
+    return null;
+  }
+  // No-media fallback: content is the anchor's own DID document (pure-reference
+  // asset — no inline media to inscribe).
+  let asJson: unknown;
+  try {
+    asJson = JSON.parse(inscription.content.toString('utf8'));
+  } catch {
+    asJson = undefined;
+  }
+  const contentDocId = (asJson as { id?: unknown } | undefined)?.id;
+  if (typeof contentDocId === 'string' && contentDocId === metaDoc.id) {
+    return null;
+  }
+  const contentHash = hashResource(inscription.content);
+  return `CONTENT_MISMATCH: anchor inscription ${anchoredSat.inscriptionId} content hashes to ${contentHash}, which is neither the log's most-recent-resource hash ${head ? head.hash : '(none)'} nor the anchor's own DID document`;
 }
 
 /**
@@ -818,12 +912,19 @@ async function evaluateNonCooperativeRotation(
     let rotationHeight: number | undefined;
     try {
       const inscription = await (ordinalsProvider as OrdinalsLookup).getInscriptionById(candidate.inscriptionId);
-      if (!inscription || inscription.content === undefined) {
-        reason = `inscription ${candidate.inscriptionId} content is missing`;
+      if (!inscription) {
+        reason = `inscription ${candidate.inscriptionId} not found`;
         continue;
       }
       rotationHeight = inscriptionBlockHeight(inscription);
-      announced = ed25519KeyHexesFromDidDocument(JSON.parse(inscription.content.toString('utf8')));
+      // #407 phase 2: the reinscribed DID document rides in metadata (content is
+      // the asset media); phase-1 reinscriptions carried it as content.
+      const doc = didDocumentFromInscription(inscription);
+      if (doc === undefined) {
+        reason = `inscription ${candidate.inscriptionId} carries no DID document`;
+        continue;
+      }
+      announced = ed25519KeyHexesFromDidDocument(doc);
     } catch (e) {
       reason = `failed to inspect inscription ${candidate.inscriptionId}: ${e instanceof Error ? e.message : String(e)}`;
       continue;
@@ -1591,6 +1692,15 @@ export async function verifyEventLog(
     uniquenessError = (await verifyUniqueness(assetDid, anchoredSat, options?.ordinalsProvider)) ?? undefined;
   }
 
+  // Content-as-ordinal integrity (#407 phase 2): a phase-2 anchor inscription's
+  // media content must hash to the log's most-recent-resource hash. Part of the
+  // btco verification contract (not opt-in); skipped on the custom-verifier path
+  // (which owns proof semantics and never establishes `anchoredSat`).
+  let contentMismatchError: string | undefined;
+  if (!options?.verifier && anchoredSat) {
+    contentMismatchError = (await verifyAnchorContentMatchesHead(log, anchoredSat, options?.ordinalsProvider)) ?? undefined;
+  }
+
   // expectedDid: reject a log that does not back the caller's expected DID.
   // Scoped to the non-custom-verifier path — that path owns proof semantics and
   // the authority binding above is skipped there. did:cel is matched by suffix
@@ -1622,9 +1732,12 @@ export async function verifyEventLog(
   if (uniquenessError) {
     errors.push(uniquenessError);
   }
+  if (contentMismatchError) {
+    errors.push(contentMismatchError);
+  }
 
   return {
-    verified: allProofsValid && allChainsValid && !authorityError && !deactivationViolated && !expectedDidError && !staleLogError && !uniquenessError,
+    verified: allProofsValid && allChainsValid && !authorityError && !deactivationViolated && !expectedDidError && !staleLogError && !uniquenessError && !contentMismatchError,
     errors,
     events: eventVerifications,
     ...(assetDid !== undefined ? { assetDid } : {}),

--- a/packages/sdk/src/cel/resourceHead.ts
+++ b/packages/sdk/src/cel/resourceHead.ts
@@ -1,0 +1,78 @@
+/**
+ * Resource-timeline head derivation (#407 phase 2 — content-as-ordinal).
+ *
+ * The anchoring inscription's CONTENT is the asset's "most-recent resource":
+ * the current head of the resource timeline. Writer and verifier MUST agree on
+ * which resource that is, so both derive it from the LOG here (never from the
+ * mutable in-memory resources array):
+ *
+ *  - the last resource-shaped `update` event's signed `toHash` (the latest
+ *    addResourceVersion), or
+ *  - failing any update, the genesis PRIMARY resource (index 0).
+ *
+ * A degraded update (in-memory advanced, log did not) is deliberately invisible
+ * here — the log is the source of provenance truth, so the writer inscribes the
+ * log-provable head, and the verifier checks against that same head.
+ */
+import type { EventLog } from './types.js';
+import { decodeDigestMultibase } from './hash.js';
+
+export interface ResourceHead {
+  /** Logical resource id (may be '' for legacy id-less genesis). */
+  resourceId: string;
+  /** Content hash as hex sha256 (AssetResource.hash form). */
+  hash: string;
+  /** MIME type, when the log recorded one. */
+  contentType?: string;
+  /** Version number, when derivable (genesis = 1, updates = toVersion). */
+  version?: number;
+}
+
+/**
+ * The current head of the resource timeline folded from the log, or undefined
+ * when the log is empty / shapeless (no genesis resources and no updates).
+ */
+export function mostRecentResourceHead(log: EventLog): ResourceHead | undefined {
+  if (!log || !Array.isArray(log.events) || log.events.length === 0) return undefined;
+
+  // Last resource-shaped update wins (resourceId + previousVersionHash + toHash).
+  // Witness-ack updates (no resourceId/previousVersionHash) and generic updates
+  // are skipped.
+  for (let i = log.events.length - 1; i >= 1; i--) {
+    const ev = log.events[i];
+    if (ev.type !== 'update') continue;
+    const d = (ev.data ?? {}) as Record<string, unknown>;
+    const resourceId = typeof d.resourceId === 'string' ? d.resourceId : undefined;
+    const previousVersionHash = typeof d.previousVersionHash === 'string' ? d.previousVersionHash : undefined;
+    const toHash = typeof d.toHash === 'string' && d.toHash.length > 0 ? d.toHash : undefined;
+    if (resourceId && previousVersionHash && toHash) {
+      return {
+        resourceId,
+        hash: toHash,
+        contentType: typeof d.contentType === 'string' ? d.contentType : undefined,
+        version: typeof d.toVersion === 'number' ? d.toVersion : undefined,
+      };
+    }
+  }
+
+  // No update: the genesis PRIMARY resource (index 0 — createAsset seeds the
+  // genesis name from resources[0].id, so index 0 is the primary media).
+  const genesis = log.events[0]?.data as { resources?: unknown; name?: unknown } | undefined;
+  const gres = genesis?.resources;
+  if (!Array.isArray(gres) || gres.length === 0) return undefined;
+  const first = gres[0] as { id?: unknown; digestMultibase?: unknown; mediaType?: unknown };
+  if (typeof first.digestMultibase !== 'string') return undefined;
+  let hash: string;
+  try {
+    hash = Buffer.from(decodeDigestMultibase(first.digestMultibase)).toString('hex');
+  } catch {
+    return undefined;
+  }
+  return {
+    resourceId: typeof first.id === 'string' ? first.id
+      : (typeof genesis?.name === 'string' ? genesis.name : ''),
+    hash,
+    contentType: typeof first.mediaType === 'string' ? first.mediaType : undefined,
+    version: 1,
+  };
+}

--- a/packages/sdk/src/cel/types.ts
+++ b/packages/sdk/src/cel/types.ts
@@ -167,6 +167,10 @@ export interface OrdinalsLookup {
     contentType: string;
     txid?: string;
     satoshi?: string;
+    blockHeight?: number;
+    // Inscription CBOR metadata (#407 phase 2): carries `{ didDocument, celLog }`
+    // for anchoring inscriptions whose content is the asset media.
+    metadata?: Record<string, unknown>;
   } | null>;
   /**
    * MUST return inscription ids oldest-first (on-chain inscription order).

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -1957,26 +1957,21 @@ export class LifecycleManager {
    * phase 2): the most-recent resource's inline bytes + its MIME type. The head
    * is derived from the LOG (mostRecentResourceHead) — the same source the
    * verifier uses — then matched by hash to the in-memory resources array to
-   * recover the bytes. Fails closed when the head cannot be derived or the
-   * matched resource carries no inline content (media we do not hold cannot be
-   * inscribed on-chain).
+   * recover the bytes.
+   *
+   * Returns null when no inline media is available (the head resource is a pure
+   * reference — hosted/hash-only, no inline bytes). Provenance still rides in
+   * metadata; the caller falls back to inscribing the DID document as content,
+   * so such assets carry NO media on-chain (honest, per the reference-only
+   * pattern this SDK supports — content-as-ordinal applies to inline media only).
    */
-  private resolveHeadMediaForInscription(asset: OriginalsAsset): { content: Buffer; contentType: string } {
+  private tryResolveHeadMedia(asset: OriginalsAsset): { content: Buffer; contentType: string } | null {
     const log = asset.celLog;
-    if (!log) {
-      throw new StructuredError('INVALID_STATE', 'Cannot inscribe: asset has no CEL log to derive the current media from.');
-    }
+    if (!log) return null;
     const head = mostRecentResourceHead(log);
-    if (!head) {
-      throw new StructuredError('INVALID_STATE', 'Cannot inscribe: no resource head could be derived from the log.');
-    }
+    if (!head) return null;
     const res = asset.resources.find(r => r.hash === head.hash);
-    if (!res || typeof res.content !== 'string') {
-      throw new StructuredError(
-        'CONTENT_UNAVAILABLE',
-        `Cannot inscribe the current media on-chain: the most-recent resource (${head.resourceId || '(unknown)'}, hash ${head.hash}) has no inline content to embed.`
-      );
-    }
+    if (!res || typeof res.content !== 'string') return null;
     return {
       content: Buffer.from(res.content, 'utf8'),
       contentType: res.contentType ?? head.contentType ?? 'application/octet-stream'
@@ -2065,9 +2060,11 @@ export class LifecycleManager {
     // current media (the most-recent resource's bytes), resolved from the LOG so
     // writer and verifier agree; its METADATA carries the byte-light provenance
     // (DID doc + CEL log). The media is sat-independent, so resolve it before the
-    // deferred window; a most-recent resource with no inline content fails closed
-    // (we cannot put media we do not hold on-chain).
-    const headMedia = this.resolveHeadMediaForInscription(asset);
+    // deferred window. When the head resource is a pure reference (no inline
+    // bytes), fall back to inscribing the DID document as content — provenance is
+    // still in metadata, just no media on-chain.
+    const headMedia = this.tryResolveHeadMedia(asset);
+    const inscriptionContentType = headMedia ? headMedia.contentType : 'application/did+json';
     // Held locally, not captured into the asset yet: buildContent runs BEFORE
     // the inscription is confirmed (satoshi known, asset.migrate succeeded).
     // Capturing here would leave a stale doc in #didDocuments with no rollback
@@ -2108,14 +2105,14 @@ export class LifecycleManager {
         // Metadata = { didDocument, celLog }. Snapshot the log AFTER the migrate
         // append so the embedded celLog head equals the #cel anchor digest.
         return {
-          content: headMedia.content,
+          content: headMedia ? headMedia.content : Buffer.from(JSON.stringify(btcoDoc)),
           metadata: {
             didDocument: btcoDoc,
             ...(asset.celLog ? { celLog: JSON.parse(serializeEventLogJson(asset.celLog)) as Record<string, unknown> } : {})
           }
         };
       },
-      headMedia.contentType,
+      inscriptionContentType,
       feeRate,
       // Key the shared money-lock by the asset's current DID so a concurrent
       // MigrationManager.migrate of the same DID is blocked at inscribe (issue #303).
@@ -2515,16 +2512,17 @@ export class LifecycleManager {
     // metadata = { didDocument: rotatedDoc, celLog }. The sat is already known
     // (reinscription targets it), so both are built synchronously; snapshot the
     // log now — the caller has already appended the rotateKey + embedded the
-    // fresh #cel anchor, so the celLog head equals that anchor.
-    const headMedia = this.resolveHeadMediaForInscription(asset);
+    // fresh #cel anchor, so the celLog head equals that anchor. No inline media
+    // (pure-reference head) → fall back to the DID document as content.
+    const headMedia = this.tryResolveHeadMedia(asset);
     const metadata: Record<string, unknown> = {
       didDocument: rotatedDoc,
       ...(asset.celLog ? { celLog: JSON.parse(serializeEventLogJson(asset.celLog)) as Record<string, unknown> } : {})
     };
     try {
       return await bitcoinManager.inscribeData(
-        headMedia.content,
-        headMedia.contentType,
+        headMedia ? headMedia.content : Buffer.from(JSON.stringify(rotatedDoc)),
+        headMedia ? headMedia.contentType : 'application/did+json',
         feeRate,
         { targetSatoshi: satoshi, metadata }
       );

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -22,16 +22,16 @@ import {
 import { encodeBase64UrlMultibase, hexToBytes } from '../utils/encoding.js';
 import { hashResource, validateCredential } from '../utils/validation.js';
 import { validateBitcoinAddress } from '../utils/bitcoin-address.js';
-import { parseSatoshiIdentifier } from '../utils/satoshi-validation.js';
+import { parseSatoshiIdentifier, validateSatoshiNumber } from '../utils/satoshi-validation.js';
 import { btcoDidPrefix, btcoDidFromSatoshi } from '../cel/btcoDid.js';
 import { KeyManager } from '../did/KeyManager.js';
 import { celSignerFromKeyPair, hexSha256ToDigestMultibase, createKeyStoreCelSigner, currentControllerVm } from '../cel/signerAdapter.js';
 import { createCelDidDocument, didCelMatchesLog, deriveDidCel, DID_CEL_PREFIX } from '../cel/celDid.js';
-import { verifyEventLog } from '../cel/algorithms/verifyEventLog.js';
+import { verifyEventLog, selectNewestAnchorInscription } from '../cel/algorithms/verifyEventLog.js';
 import { createDidManagerKeyResolver } from '../cel/keyResolver.js';
 import { PeerCelManager } from '../cel/layers/PeerCelManager.js';
 import { appendEvent } from '../cel/algorithms/appendEvent.js';
-import { computeDigestMultibase, digestMultibaseEquals } from '../cel/hash.js';
+import { computeDigestMultibase, digestMultibaseEquals, decodeDigestMultibase } from '../cel/hash.js';
 import { mostRecentResourceHead } from '../cel/resourceHead.js';
 import { canonicalizeEntryForChain } from '../cel/canonicalize.js';
 import { serializeEventLogJson, parseEventLogJson } from '../cel/serialization/json.js';
@@ -744,6 +744,207 @@ export class LifecycleManager {
     }
 
     return { asset, verification, warnings };
+  }
+
+  /**
+   * Resolve + VERIFY a complete Originals asset from a bare satoshi — the #407
+   * phase-2 chain-recovery path. Reads the NEWEST anchoring inscription on the
+   * sat, reconstructs a byte-light {@link AssetEnvelope} from its metadata
+   * (`{ didDocument, celLog }`) and content (the current media), and runs it
+   * through {@link loadAsset} — so a chain-reconstructed asset verifies with the
+   * SAME gate an envelope-loaded one does (verifyEventLog + resource binding +
+   * head freshness + uniqueness + content-as-ordinal). Provenance is recoverable
+   * from Bitcoin alone.
+   *
+   * Fail-closed: no provider, an invalid satoshi, no anchor inscription, an
+   * unprovable-newest (missing block height) inscription, missing provenance
+   * metadata, an embedded celLog head that disagrees with the on-chain `#cel`
+   * anchor, or a failed loadAsset all throw. The reconstructed head media is
+   * bound to the log's signed hash by loadAsset (a tampered media fails closed).
+   *
+   * @param satoshi - The bare satoshi number carrying the asset.
+   * @param opts.ordinalsProvider - Defaults to `config.ordinalsProvider`.
+   */
+  async resolveAssetFromSat(
+    satoshi: string,
+    opts?: { ordinalsProvider?: OrdinalsLookup }
+  ): Promise<{ asset: OriginalsAsset; verification?: VerificationResult; warnings: string[] }> {
+    const provider = opts?.ordinalsProvider ?? this.config.ordinalsProvider;
+    if (!provider) {
+      throw new StructuredError('ORD_PROVIDER_REQUIRED', 'Ordinals provider must be configured to resolve an asset from a satoshi.');
+    }
+    const sat = String(satoshi);
+    {
+      const v = validateSatoshiNumber(sat);
+      if (!v.valid) throw new StructuredError('INVALID_SATOSHI', `Invalid satoshi identifier: ${v.error}`);
+    }
+
+    // 1) Newest anchoring inscription by confirmed block height — reuses the
+    // verifier's selection so the resolver picks the SAME inscription
+    // head-freshness / the content gate check against (fail-closed on missing
+    // height, per-height newest, list-tail same-block residual).
+    const selected = await selectNewestAnchorInscription(sat, provider);
+    if ('error' in selected) {
+      throw new StructuredError('CHAIN_ASSET_NOT_FOUND', `Cannot resolve an asset from satoshi ${sat}: ${selected.error}.`);
+    }
+    const chosen = selected.inscription;
+
+    // 2) Read provenance (metadata) + media (content).
+    const metadata = chosen.metadata as { didDocument?: unknown; celLog?: unknown } | undefined;
+    const btcoDoc = metadata?.didDocument;
+    const rawCelLog = metadata?.celLog;
+    if (!btcoDoc || typeof btcoDoc !== 'object' || rawCelLog === undefined || rawCelLog === null) {
+      throw new StructuredError(
+        'CHAIN_ASSET_INVALID',
+        `Inscription ${chosen.inscriptionId} on satoshi ${sat} carries no provenance metadata (didDocument + celLog); not a phase-2 anchoring inscription.`
+      );
+    }
+
+    // 3) Parse the embedded byte-light CEL log through the JSON gate.
+    let log: EventLog;
+    try {
+      log = parseEventLogJson(JSON.stringify(rawCelLog));
+    } catch (e) {
+      throw new StructuredError('CHAIN_ASSET_INVALID', `Inscription ${chosen.inscriptionId} celLog is not a valid CEL log: ${(e as Error).message}`);
+    }
+    if (!Array.isArray(log.events) || log.events.length === 0) {
+      throw new StructuredError('CHAIN_ASSET_INVALID', `Inscription ${chosen.inscriptionId} celLog has no events.`);
+    }
+
+    // 4) The embedded celLog head MUST equal the on-chain `#cel` anchor
+    // (else the inscription is internally inconsistent). Defense-in-depth: the
+    // witness path re-derives this too, but a clear early error is worth it.
+    const anchorDigest = this.extractCelAnchorFromDoc(btcoDoc);
+    const headDigest = computeDigestMultibase(canonicalizeEntryForChain(log.events[log.events.length - 1]));
+    if (anchorDigest === undefined) {
+      throw new StructuredError('CHAIN_ASSET_INVALID', `Inscription ${chosen.inscriptionId} DID document carries no OriginalsCelAnchor; cannot confirm the embedded log head.`);
+    }
+    if (!digestMultibaseEquals(anchorDigest, headDigest)) {
+      throw new StructuredError('CHAIN_ASSET_INVALID', `Inscription ${chosen.inscriptionId}: embedded celLog head (${headDigest}) does not equal the #cel anchor (${anchorDigest}).`);
+    }
+
+    // 5) Reconstruct the byte-light AssetEnvelope. The head event needs its OWN
+    // bitcoin witness proof reattached — the writer inscribes the doc/log BEFORE
+    // the inscription id exists, so the head's witness (which names this
+    // inscription) is never in the embedded snapshot. It is fully re-verified
+    // against the chain by verifyBitcoinWitnessProof inside loadAsset.
+    const headTxid = typeof chosen.txid === 'string' ? chosen.txid : '';
+    const headWitness: WitnessProof & { txid: string; satoshi: string; inscriptionId: string } = {
+      type: 'DataIntegrityProof',
+      cryptosuite: 'bitcoin-ordinals-2024',
+      created: new Date().toISOString(),
+      verificationMethod: 'did:btco:witness',
+      proofPurpose: 'assertionMethod',
+      proofValue: `z${chosen.inscriptionId}`,
+      witnessedAt: new Date().toISOString(),
+      txid: headTxid,
+      satoshi: sat,
+      inscriptionId: chosen.inscriptionId
+    };
+    const headIdx = log.events.length - 1;
+    const events = log.events.slice();
+    events[headIdx] = { ...events[headIdx], proof: [...events[headIdx].proof, headWitness] };
+    const reconstructedLog: EventLog = { ...log, events };
+
+    // Resources from the log + the on-chain media as the head blob.
+    const resources = this.reconstructResourcesFromLog(reconstructedLog, chosen.content);
+
+    // did:cel document is DERIVED (loadAsset re-derives it anyway; supply a
+    // structurally valid one). did:btco is the on-chain metadata doc.
+    const assetDid = deriveDidCel(reconstructedLog);
+    const genesisController = (reconstructedLog.events[0]?.data as { controller?: unknown })?.controller;
+    if (typeof genesisController !== 'string' || !genesisController.startsWith('did:key:')) {
+      throw new StructuredError('CHAIN_ASSET_INVALID', `Inscription ${chosen.inscriptionId} genesis controller is not a did:key.`);
+    }
+    const celDoc = createCelDidDocument(assetDid, genesisController.slice('did:key:'.length));
+
+    const envelope: AssetEnvelope = {
+      format: ASSET_ENVELOPE_FORMAT,
+      version: ASSET_ENVELOPE_VERSION,
+      assetDid,
+      eventLog: reconstructedLog,
+      didDocuments: {
+        'did:cel': celDoc,
+        'did:btco': btcoDoc as DIDDocument
+      },
+      resources
+    };
+
+    // 6) loadAsset runs the full verification gate (incl. content-as-ordinal via
+    // the head blob's hash binding). checkHeadFreshness is engaged by the
+    // provider passthrough.
+    return this.loadAsset(envelope, { ordinalsProvider: provider });
+  }
+
+  /** Extracts the first OriginalsCelAnchor headDigestMultibase from a DID doc. */
+  private extractCelAnchorFromDoc(doc: unknown): string | undefined {
+    const services = (doc as { service?: unknown })?.service;
+    if (!Array.isArray(services)) return undefined;
+    for (const entry of services) {
+      const svc = entry as { type?: unknown; serviceEndpoint?: unknown };
+      if (svc?.type !== 'OriginalsCelAnchor') continue;
+      const head = (svc.serviceEndpoint as { headDigestMultibase?: unknown } | undefined)?.headDigestMultibase;
+      if (typeof head === 'string' && head.length > 0) return head;
+    }
+    return undefined;
+  }
+
+  /**
+   * Rebuild the byte-light resources array from a CEL log (#407 phase 2
+   * chain-recovery): every genesis resource (v1) + every resource-shaped update
+   * (v≥2), matched to the shapes loadAsset's genesis/version binding expects.
+   * Only the head resource gets inline content (the on-chain media), and only
+   * when it hashes to the log's most-recent-resource hash — so loadAsset's
+   * blob↔toHash gate (which independently re-checks it) passes; a
+   * non-utf8-roundtrippable or mismatched blob is left as a pure reference.
+   */
+  private reconstructResourcesFromLog(log: EventLog, headContent: Buffer | undefined): AssetResource[] {
+    const resources: AssetResource[] = [];
+    const genesis = log.events[0]?.data as { resources?: unknown } | undefined;
+    const gres = Array.isArray(genesis?.resources) ? genesis!.resources as Array<Record<string, unknown>> : [];
+    for (const ref of gres) {
+      const dm = ref.digestMultibase;
+      if (typeof dm !== 'string') continue;
+      let hash: string;
+      try { hash = Buffer.from(decodeDigestMultibase(dm)).toString('hex'); } catch { continue; }
+      const url = Array.isArray(ref.url) && typeof ref.url[0] === 'string' ? ref.url[0] as string : undefined;
+      resources.push({
+        id: typeof ref.id === 'string' ? ref.id : '',
+        type: 'data',
+        contentType: typeof ref.mediaType === 'string' ? ref.mediaType : 'application/octet-stream',
+        hash,
+        version: 1,
+        ...(url ? { url } : {})
+      });
+    }
+    for (let i = 1; i < log.events.length; i++) {
+      const ev = log.events[i];
+      if (ev.type !== 'update') continue;
+      const d = (ev.data ?? {}) as Record<string, unknown>;
+      const resourceId = typeof d.resourceId === 'string' ? d.resourceId : undefined;
+      const previousVersionHash = typeof d.previousVersionHash === 'string' ? d.previousVersionHash : undefined;
+      const toHash = typeof d.toHash === 'string' && d.toHash.length > 0 ? d.toHash : undefined;
+      if (!resourceId || !previousVersionHash || !toHash) continue;
+      resources.push({
+        id: resourceId,
+        type: 'data',
+        contentType: typeof d.contentType === 'string' ? d.contentType : 'application/octet-stream',
+        hash: toHash,
+        ...(typeof d.toVersion === 'number' ? { version: d.toVersion } : {}),
+        previousVersionHash
+      });
+    }
+    // Attach the on-chain media to the head resource, iff it round-trips to the
+    // head hash (loadAsset re-verifies hash(content) == signed toHash).
+    const head = mostRecentResourceHead(log);
+    if (headContent && head) {
+      const contentStr = headContent.toString('utf8');
+      if (hashResource(Buffer.from(contentStr, 'utf8')) === head.hash) {
+        const target = resources.find(r => r.hash === head.hash && r.content === undefined);
+        if (target) target.content = contentStr;
+      }
+    }
+    return resources;
   }
 
   /**

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -828,8 +828,8 @@ export class LifecycleManager {
     // the inscription id exists, so the head's witness (which names this
     // inscription) is never in the embedded snapshot. It is fully re-verified
     // against the chain by verifyBitcoinWitnessProof inside loadAsset.
-    const headTxid = typeof chosen.txid === 'string' ? chosen.txid : '';
-    const headWitness: WitnessProof & { txid: string; satoshi: string; inscriptionId: string } = {
+    const headTxid = typeof chosen.txid === 'string' ? chosen.txid : undefined;
+    const headWitness: WitnessProof & { txid?: string; satoshi: string; inscriptionId: string } = {
       type: 'DataIntegrityProof',
       cryptosuite: 'bitcoin-ordinals-2024',
       created: new Date().toISOString(),
@@ -854,7 +854,7 @@ export class LifecycleManager {
     const assetDid = deriveDidCel(reconstructedLog);
     const genesisController = (reconstructedLog.events[0]?.data as { controller?: unknown })?.controller;
     if (typeof genesisController !== 'string' || !genesisController.startsWith('did:key:')) {
-      throw new StructuredError('CHAIN_ASSET_INVALID', `Inscription ${chosen.inscriptionId} genesis controller is not a did:key.`);
+      throw new StructuredError('CHAIN_ASSET_INVALID', `Inscription ${chosen.inscriptionId} genesis controller is not a did:key (only did:key controllers are supported by resolveAssetFromSat; got: ${String(genesisController)}).`);
     }
     const celDoc = createCelDidDocument(assetDid, genesisController.slice('did:key:'.length));
 
@@ -939,8 +939,8 @@ export class LifecycleManager {
     const head = mostRecentResourceHead(log);
     if (headContent && head) {
       const contentStr = headContent.toString('utf8');
-      if (hashResource(Buffer.from(contentStr, 'utf8')) === head.hash) {
-        const target = resources.find(r => r.hash === head.hash && r.content === undefined);
+      if (hashResource(Buffer.from(contentStr, 'utf8')).toLowerCase() === head.hash.toLowerCase()) {
+        const target = resources.find(r => (!head.resourceId || r.id === head.resourceId) && r.hash === head.hash && r.content === undefined);
         if (target) target.content = contentStr;
       }
     }
@@ -2171,7 +2171,7 @@ export class LifecycleManager {
     if (!log) return null;
     const head = mostRecentResourceHead(log);
     if (!head) return null;
-    const res = asset.resources.find(r => r.hash === head.hash);
+    const res = asset.resources.find(r => (!head.resourceId || r.id === head.resourceId) && r.hash === head.hash);
     if (!res || typeof res.content !== 'string') return null;
     return {
       content: Buffer.from(res.content, 'utf8'),

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -32,6 +32,7 @@ import { createDidManagerKeyResolver } from '../cel/keyResolver.js';
 import { PeerCelManager } from '../cel/layers/PeerCelManager.js';
 import { appendEvent } from '../cel/algorithms/appendEvent.js';
 import { computeDigestMultibase, digestMultibaseEquals } from '../cel/hash.js';
+import { mostRecentResourceHead } from '../cel/resourceHead.js';
 import { canonicalizeEntryForChain } from '../cel/canonicalize.js';
 import { serializeEventLogJson, parseEventLogJson } from '../cel/serialization/json.js';
 import type { EventLog, LogEntry, ExternalReference, WitnessProof, OrdinalsLookup, VerificationResult } from '../cel/types.js';
@@ -1951,6 +1952,37 @@ export class LifecycleManager {
     return null;
   }
 
+  /**
+   * Resolve the media the anchoring inscription will carry as CONTENT (#407
+   * phase 2): the most-recent resource's inline bytes + its MIME type. The head
+   * is derived from the LOG (mostRecentResourceHead) — the same source the
+   * verifier uses — then matched by hash to the in-memory resources array to
+   * recover the bytes. Fails closed when the head cannot be derived or the
+   * matched resource carries no inline content (media we do not hold cannot be
+   * inscribed on-chain).
+   */
+  private resolveHeadMediaForInscription(asset: OriginalsAsset): { content: Buffer; contentType: string } {
+    const log = asset.celLog;
+    if (!log) {
+      throw new StructuredError('INVALID_STATE', 'Cannot inscribe: asset has no CEL log to derive the current media from.');
+    }
+    const head = mostRecentResourceHead(log);
+    if (!head) {
+      throw new StructuredError('INVALID_STATE', 'Cannot inscribe: no resource head could be derived from the log.');
+    }
+    const res = asset.resources.find(r => r.hash === head.hash);
+    if (!res || typeof res.content !== 'string') {
+      throw new StructuredError(
+        'CONTENT_UNAVAILABLE',
+        `Cannot inscribe the current media on-chain: the most-recent resource (${head.resourceId || '(unknown)'}, hash ${head.hash}) has no inline content to embed.`
+      );
+    }
+    return {
+      content: Buffer.from(res.content, 'utf8'),
+      contentType: res.contentType ?? head.contentType ?? 'application/octet-stream'
+    };
+  }
+
   async inscribeOnBitcoin(
     asset: OriginalsAsset,
     feeRate?: number
@@ -2029,6 +2061,13 @@ export class LifecycleManager {
       (d, i, arr): d is string => typeof d === 'string' && arr.indexOf(d) === i
     );
 
+    // #407 phase 2: the anchoring inscription IS the asset. Its CONTENT is the
+    // current media (the most-recent resource's bytes), resolved from the LOG so
+    // writer and verifier agree; its METADATA carries the byte-light provenance
+    // (DID doc + CEL log). The media is sat-independent, so resolve it before the
+    // deferred window; a most-recent resource with no inline content fails closed
+    // (we cannot put media we do not hold on-chain).
+    const headMedia = this.resolveHeadMediaForInscription(asset);
     // Held locally, not captured into the asset yet: buildContent runs BEFORE
     // the inscription is confirmed (satoshi known, asset.migrate succeeded).
     // Capturing here would leave a stale doc in #didDocuments with no rollback
@@ -2066,9 +2105,17 @@ export class LifecycleManager {
           }] : [])
         ];
         inscribedBtcoDoc = btcoDoc;
-        return Buffer.from(JSON.stringify(btcoDoc));
+        // Metadata = { didDocument, celLog }. Snapshot the log AFTER the migrate
+        // append so the embedded celLog head equals the #cel anchor digest.
+        return {
+          content: headMedia.content,
+          metadata: {
+            didDocument: btcoDoc,
+            ...(asset.celLog ? { celLog: JSON.parse(serializeEventLogJson(asset.celLog)) as Record<string, unknown> } : {})
+          }
+        };
       },
-      'application/did+json',
+      headMedia.contentType,
       feeRate,
       // Key the shared money-lock by the asset's current DID so a concurrent
       // MigrationManager.migrate of the same DID is blocked at inscribe (issue #303).
@@ -2081,6 +2128,7 @@ export class LifecycleManager {
       satoshi?: string;
       feeRate?: number;
       content?: Buffer;
+      metadata?: Record<string, unknown>;
     };
     const revealTxId = inscription.revealTxId ?? inscription.txid;
     const commitTxId = inscription.commitTxId;
@@ -2168,21 +2216,17 @@ export class LifecycleManager {
     // migrateToDIDBTCO (explicit network wins over the webvhNetwork mapping,
     // #247), so a tier-only config can't drift into a prefix mismatch.
     const bindingValue = `${btcoDidPrefix(this.getConfiguredBitcoinNetwork())}:${inscription.satoshi}`;
-    // Parse the echoed content ONLY as an integrity cross-check: if it parses
-    // and disagrees with the computed binding, the provider may have altered
-    // the inscription — log it (payment already happened, state is migrated;
-    // do NOT throw, the caller has the inscriptionId to investigate). Missing
-    // or non-JSON content is fine — no cross-check possible.
-    if (inscription.content) {
-      let inscribedDoc: { id?: unknown } | undefined;
-      try {
-        inscribedDoc = JSON.parse(inscription.content.toString()) as { id?: unknown };
-      } catch {
-        inscribedDoc = undefined;
-      }
+    // Cross-check the echoed METADATA DID document (#407 phase 2 moved the doc
+    // from content→metadata): if the provider echoed a didDocument whose id
+    // disagrees with the computed binding, it may have altered the inscription —
+    // log it (payment already happened, state is migrated; do NOT throw, the
+    // caller has the inscriptionId to investigate). Missing metadata is fine —
+    // no cross-check possible.
+    {
+      const inscribedDoc = (inscription.metadata as { didDocument?: { id?: unknown } } | undefined)?.didDocument;
       if (inscribedDoc && inscribedDoc.id !== bindingValue) {
         this.logger.error(
-          'Inscribed DID document id does not match expected binding — provider may have altered the inscription content',
+          'Inscribed DID document id does not match expected binding — provider may have altered the inscription metadata',
           undefined,
           { expected: bindingValue, inscribed: inscribedDoc.id, inscriptionId: inscription.inscriptionId }
         );
@@ -2467,12 +2511,22 @@ export class LifecycleManager {
     restoreLog: EventLog | undefined
   ): Promise<{ inscriptionId: string; satoshi?: string; txid?: string; revealTxId?: string }> {
     const bitcoinManager = this.deps?.bitcoinManager ?? new BitcoinManager(this.config);
+    // #407 phase 2: the reinscription IS the asset. Content = current media;
+    // metadata = { didDocument: rotatedDoc, celLog }. The sat is already known
+    // (reinscription targets it), so both are built synchronously; snapshot the
+    // log now — the caller has already appended the rotateKey + embedded the
+    // fresh #cel anchor, so the celLog head equals that anchor.
+    const headMedia = this.resolveHeadMediaForInscription(asset);
+    const metadata: Record<string, unknown> = {
+      didDocument: rotatedDoc,
+      ...(asset.celLog ? { celLog: JSON.parse(serializeEventLogJson(asset.celLog)) as Record<string, unknown> } : {})
+    };
     try {
       return await bitcoinManager.inscribeData(
-        Buffer.from(JSON.stringify(rotatedDoc)),
-        'application/did+json',
+        headMedia.content,
+        headMedia.contentType,
         feeRate,
-        { targetSatoshi: satoshi }
+        { targetSatoshi: satoshi, metadata }
       );
     } catch (error) {
       // Reinscription failed after the append — restore the pre-append log

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -901,13 +901,13 @@ export class LifecycleManager {
   private reconstructResourcesFromLog(log: EventLog, headContent: Buffer | undefined): AssetResource[] {
     const resources: AssetResource[] = [];
     const genesis = log.events[0]?.data as { resources?: unknown } | undefined;
-    const gres = Array.isArray(genesis?.resources) ? genesis!.resources as Array<Record<string, unknown>> : [];
+    const gres: Array<Record<string, unknown>> = Array.isArray(genesis?.resources) ? genesis.resources : [];
     for (const ref of gres) {
       const dm = ref.digestMultibase;
       if (typeof dm !== 'string') continue;
       let hash: string;
       try { hash = Buffer.from(decodeDigestMultibase(dm)).toString('hex'); } catch { continue; }
-      const url = Array.isArray(ref.url) && typeof ref.url[0] === 'string' ? ref.url[0] as string : undefined;
+      const url = Array.isArray(ref.url) && typeof ref.url[0] === 'string' ? ref.url[0] : undefined;
       resources.push({
         id: typeof ref.id === 'string' ? ref.id : '',
         type: 'data',

--- a/packages/sdk/src/types/bitcoin.ts
+++ b/packages/sdk/src/types/bitcoin.ts
@@ -9,6 +9,9 @@ export interface OrdinalsInscription {
   txid: string;
   vout: number;
   blockHeight?: number;
+  // Inscription CBOR metadata (#407 phase 2): `{ didDocument, celLog }` for
+  // anchoring inscriptions whose content is the asset media.
+  metadata?: Record<string, unknown>;
 }
 
 export interface BitcoinTransaction {

--- a/packages/sdk/tests/integration/CompleteLifecycle.e2e.test.ts
+++ b/packages/sdk/tests/integration/CompleteLifecycle.e2e.test.ts
@@ -246,12 +246,15 @@ describe('E2E Integration: Complete Lifecycle Flow', () => {
       const inscription = await ordinalsProvider.getInscriptionById(inscriptionId!);
       expect(inscription).not.toBeNull();
       expect(inscription?.inscriptionId).toBe(inscriptionId);
-      // The inscription is now the btco DID document itself (#375), not a bare manifest.
-      expect(inscription?.contentType).toBe('application/did+json');
-      const inscribedDoc = JSON.parse(inscription!.content.toString());
+      // #407 phase 2: the inscription CONTENT is now the current media (the
+      // most-recent resource's bytes), and the btco DID document + resource
+      // manifest ride in the inscription METADATA.
+      expect(inscription?.contentType).toBe('image/png');
+      expect(inscription!.content!.toString()).toBe('mock-image-data');
+      const inscribedDoc = (inscription!.metadata as { didDocument: { id: string; service: Array<{ type: string; serviceEndpoint: { resources: unknown[] } }> } }).didDocument;
       expect(inscribedDoc.id).toMatch(/^did:btco:/);
-      const inscribedManifest = inscribedDoc.service.find((s: { type: string }) => s.type === 'OriginalsResourceManifest');
-      expect(inscribedManifest.serviceEndpoint.resources.length).toBeGreaterThan(0);
+      const inscribedManifest = inscribedDoc.service.find((s) => s.type === 'OriginalsResourceManifest');
+      expect(inscribedManifest!.serviceEndpoint.resources.length).toBeGreaterThan(0);
 
       // ===== PHASE 4: Transfer Ownership =====
       const recipientAddress = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx';

--- a/packages/sdk/tests/integration/ResolveFromSat.e2e.test.ts
+++ b/packages/sdk/tests/integration/ResolveFromSat.e2e.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Bare-sat resolution (#407 phase 2). A resolver with ONLY the satoshi + an
+ * ordinals provider reconstructs an asset's provenance (from inscription
+ * metadata) AND its current media (from inscription content), verified, with NO
+ * envelope and NO host. Provenance is recoverable from Bitcoin alone.
+ */
+import { describe, test, expect } from 'bun:test';
+import { OriginalsSDK } from '../../src';
+import { OrdMockProvider } from '../../src/adapters/providers/OrdMockProvider';
+import { MemoryStorageAdapter } from '../../src/storage/MemoryStorageAdapter';
+import { MockKeyStore } from '../mocks/MockKeyStore';
+import { hashResource } from '../../src/utils/validation';
+
+const contentHash = (s: string) => hashResource(Buffer.from(s, 'utf8'));
+
+function makeSDK() {
+  const ordinalsProvider = new OrdMockProvider();
+  const sdk = OriginalsSDK.create({
+    network: 'regtest',
+    defaultKeyType: 'Ed25519',
+    ordinalsProvider,
+    storageAdapter: new MemoryStorageAdapter(),
+    keyStore: new MockKeyStore()
+  });
+  return { sdk, ordinalsProvider };
+}
+
+describe('resolveAssetFromSat — bare-sat chain recovery (#407 phase 2)', () => {
+  test('create → addResourceVersion → publish → inscribe → resolve reconstructs + verifies from the sat alone', async () => {
+    const { sdk, ordinalsProvider } = makeSDK();
+    const asset = await sdk.lifecycle.createAsset([
+      { id: 'art', type: 'image', contentType: 'image/png', hash: contentHash('v1-bytes'), content: 'v1-bytes' }
+    ]);
+    // Update the media so the current head is v2 — the resolver must recover v2.
+    await asset.addResourceVersion('art', 'v2-bytes', 'image/png', 'update to v2');
+    await sdk.lifecycle.publishToWeb(asset, 'example.com');
+    await sdk.lifecycle.inscribeOnBitcoin(asset, 5);
+
+    const sat = asset.bindings!['did:btco'].split(':').pop()!;
+
+    // Fresh SDK: only the sat + provider, no envelope, no host.
+    const fresh = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', ordinalsProvider });
+    const { asset: recovered, verification, warnings } = await fresh.lifecycle.resolveAssetFromSat(sat);
+
+    expect(recovered.id).toBe(asset.id);
+    expect(recovered.currentLayer).toBe('did:btco');
+    expect(verification?.verified).toBe(true);
+    // The recovered current media is v2 (the most-recent resource).
+    const head = recovered.resources.find(r => r.hash === contentHash('v2-bytes'));
+    expect(head?.content).toBe('v2-bytes');
+    // No spurious verification warnings about the head blob.
+    expect(warnings.some(w => /has no backing blob/.test(w))).toBe(false);
+  });
+
+  test('single-resource asset (no updates) round-trips the genesis media', async () => {
+    const { sdk, ordinalsProvider } = makeSDK();
+    const asset = await sdk.lifecycle.createAsset([
+      { id: 'doc', type: 'data', contentType: 'application/json', hash: contentHash('{"k":1}'), content: '{"k":1}' }
+    ]);
+    await sdk.lifecycle.inscribeOnBitcoin(asset, 5);
+    const sat = asset.bindings!['did:btco'].split(':').pop()!;
+
+    const { asset: recovered, verification } = await sdk.lifecycle.resolveAssetFromSat(sat);
+    expect(verification?.verified).toBe(true);
+    expect(recovered.resources.find(r => r.hash === contentHash('{"k":1}'))?.content).toBe('{"k":1}');
+  });
+
+  test('tampered on-chain media content → resolution fails closed', async () => {
+    const { sdk, ordinalsProvider } = makeSDK();
+    const asset = await sdk.lifecycle.createAsset([
+      { id: 'art', type: 'image', contentType: 'image/png', hash: contentHash('real-media'), content: 'real-media' }
+    ]);
+    await sdk.lifecycle.inscribeOnBitcoin(asset, 5);
+    const sat = asset.bindings!['did:btco'].split(':').pop()!;
+
+    // Tamper: rewrite the anchoring inscription's content to bytes that do NOT
+    // hash to the head resource.
+    const list = await ordinalsProvider.getInscriptionsBySatoshi(sat);
+    const insc = await ordinalsProvider.getInscriptionById(list[list.length - 1].inscriptionId);
+    (ordinalsProvider as any)['state'].inscriptionsById.get(insc!.inscriptionId).content = Buffer.from('FORGED-MEDIA');
+
+    await expect(sdk.lifecycle.resolveAssetFromSat(sat)).rejects.toThrow();
+  });
+
+  test('tampered embedded celLog (metadata) → resolution fails closed', async () => {
+    const { sdk, ordinalsProvider } = makeSDK();
+    const asset = await sdk.lifecycle.createAsset([
+      { id: 'art', type: 'image', contentType: 'image/png', hash: contentHash('media'), content: 'media' }
+    ]);
+    await sdk.lifecycle.inscribeOnBitcoin(asset, 5);
+    const sat = asset.bindings!['did:btco'].split(':').pop()!;
+
+    const list = await ordinalsProvider.getInscriptionsBySatoshi(sat);
+    const rec = (ordinalsProvider as any)['state'].inscriptionsById.get(list[list.length - 1].inscriptionId);
+    // Flip a byte in a signed genesis field of the embedded log.
+    rec.metadata.celLog.events[0].data.name = 'TAMPERED';
+
+    await expect(sdk.lifecycle.resolveAssetFromSat(sat)).rejects.toThrow();
+  });
+
+  test('no anchoring inscription on the sat → fails closed', async () => {
+    const { sdk } = makeSDK();
+    await expect(sdk.lifecycle.resolveAssetFromSat('999999999')).rejects.toThrow(/CHAIN_ASSET_NOT_FOUND|Cannot resolve/);
+  });
+});

--- a/packages/sdk/tests/mocks/adapters/MockOrdinalsProvider.ts
+++ b/packages/sdk/tests/mocks/adapters/MockOrdinalsProvider.ts
@@ -1,18 +1,31 @@
-import type { OrdinalsProvider } from '../../../src/adapters/types';
+import type { OrdinalsProvider, InscriptionParts } from '../../../src/adapters/types';
 
 export class MockOrdinalsProvider implements OrdinalsProvider {
   async createInscription(params: {
     data?: Buffer;
-    buildContent?: (satoshi: string) => Buffer | Promise<Buffer>;
+    buildContent?: (satoshi: string) => InscriptionParts | Promise<InscriptionParts>;
     contentType: string;
     feeRate?: number;
+    metadata?: Record<string, unknown>;
     targetSatoshi?: string;
   }) {
-    // Pin the sat first, then invoke deferred content with it (Task 1/2 API).
+    // Pin the sat first, then invoke deferred content with it. The deferred
+    // builder may return a bare Buffer or `{ content, metadata }` (#407 phase 2).
     const satoshi = params.targetSatoshi ?? '123';
-    const content = params.buildContent
-      ? Buffer.from(await params.buildContent(satoshi))
-      : (params.data as Buffer);
+    let content: Buffer;
+    let deferredMetadata: Record<string, unknown> | undefined;
+    if (params.buildContent) {
+      const built = await params.buildContent(satoshi);
+      if (Buffer.isBuffer(built)) {
+        content = Buffer.from(built);
+      } else {
+        content = Buffer.from(built.content);
+        deferredMetadata = built.metadata;
+      }
+    } else {
+      content = params.data as Buffer;
+    }
+    const metadata = deferredMetadata ?? params.metadata;
     return {
       inscriptionId: 'insc-mock',
       revealTxId: 'tx-reveal-mock',
@@ -23,7 +36,8 @@ export class MockOrdinalsProvider implements OrdinalsProvider {
       blockHeight: 1,
       content,
       contentType: params.contentType,
-      feeRate: params.feeRate
+      feeRate: params.feeRate,
+      ...(metadata !== undefined ? { metadata } : {})
     };
   }
 

--- a/packages/sdk/tests/mocks/adapters/OrdMockProvider.test.ts
+++ b/packages/sdk/tests/mocks/adapters/OrdMockProvider.test.ts
@@ -166,11 +166,74 @@ describe('OrdMockProvider', () => {
     const prov = new OrdMockProvider();
     const data = Buffer.from('test');
     const res = await prov.createInscription({ data, contentType: 'text/plain' });
-    
+
     // Verify satoshi is numeric
     expect(res.satoshi).toBeDefined();
     expect(Number.isNaN(Number(res.satoshi))).toBe(false);
     expect(Number(res.satoshi!)).toBeGreaterThan(0);
+  });
+
+  // #407 phase 2: inscription CBOR metadata round-trip.
+  test('static metadata round-trips through getInscriptionById', async () => {
+    const prov = new OrdMockProvider();
+    const metadata = { didDocument: { id: 'did:btco:reg:42' }, celLog: { events: [] } };
+    const res = await prov.createInscription({
+      data: Buffer.from('media-bytes'),
+      contentType: 'image/png',
+      metadata
+    });
+    expect(res.metadata).toEqual(metadata);
+    const fetched = await prov.getInscriptionById(res.inscriptionId);
+    expect(fetched?.metadata).toEqual(metadata);
+    expect(fetched?.content?.toString()).toBe('media-bytes');
+  });
+
+  test('deferred buildContent may return { content, metadata }', async () => {
+    const prov = new OrdMockProvider();
+    const res = await prov.createInscription({
+      contentType: 'image/png',
+      buildContent: (sat: string) => ({
+        content: Buffer.from('deferred-media'),
+        metadata: { didDocument: { id: `did:btco:reg:${sat}` }, celLog: { events: [1] } }
+      })
+    });
+    const fetched = await prov.getInscriptionById(res.inscriptionId);
+    expect(fetched?.content?.toString()).toBe('deferred-media');
+    expect((fetched?.metadata as { didDocument: { id: string } }).didDocument.id)
+      .toBe(`did:btco:reg:${res.satoshi}`);
+  });
+
+  test('deferred metadata wins over the static metadata param', async () => {
+    const prov = new OrdMockProvider();
+    const res = await prov.createInscription({
+      contentType: 'text/plain',
+      metadata: { source: 'static' },
+      buildContent: () => ({ content: Buffer.from('x'), metadata: { source: 'deferred' } })
+    });
+    const fetched = await prov.getInscriptionById(res.inscriptionId);
+    expect((fetched?.metadata as { source: string }).source).toBe('deferred');
+  });
+
+  test('stored metadata is isolated from later caller mutation', async () => {
+    const prov = new OrdMockProvider();
+    const metadata: Record<string, unknown> = { didDocument: { id: 'did:btco:reg:1' } };
+    const res = await prov.createInscription({ data: Buffer.from('m'), contentType: 'text/plain', metadata });
+    (metadata.didDocument as { id: string }).id = 'did:btco:reg:HACKED';
+    const fetched = await prov.getInscriptionById(res.inscriptionId);
+    expect((fetched?.metadata as { didDocument: { id: string } }).didDocument.id).toBe('did:btco:reg:1');
+  });
+
+  test('getAnchoringsForDidCel reads alsoKnownAs from metadata.didDocument', async () => {
+    const prov = new OrdMockProvider();
+    const didCel = 'did:cel:zabc';
+    await prov.createInscription({
+      data: Buffer.from('media-not-a-did-doc'),
+      contentType: 'image/png',
+      metadata: { didDocument: { id: 'did:btco:reg:7', alsoKnownAs: [didCel] } }
+    });
+    const anchorings = await prov.getAnchoringsForDidCel(didCel);
+    expect(anchorings.length).toBe(1);
+    expect(anchorings[0].satoshi).toBeTruthy();
   });
 });
 

--- a/packages/sdk/tests/unit/bitcoin/BitcoinManager.deferred.test.ts
+++ b/packages/sdk/tests/unit/bitcoin/BitcoinManager.deferred.test.ts
@@ -23,6 +23,32 @@ describe('BitcoinManager.inscribeData deferred content', () => {
     expect(second.satoshi).toBe(first.satoshi);
   });
 
+  test('threads static metadata through to the inscription (#407 phase 2)', async () => {
+    const bm = new BitcoinManager(config);
+    const metadata = { didDocument: { id: 'did:btco:reg:9' }, celLog: { events: [] } };
+    const inscription = await bm.inscribeData(
+      Buffer.from('media'),
+      'image/png',
+      undefined,
+      { metadata }
+    );
+    expect(inscription.metadata).toEqual(metadata);
+  });
+
+  test('surfaces metadata a deferred { content, metadata } builder returns', async () => {
+    const bm = new BitcoinManager(config);
+    const inscription = await bm.inscribeData(
+      (sat: string) => ({
+        content: Buffer.from('media'),
+        metadata: { didDocument: { id: `did:btco:reg:${sat}` } }
+      }),
+      'image/png'
+    );
+    expect(inscription.content?.toString()).toBe('media');
+    expect((inscription.metadata as { didDocument: { id: string } }).didDocument.id)
+      .toBe(`did:btco:reg:${inscription.satoshi}`);
+  });
+
   test('never leaks the content-builder function into inscription.content', async () => {
     // Conformant provider: supports buildContent but omits `content` in its
     // response. The builder FUNCTION must not fall through into content.


### PR DESCRIPTION
## Content-as-ordinal + provenance-in-metadata (#407 phase 2)

Second increment of epic #407 ("The CEL lives on the sat"). Builds on #409 (byte-light log). The did:btco anchoring inscription now **becomes the asset**:

- **Inscription content** = the asset's current media — the most-recent resource's bytes + its real `contentType` (a real, viewable ordinal). Pure-reference assets (no inline media) fall back to inscribing the DID document as content.
- **Inscription metadata** (CBOR) = the byte-light provenance: `{ didDocument: <did:btco doc with #cel anchor>, celLog: <byte-light CEL log snapshot> }`. The embedded `celLog` head always equals the `#cel` anchor.
- **Verifier** reads the `#cel`/witness commitment from inscription **metadata** (falling back to content for phase-1 inscriptions), and adds a content-as-ordinal gate binding the on-chain media to the log's most-recent-resource hash — fail-closed on mismatch.
- **New resolver** `LifecycleManager.resolveAssetFromSat(satoshi)` reconstructs a byte-light `AssetEnvelope` from a bare sat's newest anchoring inscription (metadata + content), reattaches the head witness proof, and runs it through the existing `loadAsset` (#377) — so a chain-reconstructed asset verifies through the **same** gate as an envelope-loaded one. **Provenance is now recoverable from Bitcoin alone.**

### Provider plumbing
`OrdinalsProvider.createInscription` gains a static `metadata` param and a `{ content, metadata }` deferred-builder return; `getInscriptionById` surfaces inscription metadata; `OrdMockProvider` round-trips metadata and reads `alsoKnownAs` from `metadata.didDocument`.

### Security
Dispatched a dedicated fable security reviewer on the writer+verifier+resolver diff (the trust-anchor move content→metadata + the new chain-reconstruction path). **VERDICT: PASS** — all fail-closed invariants confirmed (celLog head ≠ #cel → reject; tampered metadata log → verifyEventLog rejects; content ≠ most-recent-resource hash → reject; newest-inscription pick fails closed on missing height; no path where a chain-reconstructed asset verifies with weaker checks than an envelope-loaded one). No Critical/Important findings.

### Verification
`bun run build` + `bun test` (packages/sdk): **3780 pass, 0 fail, 249 skip**. `bunx tsc --noEmit` clean. `bun run lint` 0 errors.

Design spec: `docs/superpowers/specs/2026-07-14-log-on-chain-phase2-design.md` · plan: `docs/superpowers/plans/2026-07-14-log-on-chain-phase2.md`.

Builds on #409. Part of epic #407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add bare-sat provenance resolution and content-as-ordinal verification (phase 2)
> - Adds `LifecycleManager.resolveAssetFromSat`, which reconstructs a full `AssetEnvelope` from just a satoshi by reading the newest anchoring inscription and running the full `loadAsset` verification pipeline.
> - Changes inscription behavior so that the current head media (if available) is written as inscription content, while the DID document and CEL log snapshot are stored in inscription CBOR metadata; the post-inscription binding check now reads `didDocument` from `inscription.metadata` rather than parsing `inscription.content`.
> - Adds `verifyAnchorContentMatchesHead` to the event-log verifier, which enforces that a phase-2 anchor's media content hashes to the log's most-recent resource head, returning a `CONTENT_MISMATCH` error when it does not.
> - Extends `OrdinalsProvider`, `BitcoinManager`, and both mock/HTTP provider adapters to accept and propagate optional `metadata` alongside inscription content; adds the `InscriptionParts` type to represent `Buffer | { content, metadata }`.
> - Behavioral Change: `verifyEventLog` now sets `verified=false` and returns a `CONTENT_MISMATCH` error for phase-2 anchors whose media content does not match the log head; reinscriptions and new inscriptions change their content shape from pure DID-document JSON to media bytes when media is present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f0d28cb.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->