### PR TITLE
Per-event real-time chain-recoverability (#407 phase 3)

### DIFF
--- a/.changeset/fee-preview-confirm-phase4.md
+++ b/.changeset/fee-preview-confirm-phase4.md
@@ -1,0 +1,28 @@
+---
+"@originals/sdk": minor
+---
+
+Fee preview + confirm for did:btco appends (#407 phase 4). Once an asset reaches
+did:btco (the final layer) every authorship append is a mandatory, paid Bitcoin
+inscription with no hosted fallback — phase 4 makes that cost visible up front and
+consented to.
+
+- `LifecycleManager.estimateAppendCost(asset, appendKind, opts?)` — a non-mutating
+  quote for the NEXT btco append, returning `{ satoshis, feeRate, vbytes,
+  contentBytes }`. It sizes the actual payload (`opts.content` / the in-flight new
+  media for `'update'`, the reinscribed DID doc for `'rotate'`) and reuses the same
+  fee-rate source and `MAX_REASONABLE_FEE_RATE` cap as the real inscribe path, so
+  the quote tracks reality. Zero side effects — no signing, appending, or
+  inscription. Throws `ORD_PROVIDER_REQUIRED` without an ordinalsProvider.
+- `inscribeConfirm` gate — a per-call option on `addResourceVersion` and
+  `rotateBtcoKeys`, plus a config default on `OriginalsConfig`. `'now'` (default)
+  is the phase-3 behavior (inscribe immediately). A callback is awaited with the
+  estimate BEFORE any log mutation:
+  `true` proceeds; `false` cleanly ABORTS the whole append — no event appended,
+  nothing inscribed, the asset left byte-identical (abort-before-mutate). A declined
+  append throws `PROVENANCE_APPEND_DECLINED` and emits the new `cel:inscribe-declined`
+  event; a subsequent append still works (no poisoned state).
+
+No defer/re-anchor path: btco is the final layer with no hosted fallback, so the
+only control is proceed-and-pay or abort. Off-btco (did:cel/did:webvh) appends are
+unaffected — they inscribe nothing, so the gate is a no-op.

--- a/.changeset/per-event-realtime-phase3.md
+++ b/.changeset/per-event-realtime-phase3.md
@@ -1,0 +1,22 @@
+---
+"@originals/sdk": minor
+---
+
+Per-event real-time chain-recoverability (#407 phase 3). Once an asset is on
+did:btco, every authorship append now inscribes on the anchoring sat as it
+happens: `addResourceVersion` inscribes the new event (content = the new media,
+metadata = the event delta + the updated did:btco doc with a fresh `#cel` head),
+and rotations continue to reinscribe. The sat's inscription chain IS the
+always-current log — no point-in-time staleness. `resolveAssetFromSat` now WALKS
+that chain: it enumerates the sat's inscriptions, orders them strictly by
+confirmed block height (fail-closed on a missing height), concatenates each
+inscription's events (a full `celLog` snapshot is a checkpoint; an `events` delta
+extends it) into the full current log, reattaches each on-chain-anchored event's
+bitcoin witness proof, and runs the SAME `verifyEventLog` gate as any log — so a
+gap, a chain-inconsistent inscription, or tampered metadata fails closed.
+`QuickNodeProvider`/`OrdHttpProvider` `getInscriptionById` now decode inscription
+CBOR metadata (present-but-undecodable → clear fail-closed error). btco authorship
+appends are now paid Bitcoin operations: each surfaces a `cel:inscribe-cost`
+estimate, and a btco append with no ordinals provider degrades to a hosted append
+with a `cel:append-inscribe-skipped` signal. Provenance is now real-time
+recoverable from Bitcoin alone.

--- a/docs/superpowers/plans/2026-07-14-per-event-realtime-phase3.md
+++ b/docs/superpowers/plans/2026-07-14-per-event-realtime-phase3.md
@@ -1,0 +1,91 @@
+# Plan: Per-event real-time chain-recoverability (#407 phase 3)
+
+Stacks on #410 (phase 2). Spec: `docs/superpowers/specs/2026-07-14-per-event-realtime-phase3-design.md`.
+
+## Key facts established by reading the code
+
+- `verifyEventLog` enforces a STRICT contiguous hash chain: `event[i].previousEvent
+  == digest(event[i-1])`. Any gap → "Hash chain broken". So a reconstructed log
+  must be the exact contiguous event sequence.
+- After every btco inscription (migrate/rotation) a NON-inscribed witness-ack
+  `update` event is appended to the hosted log. So the inscribed snapshot is a
+  PREFIX of the hosted log; the trailing ack lands only in the next inscription's
+  delta. Pure per-op deltas must therefore include those interleaved acks or
+  continuity breaks.
+- `addResourceVersion` (OriginalsAsset) drives appends via the bound
+  `#celAppender` → `appendCelEventOrSkip(asset, type, data)`. It is the ONLY
+  caller of `#celAppender`. Witness-acks call `appendCelEventOrSkip` DIRECTLY, so
+  re-binding the appender does not make acks inscribe.
+- Migrate (`inscribeOnBitcoin`) and rotation (`rotateBtcoKeys`/`authorizeSigner`
+  → `reinscribeRotatedDoc`) already inscribe, embedding FULL `metadata.celLog`
+  snapshot + `metadata.didDocument` (with `#cel` head anchor). Content = current
+  media (or DID-doc fallback for pure-reference heads).
+- Phase-2 resolver `resolveAssetFromSat` reads ONLY the newest anchor
+  inscription's full `celLog`.
+- Provider metadata: `OrdMockProvider` already round-trips `metadata`.
+  `QuickNodeProvider`/`OrdHttpProvider` `getInscriptionById` do NOT decode CBOR
+  metadata yet. `utils/cbor.ts` `decode()` + `OrdinalsClient.getMetadata`
+  (`/r/metadata/<id>`) are the references.
+
+## Design decisions
+
+### Metadata shape (hybrid snapshot + delta)
+- **migrate / rotation**: UNCHANGED — carry FULL `metadata.celLog` (checkpoint).
+- **resource-update on btco (NEW)**: carry `metadata.events` = the DELTA of log
+  events appended since the last on-chain-committed head, plus
+  `metadata.didDocument` = the current btco doc rebuilt with fresh `#resources`
+  manifest + `#cel` head anchor. Content = the new media bytes (or DID-doc
+  fallback).
+- Delta boundary tracked in a manager `WeakMap<asset, headDigest>` set after each
+  inscription (migrate/rotation/resource-update). When the boundary is unknown,
+  FALL BACK to a FULL `celLog` snapshot (safe checkpoint) — correctness never
+  depends on the WeakMap; it is a byte-cost optimization.
+
+### Resolver — walk the chain (hybrid REPLACE/APPEND)
+1. `getInscriptionsBySatoshi(sat)` → fetch each, order by `(blockHeight asc,
+   listIdx asc)`. Missing block height on ANY anchoring inscription → fail closed.
+   Same-height ties fall back to provider list order (oldest-first contract, same
+   residual as `selectNewestAnchorInscription`); a wrong tie order yields a broken
+   chain that `verifyEventLog` rejects — fail-closed in effect.
+2. Filter to OUR anchoring inscriptions (have `metadata.celLog` OR
+   `metadata.events`).
+3. Walk oldest→newest: `metadata.celLog` → REPLACE reconstructed events
+   (checkpoint); `metadata.events` → APPEND (delta). Result = full current log.
+4. Current media = the newest inscription content that hashes to the log's
+   most-recent-resource head hash.
+5. Reattach head witness proof, build envelope, `loadAsset(env, { provider })` —
+   same full gate (verifyEventLog + resource binding + head freshness).
+
+### Provider metadata (§2b)
+- `OrdHttpProvider` / `QuickNodeProvider` `getInscriptionById`: fetch + CBOR-decode
+  inscription metadata. Decode failure on present bytes → clear fail-closed
+  error (`*_METADATA_UNDECODABLE`). Absent/404 metadata → `undefined` (a
+  legitimately metadata-less inscription; the resolver rejects it clearly).
+
+### Cost surfacing (§0/§5)
+- Before a btco resource-update inscription, estimate cost (fee rate × est. vsize)
+  and emit a `cel:inscribe-cost` manager event. When on btco but NO provider is
+  configured, degrade to a hosted append and emit a clear
+  `cel:append-inscribe-skipped` signal (reason `NO_ORDINALS_PROVIDER`) — matches
+  spec §1 "provider-absent → hosted append (degrade)". Not silent.
+
+## Commits (grep→read-window→edit→commit each)
+1. Plan (this file). ✅
+2. Provider CBOR metadata decode (OrdHttp + QuickNode) + fail-closed. Tests.
+3. Writer: `appendCelEventAndMaybeInscribe` + rebind + WeakMap boundary + set in
+   migrate/rotation.
+4. Resolver chain-walk.
+5. Cost surfacing + provider-absent degrade signal + new event types.
+6. Fixtures/tests (round-trip, immediacy, ordering, gap/tamper, cost, degrade) +
+   changeset (minor).
+7. fable security review → fixes → build/test/tsc → PR → babysit CI + Greptile.
+
+## Security invariants (fable review targets)
+- Cross-inscription continuity verified by `verifyEventLog` on the concatenated
+  log (gap/inconsistent previousEvent → reject).
+- Block-height ordering fails closed on missing height; tie mis-order → broken
+  chain → reject.
+- Tampered metadata event → verifyEventLog rejects (chain digest / signature).
+- Provider that cannot decode metadata → clear error, never silent partial
+  reconstruction.
+- Media hash-bound to signed head hash by loadAsset (tampered media → reject).

--- a/docs/superpowers/plans/2026-07-15-fee-preview-confirm-phase4.md
+++ b/docs/superpowers/plans/2026-07-15-fee-preview-confirm-phase4.md
@@ -1,0 +1,75 @@
+# Plan: Fee preview + confirm (epic #407, phase 4)
+
+Implements the [phase-4 spec](../specs/2026-07-15-fee-preview-confirm-phase4-design.md).
+Stacks on #411 (phase-3 append-inscribe path). Branch `work-fee-preview-phase4`
+off `origin/work-per-event-phase3c`.
+
+## Goal
+
+Make the unavoidable on-chain cost of a did:btco authorship append **visible up
+front** (a non-mutating preview) and **consented to** (a confirm gate that cleanly
+aborts a declined paid append). No defer path — btco is the final layer with no
+hosted fallback.
+
+## Key facts established by code reading
+
+- The bound controller appender (`OriginalsAsset.#celAppender`) is reached ONLY
+  from `addResourceVersion` with `type: 'update'`. It routes to
+  `LifecycleManager.appendCelEventAndMaybeInscribe(asset, type, data)` — the
+  phase-3 entry point that (1) `appendCelEventOrSkip` **mutates the log**, then
+  (2) `inscribeCelAppend` does the paid broadcast.
+- **Critical abort constraint:** in `#addResourceVersionCritical`, after the
+  appender returns, `this.resources.push(newResource)` runs **unconditionally**
+  (both appended and degraded cases, OriginalsAsset.ts:744). So a declined append
+  that merely *returned* would still advance `resources` — NOT byte-identical.
+  Therefore decline must **throw** so the throw propagates before line 744 (the
+  `pendingHeadMedia` `finally` still clears, log never mutated → clean no-op).
+- `bitcoinManager.estimateFeeRate()` (= `resolveFeeRate`) uses the SAME
+  feeOracle → ordinalsProvider → `MAX_REASONABLE_FEE_RATE` cap chain as
+  `estimateCost` / `capEstimatedFeeRate`, and is exactly what the real inscribe
+  path's `emitInscribeCost` already uses (`vsize = ceil(bytes/4)+200`,
+  `sats = ceil(feeRate*vsize)`). Mirroring it makes the quote track the actual cost.
+- At gate time (before `appendCelEventOrSkip`), the new media for an `update`
+  lives in `asset.pendingHeadMedia` (set by `addResourceVersion` before it calls
+  the appender). `tryResolveHeadMedia` matches by the LOG head, which has NOT
+  advanced yet at gate time, so the gate reads `pendingHeadMedia` directly.
+
+## Steps (commit after each)
+
+1. **Plan** (this file). COMMIT.
+2. **Types** (`types/common.ts`): add `AppendKind = 'update' | 'rotate'`,
+   `AppendCostEstimate = { satoshis; feeRate; vbytes; contentBytes }`,
+   `InscribeConfirm = 'now' | ((e: AppendCostEstimate) => boolean | Promise<boolean>)`;
+   add `inscribeConfirm?: InscribeConfirm` to `OriginalsConfig`. COMMIT.
+3. **Preview** (`LifecycleManager.estimateAppendCost`): non-mutating quote for the
+   next btco append. `ORD_PROVIDER_REQUIRED` without a provider. Sizes the payload
+   (opts.content → pendingHeadMedia → head media → btco-doc fallback); fee rate via
+   `bitcoinManager.estimateFeeRate()` (respects `opts.feeRate`). COMMIT.
+4. **Confirm gate**: extend the appender signature with an `opts?` carrying
+   `inscribeConfirm`; thread it from `addResourceVersion(…, opts?)` → `_bindCelAppender`
+   binding → `appendCelEventAndMaybeInscribe`. At the TOP of that method (before
+   `appendCelEventOrSkip`), when the append WILL inscribe (btco + provider) and the
+   effective `inscribeConfirm` (per-call ?? config ?? 'now') is a callback: compute
+   the estimate, `await callback(estimate)`; false → emit `cel:inscribe-declined` +
+   throw `PROVENANCE_APPEND_DECLINED` (clean no-op, abort-before-mutate). COMMIT.
+5. **Event** (`events/types.ts` + `utils/EventLogger.ts`): add
+   `cel:inscribe-declined` (interface, union, map, logger config/subscribe/case). COMMIT.
+6. **Tests** + `.changeset/fee-preview-confirm-phase4.md` (minor). COMMIT.
+
+## Testing spine (from spec §6)
+
+- Preview non-mutating + accurate; leaves asset/log/chain untouched; quote ≈ real cost.
+- Confirm true → phase-3 path proceeds & inscribes.
+- Confirm false → clean abort: no event, nothing inscribed, resources/log/media
+  identical; `cel:inscribe-declined` fires; a follow-up append still works.
+- Default (`'now'`/unset) preserves phase-3 behavior.
+- `estimateAppendCost` without provider → `ORD_PROVIDER_REQUIRED`.
+- Off-btco append ignores the gate (no inscription, no prompt).
+
+## Security review
+
+One fable reviewer on the gate + preview before PR: confirm `estimateAppendCost`
+is truly non-mutating; a false confirm leaves the asset byte-identical (no orphaned
+event, no `UNPROVABLE_BASE`, no half-inscribed state) and a later append still
+works; the gate sits before mutation (not between append and inscribe); the
+estimate can't be used to skip the paid inscription while still appending.

--- a/docs/superpowers/specs/2026-07-14-per-event-realtime-phase3-design.md
+++ b/docs/superpowers/specs/2026-07-14-per-event-realtime-phase3-design.md
@@ -1,0 +1,107 @@
+# Design: Per-event real-time chain-recoverability (epic #407, phase 3)
+
+> Third increment of epic #407 ("The CEL lives on the sat"). Phase 2 (#410) put
+> a point-in-time log snapshot on-chain (recoverable as-of-last-inscription).
+> Phase 3 makes it **real-time**: once an asset is on did:btco, **every
+> authorship append inscribes as it happens**, so the sat's inscription chain
+> IS the always-current log. Every btco append becomes a paid Bitcoin op.
+>
+> **Stacks on #410** (phase 2's resolver + content-as-ordinal + metadata
+> plumbing). Branch off the phase-2 branch / main-after-#410.
+
+## 0. Decision record
+
+- **Mandatory per-event inscription.** For a did:btco asset, every authorship
+  append (`addResourceVersion`, `rotateKey`, any CEL append) is inscribed on the
+  anchoring sat as it happens. The on-chain log is always current — no
+  point-in-time staleness. This is deliberate: it removes the free-webvh append
+  benefit for btco assets (every append costs an inscription + confirmation).
+- **Each append inscribes a delta, not a full re-snapshot.** Content = any NEW
+  content the append introduces (a resource update → the new primary media; a
+  rotation → no new content). Metadata = the new event(s) + the updated
+  did:btco DID doc / `#cel` head.
+- **The sat's inscription chain = the log.** The phase-2 inscription is the base
+  snapshot (all pre-btco events + genesis media); each subsequent append adds one
+  inscription. Reconstruction concatenates them in block order.
+- **Cost is surfaced, not hidden.** Append ops report a cost estimate and require
+  explicit intent (they are paid Bitcoin ops). The full tier/who-pays UX is a
+  later phase; per-event just forces cost-awareness.
+
+## 1. Append path — btco appends become Bitcoin ops
+
+Today (post phase 2): a did:btco asset's `addResourceVersion`/CEL appends write
+the signed event to the hosted log; only `rotateBtcoKeys` re-inscribes.
+Phase 3: for a did:btco asset, the CEL-append path (`appendCelEventOrSkip`-driven
+appends: `addResourceVersion`, and rotation) **also inscribes** the new event:
+1. Sign + append the event to the log (as today).
+2. Inscribe on the anchoring sat via `bitcoinManager.inscribeData({ buildContent })`:
+   content = new media (resource update) or none (rotation); metadata =
+   `{ event(s): [<new event>], didDocument: <updated did:btco doc with #cel head> }`.
+3. Attach the bitcoin witness proof (as the existing inscribe/rotate paths do).
+- Requires the ordinalsProvider; off-btco or provider-absent → hosted append as
+  today (degrade unchanged).
+- Async + confirmation-bearing: the append now returns after inscription (mirrors
+  `inscribeOnBitcoin`/`rotateBtcoKeys` sequencing, incl. the `buildContent`
+  sat-pinning window and lock).
+
+## 2. Reconstruction — resolver walks the chain
+
+Extends the phase-2 resolver (which read one snapshot inscription):
+1. `getInscriptionsBySatoshi(sat)` → all inscriptions, ordered by confirmed block
+   height (fail-closed on missing height / ambiguous ties).
+2. For each, `getInscriptionById` → read `metadata.event(s)` and (newest
+   content-bearing) `content`.
+3. **Concatenate** the events across inscriptions in order → the full current
+   log. Current media = the newest content-bearing inscription's content.
+4. Run `verifyEventLog` on the concatenated log (all anchored-sat / uniqueness /
+   continuity / witness checks apply — chain origin never relaxes verification),
+   and confirm the current media hashes to the log's most-recent-resource hash.
+Returns the verified, **always-current** asset from the bare sat.
+
+## 2b. Provider metadata plumbing (carry-over)
+
+Phase 2 plumbed `metadata` through `OrdMockProvider`. Phase 3 requires it on the
+**production** providers used to read/reconstruct a real chain — ensure
+`QuickNodeProvider` / `OrdHttpProvider` `getInscriptionById` decode inscription
+metadata (a provider that cannot read metadata cannot reconstruct → fail closed
+with a clear error). (Finish the metadata read-decode that phase 2 began.)
+
+## 3. Integrity / security
+
+- Each inscription's event(s) chain from the prior (`previousEvent` hash) and
+  commit to the new `#cel` head; a gap or inconsistent chain across inscriptions
+  → reject.
+- Ordering strictly by confirmed block height; same-block ambiguity fails closed.
+- `verifyEventLog` gates the full concatenated log identically to any log.
+- Media hash-check unchanged (content ≠ most-recent-resource hash → reject).
+
+## 4. Boundaries / deferred (later #407 phases)
+
+- Checkpoint/squash tier + the full fee / who-pays / tier-selection UX.
+- Secondary / older-version content as separate `did:btco`-addressed ordinals.
+- Batching/debounce of appends (this phase inscribes each append immediately).
+
+## 5. Testing spine
+
+- **Real-time round-trip:** create → publish → inscribe → `addResourceVersion`
+  (inscribes) → `rotateKey` (inscribes); a resolver with ONLY the sat + provider
+  rebuilds the FULL current log (all events, in order) + current media, verified,
+  no envelope/host.
+- **Immediacy:** an append is on-chain immediately (recoverable before any later
+  rotation), unlike phase 2's point-in-time.
+- **Ordering:** the inscription chain reconstructs events in correct order across
+  several appends.
+- **Gap/tamper:** a missing or chain-inconsistent inscription → reject; tampered
+  event metadata → `verifyEventLog` rejects.
+- **Cost surfacing:** a btco append reports a cost estimate and requires the
+  provider (fails clearly without one).
+- **Degrade:** off-btco / no-provider append behaves as the hosted append (phase
+  ≤2) — unchanged.
+
+## 6. Changeset
+
+`@originals/sdk` **minor** — did:btco authorship appends (`addResourceVersion`,
+`rotateKey`) now inscribe each event on the anchoring sat, making the on-chain
+log always current; the resolver reconstructs the full log from the sat's
+inscription chain. Provenance is now **real-time** recoverable from Bitcoin
+alone (#407). btco appends are now paid Bitcoin operations.

--- a/docs/superpowers/specs/2026-07-15-fee-preview-confirm-phase4-design.md
+++ b/docs/superpowers/specs/2026-07-15-fee-preview-confirm-phase4-design.md
@@ -1,0 +1,106 @@
+# Design: Fee preview + confirm (epic #407, phase 4)
+
+> Fourth increment of epic #407. Phase 3 (#411) made every did:btco authorship
+> append a **mandatory, paid** Bitcoin inscription — and that mandate is not a
+> choice: once an asset reaches did:btco (the final layer) there is **no webvh
+> host to fall back to**, so a btco append must inscribe or not happen at all.
+> Phase 4 makes that unavoidable cost **visible up front** (a preview) and
+> **consented to** (a confirm gate) — no surprise spends.
+>
+> **Stacks on #411** (the phase-3 append-inscribe path). Branch off #411 /
+> main-after-#411.
+
+## 0. Decision record
+
+- **Preview, not just post-hoc events.** Phase 3 emits `cel:inscribe-cost`
+  *after* inscribing. Phase 4 adds a **non-mutating estimate returned to the
+  caller BEFORE committing**, extending the existing `LifecycleManager.estimateCost`
+  (the "quote-only" did:btco cost path) to cover an append.
+- **Control = confirm/cancel, NOT defer.** A btco append cannot fall back to
+  hosted/webvh (final layer, no host). So the only control is: see the cost, then
+  proceed-and-pay or abort. There is no cheaper-by-deferring path.
+- **The cheaper path is a different phase.** The only way to pay *less* on-chain
+  is a weaker guarantee — the checkpoint/squash tier — which is its own later
+  increment, not this one.
+- **No re-anchor / no defer state.** Both assumed a hosted fallback that does not
+  exist for btco assets; dropped.
+
+## 1. Preview — `estimateAppendCost`
+
+A non-mutating quote for the *next* btco append:
+```
+estimateAppendCost(asset, appendKind: 'update' | 'rotate', opts?): Promise<{
+  satoshis: number;         // estimated total inscription cost
+  feeRate: number;          // the (capped) fee rate used
+  vbytes: number;           // estimated tx vsize
+  contentBytes: number;     // size of the media/content being inscribed
+}>
+```
+- Reuses `estimateCost`'s fee-oracle + `capEstimatedFeeRate` (same source/cap as
+  the real inscribe path, so the quote tracks reality).
+- Sizes the actual payload the append would inscribe (new media for an `update`;
+  event-only for a `rotate`) so the estimate reflects *this* append.
+- Requires the ordinalsProvider (a btco op); throws `ORD_PROVIDER_REQUIRED`
+  otherwise. Zero side effects — no signing, no append, no inscription.
+
+## 2. Control — the confirm gate
+
+A knob on the btco append path (`addResourceVersion`/`rotateKey`), via a per-call
+option and a config default:
+- **`inscribeConfirm: 'now'`** (default, = phase-3 behavior) — inscribe
+  immediately, no prompt.
+- **`inscribeConfirm: <callback>`** — before inscribing, call
+  `await callback(estimate)` (the §1 estimate). If it returns `true`, proceed and
+  inscribe. If it returns `false`, **abort the entire append**: no event is
+  appended, nothing is inscribed, no partial state — the operation is a clean
+  no-op that surfaces a `PROVENANCE_APPEND_DECLINED` result/signal.
+- Config-level default `inscribeConfirm` on `OriginalsConfig` sets the policy for
+  all btco appends unless a call overrides it.
+
+## 3. Abort semantics (the load-bearing detail)
+
+When the confirm callback returns false, the append is aborted **before** the log
+is mutated — the sign+append and the inscription happen together downstream of the
+gate, so declining leaves the asset exactly as it was (no orphaned event, no
+UNPROVABLE_BASE, no half-inscribed state). The gate sits *before* `appendCelEventAndMaybeInscribe`
+(the phase-3 entry point), not between append and inscribe.
+
+## 4. Surfacing / events
+
+- The §1 estimate is **returned** to the caller (and passed to the confirm
+  callback) — not only emitted as an event.
+- `cel:inscribe-cost` (phase 3) still fires on the actual inscription.
+- New `cel:inscribe-declined` signal when a confirm gate aborts an append.
+
+## 5. Boundaries / deferred
+
+- Checkpoint/squash tier (the only *cheaper on-chain* option) — its own phase.
+- Secondary-content inscription — its own phase.
+- Payment rails / who-pays / wallet integration — out of scope (this is estimate
+  + consent, not payments).
+- Off-btco appends (did:cel/did:webvh, still free/hosted) — unaffected; the
+  preview/confirm apply only to btco appends that actually inscribe.
+
+## 6. Testing spine
+
+- **Preview non-mutating + accurate:** `estimateAppendCost` returns a plausible
+  quote and leaves the asset/log/chain untouched; the quote ≈ the actual cost the
+  subsequent real append incurs (same fee-rate source).
+- **Confirm true:** append proceeds and inscribes normally (phase-3 path).
+- **Confirm false → clean abort:** no event appended, nothing inscribed, asset
+  unchanged (log head, resources, current media all identical to before);
+  `cel:inscribe-declined` fires; a follow-up append still works (no poisoned
+  state).
+- **Default preserved:** with no `inscribeConfirm` (or `'now'`), btco appends
+  behave exactly as phase 3.
+- **Provider required:** `estimateAppendCost` without an ordinalsProvider →
+  `ORD_PROVIDER_REQUIRED`.
+- **Off-btco unaffected:** a did:cel/did:webvh append ignores the gate (no
+  inscription, no prompt).
+
+## 7. Changeset
+
+`@originals/sdk` **minor** — `estimateAppendCost` previews a did:btco append's
+inscription cost without committing; a per-call / config `inscribeConfirm` gate
+lets callers approve or cleanly abort a paid append after seeing the estimate.
+Informed consent on the unavoidable cost of appending to a btco asset (#407).

--- a/packages/sdk/src/adapters/providers/OrdHttpProvider.ts
+++ b/packages/sdk/src/adapters/providers/OrdHttpProvider.ts
@@ -1,6 +1,8 @@
 /* istanbul ignore file */
 import type { OrdinalsProvider, InscriptionParts } from '../types.js';
 import { StructuredError } from '../../utils/telemetry.js';
+import { decode as decodeCbor } from '../../utils/cbor.js';
+import { hexToBytes } from '../../utils/encoding.js';
 
 interface HttpProviderOptions {
   baseUrl: string;
@@ -109,6 +111,13 @@ export class OrdHttpProvider implements OrdinalsProvider {
       vout = Number(v) || 0;
     }
 
+    // #407 phase 3: decode the inscription's CBOR metadata (`{ didDocument,
+    // celLog | events }`) so a real chain can be reconstructed. Absent metadata
+    // is fine (undefined); metadata BYTES that fail to decode fail closed — a
+    // provider that cannot read present metadata must never yield a silent
+    // partial reconstruction.
+    const metadata = await this.fetchMetadata(id, data);
+
     const contentType = data.content_type || 'application/octet-stream';
     // The content URL may come from the (untrusted) indexer response. Pin it to
     // baseUrl's origin before fetching so a malicious endpoint cannot redirect
@@ -128,8 +137,43 @@ export class OrdHttpProvider implements OrdinalsProvider {
       txid,
       vout,
       satoshi: String(data.sat ?? ''),
-      blockHeight: data.block_height
+      blockHeight: data.block_height,
+      ...(metadata !== undefined ? { metadata } : {})
     };
+  }
+
+  /**
+   * Fetch + CBOR-decode an inscription's metadata (#407 phase 3). Prefers an
+   * inline hex `metadata` field on the indexer JSON, else the ord recursive
+   * endpoint `/r/metadata/<id>` (same-origin, capped). Returns `undefined` when
+   * no metadata exists (a 404 / absent field). Throws a clear fail-closed error
+   * when metadata bytes are PRESENT but cannot be hex/CBOR decoded — a provider
+   * that cannot read present metadata must not silently drop provenance.
+   */
+  private async fetchMetadata(id: string, indexerJson: any): Promise<Record<string, unknown> | undefined> {
+    let hex: string | undefined;
+    if (typeof indexerJson?.metadata === 'string' && indexerJson.metadata.length > 0) {
+      hex = indexerJson.metadata;
+    } else {
+      const url = buildUrl(this.baseUrl, `/r/metadata/${id}`);
+      const result = await fetchBytesWithLimit(url, this.maxJsonBytes, { headers: { 'Accept': 'application/json' } });
+      if (!result) return undefined; // no metadata endpoint / 404 → legitimately none
+      let text = new TextDecoder().decode(result.bytes).trim();
+      if (text.length === 0) return undefined;
+      if (text.startsWith('"') && text.endsWith('"')) {
+        try { text = JSON.parse(text) as string; } catch { /* keep raw */ }
+      }
+      hex = text;
+    }
+    try {
+      return decodeCbor<Record<string, unknown>>(hexToBytes(hex));
+    } catch (e) {
+      throw new StructuredError(
+        'ORD_METADATA_UNDECODABLE',
+        `OrdHttpProvider: inscription ${id} carries metadata that could not be hex/CBOR decoded (${e instanceof Error ? e.message : String(e)}); refusing to reconstruct from partial provenance`,
+        { inscriptionId: id }
+      );
+    }
   }
 
   async getInscriptionsBySatoshi(satoshi: string) {

--- a/packages/sdk/src/adapters/providers/OrdHttpProvider.ts
+++ b/packages/sdk/src/adapters/providers/OrdHttpProvider.ts
@@ -166,15 +166,32 @@ export class OrdHttpProvider implements OrdinalsProvider {
       }
     }
     // The ord recursive `/r/metadata/<id>` route serves hex CBOR ONLY when
-    // metadata exists. A 404 / empty body → no metadata (undefined). But a
-    // PRESENT non-empty body that does not hex/CBOR decode is a hard fail-closed
-    // error: swallowing it to undefined would let a transient fault or a
-    // garbage-serving endpoint drop a real anchoring inscription and silently
-    // truncate the chain tail. Fable I2.
+    // metadata exists. Distinguish the status EXPLICITLY (Greptile): ONLY a 404
+    // (genuinely no metadata) or an empty body degrades to undefined; a 5xx /
+    // other transient fault must THROW — swallowing it would let a flaky endpoint
+    // drop a real anchoring inscription and silently truncate the chain tail
+    // (I2). A present non-empty body that does not hex/CBOR decode is likewise a
+    // hard fail-closed error. Direct fetch so the status code is visible
+    // (fetchBytesWithLimit collapses every non-ok to null).
     const url = buildUrl(this.baseUrl, `/r/metadata/${id}`);
-    const result = await fetchBytesWithLimit(url, this.maxJsonBytes, { headers: { 'Accept': 'application/json' } });
-    if (!result) return undefined;
-    let text = new TextDecoder().decode(result.bytes).trim();
+    const res = await (globalThis as any).fetch(url, { redirect: 'error', headers: { 'Accept': 'application/json' } });
+    if (res.status === 404) return undefined; // genuinely no metadata on this inscription
+    if (!res.ok) {
+      throw new StructuredError(
+        'ORD_METADATA_UNAVAILABLE',
+        `OrdHttpProvider: inscription ${id} /r/metadata returned HTTP ${res.status}; refusing to reconstruct from possibly-incomplete provenance`,
+        { inscriptionId: id }
+      );
+    }
+    const lenHeader = res.headers?.get?.('content-length');
+    if (lenHeader && Number(lenHeader) > this.maxJsonBytes) {
+      throw new Error(`OrdHttpProvider: /r/metadata response exceeds ${this.maxJsonBytes} bytes (Content-Length ${lenHeader})`);
+    }
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    if (bytes.byteLength > this.maxJsonBytes) {
+      throw new Error(`OrdHttpProvider: /r/metadata response body exceeds ${this.maxJsonBytes} bytes`);
+    }
+    let text = new TextDecoder().decode(bytes).trim();
     if (text.length === 0) return undefined;
     if (text.startsWith('"') && text.endsWith('"')) {
       try { text = JSON.parse(text) as string; } catch { /* keep raw */ }

--- a/packages/sdk/src/adapters/providers/OrdHttpProvider.ts
+++ b/packages/sdk/src/adapters/providers/OrdHttpProvider.ts
@@ -165,6 +165,7 @@ export class OrdHttpProvider implements OrdinalsProvider {
       }
       hex = text;
     }
+    if (!hex) return undefined;
     try {
       return decodeCbor<Record<string, unknown>>(hexToBytes(hex));
     } catch (e) {

--- a/packages/sdk/src/adapters/providers/OrdHttpProvider.ts
+++ b/packages/sdk/src/adapters/providers/OrdHttpProvider.ts
@@ -166,11 +166,11 @@ export class OrdHttpProvider implements OrdinalsProvider {
       }
     }
     // The ord recursive `/r/metadata/<id>` route serves hex CBOR ONLY when
-    // metadata exists. A 404, an empty body, or a non-hex/undecodable body all
-    // mean "no CBOR metadata in the expected form" → undefined. This is not a
-    // silent security hole: the resolver fails closed when an anchoring
-    // inscription lacks provenance metadata, and a malicious endpoint could
-    // equally 404 the route.
+    // metadata exists. A 404 / empty body → no metadata (undefined). But a
+    // PRESENT non-empty body that does not hex/CBOR decode is a hard fail-closed
+    // error: swallowing it to undefined would let a transient fault or a
+    // garbage-serving endpoint drop a real anchoring inscription and silently
+    // truncate the chain tail. Fable I2.
     const url = buildUrl(this.baseUrl, `/r/metadata/${id}`);
     const result = await fetchBytesWithLimit(url, this.maxJsonBytes, { headers: { 'Accept': 'application/json' } });
     if (!result) return undefined;
@@ -181,8 +181,12 @@ export class OrdHttpProvider implements OrdinalsProvider {
     }
     try {
       return decodeCbor<Record<string, unknown>>(hexToBytes(text));
-    } catch {
-      return undefined;
+    } catch (e) {
+      throw new StructuredError(
+        'ORD_METADATA_UNDECODABLE',
+        `OrdHttpProvider: inscription ${id} /r/metadata response is present but could not be hex/CBOR decoded (${e instanceof Error ? e.message : String(e)}); refusing to reconstruct from partial provenance`,
+        { inscriptionId: id }
+      );
     }
   }
 

--- a/packages/sdk/src/adapters/providers/OrdHttpProvider.ts
+++ b/packages/sdk/src/adapters/providers/OrdHttpProvider.ts
@@ -111,13 +111,6 @@ export class OrdHttpProvider implements OrdinalsProvider {
       vout = Number(v) || 0;
     }
 
-    // #407 phase 3: decode the inscription's CBOR metadata (`{ didDocument,
-    // celLog | events }`) so a real chain can be reconstructed. Absent metadata
-    // is fine (undefined); metadata BYTES that fail to decode fail closed — a
-    // provider that cannot read present metadata must never yield a silent
-    // partial reconstruction.
-    const metadata = await this.fetchMetadata(id, data);
-
     const contentType = data.content_type || 'application/octet-stream';
     // The content URL may come from the (untrusted) indexer response. Pin it to
     // baseUrl's origin before fetching so a malicious endpoint cannot redirect
@@ -129,6 +122,14 @@ export class OrdHttpProvider implements OrdinalsProvider {
     const buf = (globalThis as any).Buffer
       ? (globalThis as any).Buffer.from(content.bytes)
       : content.bytes as any;
+
+    // #407 phase 3: decode the inscription's CBOR metadata (`{ didDocument,
+    // celLog | events }`) so a real chain can be reconstructed. Fetched AFTER the
+    // content (so the content SSRF/size guards run first). Absent metadata is fine
+    // (undefined) — the resolver fails closed when an anchoring inscription lacks
+    // provenance metadata; an explicit inline `metadata` field that fails to decode
+    // is a hard error (present-but-undecodable).
+    const metadata = await this.fetchMetadata(id, data);
 
     return {
       inscriptionId: data.inscription_id || id,
@@ -151,29 +152,37 @@ export class OrdHttpProvider implements OrdinalsProvider {
    * that cannot read present metadata must not silently drop provenance.
    */
   private async fetchMetadata(id: string, indexerJson: any): Promise<Record<string, unknown> | undefined> {
-    let hex: string | undefined;
+    // An INLINE hex `metadata` field is an EXPLICIT provenance declaration:
+    // present-but-undecodable is a hard fail-closed error.
     if (typeof indexerJson?.metadata === 'string' && indexerJson.metadata.length > 0) {
-      hex = indexerJson.metadata;
-    } else {
-      const url = buildUrl(this.baseUrl, `/r/metadata/${id}`);
-      const result = await fetchBytesWithLimit(url, this.maxJsonBytes, { headers: { 'Accept': 'application/json' } });
-      if (!result) return undefined; // no metadata endpoint / 404 → legitimately none
-      let text = new TextDecoder().decode(result.bytes).trim();
-      if (text.length === 0) return undefined;
-      if (text.startsWith('"') && text.endsWith('"')) {
-        try { text = JSON.parse(text) as string; } catch { /* keep raw */ }
+      try {
+        return decodeCbor<Record<string, unknown>>(hexToBytes(indexerJson.metadata));
+      } catch (e) {
+        throw new StructuredError(
+          'ORD_METADATA_UNDECODABLE',
+          `OrdHttpProvider: inscription ${id} carries an inline metadata field that could not be hex/CBOR decoded (${e instanceof Error ? e.message : String(e)}); refusing to reconstruct from partial provenance`,
+          { inscriptionId: id }
+        );
       }
-      hex = text;
     }
-    if (!hex) return undefined;
+    // The ord recursive `/r/metadata/<id>` route serves hex CBOR ONLY when
+    // metadata exists. A 404, an empty body, or a non-hex/undecodable body all
+    // mean "no CBOR metadata in the expected form" → undefined. This is not a
+    // silent security hole: the resolver fails closed when an anchoring
+    // inscription lacks provenance metadata, and a malicious endpoint could
+    // equally 404 the route.
+    const url = buildUrl(this.baseUrl, `/r/metadata/${id}`);
+    const result = await fetchBytesWithLimit(url, this.maxJsonBytes, { headers: { 'Accept': 'application/json' } });
+    if (!result) return undefined;
+    let text = new TextDecoder().decode(result.bytes).trim();
+    if (text.length === 0) return undefined;
+    if (text.startsWith('"') && text.endsWith('"')) {
+      try { text = JSON.parse(text) as string; } catch { /* keep raw */ }
+    }
     try {
-      return decodeCbor<Record<string, unknown>>(hexToBytes(hex));
-    } catch (e) {
-      throw new StructuredError(
-        'ORD_METADATA_UNDECODABLE',
-        `OrdHttpProvider: inscription ${id} carries metadata that could not be hex/CBOR decoded (${e instanceof Error ? e.message : String(e)}); refusing to reconstruct from partial provenance`,
-        { inscriptionId: id }
-      );
+      return decodeCbor<Record<string, unknown>>(hexToBytes(text));
+    } catch {
+      return undefined;
     }
   }
 

--- a/packages/sdk/src/adapters/providers/OrdHttpProvider.ts
+++ b/packages/sdk/src/adapters/providers/OrdHttpProvider.ts
@@ -15,6 +15,11 @@ interface HttpProviderOptions {
 const DEFAULT_MAX_JSON_BYTES = 1 * 1024 * 1024;
 const DEFAULT_MAX_CONTENT_BYTES = 5 * 1024 * 1024;
 
+// Inscription id shape (`<64-hex txid>i<vout>`). Ids arrive from the untrusted
+// indexer JSON and are interpolated into URL paths; a format guard closes a
+// path-traversal gap (e.g. `../../admin`) consistently with QuickNodeProvider.
+const INSCRIPTION_ID_RE = /^[0-9a-f]{64}i\d+$/i;
+
 /**
  * Documentation placeholder — never a reachable host. createOrdinalsProviderFromEnv
  * refuses to build a live provider pointed at it (issue #328).
@@ -99,6 +104,10 @@ export class OrdHttpProvider implements OrdinalsProvider {
 
   async getInscriptionById(id: string) {
     if (!id) return null;
+    // Guard the id BEFORE it reaches any URL path (`/inscription`, `/content`,
+    // `/r/metadata`): a compromised indexer could otherwise return a crafted id
+    // (`../../admin`) that resolves to a different same-origin path.
+    if (!INSCRIPTION_ID_RE.test(id)) return null;
     const data = await fetchJson<any>(buildUrl(this.baseUrl, `/inscription/${id}`), this.maxJsonBytes);
     if (!data) return null;
     // Expecting a shape similar to Ordinals indexers; adapt minimally
@@ -211,7 +220,10 @@ export class OrdHttpProvider implements OrdinalsProvider {
     if (!satoshi) return [];
     const data = await fetchJson<any>(buildUrl(this.baseUrl, `/sat/${satoshi}`), this.maxJsonBytes);
     const ids: string[] = Array.isArray(data?.inscription_ids) ? data.inscription_ids : [];
-    return ids.map((inscriptionId) => ({ inscriptionId }));
+    // Drop malformed ids at the source so they never enter the chain walk / a URL path.
+    return ids
+      .filter((inscriptionId) => typeof inscriptionId === 'string' && INSCRIPTION_ID_RE.test(inscriptionId))
+      .map((inscriptionId) => ({ inscriptionId }));
   }
 
   // Transaction submission, status, fee estimation and inscription

--- a/packages/sdk/src/adapters/providers/QuickNodeProvider.ts
+++ b/packages/sdk/src/adapters/providers/QuickNodeProvider.ts
@@ -1,6 +1,8 @@
 import type { OrdinalsProvider, InscriptionParts } from '../types.js';
 import { StructuredError } from '../../utils/telemetry.js';
 import { validateSatoshiNumber } from '../../utils/satoshi-validation.js';
+import { decode as decodeCbor } from '../../utils/cbor.js';
+import { hexToBytes } from '../../utils/encoding.js';
 
 export interface QuickNodeProviderOptions {
   /**
@@ -391,6 +393,11 @@ export class QuickNodeProvider implements OrdinalsProvider {
       ? info.height
       : (typeof info.genesis_height === 'number' ? info.genesis_height : undefined);
 
+    // #407 phase 3: decode the inscription's CBOR metadata so a real chain can
+    // be walked/reconstructed. Absent → undefined; present-but-undecodable →
+    // fail closed (never a silent partial reconstruction).
+    const metadata = await this.fetchMetadata(id, info);
+
     return {
       inscriptionId,
       content,
@@ -399,7 +406,52 @@ export class QuickNodeProvider implements OrdinalsProvider {
       vout,
       satoshi,
       blockHeight,
+      ...(metadata !== undefined ? { metadata } : {}),
     };
+  }
+
+  /**
+   * Fetch + CBOR-decode an inscription's metadata (#407 phase 3). Prefers an
+   * inline hex `metadata` field on the `ord_getInscription` result, else the
+   * `ord_getMetadata` RPC. Returns `undefined` when no metadata exists (RPC
+   * not-found / absent field). Throws a clear fail-closed error when metadata
+   * bytes are PRESENT but cannot be hex/CBOR decoded.
+   */
+  private async fetchMetadata(id: string, info: QuickNodeInscription): Promise<Record<string, unknown> | undefined> {
+    let hex: string | undefined;
+    const inlineMeta = (info as { metadata?: unknown }).metadata;
+    if (typeof inlineMeta === 'string' && inlineMeta.length > 0) {
+      hex = inlineMeta;
+    } else {
+      let raw: unknown;
+      try {
+        raw = await this.rpcCall<unknown>('ord_getMetadata', [id]);
+      } catch (err) {
+        if (QuickNodeProvider.isNotFound(err)) return undefined;
+        throw err;
+      }
+      if (raw === null || raw === undefined) return undefined;
+      if (typeof raw === 'object') {
+        const obj = raw as Record<string, unknown>;
+        const inner = obj.metadata ?? obj.hex ?? obj.data;
+        if (typeof inner === 'string') hex = inner;
+        else return raw as Record<string, unknown>; // already decoded object
+      } else if (typeof raw === 'string') {
+        hex = raw;
+      } else {
+        return undefined;
+      }
+    }
+    if (!hex) return undefined;
+    try {
+      return decodeCbor<Record<string, unknown>>(hexToBytes(hex));
+    } catch (e) {
+      throw new StructuredError(
+        'QUICKNODE_METADATA_UNDECODABLE',
+        `QuickNodeProvider: inscription ${id} carries metadata that could not be hex/CBOR decoded (${e instanceof Error ? e.message : String(e)}); refusing to reconstruct from partial provenance`,
+        { inscriptionId: id }
+      );
+    }
   }
 
   async getInscriptionsBySatoshi(satoshi: string) {

--- a/packages/sdk/src/adapters/providers/QuickNodeProvider.ts
+++ b/packages/sdk/src/adapters/providers/QuickNodeProvider.ts
@@ -58,6 +58,7 @@ const DEFAULT_MAX_CONTENT_BYTES = 5 * 1024 * 1024;
 
 /** Bitcoin Core RPC error code for "No such mempool or blockchain transaction". */
 const RPC_INVALID_ADDRESS_OR_KEY = -5;
+const JSON_RPC_METHOD_NOT_FOUND = -32601;
 
 interface JsonRpcError {
   code?: number;
@@ -235,6 +236,19 @@ export class QuickNodeProvider implements OrdinalsProvider {
     const rpcMessage = err.details?.rpcMessage;
     if (typeof rpcMessage !== 'string') return false;
     return /^(?:inscription|sat(?:oshi)?|output|content|transaction|tx)\b[^]*\bnot found\.?$/i.test(rpcMessage.trim());
+  }
+
+  /**
+   * True when the endpoint does not implement an RPC method (JSON-RPC -32601 or
+   * an ord/gateway "method not found" message) — distinct from a transient
+   * transport fault, which must propagate. Used so a missing `ord_getMetadata`
+   * (older ord add-on) degrades to "no metadata" while a 500/timeout does not.
+   */
+  private static isMethodNotFound(err: unknown): boolean {
+    if (!(err instanceof StructuredError) || err.code !== 'QUICKNODE_RPC_ERROR') return false;
+    if (err.details?.rpcCode === JSON_RPC_METHOD_NOT_FOUND) return true;
+    const rpcMessage = err.details?.rpcMessage;
+    return typeof rpcMessage === 'string' && /method not found/i.test(rpcMessage);
   }
 
   /**
@@ -426,13 +440,15 @@ export class QuickNodeProvider implements OrdinalsProvider {
       let raw: unknown;
       try {
         raw = await this.rpcCall<unknown>('ord_getMetadata', [id]);
-      } catch {
-        // The endpoint may not expose ord_getMetadata (older ord add-on), or the
-        // inscription simply has none. Metadata-UNAVAILABLE degrades to undefined:
-        // the resolver then fails closed (an anchoring inscription lacking
-        // provenance metadata is rejected) — only PRESENT-but-undecodable bytes
-        // (the decode branch below) are a hard provider-level error.
-        return undefined;
+      } catch (err) {
+        // ONLY degrade to undefined when the metadata genuinely isn't there:
+        // the endpoint lacks ord_getMetadata (older add-on → JSON-RPC method
+        // not found) or the inscription has none (isNotFound). A transient
+        // fault (HTTP 500, timeout, rate-limit) must PROPAGATE — swallowing it
+        // would let the resolver silently truncate the chain to a stale log.
+        // Fable I2.
+        if (QuickNodeProvider.isNotFound(err) || QuickNodeProvider.isMethodNotFound(err)) return undefined;
+        throw err;
       }
       if (raw === null || raw === undefined) return undefined;
       if (typeof raw === 'object') {

--- a/packages/sdk/src/adapters/providers/QuickNodeProvider.ts
+++ b/packages/sdk/src/adapters/providers/QuickNodeProvider.ts
@@ -426,9 +426,13 @@ export class QuickNodeProvider implements OrdinalsProvider {
       let raw: unknown;
       try {
         raw = await this.rpcCall<unknown>('ord_getMetadata', [id]);
-      } catch (err) {
-        if (QuickNodeProvider.isNotFound(err)) return undefined;
-        throw err;
+      } catch {
+        // The endpoint may not expose ord_getMetadata (older ord add-on), or the
+        // inscription simply has none. Metadata-UNAVAILABLE degrades to undefined:
+        // the resolver then fails closed (an anchoring inscription lacking
+        // provenance metadata is rejected) — only PRESENT-but-undecodable bytes
+        // (the decode branch below) are a hard provider-level error.
+        return undefined;
       }
       if (raw === null || raw === undefined) return undefined;
       if (typeof raw === 'object') {

--- a/packages/sdk/src/bitcoin/BitcoinManager.ts
+++ b/packages/sdk/src/bitcoin/BitcoinManager.ts
@@ -47,6 +47,15 @@ export class BitcoinManager {
     return this.ord;
   }
 
+  /**
+   * Public fee-rate estimate (sat/vB) via the same feeOracle→provider fallback
+   * the paid inscribe path uses. Returns undefined when no source yields a
+   * plausible rate. Used to surface btco-append cost (#407 phase 3).
+   */
+  async estimateFeeRate(targetBlocks = 1): Promise<number | undefined> {
+    return this.resolveFeeRate(targetBlocks);
+  }
+
   private async resolveFeeRate(targetBlocks = 1, provided?: number): Promise<number | undefined> {
     // 1) An explicitly provided fee rate always wins: estimators must not
     // silently override what the caller asked to pay.

--- a/packages/sdk/src/events/types.ts
+++ b/packages/sdk/src/events/types.ts
@@ -416,6 +416,26 @@ export interface CelInscribeCostEvent extends BaseEvent {
 }
 
 /**
+ * Emitted (#407 phase 4) when an `inscribeConfirm` callback returns false and a
+ * paid did:btco authorship append is cleanly ABORTED before any log mutation:
+ * no event appended, nothing inscribed, the asset left byte-identical. Carries
+ * the estimate the caller declined.
+ */
+export interface CelInscribeDeclinedEvent extends BaseEvent {
+  type: 'cel:inscribe-declined';
+  asset: { id: string };
+  /** Which append kind was declined. */
+  appendKind: 'update' | 'rotate';
+  /** The cost estimate presented to (and rejected by) the confirm callback. */
+  estimate: {
+    satoshis: number;
+    feeRate: number;
+    vbytes: number;
+    contentBytes: number;
+  };
+}
+
+/**
  * Emitted (#407 phase 3) after a did:btco authorship append is inscribed on the
  * anchoring sat, making the on-chain log current for that event.
  */
@@ -456,6 +476,7 @@ export type OriginalsEvent =
   | CelAppendSkippedEvent
   | CelAppendInscribeSkippedEvent
   | CelInscribeCostEvent
+  | CelInscribeDeclinedEvent
   | ResourceInscribedEvent
   | CelHostFailedEvent
   | KeyRotatedEvent;
@@ -495,6 +516,7 @@ export interface EventTypeMap {
   'cel:append-skipped': CelAppendSkippedEvent;
   'cel:append-inscribe-skipped': CelAppendInscribeSkippedEvent;
   'cel:inscribe-cost': CelInscribeCostEvent;
+  'cel:inscribe-declined': CelInscribeDeclinedEvent;
   'resource:inscribed': ResourceInscribedEvent;
   'cel:host-failed': CelHostFailedEvent;
   'key:rotated': KeyRotatedEvent;

--- a/packages/sdk/src/events/types.ts
+++ b/packages/sdk/src/events/types.ts
@@ -387,6 +387,46 @@ export interface KeyRotatedEvent extends BaseEvent {
 }
 
 /**
+ * Emitted (#407 phase 3) when a did:btco authorship append (addResourceVersion)
+ * cannot inscribe on the anchoring sat because no ordinals provider is
+ * configured: the hosted log still advanced, but the ALWAYS-CURRENT on-chain log
+ * did NOT — surfaced so the degrade is never silent.
+ */
+export interface CelAppendInscribeSkippedEvent extends BaseEvent {
+  type: 'cel:append-inscribe-skipped';
+  asset: { id: string };
+  /** Why the on-chain inscription was skipped. */
+  reason: 'NO_ORDINALS_PROVIDER';
+}
+
+/**
+ * Emitted (#407 phase 3) with a cost estimate BEFORE a paid btco append
+ * inscription, so callers are cost-aware (every btco authorship append is now a
+ * paid Bitcoin op). Best-effort/ballpark — not a billing figure.
+ */
+export interface CelInscribeCostEvent extends BaseEvent {
+  type: 'cel:inscribe-cost';
+  asset: { id: string };
+  /** Resolved fee rate (sat/vB), when an estimator was available. */
+  feeRate?: number;
+  /** Rough commit+reveal virtual size (vB). */
+  estVsize: number;
+  /** Approximate total cost (sats) = feeRate × estVsize, when feeRate resolved. */
+  estSats?: number;
+}
+
+/**
+ * Emitted (#407 phase 3) after a did:btco authorship append is inscribed on the
+ * anchoring sat, making the on-chain log current for that event.
+ */
+export interface ResourceInscribedEvent extends BaseEvent {
+  type: 'resource:inscribed';
+  asset: { id: string };
+  did: string;
+  inscriptionId: string;
+}
+
+/**
  * Union type of all possible events
  */
 export type OriginalsEvent =
@@ -414,6 +454,9 @@ export type OriginalsEvent =
   | KeyUnpersistedEvent
   | DidLogUnhostedEvent
   | CelAppendSkippedEvent
+  | CelAppendInscribeSkippedEvent
+  | CelInscribeCostEvent
+  | ResourceInscribedEvent
   | CelHostFailedEvent
   | KeyRotatedEvent;
 
@@ -450,6 +493,9 @@ export interface EventTypeMap {
   'key:unpersisted': KeyUnpersistedEvent;
   'did:log-unhosted': DidLogUnhostedEvent;
   'cel:append-skipped': CelAppendSkippedEvent;
+  'cel:append-inscribe-skipped': CelAppendInscribeSkippedEvent;
+  'cel:inscribe-cost': CelInscribeCostEvent;
+  'resource:inscribed': ResourceInscribedEvent;
   'cel:host-failed': CelHostFailedEvent;
   'key:rotated': KeyRotatedEvent;
 }

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -897,27 +897,35 @@ export class LifecycleManager {
       throw new StructuredError('CHAIN_ASSET_INVALID', `Newest inscription ${newest.inscriptionId}: reconstructed log head (${headDigest}) does not equal its #cel anchor (${anchorDigest}); the chain is truncated or inconsistent.`);
     }
 
-    // 5) Reconstruct the byte-light AssetEnvelope. The head event needs its OWN
-    // bitcoin witness proof reattached — the writer inscribes the doc/log BEFORE
-    // the inscription id exists, so the head's witness (which names the newest
-    // inscription) is never in the embedded snapshot/delta. It is fully
-    // re-verified against the chain by verifyBitcoinWitnessProof inside loadAsset.
-    const headTxid = typeof newest.txid === 'string' ? newest.txid : undefined;
-    const headWitness: WitnessProof & { txid?: string; satoshi: string; inscriptionId: string } = {
-      type: 'DataIntegrityProof',
-      cryptosuite: 'bitcoin-ordinals-2024',
-      created: new Date().toISOString(),
-      verificationMethod: 'did:btco:witness',
-      proofPurpose: 'assertionMethod',
-      proofValue: `z${newest.inscriptionId}`,
-      witnessedAt: new Date().toISOString(),
-      txid: headTxid,
-      satoshi: sat,
-      inscriptionId: newest.inscriptionId
-    };
-    const headIdx = log.events.length - 1;
+    // 5) Reconstruct the byte-light AssetEnvelope. Each inscription witnessed the
+    // event its own `#cel` anchor commits to (migrate, a resource-update, a
+    // rotation), but that event's bitcoin witness proof is never in the embedded
+    // snapshot/delta — the writer inscribes the doc/log BEFORE the inscription id
+    // exists. Reattach, PER LINK, the witness to the event its anchor commits to,
+    // so every on-chain-anchored event carries its proof (not just the head). Each
+    // is fully re-verified against the chain by verifyBitcoinWitnessProof inside
+    // loadAsset (it must commit to that event's digest, or verification fails).
+    const eventDigests = log.events.map(ev => computeDigestMultibase(canonicalizeEntryForChain(ev)));
     const events = log.events.slice();
-    events[headIdx] = { ...events[headIdx], proof: [...events[headIdx].proof, headWitness] };
+    for (const link of links) {
+      const linkAnchor = this.extractCelAnchorFromDoc(link.didDocument);
+      if (linkAnchor === undefined) continue;
+      const evIdx = eventDigests.findIndex(d => digestMultibaseEquals(linkAnchor, d));
+      if (evIdx < 0) continue; // anchor commits to an event not in the reconstructed log
+      const witness: WitnessProof & { txid?: string; satoshi: string; inscriptionId: string } = {
+        type: 'DataIntegrityProof',
+        cryptosuite: 'bitcoin-ordinals-2024',
+        created: new Date().toISOString(),
+        verificationMethod: 'did:btco:witness',
+        proofPurpose: 'assertionMethod',
+        proofValue: `z${link.inscriptionId}`,
+        witnessedAt: new Date().toISOString(),
+        ...(typeof link.txid === 'string' ? { txid: link.txid } : {}),
+        satoshi: sat,
+        inscriptionId: link.inscriptionId
+      };
+      events[evIdx] = { ...events[evIdx], proof: [...events[evIdx].proof, witness] };
+    }
     const reconstructedLog: EventLog = { ...log, events };
 
     // Current media = the newest inscription content that hashes to the log's
@@ -2403,6 +2411,16 @@ export class LifecycleManager {
     if (!log) return null;
     const head = mostRecentResourceHead(log);
     if (!head) return null;
+    // Prefer the in-flight new-version media (#407 phase 3): during a btco
+    // resource-update inscription the log head already points at the new version,
+    // but asset.resources has not advanced yet — the bytes live in pendingHeadMedia.
+    const pending = asset.pendingHeadMedia;
+    if (pending && pending.hash === head.hash && (!head.resourceId || pending.resourceId === head.resourceId)) {
+      return {
+        content: Buffer.from(pending.content, 'utf8'),
+        contentType: pending.contentType ?? head.contentType ?? 'application/octet-stream'
+      };
+    }
     const res = asset.resources.find(r => (!head.resourceId || r.id === head.resourceId) && r.hash === head.hash);
     if (!res || typeof res.content !== 'string') return null;
     return {

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -831,7 +831,14 @@ export class LifecycleManager {
         // partial reconstruction.
         throw new StructuredError('CHAIN_ASSET_INVALID', `Failed to fetch inscription ${inscriptionId} on satoshi ${sat}: ${e instanceof Error ? e.message : String(e)}.`);
       }
-      if (!insc) continue;
+      // The provider JUST listed this id, so a null (fetch miss / transient
+      // fault the provider swallowed to null) is NOT "not an anchor" — it could
+      // be the newest inscription, and silently skipping it would truncate the
+      // chain tail to a self-consistent STALE log that still verifies. Fail
+      // closed. Fable I2.
+      if (!insc) {
+        throw new StructuredError('CHAIN_ASSET_INVALID', `Inscription ${inscriptionId} listed on satoshi ${sat} could not be fetched; refusing to reconstruct from a possibly-truncated chain.`);
+      }
       const meta = insc.metadata as { didDocument?: unknown; celLog?: unknown; events?: unknown } | undefined;
       if (!meta || !meta.didDocument || typeof meta.didDocument !== 'object') continue;
       const snapshot = meta.celLog !== undefined && meta.celLog !== null
@@ -2267,6 +2274,11 @@ export class LifecycleManager {
     type: 'migrate' | 'rotateKey' | 'update',
     data: unknown
   ): Promise<string | null> {
+    // Snapshot the pre-append log BEFORE appendCelEventOrSkip advances it — the
+    // inscribe-failure rollback restores THIS (capturing after the append would
+    // restore the log to itself, leaving it permanently ahead of the chain and
+    // bricking future updates via UNPROVABLE_BASE). Fable I1.
+    const celLogBefore = asset.celLog;
     const digest = await this.appendCelEventOrSkip(asset, type, data);
     // Only inscribe genuine authorship appends that LANDED on a btco asset.
     if (digest === null || asset.currentLayer !== 'did:btco') {
@@ -2284,7 +2296,7 @@ export class LifecycleManager {
       });
       return digest;
     }
-    await this.inscribeCelAppend(asset, digest);
+    await this.inscribeCelAppend(asset, digest, celLogBefore);
     return digest;
   }
 
@@ -2297,7 +2309,7 @@ export class LifecycleManager {
    * before broadcast) the pre-append log is restored so the in-memory log never
    * runs ahead of the chain.
    */
-  private async inscribeCelAppend(asset: OriginalsAsset, headDigest: string): Promise<void> {
+  private async inscribeCelAppend(asset: OriginalsAsset, headDigest: string, celLogBefore: EventLog | undefined): Promise<void> {
     const log = asset.celLog;
     const btcoDid = asset.bindings?.['did:btco'];
     if (!log || !btcoDid) return; // defensive: btco asset always has both
@@ -2328,7 +2340,6 @@ export class LifecycleManager {
     // Cost surfacing (spec §0/§5): estimate + emit BEFORE the paid broadcast.
     await this.emitInscribeCost(asset, headMedia?.content ?? Buffer.from(JSON.stringify(btcoDoc)));
 
-    const celLogBefore = log;
     const bitcoinManager = this.deps?.bitcoinManager ?? new BitcoinManager(this.config);
     let inscription: { inscriptionId: string; satoshi?: string; txid?: string; revealTxId?: string };
     try {
@@ -2339,8 +2350,14 @@ export class LifecycleManager {
         { targetSatoshi: satoshi, metadata, lockKey: asset.id }
       );
     } catch (error) {
-      // Failed after the append — restore the pre-append log (nothing was paid).
-      asset._replaceCelLog(celLogBefore);
+      // Failed after the append (nothing paid before broadcast) — restore the
+      // PRE-append log AND re-persist it: appendCelEventOrSkip already advanced the
+      // hosted copy, so without this the stored log would stay ahead of the chain
+      // and every future update would degrade UNPROVABLE_BASE. Fable I1.
+      if (celLogBefore) {
+        asset._replaceCelLog(celLogBefore);
+        await this.persistCelArtifacts(asset);
+      }
       throw error;
     }
 

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -6,7 +6,10 @@ import {
   ExternalSigner,
   VerifiableCredential,
   LayerType,
-  DIDDocument
+  DIDDocument,
+  AppendKind,
+  AppendCostEstimate,
+  InscribeConfirm
 } from '../types/index.js';
 import { BitcoinManager, MAX_REASONABLE_FEE_RATE } from '../bitcoin/BitcoinManager.js';
 import { DIDManager } from '../did/DIDManager.js';
@@ -340,7 +343,7 @@ export class LifecycleManager {
     const asset = new OriginalsAsset(resources, didDoc, [], log);
     // Bind the controller append path so addResourceVersion can write signed
     // `update` events with the same degrade contract as the other authorship ops.
-    asset._bindCelAppender((type, data) => this.appendCelEventAndMaybeInscribe(asset, type, data));
+    asset._bindCelAppender((type, data, opts) => this.appendCelEventAndMaybeInscribe(asset, type, data, opts));
 
     // Persist the genesis CEL at the conventional cel/<suffix>.json key so
     // the did:cel resolves from storage immediately (best-effort, never gates).
@@ -742,7 +745,7 @@ export class LifecycleManager {
       log,
       { currentLayer: folded.currentLayer, bindings: folded.bindings, provenance }
     );
-    asset._bindCelAppender((type, data) => this.appendCelEventAndMaybeInscribe(asset, type, data));
+    asset._bindCelAppender((type, data, opts) => this.appendCelEventAndMaybeInscribe(asset, type, data, opts));
 
     // Repopulate captured DID docs so re-serializing a loaded asset is
     // lossless. Only for layers cross-checked against the fold in step 5
@@ -2274,8 +2277,41 @@ export class LifecycleManager {
   private async appendCelEventAndMaybeInscribe(
     asset: OriginalsAsset,
     type: 'migrate' | 'rotateKey' | 'update',
-    data: unknown
+    data: unknown,
+    opts?: { inscribeConfirm?: InscribeConfirm }
   ): Promise<string | null> {
+    // Confirm gate (#407 phase 4): consent to the unavoidable on-chain cost BEFORE
+    // any log mutation. Only paid appends prompt — a btco asset WITH a provider (the
+    // ones that actually inscribe below). Off-btco / provider-absent appends inscribe
+    // nothing, so there is no cost to consent to and the gate is a no-op.
+    const gateProvider = this.config.ordinalsProvider ?? this.deps?.bitcoinManager?.ordinalsProvider;
+    const willInscribe = asset.currentLayer === 'did:btco' && !!gateProvider;
+    const confirm = opts?.inscribeConfirm ?? this.config.inscribeConfirm ?? 'now';
+    if (willInscribe && typeof confirm === 'function') {
+      const appendKind: AppendKind = type === 'rotateKey' ? 'rotate' : 'update';
+      // Estimate reflects THIS append (for 'update', pendingHeadMedia is already set
+      // by addResourceVersion and the log head has not advanced yet → sized correctly).
+      const estimate = await this.estimateAppendCost(asset, appendKind);
+      const approved = await confirm(estimate);
+      if (!approved) {
+        // Abort-before-mutate (spec §3): nothing was appended or inscribed, so the
+        // asset is byte-identical. THROW rather than return null — addResourceVersion
+        // pushes the new resource version unconditionally once the appender RETURNS
+        // (OriginalsAsset.ts), so only a throw guarantees a clean no-op.
+        await this.eventEmitter.emit({
+          type: 'cel:inscribe-declined',
+          timestamp: new Date().toISOString(),
+          asset: { id: asset.id },
+          appendKind,
+          estimate
+        });
+        throw new StructuredError(
+          'PROVENANCE_APPEND_DECLINED',
+          'The inscribeConfirm gate declined the paid did:btco append; nothing was appended or inscribed.'
+        );
+      }
+    }
+
     // Snapshot the pre-append log BEFORE appendCelEventOrSkip advances it — the
     // inscribe-failure rollback restores THIS (capturing after the append would
     // restore the log to itself, leaving it permanently ahead of the chain and
@@ -3108,7 +3144,8 @@ export class LifecycleManager {
   async rotateBtcoKeys(
     asset: OriginalsAsset,
     newVerificationMethod: { publicKeyMultibase: string; privateKey?: string },
-    feeRate?: number
+    feeRate?: number,
+    opts?: { inscribeConfirm?: InscribeConfirm }
   ): Promise<{ inscriptionId: string; did: string }> {
     if (asset.currentLayer !== 'did:btco') {
       throw new StructuredError('INVALID_STATE', 'Key rotation requires the asset to be on the did:btco layer.');
@@ -3134,6 +3171,31 @@ export class LifecycleManager {
     const satoshi = btcoDid.split(':').pop()!;
     // Shared rotated-doc build (backLinks + manifest + NETWORK_MISMATCH guard).
     const rotatedDoc = this.buildRotatedBtcoDoc(asset, satoshi, btcoDid, newVerificationMethod.publicKeyMultibase);
+
+    // Confirm gate (#407 phase 4): a cooperative rotation reinscribes on-chain
+    // (paid), so consent to the cost BEFORE any mutation (log OR keyStore) — same
+    // abort-before-mutate contract as the update path. A provider is guaranteed
+    // here (btco asset). On decline, throw before the rotateKey append and before
+    // registering the incoming key; the finally releases the concurrency claim,
+    // leaving the asset byte-identical.
+    const rotateConfirm = opts?.inscribeConfirm ?? this.config.inscribeConfirm ?? 'now';
+    if (typeof rotateConfirm === 'function') {
+      const estimate = await this.estimateAppendCost(asset, 'rotate', { feeRate });
+      const approved = await rotateConfirm(estimate);
+      if (!approved) {
+        await this.eventEmitter.emit({
+          type: 'cel:inscribe-declined',
+          timestamp: new Date().toISOString(),
+          asset: { id: asset.id },
+          appendKind: 'rotate',
+          estimate
+        });
+        throw new StructuredError(
+          'PROVENANCE_APPEND_DECLINED',
+          'The inscribeConfirm gate declined the paid did:btco key rotation; nothing was appended or inscribed.'
+        );
+      }
+    }
 
     // Append-first (#365): rotateKey signed by the CURRENT controller — the
     // cooperative-rotation contract (the verifier only accepts rotations
@@ -3787,8 +3849,107 @@ export class LifecycleManager {
   }
 
   /**
+   * Non-mutating cost preview for the NEXT did:btco authorship append (#407 phase
+   * 4). Returns `{ satoshis, feeRate, vbytes, contentBytes }` for an `'update'`
+   * (new media) or `'rotate'` (event-only reinscription) without signing,
+   * appending, or inscribing anything — pure quote.
+   *
+   * Fee rate comes from the SAME resolver the real inscribe path uses
+   * (`bitcoinManager.estimateFeeRate` → feeOracle→provider, absurd
+   * >`MAX_REASONABLE_FEE_RATE` sources skipped; an explicit `opts.feeRate` wins).
+   * The vsize ballpark mirrors
+   * `emitInscribeCost` (content/4 witness discount + ~200 vB overhead), so the
+   * quote tracks the cost the subsequent real append incurs.
+   *
+   * For a STANDALONE `'update'` quote (not driven by the confirm gate), pass the
+   * intended new bytes as `opts.content` — otherwise the estimate is
+   * content-agnostic: with no in-flight `pendingHeadMedia` it sizes the CURRENT
+   * head media as a proxy and will underquote a larger upgrade. The confirm gate
+   * always sizes correctly (pendingHeadMedia is set before it runs).
+   *
+   * @throws StructuredError('ORD_PROVIDER_REQUIRED') when no ordinalsProvider is
+   *   configured — a btco op cannot be quoted without one.
+   */
+  async estimateAppendCost(
+    asset: OriginalsAsset,
+    appendKind: AppendKind,
+    opts?: { content?: string | Buffer; contentType?: string; feeRate?: number }
+  ): Promise<AppendCostEstimate> {
+    const provider = this.config.ordinalsProvider ?? this.deps?.bitcoinManager?.ordinalsProvider;
+    if (!provider) {
+      throw new StructuredError(
+        'ORD_PROVIDER_REQUIRED',
+        'An ordinalsProvider must be configured to estimate a did:btco append cost.'
+      );
+    }
+    // Same resolveFeeRate chain the real inscription uses (explicit override wins,
+    // else feeOracle→provider, absurd sources skipped). Conservative default when
+    // nothing resolves, so the quote is always a usable number for the confirm
+    // callback (matches estimateCost's fallback). Short-circuit an explicit
+    // opts.feeRate so we skip the fee-oracle round-trip it would only override.
+    let feeRate: number;
+    if (typeof opts?.feeRate === 'number' && Number.isFinite(opts.feeRate) && opts.feeRate > 0) {
+      feeRate = opts.feeRate;
+    } else {
+      const bitcoinManager = this.deps?.bitcoinManager ?? new BitcoinManager(this.config);
+      const resolved = await bitcoinManager.estimateFeeRate();
+      feeRate = (typeof resolved === 'number' && resolved > 0) ? resolved : 10;
+    }
+    const contentBytes = this.resolveAppendPayloadBytes(asset, appendKind, opts);
+    // Ballpark commit+reveal vsize (mirrors emitInscribeCost): a cost-awareness
+    // figure, not a billing number.
+    const vbytes = Math.ceil(contentBytes / 4) + 200;
+    const satoshis = Math.ceil(feeRate * vbytes);
+    return { satoshis, feeRate, vbytes, contentBytes };
+  }
+
+  /**
+   * Byte size of the content the next btco append would inscribe (#407 phase 4).
+   * Mirrors the real inscribe path's content selection so the estimate matches:
+   * caller-supplied content → in-flight new media (`pendingHeadMedia`, the
+   * confirm-gate case, since the log head has not advanced yet) → current head
+   * media → the DID document (pure-reference-head fallback). Pure/read-only.
+   *
+   * For `'rotate'`, this deliberately sizes the head MEDIA (when present), NOT the
+   * rotated DID doc: `reinscribeRotatedDoc` inscribes `headMedia.content` as the
+   * ordinal CONTENT and carries the rotated doc in METADATA, falling back to the
+   * DID doc as content only for a pure-reference head. So media size IS the paid
+   * cost of a rotation on an asset with media; the DID-doc fallback below applies
+   * to both kinds only when there is no inline media.
+   */
+  private resolveAppendPayloadBytes(
+    asset: OriginalsAsset,
+    appendKind: AppendKind,
+    opts?: { content?: string | Buffer }
+  ): number {
+    if (opts?.content !== undefined) {
+      const buf = Buffer.isBuffer(opts.content) ? opts.content : Buffer.from(String(opts.content), 'utf8');
+      return buf.byteLength;
+    }
+    if (appendKind === 'update' && asset.pendingHeadMedia) {
+      return Buffer.from(asset.pendingHeadMedia.content, 'utf8').byteLength;
+    }
+    // Head media is the inscribed CONTENT for BOTH kinds when present (update:
+    // reinscribeCelAppend; rotate: reinscribeRotatedDoc) — so this is the paid size.
+    const headMedia = this.tryResolveHeadMedia(asset);
+    if (headMedia) return headMedia.content.byteLength;
+    // Pure-reference head → the inscribe path falls back to the DID document as
+    // content; size the current btco doc (rebuilt with the current controller key).
+    const log = asset.celLog;
+    const btcoDid = asset.bindings?.['did:btco'];
+    if (log && btcoDid) {
+      const satoshi = btcoDid.split(':').pop()!;
+      const vm = currentControllerVm(log);
+      const controllerPubMb = vm.split('#')[0].slice('did:key:'.length);
+      const btcoDoc = this.buildRotatedBtcoDoc(asset, satoshi, btcoDid, controllerPubMb);
+      return Buffer.from(JSON.stringify(btcoDoc)).byteLength;
+    }
+    return 0;
+  }
+
+  /**
    * Estimate the cost of migrating an asset to a target layer
-   * 
+   *
    * Returns a detailed breakdown of expected costs for Bitcoin operations.
    * For did:webvh migrations, costs are minimal (only hosting).
    * 

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -856,7 +856,7 @@ export class LifecycleManager {
       });
     }
     if (links.length === 0) {
-      throw new StructuredError('CHAIN_ASSET_NOT_FOUND', `No Originals anchoring inscription found on satoshi ${sat}.`);
+      throw new StructuredError('CHAIN_ASSET_NOT_FOUND', `Cannot resolve an asset from satoshi ${sat}: no Originals anchoring inscription found.`);
     }
     links.sort((a, b) => a.blockHeight - b.blockHeight || a.listIdx - b.listIdx);
 

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -943,7 +943,9 @@ export class LifecycleManager {
     if (head) {
       for (let i = links.length - 1; i >= 0; i--) {
         const c = links[i].content;
-        if (c && hashResource(Buffer.from(c.toString('utf8'), 'utf8')).toLowerCase() === head.hash.toLowerCase()) {
+        // Hash the RAW bytes — a utf8 decode/encode round-trip would corrupt
+        // binary media (JPEG/PNG) and silently drop it (Greptile P1).
+        if (c && hashResource(c).toLowerCase() === head.hash.toLowerCase()) {
           headContent = c;
           break;
         }
@@ -2336,11 +2338,13 @@ export class LifecycleManager {
       metadata.celLog = JSON.parse(serializeEventLogJson(log)) as Record<string, unknown>;
     }
 
+    // Resolve the BitcoinManager ONCE so the surfaced cost estimate and the
+    // actual inscription share one instance / fee-rate lookup (Greptile P2).
+    const bitcoinManager = this.deps?.bitcoinManager ?? new BitcoinManager(this.config);
     const headMedia = this.tryResolveHeadMedia(asset);
     // Cost surfacing (spec §0/§5): estimate + emit BEFORE the paid broadcast.
-    await this.emitInscribeCost(asset, headMedia?.content ?? Buffer.from(JSON.stringify(btcoDoc)));
+    await this.emitInscribeCost(bitcoinManager, asset, headMedia?.content ?? Buffer.from(JSON.stringify(btcoDoc)));
 
-    const bitcoinManager = this.deps?.bitcoinManager ?? new BitcoinManager(this.config);
     let inscription: { inscriptionId: string; satoshi?: string; txid?: string; revealTxId?: string };
     try {
       inscription = await bitcoinManager.inscribeData(
@@ -2353,10 +2357,19 @@ export class LifecycleManager {
       // Failed after the append (nothing paid before broadcast) — restore the
       // PRE-append log AND re-persist it: appendCelEventOrSkip already advanced the
       // hosted copy, so without this the stored log would stay ahead of the chain
-      // and every future update would degrade UNPROVABLE_BASE. Fable I1.
+      // and every future update would degrade UNPROVABLE_BASE. Fable I1. The
+      // re-persist is best-effort and MUST NOT mask the original broadcast error
+      // (Greptile P2), so it is guarded independently.
       if (celLogBefore) {
         asset._replaceCelLog(celLogBefore);
-        await this.persistCelArtifacts(asset);
+        try {
+          await this.persistCelArtifacts(asset);
+        } catch (persistErr) {
+          this.logger.warn('rollback re-persist failed (non-gating)', {
+            assetId: asset.id,
+            error: (persistErr as Error)?.message ?? String(persistErr)
+          });
+        }
       }
       throw error;
     }
@@ -2389,9 +2402,8 @@ export class LifecycleManager {
    * cost (fee rate × rough vsize). Never gates — an estimator failure must not
    * block the paid op the caller already intends.
    */
-  private async emitInscribeCost(asset: OriginalsAsset, content: Buffer): Promise<void> {
+  private async emitInscribeCost(bitcoinManager: BitcoinManager, asset: OriginalsAsset, content: Buffer): Promise<void> {
     try {
-      const bitcoinManager = this.deps?.bitcoinManager ?? new BitcoinManager(this.config);
       const feeRate = await bitcoinManager.estimateFeeRate();
       // Rough commit+reveal vsize: content bytes / 4 (witness discount) + ~200
       // vB overhead. A ballpark for cost-awareness, not a billing figure.

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -27,7 +27,7 @@ import { btcoDidPrefix, btcoDidFromSatoshi } from '../cel/btcoDid.js';
 import { KeyManager } from '../did/KeyManager.js';
 import { celSignerFromKeyPair, hexSha256ToDigestMultibase, createKeyStoreCelSigner, currentControllerVm } from '../cel/signerAdapter.js';
 import { createCelDidDocument, didCelMatchesLog, deriveDidCel, DID_CEL_PREFIX } from '../cel/celDid.js';
-import { verifyEventLog, selectNewestAnchorInscription } from '../cel/algorithms/verifyEventLog.js';
+import { verifyEventLog } from '../cel/algorithms/verifyEventLog.js';
 import { createDidManagerKeyResolver } from '../cel/keyResolver.js';
 import { PeerCelManager } from '../cel/layers/PeerCelManager.js';
 import { appendEvent } from '../cel/algorithms/appendEvent.js';
@@ -790,82 +790,158 @@ export class LifecycleManager {
       if (!v.valid) throw new StructuredError('INVALID_SATOSHI', `Invalid satoshi identifier: ${v.error}`);
     }
 
-    // 1) Newest anchoring inscription by confirmed block height — reuses the
-    // verifier's selection so the resolver picks the SAME inscription
-    // head-freshness / the content gate check against (fail-closed on missing
-    // height, per-height newest, list-tail same-block residual).
-    const selected = await selectNewestAnchorInscription(sat, provider);
-    if ('error' in selected) {
-      throw new StructuredError('CHAIN_ASSET_NOT_FOUND', `Cannot resolve an asset from satoshi ${sat}: ${selected.error}.`);
+    // 1) Enumerate the sat's inscription chain (#407 phase 3). Each btco
+    // authorship append adds one inscription; walking them in confirmed-block
+    // order reconstructs the ALWAYS-CURRENT log — not just phase-2's point-in-time
+    // newest snapshot.
+    if (typeof provider.getInscriptionsBySatoshi !== 'function') {
+      throw new StructuredError('ORD_PROVIDER_REQUIRED', `The ordinals provider cannot enumerate inscriptions on satoshi ${sat}.`);
     }
-    const chosen = selected.inscription;
-
-    // 2) Read provenance (metadata) + media (content).
-    const metadata = chosen.metadata as { didDocument?: unknown; celLog?: unknown } | undefined;
-    const btcoDoc = metadata?.didDocument;
-    const rawCelLog = metadata?.celLog;
-    if (!btcoDoc || typeof btcoDoc !== 'object' || rawCelLog === undefined || rawCelLog === null) {
-      throw new StructuredError(
-        'CHAIN_ASSET_INVALID',
-        `Inscription ${chosen.inscriptionId} on satoshi ${sat} carries no provenance metadata (didDocument + celLog); not a phase-2 anchoring inscription.`
-      );
+    let onSat: Array<{ inscriptionId: string }>;
+    try {
+      onSat = await provider.getInscriptionsBySatoshi(sat);
+    } catch (e) {
+      throw new StructuredError('CHAIN_ASSET_NOT_FOUND', `Failed to enumerate inscriptions on satoshi ${sat}: ${e instanceof Error ? e.message : String(e)}.`);
     }
 
-    // 3) Parse the embedded byte-light CEL log through the JSON gate.
+    // 2) Fetch each, keeping OUR anchoring inscriptions (metadata carries a
+    // didDocument AND either a full celLog snapshot or an events delta). Order
+    // strictly by confirmed block height (list index as the documented
+    // same-block residual). A missing block height on any anchoring inscription
+    // fails closed — the chain order would be unprovable.
+    type Link = {
+      inscriptionId: string;
+      listIdx: number;
+      blockHeight: number;
+      didDocument: unknown;
+      snapshotEvents?: unknown[]; // full celLog (checkpoint) → REPLACE
+      deltaEvents?: unknown[];    // events delta → APPEND
+      content?: Buffer;
+      txid?: string;
+    };
+    const links: Link[] = [];
+    for (let idx = 0; idx < onSat.length; idx++) {
+      const inscriptionId = onSat[idx].inscriptionId;
+      let insc: Awaited<ReturnType<OrdinalsLookup['getInscriptionById']>>;
+      try {
+        insc = await provider.getInscriptionById(inscriptionId);
+      } catch (e) {
+        // A metadata-undecodable error (or any fetch failure) fails closed: a
+        // provider that cannot read an inscription must not yield a silent
+        // partial reconstruction.
+        throw new StructuredError('CHAIN_ASSET_INVALID', `Failed to fetch inscription ${inscriptionId} on satoshi ${sat}: ${e instanceof Error ? e.message : String(e)}.`);
+      }
+      if (!insc) continue;
+      const meta = insc.metadata as { didDocument?: unknown; celLog?: unknown; events?: unknown } | undefined;
+      if (!meta || !meta.didDocument || typeof meta.didDocument !== 'object') continue;
+      const snapshot = meta.celLog !== undefined && meta.celLog !== null
+        ? (meta.celLog as { events?: unknown }).events
+        : undefined;
+      const delta = Array.isArray(meta.events) ? meta.events : undefined;
+      if (snapshot === undefined && delta === undefined) continue; // not an anchoring inscription
+      const rawHeight = (insc as { blockHeight?: unknown }).blockHeight;
+      const height = typeof rawHeight === 'number' && Number.isInteger(rawHeight) && rawHeight >= 0 ? rawHeight : undefined;
+      if (height === undefined) {
+        throw new StructuredError('CHAIN_ASSET_INVALID', `Anchoring inscription ${inscriptionId} on satoshi ${sat} has no confirmed block height; the chain order is unprovable.`);
+      }
+      links.push({
+        inscriptionId,
+        listIdx: idx,
+        blockHeight: height,
+        didDocument: meta.didDocument,
+        ...(Array.isArray(snapshot) ? { snapshotEvents: snapshot } : {}),
+        ...(delta ? { deltaEvents: delta } : {}),
+        ...(insc.content !== undefined ? { content: insc.content } : {}),
+        ...(typeof insc.txid === 'string' ? { txid: insc.txid } : {})
+      });
+    }
+    if (links.length === 0) {
+      throw new StructuredError('CHAIN_ASSET_NOT_FOUND', `No Originals anchoring inscription found on satoshi ${sat}.`);
+    }
+    links.sort((a, b) => a.blockHeight - b.blockHeight || a.listIdx - b.listIdx);
+
+    // 3) Walk oldest→newest, concatenating events: a full celLog snapshot is a
+    // checkpoint (REPLACE); an events delta extends (APPEND). The result is the
+    // full current log; verifyEventLog (below, via loadAsset) enforces contiguous
+    // hash-chain continuity, so any gap or mis-ordered same-block link fails
+    // closed there — the resolver never trusts the concatenation blindly.
+    let rawEvents: unknown[] = [];
+    for (const link of links) {
+      if (link.snapshotEvents) {
+        rawEvents = link.snapshotEvents.slice();
+      } else if (link.deltaEvents) {
+        rawEvents = rawEvents.concat(link.deltaEvents);
+      }
+    }
+    const newest = links[links.length - 1];
+    const btcoDoc = newest.didDocument;
+
     let log: EventLog;
     try {
-      log = parseEventLogJson(JSON.stringify(rawCelLog));
+      log = parseEventLogJson(JSON.stringify({ events: rawEvents }));
     } catch (e) {
-      throw new StructuredError('CHAIN_ASSET_INVALID', `Inscription ${chosen.inscriptionId} celLog is not a valid CEL log: ${(e as Error).message}`);
+      throw new StructuredError('CHAIN_ASSET_INVALID', `Reconstructed log from satoshi ${sat} is not a valid CEL log: ${(e as Error).message}`);
     }
     if (!Array.isArray(log.events) || log.events.length === 0) {
-      throw new StructuredError('CHAIN_ASSET_INVALID', `Inscription ${chosen.inscriptionId} celLog has no events.`);
+      throw new StructuredError('CHAIN_ASSET_INVALID', `Reconstructed log from satoshi ${sat} has no events.`);
     }
 
-    // 4) The embedded celLog head MUST equal the on-chain `#cel` anchor
-    // (else the inscription is internally inconsistent). Defense-in-depth: the
-    // witness path re-derives this too, but a clear early error is worth it.
+    // 4) The newest inscription's `#cel` anchor MUST equal the reconstructed log
+    // head (else the newest link is inconsistent with the concatenated chain).
     const anchorDigest = this.extractCelAnchorFromDoc(btcoDoc);
     const headDigest = computeDigestMultibase(canonicalizeEntryForChain(log.events[log.events.length - 1]));
     if (anchorDigest === undefined) {
-      throw new StructuredError('CHAIN_ASSET_INVALID', `Inscription ${chosen.inscriptionId} DID document carries no OriginalsCelAnchor; cannot confirm the embedded log head.`);
+      throw new StructuredError('CHAIN_ASSET_INVALID', `Newest inscription ${newest.inscriptionId} DID document carries no OriginalsCelAnchor; cannot confirm the reconstructed log head.`);
     }
     if (!digestMultibaseEquals(anchorDigest, headDigest)) {
-      throw new StructuredError('CHAIN_ASSET_INVALID', `Inscription ${chosen.inscriptionId}: embedded celLog head (${headDigest}) does not equal the #cel anchor (${anchorDigest}).`);
+      throw new StructuredError('CHAIN_ASSET_INVALID', `Newest inscription ${newest.inscriptionId}: reconstructed log head (${headDigest}) does not equal its #cel anchor (${anchorDigest}); the chain is truncated or inconsistent.`);
     }
 
     // 5) Reconstruct the byte-light AssetEnvelope. The head event needs its OWN
     // bitcoin witness proof reattached — the writer inscribes the doc/log BEFORE
-    // the inscription id exists, so the head's witness (which names this
-    // inscription) is never in the embedded snapshot. It is fully re-verified
-    // against the chain by verifyBitcoinWitnessProof inside loadAsset.
-    const headTxid = typeof chosen.txid === 'string' ? chosen.txid : undefined;
+    // the inscription id exists, so the head's witness (which names the newest
+    // inscription) is never in the embedded snapshot/delta. It is fully
+    // re-verified against the chain by verifyBitcoinWitnessProof inside loadAsset.
+    const headTxid = typeof newest.txid === 'string' ? newest.txid : undefined;
     const headWitness: WitnessProof & { txid?: string; satoshi: string; inscriptionId: string } = {
       type: 'DataIntegrityProof',
       cryptosuite: 'bitcoin-ordinals-2024',
       created: new Date().toISOString(),
       verificationMethod: 'did:btco:witness',
       proofPurpose: 'assertionMethod',
-      proofValue: `z${chosen.inscriptionId}`,
+      proofValue: `z${newest.inscriptionId}`,
       witnessedAt: new Date().toISOString(),
       txid: headTxid,
       satoshi: sat,
-      inscriptionId: chosen.inscriptionId
+      inscriptionId: newest.inscriptionId
     };
     const headIdx = log.events.length - 1;
     const events = log.events.slice();
     events[headIdx] = { ...events[headIdx], proof: [...events[headIdx].proof, headWitness] };
     const reconstructedLog: EventLog = { ...log, events };
 
-    // Resources from the log + the on-chain media as the head blob.
-    const resources = this.reconstructResourcesFromLog(reconstructedLog, chosen.content);
+    // Current media = the newest inscription content that hashes to the log's
+    // most-recent-resource head (a rotation's newest inscription carries no new
+    // media, so the media may live in an earlier resource-update inscription).
+    const head = mostRecentResourceHead(reconstructedLog);
+    let headContent: Buffer | undefined;
+    if (head) {
+      for (let i = links.length - 1; i >= 0; i--) {
+        const c = links[i].content;
+        if (c && hashResource(Buffer.from(c.toString('utf8'), 'utf8')).toLowerCase() === head.hash.toLowerCase()) {
+          headContent = c;
+          break;
+        }
+      }
+    }
+    const resources = this.reconstructResourcesFromLog(reconstructedLog, headContent);
 
     // did:cel document is DERIVED (loadAsset re-derives it anyway; supply a
     // structurally valid one). did:btco is the on-chain metadata doc.
     const assetDid = deriveDidCel(reconstructedLog);
     const genesisController = (reconstructedLog.events[0]?.data as { controller?: unknown })?.controller;
     if (typeof genesisController !== 'string' || !genesisController.startsWith('did:key:')) {
-      throw new StructuredError('CHAIN_ASSET_INVALID', `Inscription ${chosen.inscriptionId} genesis controller is not a did:key (only did:key controllers are supported by resolveAssetFromSat; got: ${String(genesisController)}).`);
+      throw new StructuredError('CHAIN_ASSET_INVALID', `Reconstructed genesis controller is not a did:key (only did:key controllers are supported by resolveAssetFromSat; got: ${String(genesisController)}).`);
     }
     const celDoc = createCelDidDocument(assetDid, genesisController.slice('did:key:'.length));
 

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -167,6 +167,17 @@ export class LifecycleManager {
    */
   private inFlightAssets = new Set<string>();
 
+  /**
+   * #407 phase 3: chain digest of the newest CEL event already committed
+   * on-chain for a btco asset (the snapshot head of the last inscription:
+   * migrate / rotation / resource-update). A subsequent btco resource-update
+   * inscribes only the DELTA of events appended since this head. Best-effort
+   * optimization ONLY: when the boundary is unknown (empty map, digest not
+   * found in the log), the append inscribes a FULL celLog snapshot instead —
+   * correctness never depends on this map.
+   */
+  private lastInscribedHead = new WeakMap<OriginalsAsset, string>();
+
   constructor(
     private config: OriginalsConfig,
     private didManager: DIDManager,
@@ -329,7 +340,7 @@ export class LifecycleManager {
     const asset = new OriginalsAsset(resources, didDoc, [], log);
     // Bind the controller append path so addResourceVersion can write signed
     // `update` events with the same degrade contract as the other authorship ops.
-    asset._bindCelAppender((type, data) => this.appendCelEventOrSkip(asset, type, data));
+    asset._bindCelAppender((type, data) => this.appendCelEventAndMaybeInscribe(asset, type, data));
 
     // Persist the genesis CEL at the conventional cel/<suffix>.json key so
     // the did:cel resolves from storage immediately (best-effort, never gates).
@@ -731,7 +742,7 @@ export class LifecycleManager {
       log,
       { currentLayer: folded.currentLayer, bindings: folded.bindings, provenance }
     );
-    asset._bindCelAppender((type, data) => this.appendCelEventOrSkip(asset, type, data));
+    asset._bindCelAppender((type, data) => this.appendCelEventAndMaybeInscribe(asset, type, data));
 
     // Repopulate captured DID docs so re-serializing a loaded asset is
     // lossless. Only for layers cross-checked against the fold in step 5
@@ -2154,6 +2165,151 @@ export class LifecycleManager {
   }
 
   /**
+   * Controller-append entry point BOUND to `addResourceVersion` (#407 phase 3).
+   * First runs the standard hosted append (`appendCelEventOrSkip`); then, for a
+   * did:btco asset whose append LANDED, inscribes the new event on the anchoring
+   * sat so the on-chain log is always current (real-time recoverability). The
+   * witness-ack path calls `appendCelEventOrSkip` DIRECTLY (not this), so acks do
+   * NOT trigger a nested inscription. Migrate/rotation inscribe on their own
+   * paths, so only genuine post-btco authorship appends (resource updates) reach
+   * the inscribe branch here.
+   *
+   * Degrade (spec §1): off-btco, a degraded append (digest null), or no ordinals
+   * provider → hosted append only, with a clear `cel:append-inscribe-skipped`
+   * signal in the provider-absent case (never silent).
+   */
+  private async appendCelEventAndMaybeInscribe(
+    asset: OriginalsAsset,
+    type: 'migrate' | 'rotateKey' | 'update',
+    data: unknown
+  ): Promise<string | null> {
+    const digest = await this.appendCelEventOrSkip(asset, type, data);
+    // Only inscribe genuine authorship appends that LANDED on a btco asset.
+    if (digest === null || asset.currentLayer !== 'did:btco') {
+      return digest;
+    }
+    const provider = this.config.ordinalsProvider ?? this.deps?.bitcoinManager?.ordinalsProvider;
+    if (!provider) {
+      // Spec §1: provider-absent → hosted append (degrade), not a crash. Surface
+      // it clearly so callers know the on-chain log did NOT advance this append.
+      await this.eventEmitter.emit({
+        type: 'cel:append-inscribe-skipped',
+        timestamp: new Date().toISOString(),
+        asset: { id: asset.id },
+        reason: 'NO_ORDINALS_PROVIDER'
+      });
+      return digest;
+    }
+    await this.inscribeCelAppend(asset, digest);
+    return digest;
+  }
+
+  /**
+   * Inscribe a just-appended btco authorship event on the anchoring sat (#407
+   * phase 3). Content = the new head media (or DID-doc fallback for a
+   * pure-reference head); metadata = `{ didDocument: <btco doc w/ fresh #cel
+   * head>, events: <delta since last on-chain head> | celLog: <full snapshot> }`.
+   * Mirrors `reinscribeRotatedDoc`'s sat-pin + rollback: on failure (nothing paid
+   * before broadcast) the pre-append log is restored so the in-memory log never
+   * runs ahead of the chain.
+   */
+  private async inscribeCelAppend(asset: OriginalsAsset, headDigest: string): Promise<void> {
+    const log = asset.celLog;
+    const btcoDid = asset.bindings?.['did:btco'];
+    if (!log || !btcoDid) return; // defensive: btco asset always has both
+    const satoshi = btcoDid.split(':').pop()!;
+
+    // Rebuild the btco doc with the CURRENT controller key + refreshed resource
+    // manifest, then embed the fresh #cel head (the just-appended event).
+    const vm = currentControllerVm(log);
+    const controllerPubMb = vm.split('#')[0].slice('did:key:'.length);
+    const btcoDoc = this.buildRotatedBtcoDoc(asset, satoshi, btcoDid, controllerPubMb);
+    this.embedCelAnchor(btcoDoc, headDigest);
+
+    // Delta since the last on-chain head, else a full snapshot (safe checkpoint).
+    const metadata: Record<string, unknown> = { didDocument: btcoDoc };
+    const lastHead = this.lastInscribedHead.get(asset);
+    const boundaryIdx = lastHead !== undefined
+      ? log.events.findIndex(ev => digestMultibaseEquals(lastHead, computeDigestMultibase(canonicalizeEntryForChain(ev))))
+      : -1;
+    if (boundaryIdx >= 0 && boundaryIdx < log.events.length - 1) {
+      const delta = log.events.slice(boundaryIdx + 1);
+      metadata.events = JSON.parse(serializeEventLogJson({ ...log, events: delta })).events;
+    } else {
+      // No known boundary → full snapshot; the resolver treats it as a checkpoint.
+      metadata.celLog = JSON.parse(serializeEventLogJson(log)) as Record<string, unknown>;
+    }
+
+    const headMedia = this.tryResolveHeadMedia(asset);
+    // Cost surfacing (spec §0/§5): estimate + emit BEFORE the paid broadcast.
+    await this.emitInscribeCost(asset, headMedia?.content ?? Buffer.from(JSON.stringify(btcoDoc)));
+
+    const celLogBefore = log;
+    const bitcoinManager = this.deps?.bitcoinManager ?? new BitcoinManager(this.config);
+    let inscription: { inscriptionId: string; satoshi?: string; txid?: string; revealTxId?: string };
+    try {
+      inscription = await bitcoinManager.inscribeData(
+        headMedia ? headMedia.content : Buffer.from(JSON.stringify(btcoDoc)),
+        headMedia ? headMedia.contentType : 'application/did+json',
+        undefined,
+        { targetSatoshi: satoshi, metadata, lockKey: asset.id }
+      );
+    } catch (error) {
+      // Failed after the append — restore the pre-append log (nothing was paid).
+      asset._replaceCelLog(celLogBefore);
+      throw error;
+    }
+
+    // Attach the head's own bitcoin witness proof (post-hoc; excluded from the
+    // chain digest, so it cannot break the anchored head). Then capture the
+    // updated btco doc and advance the on-chain head boundary.
+    if (inscription.satoshi) {
+      this.attachBitcoinWitnessProof(asset, {
+        satoshi: inscription.satoshi,
+        inscriptionId: inscription.inscriptionId,
+        txid: inscription.revealTxId ?? inscription.txid ?? ''
+      });
+    }
+    asset._captureDidDocument('did:btco', btcoDoc);
+    this.lastInscribedHead.set(asset, headDigest);
+
+    await this.eventEmitter.emit({
+      type: 'resource:inscribed',
+      timestamp: new Date().toISOString(),
+      asset: { id: asset.id },
+      did: btcoDid,
+      inscriptionId: inscription.inscriptionId
+    });
+  }
+
+  /**
+   * Best-effort cost estimate for a btco append inscription (spec §0/§5). Emits
+   * `cel:inscribe-cost` with the resolved fee rate and an approximate total sat
+   * cost (fee rate × rough vsize). Never gates — an estimator failure must not
+   * block the paid op the caller already intends.
+   */
+  private async emitInscribeCost(asset: OriginalsAsset, content: Buffer): Promise<void> {
+    try {
+      const bitcoinManager = this.deps?.bitcoinManager ?? new BitcoinManager(this.config);
+      const feeRate = await bitcoinManager.estimateFeeRate();
+      // Rough commit+reveal vsize: content bytes / 4 (witness discount) + ~200
+      // vB overhead. A ballpark for cost-awareness, not a billing figure.
+      const estVsize = Math.ceil(content.byteLength / 4) + 200;
+      const estSats = typeof feeRate === 'number' ? Math.ceil(feeRate * estVsize) : undefined;
+      await this.eventEmitter.emit({
+        type: 'cel:inscribe-cost',
+        timestamp: new Date().toISOString(),
+        asset: { id: asset.id },
+        ...(typeof feeRate === 'number' ? { feeRate } : {}),
+        estVsize,
+        ...(estSats !== undefined ? { estSats } : {})
+      });
+    } catch {
+      // non-gating
+    }
+  }
+
+  /**
    * Resolve the media the anchoring inscription will carry as CONTENT (#407
    * phase 2): the most-recent resource's inline bytes + its MIME type. The head
    * is derived from the LOG (mostRecentResourceHead) — the same source the
@@ -2374,6 +2530,9 @@ export class LifecycleManager {
         proof: [...events[migrateIdx].proof, witnessProof]
       };
       asset._replaceCelLog({ ...log, events });
+      // #407 phase 3: the migrate event is now the on-chain head; a subsequent
+      // btco resource-update inscribes only the delta appended after it.
+      this.lastInscribedHead.set(asset, celHeadDigest);
     }
 
     // Capture the layer before migration for accurate metrics
@@ -2908,6 +3067,11 @@ export class LifecycleManager {
     // Reinscription succeeded — the rotated doc is now the resolvable btco doc;
     // it REPLACES the inscription-time capture for serialize().
     asset._captureDidDocument('did:btco', rotatedDoc);
+    // #407 phase 3: the rotateKey event is the new on-chain head; a subsequent
+    // btco resource-update inscribes only the delta appended after it.
+    if (celHeadDigest !== null) {
+      this.lastInscribedHead.set(asset, celHeadDigest);
+    }
 
     // Witness acknowledgment (map §5.1): controller-signed update recording the
     // reinscription. Folds to the CURRENT (post-rotation) controller; degrades
@@ -3055,6 +3219,9 @@ export class LifecycleManager {
 
     // Reinscription succeeded — the rotated doc is the resolvable btco doc.
     asset._captureDidDocument('did:btco', rotatedDoc);
+    // #407 phase 3: the rotateKey event is the new on-chain head; a subsequent
+    // btco resource-update inscribes only the delta appended after it.
+    this.lastInscribedHead.set(asset, celHeadDigest);
 
     // Direct best-effort persist (issue: no-keyStore gap): with no keyStore,
     // appendWitnessAcknowledgment below degrades to a skip and never reaches

--- a/packages/sdk/src/lifecycle/OriginalsAsset.ts
+++ b/packages/sdk/src/lifecycle/OriginalsAsset.ts
@@ -1,8 +1,9 @@
-import { 
-  AssetResource, 
-  DIDDocument, 
-  VerifiableCredential, 
-  LayerType 
+import {
+  AssetResource,
+  DIDDocument,
+  VerifiableCredential,
+  LayerType,
+  InscribeConfirm
 } from '../types/index.js';
 import { validateDIDDocument, validateCredential, hashResource } from '../utils/validation.js';
 import { StructuredError } from '../utils/telemetry.js';
@@ -72,7 +73,11 @@ export class OriginalsAsset {
   // event via the manager's degrade-aware path and returns the new head digest,
   // or null when the append was skipped (no keyStore / no signing key). Undefined
   // for assets constructed outside the lifecycle (they degrade in-memory only).
-  #celAppender?: (type: 'migrate' | 'rotateKey' | 'update', data: unknown) => Promise<string | null>;
+  #celAppender?: (
+    type: 'migrate' | 'rotateKey' | 'update',
+    data: unknown,
+    opts?: { inscribeConfirm?: InscribeConfirm }
+  ) => Promise<string | null>;
   // Per-asset serialization for addResourceVersion: the sync→async cutover made
   // the shared #celLog read-modify-write span await points, so concurrent calls
   // raced (a later _replaceCelLog clobbered an earlier signed append, or landed
@@ -195,7 +200,11 @@ export class OriginalsAsset {
    * contract (cel:append-skipped) as the other authorship ops.
    */
   _bindCelAppender(
-    fn: (type: 'migrate' | 'rotateKey' | 'update', data: unknown) => Promise<string | null>
+    fn: (
+      type: 'migrate' | 'rotateKey' | 'update',
+      data: unknown,
+      opts?: { inscribeConfirm?: InscribeConfirm }
+    ) => Promise<string | null>
   ): void {
     this.#celAppender = fn;
   }
@@ -597,7 +606,8 @@ export class OriginalsAsset {
     resourceId: string,
     newContent: string,
     contentType: string,
-    changes?: string
+    changes?: string,
+    opts?: { inscribeConfirm?: InscribeConfirm }
   ): Promise<AssetResource> {
     // AssetResource.content is a string; a Buffer used to be silently dropped
     // (only its hash was stored), unrecoverably losing the binary content
@@ -617,7 +627,7 @@ export class OriginalsAsset {
     // second queued call re-reads the head INSIDE its turn, so it chains from
     // the first call's committed result rather than a stale snapshot (Finding 2).
     const run = this.#appendChain.then(() =>
-      this.#addResourceVersionCritical(resourceId, newContent, contentType, changes)
+      this.#addResourceVersionCritical(resourceId, newContent, contentType, changes, opts)
     );
     // Keep the chain alive across a rejected turn without swallowing it for the caller.
     this.#appendChain = run.catch(() => {});
@@ -649,7 +659,8 @@ export class OriginalsAsset {
     resourceId: string,
     newContent: string,
     contentType: string,
-    changes?: string
+    changes?: string,
+    opts?: { inscribeConfirm?: InscribeConfirm }
   ): Promise<AssetResource> {
     // RE-READ the current head inside the turn (a prior queued call may have
     // just committed a new version).
@@ -723,7 +734,7 @@ export class OriginalsAsset {
             previousVersionHash: currentResource.hash,
             toHash: newHash,
             toVersion: newVersion
-          });
+          }, opts);
         } finally {
           this.#pendingHeadMedia = undefined;
         }

--- a/packages/sdk/src/lifecycle/OriginalsAsset.ts
+++ b/packages/sdk/src/lifecycle/OriginalsAsset.ts
@@ -80,6 +80,17 @@ export class OriginalsAsset {
   // to run its critical section — re-read head, base-check, append — to
   // completion before the next begins.
   #appendChain: Promise<unknown> = Promise.resolve();
+  // #407 phase 3: the new version's inline bytes, exposed transiently WHILE the
+  // bound appender runs (addResourceVersion appends+inscribes BEFORE pushing the
+  // new resource, so the per-event inscription can carry the new media as
+  // content). Set before the appender, cleared in a finally — so a failed append
+  // never leaves resources/pending advanced past the log.
+  #pendingHeadMedia?: { resourceId: string; hash: string; content: string; contentType: string };
+
+  /** #407 phase 3: the pending new-version media, if an append is in flight. */
+  get pendingHeadMedia(): { resourceId: string; hash: string; content: string; contentType: string } | undefined {
+    return this.#pendingHeadMedia;
+  }
 
   constructor(
     resources: AssetResource[],
@@ -700,13 +711,22 @@ export class OriginalsAsset {
         // `toHash`, never the bytes. Content lives in the resources array /
         // serialize() envelope blobs (content-addressed store), keyed by hash.
         // This keeps the log byte-light so it can be inscribed cheaply (phase 2).
-        const digest = await this.#celAppender('update', {
-          resourceId,
-          contentType,
-          previousVersionHash: currentResource.hash,
-          toHash: newHash,
-          toVersion: newVersion
-        });
+        // Expose the new bytes transiently so a btco per-event inscription (phase
+        // 3) can carry them as content — resources itself advances only AFTER a
+        // successful append, so pending is the only pre-push view of the new media.
+        this.#pendingHeadMedia = { resourceId, hash: newHash, content: newContent, contentType };
+        let digest: string | null;
+        try {
+          digest = await this.#celAppender('update', {
+            resourceId,
+            contentType,
+            previousVersionHash: currentResource.hash,
+            toHash: newHash,
+            toVersion: newVersion
+          });
+        } finally {
+          this.#pendingHeadMedia = undefined;
+        }
         appended = digest !== null; // null ⇒ the manager already emitted cel:append-skipped
       }
     } else {

--- a/packages/sdk/src/types/common.ts
+++ b/packages/sdk/src/types/common.ts
@@ -9,6 +9,47 @@ import type { OperationLock } from '../utils/OperationLock.js';
 // Base types for the Originals protocol
 export type LayerType = 'did:cel' | 'did:webvh' | 'did:btco';
 
+/**
+ * Which kind of did:btco authorship append a cost preview is for (#407 phase 4):
+ * `'update'` sizes the new media (a resource-version inscription); `'rotate'`
+ * sizes the event-only reinscription (the rotated DID document).
+ */
+export type AppendKind = 'update' | 'rotate';
+
+/**
+ * Non-mutating cost quote for the NEXT did:btco authorship append (#407 phase 4).
+ * Same fee-rate source/cap as the real inscribe path, so it tracks reality; a
+ * ballpark for cost-awareness/consent, not a billing figure.
+ */
+export interface AppendCostEstimate {
+  /** Estimated total inscription cost (sats) = feeRate × vbytes. */
+  satoshis: number;
+  /** The fee rate used (sat/vB), from the same resolver the real inscribe path
+   * uses (feeOracle→provider, absurd >MAX_REASONABLE_FEE_RATE sources skipped; an
+   * explicit override passes through). */
+  feeRate: number;
+  /** Estimated commit+reveal virtual size (vB). */
+  vbytes: number;
+  /** Size of the media/content being inscribed (bytes). */
+  contentBytes: number;
+}
+
+/**
+ * Confirm-gate policy for a paid did:btco authorship append (#407 phase 4).
+ * `'now'` (default) inscribes immediately (phase-3 behavior). A callback is
+ * awaited with the {@link AppendCostEstimate} BEFORE any log mutation: `true`
+ * proceeds and inscribes; `false` cleanly ABORTS the whole append (no event
+ * appended, nothing inscribed — a byte-identical no-op that throws
+ * `PROVENANCE_APPEND_DECLINED` and emits `cel:inscribe-declined`).
+ *
+ * The callback runs INSIDE the asset's append turn; it must not call another
+ * mutating op on the SAME asset (e.g. `addResourceVersion`/`rotateBtcoKeys`),
+ * which would queue behind its own turn and deadlock. Inspect and decide only.
+ */
+export type InscribeConfirm =
+  | 'now'
+  | ((estimate: AppendCostEstimate) => boolean | Promise<boolean>);
+
 export interface OriginalsConfig {
   network: 'mainnet' | 'regtest' | 'signet';
   bitcoinRpcUrl?: string;
@@ -23,6 +64,12 @@ export interface OriginalsConfig {
   didCache?: DIDCacheConfig;
   feeOracle?: FeeOracleAdapter;
   ordinalsProvider?: OrdinalsProvider;
+  // Default confirm-gate policy for paid did:btco authorship appends (#407 phase
+  // 4). Omitted/'now' = inscribe immediately (phase-3 behavior); a callback is
+  // consulted before each gated paid btco append (addResourceVersion,
+  // rotateBtcoKeys) and can cleanly abort it. Overridable per call (their
+  // opts.inscribeConfirm).
+  inscribeConfirm?: InscribeConfirm;
   // Shared keyed lock coordinating money-spending inscriptions across managers
   // (issue #303). OriginalsSDK injects one instance so all managers share it.
   operationLock?: OperationLock;

--- a/packages/sdk/src/utils/EventLogger.ts
+++ b/packages/sdk/src/utils/EventLogger.ts
@@ -43,6 +43,7 @@ export interface EventLoggingConfig {
   'cel:append-skipped'?: LogLevel | false;
   'cel:append-inscribe-skipped'?: LogLevel | false;
   'cel:inscribe-cost'?: LogLevel | false;
+  'cel:inscribe-declined'?: LogLevel | false;
   'resource:inscribed'?: LogLevel | false;
   'cel:host-failed'?: LogLevel | false;
   'key:rotated'?: LogLevel | false;
@@ -78,6 +79,7 @@ const DEFAULT_EVENT_CONFIG: EventLoggingConfig = {
   'cel:append-skipped': 'warn',
   'cel:append-inscribe-skipped': 'warn',
   'cel:inscribe-cost': 'info',
+  'cel:inscribe-declined': 'warn',
   'resource:inscribed': 'info',
   'cel:host-failed': 'warn',
   'key:rotated': 'info'
@@ -132,6 +134,7 @@ export class EventLogger {
       'cel:append-skipped',
       'cel:append-inscribe-skipped',
       'cel:inscribe-cost',
+      'cel:inscribe-declined',
       'resource:inscribed',
       'cel:host-failed',
       'key:rotated'
@@ -255,6 +258,15 @@ export class EventLogger {
         data = {
           assetId: event.asset.id,
           reason: event.reason
+        };
+        break;
+
+      case 'cel:inscribe-declined':
+        message = 'Paid btco append declined at confirm gate';
+        data = {
+          assetId: event.asset.id,
+          appendKind: event.appendKind,
+          estimate: event.estimate
         };
         break;
 

--- a/packages/sdk/src/utils/EventLogger.ts
+++ b/packages/sdk/src/utils/EventLogger.ts
@@ -41,6 +41,9 @@ export interface EventLoggingConfig {
   'key:unpersisted'?: LogLevel | false;
   'did:log-unhosted'?: LogLevel | false;
   'cel:append-skipped'?: LogLevel | false;
+  'cel:append-inscribe-skipped'?: LogLevel | false;
+  'cel:inscribe-cost'?: LogLevel | false;
+  'resource:inscribed'?: LogLevel | false;
   'cel:host-failed'?: LogLevel | false;
   'key:rotated'?: LogLevel | false;
 }
@@ -73,6 +76,9 @@ const DEFAULT_EVENT_CONFIG: EventLoggingConfig = {
   'key:unpersisted': 'warn',
   'did:log-unhosted': 'warn',
   'cel:append-skipped': 'warn',
+  'cel:append-inscribe-skipped': 'warn',
+  'cel:inscribe-cost': 'info',
+  'resource:inscribed': 'info',
   'cel:host-failed': 'warn',
   'key:rotated': 'info'
 };
@@ -124,6 +130,9 @@ export class EventLogger {
       'key:unpersisted',
       'did:log-unhosted',
       'cel:append-skipped',
+      'cel:append-inscribe-skipped',
+      'cel:inscribe-cost',
+      'resource:inscribed',
       'cel:host-failed',
       'key:rotated'
     ];

--- a/packages/sdk/tests/integration/FeePreviewConfirm.e2e.test.ts
+++ b/packages/sdk/tests/integration/FeePreviewConfirm.e2e.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Fee preview + confirm for did:btco appends (#407 phase 4). estimateAppendCost
+ * previews the unavoidable inscription cost without committing; an inscribeConfirm
+ * gate lets a caller approve or CLEANLY ABORT a paid append after seeing the
+ * estimate. A declined append is a byte-identical no-op — no event, nothing
+ * inscribed, a follow-up append still works.
+ */
+import { describe, test, expect } from 'bun:test';
+import { OriginalsSDK } from '../../src';
+import { OrdMockProvider } from '../../src/adapters/providers/OrdMockProvider';
+import { MemoryStorageAdapter } from '../../src/storage/MemoryStorageAdapter';
+import { MockKeyStore } from '../mocks/MockKeyStore';
+import { KeyManager } from '../../src/did/KeyManager';
+import { hashResource } from '../../src/utils/validation';
+import type { AppendCostEstimate } from '../../src/types';
+
+const contentHash = (s: string) => hashResource(Buffer.from(s, 'utf8'));
+
+function makeSDK(extra: Record<string, unknown> = {}) {
+  const ordinalsProvider = new OrdMockProvider();
+  const sdk = OriginalsSDK.create({
+    network: 'regtest',
+    defaultKeyType: 'Ed25519',
+    ordinalsProvider,
+    storageAdapter: new MemoryStorageAdapter(),
+    keyStore: new MockKeyStore(),
+    ...extra
+  });
+  return { sdk, ordinalsProvider };
+}
+
+const inssOnSat = (p: OrdMockProvider, sat: string) =>
+  (p as any)['state'].inscriptionsBySatoshi.get(sat) as string[] | undefined;
+
+async function btcoAsset(sdk: OriginalsSDK, seed = 'v1') {
+  const asset = await sdk.lifecycle.createAsset([
+    { id: 'art', type: 'image', contentType: 'image/png', hash: contentHash(seed), content: seed }
+  ]);
+  await sdk.lifecycle.inscribeOnBitcoin(asset, 5);
+  const sat = asset.bindings!['did:btco'].split(':').pop()!;
+  return { asset, sat };
+}
+
+describe('fee preview + confirm (#407 phase 4)', () => {
+  test('estimateAppendCost previews a plausible quote and mutates NOTHING', async () => {
+    const { sdk, ordinalsProvider } = makeSDK();
+    const { asset, sat } = await btcoAsset(sdk);
+
+    const eventsBefore = asset.celLog!.events.length;
+    const resourcesBefore = asset.resources.length;
+    const inssBefore = inssOnSat(ordinalsProvider, sat)!.length;
+    const logHeadBefore = JSON.stringify(asset.celLog!.events);
+
+    const estimate = await sdk.lifecycle.estimateAppendCost(asset, 'update', { content: 'v2-media' });
+    expect(estimate.satoshis).toBeGreaterThan(0);
+    expect(estimate.feeRate).toBeGreaterThan(0);
+    expect(estimate.vbytes).toBeGreaterThan(0);
+    expect(estimate.contentBytes).toBe(Buffer.from('v2-media', 'utf8').byteLength);
+    // satoshis = feeRate × vbytes, vbytes = ceil(contentBytes/4)+200.
+    expect(estimate.vbytes).toBe(Math.ceil(estimate.contentBytes / 4) + 200);
+    expect(estimate.satoshis).toBe(Math.ceil(estimate.feeRate * estimate.vbytes));
+
+    // Zero side effects: log, resources, and the chain are untouched.
+    expect(asset.celLog!.events.length).toBe(eventsBefore);
+    expect(asset.resources.length).toBe(resourcesBefore);
+    expect(inssOnSat(ordinalsProvider, sat)!.length).toBe(inssBefore);
+    expect(JSON.stringify(asset.celLog!.events)).toBe(logHeadBefore);
+  });
+
+  test('estimateAppendCost without an ordinalsProvider throws ORD_PROVIDER_REQUIRED', async () => {
+    // Build a btco asset WITH a provider, then quote via a provider-less SDK.
+    const { sdk } = makeSDK();
+    const { asset } = await btcoAsset(sdk);
+    const noProvider = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519' });
+    await expect(noProvider.lifecycle.estimateAppendCost(asset, 'update', { content: 'x' }))
+      .rejects.toMatchObject({ code: 'ORD_PROVIDER_REQUIRED' });
+  });
+
+  test('the preview quote ≈ the actual cost the real append incurs (same fee source)', async () => {
+    const { sdk } = makeSDK();
+    const { asset } = await btcoAsset(sdk);
+
+    const preview = await sdk.lifecycle.estimateAppendCost(asset, 'update', { content: 'v2' });
+    let cost: { feeRate?: number; estVsize: number; estSats?: number } | undefined;
+    sdk.lifecycle.on('cel:inscribe-cost', (e: any) => { cost = e; });
+
+    await asset.addResourceVersion('art', 'v2', 'image/png', 'to v2');
+    expect(cost).toBeDefined();
+    expect(cost!.feeRate).toBe(preview.feeRate);
+    expect(cost!.estVsize).toBe(preview.vbytes);
+    expect(cost!.estSats).toBe(preview.satoshis);
+  });
+
+  test('inscribeConfirm callback → true proceeds and inscribes (phase-3 path)', async () => {
+    const { sdk, ordinalsProvider } = makeSDK();
+    const { asset, sat } = await btcoAsset(sdk);
+    const before = inssOnSat(ordinalsProvider, sat)!.length;
+
+    let seen: AppendCostEstimate | undefined;
+    await asset.addResourceVersion('art', 'v2', 'image/png', 'to v2', {
+      inscribeConfirm: (est) => { seen = est; return true; }
+    });
+
+    expect(seen).toBeDefined();
+    expect(seen!.contentBytes).toBe(Buffer.from('v2', 'utf8').byteLength);
+    expect(inssOnSat(ordinalsProvider, sat)!.length).toBe(before + 1);
+    expect(asset.resources.find(r => r.hash === contentHash('v2'))?.content).toBe('v2');
+  });
+
+  test('inscribeConfirm → false ABORTS cleanly: no event, nothing inscribed, byte-identical; a follow-up still works', async () => {
+    const { sdk, ordinalsProvider } = makeSDK();
+    const { asset, sat } = await btcoAsset(sdk);
+
+    const eventsBefore = asset.celLog!.events.length;
+    const resourcesBefore = asset.resources.length;
+    const inssBefore = inssOnSat(ordinalsProvider, sat)!.length;
+    const logBefore = JSON.stringify(asset.celLog!.events);
+
+    let declined: any;
+    sdk.lifecycle.on('cel:inscribe-declined', (e: any) => { declined = e; });
+
+    await expect(
+      asset.addResourceVersion('art', 'v2', 'image/png', 'to v2', { inscribeConfirm: () => false })
+    ).rejects.toMatchObject({ code: 'PROVENANCE_APPEND_DECLINED' });
+
+    // Byte-identical: no event appended, nothing inscribed, no new resource version.
+    expect(asset.celLog!.events.length).toBe(eventsBefore);
+    expect(asset.resources.length).toBe(resourcesBefore);
+    expect(inssOnSat(ordinalsProvider, sat)!.length).toBe(inssBefore);
+    expect(JSON.stringify(asset.celLog!.events)).toBe(logBefore);
+    expect(asset.resources.find(r => r.hash === contentHash('v2'))).toBeUndefined();
+    // The declined event carries the estimate the caller rejected.
+    expect(declined).toBeDefined();
+    expect(declined.appendKind).toBe('update');
+    expect(declined.estimate.satoshis).toBeGreaterThan(0);
+
+    // No poisoned state: a subsequent append proceeds and inscribes normally.
+    await asset.addResourceVersion('art', 'v2b', 'image/png', 'to v2b');
+    expect(inssOnSat(ordinalsProvider, sat)!.length).toBe(inssBefore + 1);
+    expect(asset.resources.find(r => r.hash === contentHash('v2b'))?.content).toBe('v2b');
+  });
+
+  test('config-level inscribeConfirm default gates all btco appends unless overridden', async () => {
+    let calls = 0;
+    const { sdk, ordinalsProvider } = makeSDK({ inscribeConfirm: () => { calls++; return false; } });
+    const { asset, sat } = await btcoAsset(sdk);
+    const before = inssOnSat(ordinalsProvider, sat)!.length;
+
+    // Config default declines.
+    await expect(asset.addResourceVersion('art', 'v2', 'image/png', 'to v2'))
+      .rejects.toMatchObject({ code: 'PROVENANCE_APPEND_DECLINED' });
+    expect(calls).toBe(1);
+    expect(inssOnSat(ordinalsProvider, sat)!.length).toBe(before);
+
+    // Per-call override wins over the config default.
+    await asset.addResourceVersion('art', 'v2', 'image/png', 'to v2', { inscribeConfirm: 'now' });
+    expect(calls).toBe(1); // config callback not consulted for the overridden call
+    expect(inssOnSat(ordinalsProvider, sat)!.length).toBe(before + 1);
+  });
+
+  test("default (no inscribeConfirm) preserves phase-3 behavior — append inscribes, no prompt", async () => {
+    const { sdk, ordinalsProvider } = makeSDK();
+    const { asset, sat } = await btcoAsset(sdk);
+    const before = inssOnSat(ordinalsProvider, sat)!.length;
+    await asset.addResourceVersion('art', 'v2', 'image/png', 'to v2');
+    expect(inssOnSat(ordinalsProvider, sat)!.length).toBe(before + 1);
+  });
+
+  test("rotate estimate sizes the PAID content (head media), matching reinscribeRotatedDoc — not the DID doc", async () => {
+    const { sdk } = makeSDK();
+    // Media large enough that DID-doc size and media size are unambiguously different.
+    const media = 'M'.repeat(4096);
+    const { asset } = await btcoAsset(sdk, media);
+
+    const est = await sdk.lifecycle.estimateAppendCost(asset, 'rotate');
+    // reinscribeRotatedDoc inscribes headMedia.content as CONTENT (doc rides in
+    // metadata), so the paid content size IS the head media — not the DID doc.
+    expect(est.contentBytes).toBe(Buffer.from(media, 'utf8').byteLength);
+  });
+
+  test('rotateBtcoKeys is gated: decline aborts cleanly; a subsequent rotation with true inscribes', async () => {
+    const { sdk, ordinalsProvider } = makeSDK();
+    const { asset, sat } = await btcoAsset(sdk);
+    const eventsBefore = asset.celLog!.events.length;
+    const inssBefore = inssOnSat(ordinalsProvider, sat)!.length;
+
+    let declined: any;
+    sdk.lifecycle.on('cel:inscribe-declined', (e: any) => { declined = e; });
+
+    const k1 = await new KeyManager().generateKeyPair('Ed25519');
+    await expect(
+      sdk.lifecycle.rotateBtcoKeys(
+        asset,
+        { publicKeyMultibase: k1.publicKey, privateKey: k1.privateKey },
+        5,
+        { inscribeConfirm: () => false }
+      )
+    ).rejects.toMatchObject({ code: 'PROVENANCE_APPEND_DECLINED' });
+
+    // Byte-identical: no rotateKey event appended, no reinscription.
+    expect(asset.celLog!.events.length).toBe(eventsBefore);
+    expect(inssOnSat(ordinalsProvider, sat)!.length).toBe(inssBefore);
+    expect(declined?.appendKind).toBe('rotate');
+
+    // A subsequent rotation proceeds (concurrency claim was released on abort).
+    const k2 = await new KeyManager().generateKeyPair('Ed25519');
+    const res = await sdk.lifecycle.rotateBtcoKeys(
+      asset,
+      { publicKeyMultibase: k2.publicKey, privateKey: k2.privateKey },
+      5,
+      { inscribeConfirm: () => true }
+    );
+    expect(res.inscriptionId).toBeDefined();
+    expect(inssOnSat(ordinalsProvider, sat)!.length).toBe(inssBefore + 1);
+  });
+
+  test('off-btco append IGNORES the gate (no inscription, callback never consulted)', async () => {
+    const { sdk } = makeSDK();
+    // Stay on did:webvh — not the final layer, no inscription, so no cost to consent to.
+    const asset = await sdk.lifecycle.createAsset([
+      { id: 'art', type: 'image', contentType: 'image/png', hash: contentHash('v1'), content: 'v1' }
+    ]);
+    await sdk.lifecycle.publishToWeb(asset, 'example.com');
+
+    let consulted = false;
+    const res = await asset.addResourceVersion('art', 'v2', 'image/png', 'to v2', {
+      inscribeConfirm: () => { consulted = true; return false; }
+    });
+    expect(consulted).toBe(false);
+    expect(res.content).toBe('v2');
+    expect(asset.resources.find(r => r.hash === contentHash('v2'))?.content).toBe('v2');
+  });
+});

--- a/packages/sdk/tests/integration/PerEventRealtime.e2e.test.ts
+++ b/packages/sdk/tests/integration/PerEventRealtime.e2e.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Per-event real-time chain-recoverability (#407 phase 3). Once an asset is on
+ * did:btco, every authorship append (addResourceVersion, rotateKey) inscribes on
+ * the anchoring sat as it happens, so the sat's inscription chain IS the
+ * always-current log. A resolver with ONLY the sat + a provider walks the chain
+ * and rebuilds the FULL current log + current media, verified — no envelope, no
+ * host.
+ */
+import { describe, test, expect } from 'bun:test';
+import { OriginalsSDK } from '../../src';
+import { OrdMockProvider } from '../../src/adapters/providers/OrdMockProvider';
+import { MemoryStorageAdapter } from '../../src/storage/MemoryStorageAdapter';
+import { MockKeyStore } from '../mocks/MockKeyStore';
+import { KeyManager } from '../../src/did/KeyManager';
+import { hashResource } from '../../src/utils/validation';
+
+const contentHash = (s: string) => hashResource(Buffer.from(s, 'utf8'));
+
+function makeSDK(keyStore = new MockKeyStore()) {
+  const ordinalsProvider = new OrdMockProvider();
+  const sdk = OriginalsSDK.create({
+    network: 'regtest',
+    defaultKeyType: 'Ed25519',
+    ordinalsProvider,
+    storageAdapter: new MemoryStorageAdapter(),
+    keyStore
+  });
+  return { sdk, ordinalsProvider, keyStore };
+}
+
+const inssOnSat = (p: OrdMockProvider, sat: string) =>
+  (p as any)['state'].inscriptionsBySatoshi.get(sat) as string[] | undefined;
+const recOf = (p: OrdMockProvider, id: string) =>
+  (p as any)['state'].inscriptionsById.get(id);
+
+describe('per-event real-time chain recovery (#407 phase 3)', () => {
+  test('real-time round-trip: create → publish → inscribe → addResourceVersion (inscribes) → rotateKey (inscribes) rebuilds the FULL current log from the sat alone', async () => {
+    const { sdk, ordinalsProvider } = makeSDK();
+    const asset = await sdk.lifecycle.createAsset([
+      { id: 'art', type: 'image', contentType: 'image/png', hash: contentHash('v1'), content: 'v1' }
+    ]);
+    await sdk.lifecycle.publishToWeb(asset, 'example.com');
+    await sdk.lifecycle.inscribeOnBitcoin(asset, 5);
+    const sat = asset.bindings!['did:btco'].split(':').pop()!;
+    const afterMigrate = inssOnSat(ordinalsProvider, sat)!.length;
+
+    // Each btco authorship append inscribes as it happens.
+    await asset.addResourceVersion('art', 'v2', 'image/png', 'to v2');
+    expect(inssOnSat(ordinalsProvider, sat)!.length).toBe(afterMigrate + 1);
+    await asset.addResourceVersion('art', 'v3', 'image/png', 'to v3');
+    expect(inssOnSat(ordinalsProvider, sat)!.length).toBe(afterMigrate + 2);
+
+    // A cooperative rotation also inscribes.
+    const newKey = await new KeyManager().generateKeyPair('Ed25519');
+    await sdk.lifecycle.rotateBtcoKeys(asset, { publicKeyMultibase: newKey.publicKey, privateKey: newKey.privateKey }, 5);
+    expect(inssOnSat(ordinalsProvider, sat)!.length).toBe(afterMigrate + 3);
+
+    // Fresh resolver: only the sat + provider.
+    const fresh = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', ordinalsProvider });
+    const { asset: recovered, verification } = await fresh.lifecycle.resolveAssetFromSat(sat);
+
+    expect(verification?.verified).toBe(true);
+    expect(recovered.id).toBe(asset.id);
+    expect(recovered.currentLayer).toBe('did:btco');
+    // The reconstructed log is a PREFIX of the live hosted log — it may omit only
+    // a trailing witness-ack update that was appended AFTER (not inscribed by) the
+    // last inscription. Every authorship event is present, in order.
+    const recTypes = recovered.celLog!.events.map(e => e.type);
+    const hostTypes = asset.celLog!.events.map(e => e.type);
+    expect(hostTypes.slice(0, recTypes.length)).toEqual(recTypes);
+    expect(recTypes).toEqual(expect.arrayContaining(['migrate', 'rotateKey']));
+    expect(recTypes.filter(t => t === 'update').length).toBeGreaterThanOrEqual(2);
+    // Current media is v3 (the most-recent resource update).
+    expect(recovered.resources.find(r => r.hash === contentHash('v3'))?.content).toBe('v3');
+  });
+
+  test('immediacy: an addResourceVersion is recoverable IMMEDIATELY, before any later append', async () => {
+    const { sdk, ordinalsProvider } = makeSDK();
+    const asset = await sdk.lifecycle.createAsset([
+      { id: 'art', type: 'image', contentType: 'image/png', hash: contentHash('a'), content: 'a' }
+    ]);
+    await sdk.lifecycle.inscribeOnBitcoin(asset, 5);
+    const sat = asset.bindings!['did:btco'].split(':').pop()!;
+
+    await asset.addResourceVersion('art', 'b', 'image/png', 'to b');
+    // Resolve right now — no rotation, no further appends.
+    const { asset: recovered, verification } = await sdk.lifecycle.resolveAssetFromSat(sat);
+    expect(verification?.verified).toBe(true);
+    expect(recovered.resources.find(r => r.hash === contentHash('b'))?.content).toBe('b');
+  });
+
+  test('ordering: several appends reconstruct events in the correct order across the chain', async () => {
+    const { sdk, ordinalsProvider } = makeSDK();
+    const asset = await sdk.lifecycle.createAsset([
+      { id: 'art', type: 'image', contentType: 'image/png', hash: contentHash('0'), content: '0' }
+    ]);
+    await sdk.lifecycle.inscribeOnBitcoin(asset, 5);
+    const sat = asset.bindings!['did:btco'].split(':').pop()!;
+    for (const v of ['1', '2', '3', '4']) {
+      await asset.addResourceVersion('art', v, 'image/png', `to ${v}`);
+    }
+    const { asset: recovered, verification } = await sdk.lifecycle.resolveAssetFromSat(sat);
+    expect(verification?.verified).toBe(true);
+    // The resource-update toHashes appear in ascending version order.
+    const updates = recovered.celLog!.events.filter(e => e.type === 'update' && (e.data as any).toHash);
+    expect(updates.map(e => (e.data as any).toHash)).toEqual(
+      ['1', '2', '3', '4'].map(contentHash)
+    );
+    expect(recovered.resources.find(r => r.hash === contentHash('4'))?.content).toBe('4');
+  });
+
+  test('gap: a removed middle inscription breaks continuity → resolution fails closed', async () => {
+    const { sdk, ordinalsProvider } = makeSDK();
+    const asset = await sdk.lifecycle.createAsset([
+      { id: 'art', type: 'image', contentType: 'image/png', hash: contentHash('g0'), content: 'g0' }
+    ]);
+    await sdk.lifecycle.inscribeOnBitcoin(asset, 5);
+    const sat = asset.bindings!['did:btco'].split(':').pop()!;
+    await asset.addResourceVersion('art', 'g1', 'image/png', 'to g1');
+    await asset.addResourceVersion('art', 'g2', 'image/png', 'to g2');
+
+    // Drop the FIRST resource-update inscription (index afterMigrate) — the
+    // second update's delta now chains from a missing event → broken chain.
+    const list = inssOnSat(ordinalsProvider, sat)!;
+    const removed = list.splice(list.length - 2, 1)[0];
+    (ordinalsProvider as any)['state'].inscriptionsById.delete(removed);
+
+    await expect(sdk.lifecycle.resolveAssetFromSat(sat)).rejects.toThrow();
+  });
+
+  test('tamper: a mutated delta event in metadata → resolution fails closed', async () => {
+    const { sdk, ordinalsProvider } = makeSDK();
+    const asset = await sdk.lifecycle.createAsset([
+      { id: 'art', type: 'image', contentType: 'image/png', hash: contentHash('t0'), content: 't0' }
+    ]);
+    await sdk.lifecycle.inscribeOnBitcoin(asset, 5);
+    const sat = asset.bindings!['did:btco'].split(':').pop()!;
+    await asset.addResourceVersion('art', 't1', 'image/png', 'to t1');
+
+    // Flip a signed field in the newest inscription's delta event(s).
+    const list = inssOnSat(ordinalsProvider, sat)!;
+    const rec = recOf(ordinalsProvider, list[list.length - 1]);
+    const evs = rec.metadata.events as any[];
+    evs[evs.length - 1].data.toHash = contentHash('FORGED');
+
+    await expect(sdk.lifecycle.resolveAssetFromSat(sat)).rejects.toThrow();
+  });
+
+  test('cost surfacing: a btco append emits cel:inscribe-cost', async () => {
+    const { sdk } = makeSDK();
+    const asset = await sdk.lifecycle.createAsset([
+      { id: 'art', type: 'image', contentType: 'image/png', hash: contentHash('c0'), content: 'c0' }
+    ]);
+    await sdk.lifecycle.inscribeOnBitcoin(asset, 5);
+
+    const costs: any[] = [];
+    sdk.lifecycle.on('cel:inscribe-cost', (e) => costs.push(e));
+    await asset.addResourceVersion('art', 'c1', 'image/png', 'to c1');
+    expect(costs.length).toBe(1);
+    expect(costs[0].estVsize).toBeGreaterThan(0);
+  });
+
+  test('degrade: a btco asset in a provider-less manager appends to the host and signals the skipped inscription', async () => {
+    const keyStore = new MockKeyStore();
+    const { sdk, ordinalsProvider } = makeSDK(keyStore);
+    const asset = await sdk.lifecycle.createAsset([
+      { id: 'art', type: 'image', contentType: 'image/png', hash: contentHash('d0'), content: 'd0' }
+    ]);
+    await sdk.lifecycle.inscribeOnBitcoin(asset, 5);
+    const sat = asset.bindings!['did:btco'].split(':').pop()!;
+
+    // Provider-LESS SDK sharing the same keyStore (so it can sign the append),
+    // recovering the asset via an explicitly-passed provider for verification.
+    const providerless = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore });
+    const { asset: recovered } = await providerless.lifecycle.resolveAssetFromSat(sat, { ordinalsProvider });
+
+    const skipped: any[] = [];
+    providerless.lifecycle.on('cel:append-inscribe-skipped', (e) => skipped.push(e));
+    const before = inssOnSat(ordinalsProvider, sat)!.length;
+    await recovered.addResourceVersion('art', 'd1', 'image/png', 'to d1');
+
+    // No new inscription (no provider), but a clear degrade signal fired.
+    expect(inssOnSat(ordinalsProvider, sat)!.length).toBe(before);
+    expect(skipped.map(e => e.reason)).toContain('NO_ORDINALS_PROVIDER');
+  });
+});

--- a/packages/sdk/tests/integration/PerEventRealtime.e2e.test.ts
+++ b/packages/sdk/tests/integration/PerEventRealtime.e2e.test.ts
@@ -160,6 +160,51 @@ describe('per-event real-time chain recovery (#407 phase 3)', () => {
     expect(costs[0].estVsize).toBeGreaterThan(0);
   });
 
+  test('rollback (fable I1): an inscribe failure restores the pre-append log and does not brick future updates', async () => {
+    const { sdk, ordinalsProvider } = makeSDK();
+    const asset = await sdk.lifecycle.createAsset([
+      { id: 'art', type: 'image', contentType: 'image/png', hash: contentHash('r0'), content: 'r0' }
+    ]);
+    await sdk.lifecycle.inscribeOnBitcoin(asset, 5);
+    const lenBefore = asset.celLog!.events.length;
+
+    // Force the paid inscription to fail AFTER the hosted append.
+    const realCreate = ordinalsProvider.createInscription.bind(ordinalsProvider);
+    (ordinalsProvider as any).createInscription = async () => { throw new Error('broadcast failed'); };
+    await expect(asset.addResourceVersion('art', 'r1', 'image/png', 'to r1')).rejects.toThrow();
+    // The signed update was rolled back — the log is NOT ahead of the chain.
+    expect(asset.celLog!.events.length).toBe(lenBefore);
+
+    // Recovery: with the provider healthy again, the next update appends+inscribes
+    // cleanly (no permanent UNPROVABLE_BASE brick), and resolves from the sat.
+    (ordinalsProvider as any).createInscription = realCreate;
+    await asset.addResourceVersion('art', 'r1', 'image/png', 'retry to r1');
+    expect(asset.celLog!.events.length).toBe(lenBefore + 1);
+    const sat = asset.bindings!['did:btco'].split(':').pop()!;
+    const { asset: recovered, verification } = await sdk.lifecycle.resolveAssetFromSat(sat);
+    expect(verification?.verified).toBe(true);
+    expect(recovered.resources.find(r => r.hash === contentHash('r1'))?.content).toBe('r1');
+  });
+
+  test('tail truncation (fable I2): a listed-but-unfetchable newest inscription fails closed, not a stale resolve', async () => {
+    const { sdk, ordinalsProvider } = makeSDK();
+    const asset = await sdk.lifecycle.createAsset([
+      { id: 'art', type: 'image', contentType: 'image/png', hash: contentHash('s0'), content: 's0' }
+    ]);
+    await sdk.lifecycle.inscribeOnBitcoin(asset, 5);
+    const sat = asset.bindings!['did:btco'].split(':').pop()!;
+    await asset.addResourceVersion('art', 's1', 'image/png', 'to s1');
+
+    // Simulate a transient fault: the provider still LISTS the newest inscription
+    // but returns null when fetched (as OrdHttp would on a 500). Dropping it would
+    // truncate the tail to a self-consistent STALE (s0) asset — must fail closed.
+    const newestId = inssOnSat(ordinalsProvider, sat)!.slice(-1)[0];
+    const realGet = ordinalsProvider.getInscriptionById.bind(ordinalsProvider);
+    (ordinalsProvider as any).getInscriptionById = async (id: string) =>
+      id === newestId ? null : realGet(id);
+    await expect(sdk.lifecycle.resolveAssetFromSat(sat)).rejects.toThrow(/CHAIN_ASSET_INVALID|could not be fetched/);
+  });
+
   test('degrade: a btco asset in a provider-less manager appends to the host and signals the skipped inscription', async () => {
     const keyStore = new MockKeyStore();
     const { sdk, ordinalsProvider } = makeSDK(keyStore);

--- a/packages/sdk/tests/security/ord-http-provider-ssrf.test.ts
+++ b/packages/sdk/tests/security/ord-http-provider-ssrf.test.ts
@@ -27,6 +27,16 @@ function jsonResponse(body: unknown) {
   };
 }
 
+function notFoundResponse() {
+  return {
+    ok: false,
+    status: 404,
+    headers: { get: () => null },
+    async arrayBuffer() { return new ArrayBuffer(0); },
+    async text() { return ''; }
+  };
+}
+
 function bytesResponse(bytes: Uint8Array, contentLength?: number) {
   return {
     ok: true,
@@ -61,6 +71,7 @@ describe('OrdHttpProvider SSRF / size hardening (#265)', () => {
 
   test('accepts a same-origin content_url', async () => {
     installFetch(async (url) => {
+      if (url.includes('/r/metadata/')) return notFoundResponse(); // no CBOR metadata
       if (url.includes('/inscription/')) {
         return jsonResponse({ content_url: `${BASE}/content/abc`, content_type: 'text/plain', sat: '123' });
       }
@@ -76,6 +87,7 @@ describe('OrdHttpProvider SSRF / size hardening (#265)', () => {
     const inits: any[] = [];
     installFetch(async (url, init) => {
       inits.push({ url, init });
+      if (url.includes('/r/metadata/')) return notFoundResponse();
       if (url.includes('/inscription/')) {
         return jsonResponse({ content_url: `${BASE}/content/abc`, content_type: 'text/plain', sat: '123' });
       }

--- a/packages/sdk/tests/security/ord-http-provider-ssrf.test.ts
+++ b/packages/sdk/tests/security/ord-http-provider-ssrf.test.ts
@@ -9,6 +9,9 @@ import { OrdHttpProvider } from '../../src/adapters/providers/OrdHttpProvider';
  */
 
 const BASE = 'https://ord.example.com/api';
+// Well-formed inscription id (`<64-hex>i<vout>`) — OrdHttpProvider now rejects
+// malformed ids before any fetch, so these SSRF/size tests use a valid shape.
+const ID = 'a'.repeat(64) + 'i0';
 const realFetch = (globalThis as any).fetch;
 
 function installFetch(handler: (url: string, init?: any) => Promise<any>) {
@@ -63,7 +66,7 @@ describe('OrdHttpProvider SSRF / size hardening (#265)', () => {
     });
 
     const provider = new OrdHttpProvider({ baseUrl: BASE });
-    await expect(provider.getInscriptionById('abc')).rejects.toThrow(/SSRF|different|origin/i);
+    await expect(provider.getInscriptionById(ID)).rejects.toThrow(/SSRF|different|origin/i);
 
     // The internal address must never have been requested.
     expect(fetched.some((u) => u.includes('169.254.169.254'))).toBe(false);
@@ -78,7 +81,7 @@ describe('OrdHttpProvider SSRF / size hardening (#265)', () => {
       return bytesResponse(new Uint8Array([104, 105])); // "hi"
     });
     const provider = new OrdHttpProvider({ baseUrl: BASE });
-    const res = await provider.getInscriptionById('abc');
+    const res = await provider.getInscriptionById(ID);
     expect(res).not.toBeNull();
     expect(res!.contentType).toBe('text/plain');
   });
@@ -94,7 +97,7 @@ describe('OrdHttpProvider SSRF / size hardening (#265)', () => {
       return bytesResponse(new Uint8Array([1]));
     });
     const provider = new OrdHttpProvider({ baseUrl: BASE });
-    await provider.getInscriptionById('abc');
+    await provider.getInscriptionById(ID);
     // Every fetch this provider makes must opt out of redirect-following so a
     // same-origin URL cannot 30x-redirect us to an internal host.
     expect(inits.length).toBeGreaterThan(0);
@@ -112,7 +115,7 @@ describe('OrdHttpProvider SSRF / size hardening (#265)', () => {
       return bytesResponse(new Uint8Array([104, 105])); // "hi"
     });
     const provider = new OrdHttpProvider({ baseUrl: BASE });
-    await expect(provider.getInscriptionById('abc')).rejects.toThrow(/ORD_METADATA_UNAVAILABLE|HTTP 503/);
+    await expect(provider.getInscriptionById(ID)).rejects.toThrow(/ORD_METADATA_UNAVAILABLE|HTTP 503/);
   });
 
   test('a 404 on /r/metadata degrades to no metadata (not an error)', async () => {
@@ -124,7 +127,7 @@ describe('OrdHttpProvider SSRF / size hardening (#265)', () => {
       return bytesResponse(new Uint8Array([104, 105]));
     });
     const provider = new OrdHttpProvider({ baseUrl: BASE });
-    const res = await provider.getInscriptionById('abc');
+    const res = await provider.getInscriptionById(ID);
     expect(res).not.toBeNull();
     expect((res as any).metadata).toBeUndefined();
   });
@@ -138,7 +141,27 @@ describe('OrdHttpProvider SSRF / size hardening (#265)', () => {
       return bytesResponse(new Uint8Array([0]), 50 * 1024 * 1024);
     });
     const provider = new OrdHttpProvider({ baseUrl: BASE, maxContentBytes: 1024 });
-    await expect(provider.getInscriptionById('abc')).rejects.toThrow(/exceeds .* bytes/);
+    await expect(provider.getInscriptionById(ID)).rejects.toThrow(/exceeds .* bytes/);
+  });
+
+  test('rejects a malformed inscription id before any fetch (path-traversal guard — Greptile)', async () => {
+    const fetched: string[] = [];
+    installFetch(async (url) => { fetched.push(url); return jsonResponse({}); });
+    const provider = new OrdHttpProvider({ baseUrl: BASE });
+    // A compromised indexer id like `../../admin` must never reach a URL path.
+    expect(await provider.getInscriptionById('../../admin')).toBeNull();
+    expect(await provider.getInscriptionById('not-an-id')).toBeNull();
+    expect(fetched.length).toBe(0);
+  });
+
+  test('getInscriptionsBySatoshi drops malformed ids from the indexer', async () => {
+    installFetch(async (url) => {
+      if (url.includes('/sat/')) return jsonResponse({ inscription_ids: [ID, '../../admin', 'garbage'] });
+      return jsonResponse({});
+    });
+    const provider = new OrdHttpProvider({ baseUrl: BASE });
+    const list = await provider.getInscriptionsBySatoshi('123');
+    expect(list).toEqual([{ inscriptionId: ID }]);
   });
 
   test('rejects an oversized content body (actual bytes exceed cap with no header)', async () => {
@@ -155,6 +178,6 @@ describe('OrdHttpProvider SSRF / size hardening (#265)', () => {
       };
     });
     const provider = new OrdHttpProvider({ baseUrl: BASE, maxContentBytes: 1024 });
-    await expect(provider.getInscriptionById('abc')).rejects.toThrow(/exceeds .* bytes/);
+    await expect(provider.getInscriptionById(ID)).rejects.toThrow(/exceeds .* bytes/);
   });
 });

--- a/packages/sdk/tests/security/ord-http-provider-ssrf.test.ts
+++ b/packages/sdk/tests/security/ord-http-provider-ssrf.test.ts
@@ -101,6 +101,34 @@ describe('OrdHttpProvider SSRF / size hardening (#265)', () => {
     expect(inits.every((c) => c.init?.redirect === 'error')).toBe(true);
   });
 
+  test('a 5xx on /r/metadata fails closed (does not silently drop provenance — Greptile/I2)', async () => {
+    installFetch(async (url) => {
+      if (url.includes('/r/metadata/')) {
+        return { ok: false, status: 503, headers: { get: () => null }, async arrayBuffer() { return new ArrayBuffer(0); } };
+      }
+      if (url.includes('/inscription/')) {
+        return jsonResponse({ content_url: `${BASE}/content/abc`, content_type: 'text/plain', sat: '123' });
+      }
+      return bytesResponse(new Uint8Array([104, 105])); // "hi"
+    });
+    const provider = new OrdHttpProvider({ baseUrl: BASE });
+    await expect(provider.getInscriptionById('abc')).rejects.toThrow(/ORD_METADATA_UNAVAILABLE|HTTP 503/);
+  });
+
+  test('a 404 on /r/metadata degrades to no metadata (not an error)', async () => {
+    installFetch(async (url) => {
+      if (url.includes('/r/metadata/')) return notFoundResponse();
+      if (url.includes('/inscription/')) {
+        return jsonResponse({ content_url: `${BASE}/content/abc`, content_type: 'text/plain', sat: '123' });
+      }
+      return bytesResponse(new Uint8Array([104, 105]));
+    });
+    const provider = new OrdHttpProvider({ baseUrl: BASE });
+    const res = await provider.getInscriptionById('abc');
+    expect(res).not.toBeNull();
+    expect((res as any).metadata).toBeUndefined();
+  });
+
   test('rejects an oversized content body (declared Content-Length)', async () => {
     installFetch(async (url) => {
       if (url.includes('/inscription/')) {

--- a/packages/sdk/tests/unit/adapters/OrdHttpProvider.not-implemented.test.ts
+++ b/packages/sdk/tests/unit/adapters/OrdHttpProvider.not-implemented.test.ts
@@ -91,12 +91,13 @@ describe('OrdHttpProvider write-path methods fail loudly instead of fabricating 
   });
 
   test('read path getInscriptionsBySatoshi still works (not part of the stub hardening)', async () => {
+    const id = 'a'.repeat(64) + 'i1'; // well-formed inscription id (provider filters malformed ids)
     (globalThis as Record<string, unknown>).fetch = async () => ({
       ok: true,
-      arrayBuffer: async () => new TextEncoder().encode(JSON.stringify({ inscription_ids: ['i1'] })).buffer
+      arrayBuffer: async () => new TextEncoder().encode(JSON.stringify({ inscription_ids: [id] })).buffer
     });
     const result = await provider.getInscriptionsBySatoshi('123');
-    expect(result).toEqual([{ inscriptionId: 'i1' }]);
+    expect(result).toEqual([{ inscriptionId: id }]);
   });
 });
 

--- a/packages/sdk/tests/unit/utils/scenarios.test.ts
+++ b/packages/sdk/tests/unit/utils/scenarios.test.ts
@@ -337,6 +337,10 @@ describe('UTILS-VERIFY-020: OrdHttpProvider URL construction', () => {
 
     (globalThis as any).fetch = async (url: string) => {
       fetchedUrls.push(url);
+      // The ord recursive CBOR-metadata route has no metadata here → 404.
+      if (url.includes('/r/metadata/')) {
+        return { ok: false, status: 404, arrayBuffer: async () => new ArrayBuffer(0) };
+      }
       // Return a minimal valid response for metadata call
       const body = JSON.stringify({
         inscription_id: 'abc123',
@@ -373,6 +377,9 @@ describe('UTILS-VERIFY-020: OrdHttpProvider URL construction', () => {
 
     (globalThis as any).fetch = async (url: string) => {
       fetchedUrls.push(url);
+      if (url.includes('/r/metadata/')) {
+        return { ok: false, status: 404, arrayBuffer: async () => new ArrayBuffer(0) };
+      }
       const body = JSON.stringify({
         inscription_id: 'xyz',
         content_type: 'text/plain',

--- a/packages/sdk/tests/unit/utils/scenarios.test.ts
+++ b/packages/sdk/tests/unit/utils/scenarios.test.ts
@@ -334,6 +334,7 @@ describe('UTILS-VERIFY-020: OrdHttpProvider URL construction', () => {
   test('builds inscription URL correctly from baseUrl without trailing slash', async () => {
     const fetchedUrls: string[] = [];
     const originalFetch = (globalThis as any).fetch;
+    const id = 'a'.repeat(64) + 'i0'; // well-formed inscription id (provider rejects malformed ids pre-fetch)
 
     (globalThis as any).fetch = async (url: string) => {
       fetchedUrls.push(url);
@@ -343,9 +344,9 @@ describe('UTILS-VERIFY-020: OrdHttpProvider URL construction', () => {
       }
       // Return a minimal valid response for metadata call
       const body = JSON.stringify({
-        inscription_id: 'abc123',
+        inscription_id: id,
         content_type: 'text/plain',
-        content_url: 'http://ord.local/content/abc123',
+        content_url: `http://ord.local/content/${id}`,
         txid: 'txidabc',
         vout: 0,
         sat: 12345,
@@ -361,19 +362,20 @@ describe('UTILS-VERIFY-020: OrdHttpProvider URL construction', () => {
 
     try {
       const provider = new OrdHttpProvider({ baseUrl: 'http://ord.local' });
-      await provider.getInscriptionById('abc123');
+      await provider.getInscriptionById(id);
     } finally {
       (globalThis as any).fetch = originalFetch;
     }
 
     expect(fetchedUrls.length).toBeGreaterThan(0);
     // First call should be the metadata endpoint
-    expect(fetchedUrls[0]).toBe('http://ord.local/inscription/abc123');
+    expect(fetchedUrls[0]).toBe(`http://ord.local/inscription/${id}`);
   });
 
   test('strips trailing slash from baseUrl', async () => {
     const fetchedUrls: string[] = [];
     const originalFetch = (globalThis as any).fetch;
+    const id = 'b'.repeat(64) + 'i0'; // well-formed inscription id (provider rejects malformed ids pre-fetch)
 
     (globalThis as any).fetch = async (url: string) => {
       fetchedUrls.push(url);
@@ -381,9 +383,9 @@ describe('UTILS-VERIFY-020: OrdHttpProvider URL construction', () => {
         return { ok: false, status: 404, arrayBuffer: async () => new ArrayBuffer(0) };
       }
       const body = JSON.stringify({
-        inscription_id: 'xyz',
+        inscription_id: id,
         content_type: 'text/plain',
-        content_url: 'http://ord.local/content/xyz',
+        content_url: `http://ord.local/content/${id}`,
         txid: 'txidxyz',
         vout: 0,
         sat: 99,
@@ -399,13 +401,13 @@ describe('UTILS-VERIFY-020: OrdHttpProvider URL construction', () => {
 
     try {
       const provider = new OrdHttpProvider({ baseUrl: 'http://ord.local/' });
-      await provider.getInscriptionById('xyz');
+      await provider.getInscriptionById(id);
     } finally {
       (globalThis as any).fetch = originalFetch;
     }
 
     // Should NOT produce double slash
-    expect(fetchedUrls[0]).toBe('http://ord.local/inscription/xyz');
+    expect(fetchedUrls[0]).toBe(`http://ord.local/inscription/${id}`);
   });
 
   test('estimateFee throws NOT_IMPLEMENTED instead of returning a fabricated rate (#318)', async () => {

--- a/packages/sdk/tests/unit/utils/utils-coverage.test.ts
+++ b/packages/sdk/tests/unit/utils/utils-coverage.test.ts
@@ -275,8 +275,11 @@ describe('[UTILS-VERIFY-017] OrdHttpProvider — fetch stub; URL + parsed result
 
   test('getInscriptionsBySatoshi hits correct URL and returns parsed inscription ids', async () => {
     const capturedUrls: string[] = [];
+    // Well-formed inscription ids (`<64-hex>i<vout>`) — provider filters malformed ids.
+    const idA = 'a'.repeat(64) + 'i0';
+    const idB = 'b'.repeat(64) + 'i0';
     const mockResponse = {
-      inscription_ids: ['insc-aaa', 'insc-bbb'],
+      inscription_ids: [idA, idB],
     };
 
     (globalThis as Record<string, unknown>).fetch = async (url: string, _opts?: unknown) => {
@@ -297,8 +300,8 @@ describe('[UTILS-VERIFY-017] OrdHttpProvider — fetch stub; URL + parsed result
 
     // Parsed result should map inscription_ids to objects
     expect(result).toHaveLength(2);
-    expect(result[0]).toEqual({ inscriptionId: 'insc-aaa' });
-    expect(result[1]).toEqual({ inscriptionId: 'insc-bbb' });
+    expect(result[0]).toEqual({ inscriptionId: idA });
+    expect(result[1]).toEqual({ inscriptionId: idB });
   });
 
   test('getInscriptionsBySatoshi returns [] when server responds not-ok', async () => {


### PR DESCRIPTION
## Per-event real-time chain-recoverability (#407 phase 3)

Third increment of epic #407 ("The CEL lives on the sat"). Phase 2 (#410) put a point-in-time log snapshot on-chain. Phase 3 makes it **real-time**: once an asset is on did:btco, **every authorship append inscribes as it happens**, so the sat's inscription chain IS the always-current log. Provenance is now recoverable from Bitcoin alone, current as of the latest append.

**Stacks on #410** (base `work-log-on-chain-phase2`, since #410 is not yet merged). Spec: `docs/superpowers/specs/2026-07-14-per-event-realtime-phase3-design.md`; plan: `docs/superpowers/plans/2026-07-14-per-event-realtime-phase3.md`.

### What changed
- **Append path (§1):** for a did:btco asset, `addResourceVersion` now inscribes the new event on the anchoring sat (content = the new media, metadata = the event **delta** + the updated did:btco doc with a fresh `#cel` head). Rotations continue to reinscribe. Off-btco / no-provider → hosted append as before (degrade), with a clear `cel:append-inscribe-skipped` signal — never silent.
- **Resolver (§2):** `resolveAssetFromSat` now **walks the inscription chain** — enumerates the sat's inscriptions, orders strictly by confirmed block height (fail-closed on a missing height), concatenates events (a full `celLog` snapshot is a checkpoint that REPLACEs; an `events` delta APPENDs), reattaches each on-chain-anchored event's bitcoin witness proof, and runs the **same** `verifyEventLog` gate as any log. A gap, a chain-inconsistent inscription, a truncated tail, or tampered metadata all fail closed.
- **Provider metadata (§2b):** `QuickNodeProvider` / `OrdHttpProvider` `getInscriptionById` now decode inscription CBOR metadata; a present-but-undecodable payload is a clear fail-closed error, while a genuinely method-absent endpoint degrades to "no metadata" (the resolver then fails closed).
- **Cost surfacing (§0/§5):** btco appends are now paid Bitcoin ops — each emits a `cel:inscribe-cost` estimate.

### Design notes
- `verifyEventLog` enforces a strict contiguous hash chain, so the concatenated log is never trusted blindly — any mis-concatenation is rejected there.
- The delta boundary (a per-asset WeakMap of the last on-chain head) is a byte-cost optimization only: when unknown it falls back to a full-snapshot checkpoint, so correctness never depends on it.

### Security review (fable)
One fable reviewer audited the append-inscribe path, the chain-walking resolver, and verification. No Critical findings. Two Important findings fixed:
- **I1** — `inscribeCelAppend` rollback was a no-op (it captured the post-append log); a transient inscribe failure stranded the hosted log ahead of the chain and bricked future updates via `UNPROVABLE_BASE`. Now captures the pre-append log and re-persists on rollback.
- **I2** — provider read-leniency let a transient fault silently truncate the chain **tail** to a verified-stale asset. A listed-but-unfetchable inscription now fails closed; QuickNode only swallows method-not-found from `ord_getMetadata`; OrdHttp's recursive metadata route fails closed on a present-but-undecodable body.

Both fixes have regression tests. All fail-closed invariants (cross-inscription chaining, block-height ordering, tampered-metadata rejection, per-link witness re-verification, media hash-binding) confirmed holding.

### Verification
- `bun test`: 3789 pass, 0 fail (the pre-existing CEL-CLI subprocess tests are flaky on the base branch and unrelated).
- `bunx tsc --noEmit`: clean. `bun run build`: clean.
- New tests in `packages/sdk/tests/integration/PerEventRealtime.e2e.test.ts`: real-time round-trip, immediacy, ordering, gap, tamper, cost, degrade, plus I1/I2 regressions.

Closes part of #407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-event real-time chain-recoverability and fee preview/confirm gate for did:btco appends
> - Each `addResourceVersion` append on a did:btco asset now triggers an on-chain inscription immediately after the hosted CEL log advances, making every event independently recoverable from chain without waiting for a full rotation.
> - `resolveAssetFromSatoshi` reconstructs the full CEL log from all anchoring inscriptions (snapshots + deltas), attaches per-event bitcoin witness proofs, and selects media by matching the most recent resource head hash.
> - A new `inscribeConfirm` gate (per-call or via `OriginalsConfig`) lets callers preview cost (`estimateAppendCost`) and approve or decline before any paid broadcast; declining emits `cel:inscribe-declined` and throws `PROVENANCE_APPEND_DECLINED` with no state mutation.
> - `OrdHttpProvider` and `QuickNodeProvider` now fetch and decode CBOR inscription metadata, which is required for delta/snapshot reconstruction during resolution.
> - `OriginalsAsset` exposes `pendingHeadMedia` during an in-flight append so `LifecycleManager` can use the new media bytes as inscription content before `asset.resources` advances.
> - Risk: inscription failures after a hosted append now roll back the in-memory CEL log to keep host and chain in sync; a gap or tampered inscription during `resolveAssetFromSatoshi` throws rather than returning a stale asset.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0461279.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->