### PR TITLE
Fee preview + confirm for btco appends (#407 phase 4)

### DIFF
--- a/.changeset/fee-preview-confirm-phase4.md
+++ b/.changeset/fee-preview-confirm-phase4.md
@@ -14,9 +14,10 @@ consented to.
   fee-rate source and `MAX_REASONABLE_FEE_RATE` cap as the real inscribe path, so
   the quote tracks reality. Zero side effects — no signing, appending, or
   inscription. Throws `ORD_PROVIDER_REQUIRED` without an ordinalsProvider.
-- `inscribeConfirm` gate — a per-call option on `addResourceVersion` and a config
-  default on `OriginalsConfig`. `'now'` (default) is the phase-3 behavior (inscribe
-  immediately). A callback is awaited with the estimate BEFORE any log mutation:
+- `inscribeConfirm` gate — a per-call option on `addResourceVersion` and
+  `rotateBtcoKeys`, plus a config default on `OriginalsConfig`. `'now'` (default)
+  is the phase-3 behavior (inscribe immediately). A callback is awaited with the
+  estimate BEFORE any log mutation:
   `true` proceeds; `false` cleanly ABORTS the whole append — no event appended,
   nothing inscribed, the asset left byte-identical (abort-before-mutate). A declined
   append throws `PROVENANCE_APPEND_DECLINED` and emits the new `cel:inscribe-declined`

--- a/.changeset/fee-preview-confirm-phase4.md
+++ b/.changeset/fee-preview-confirm-phase4.md
@@ -1,0 +1,27 @@
+---
+"@originals/sdk": minor
+---
+
+Fee preview + confirm for did:btco appends (#407 phase 4). Once an asset reaches
+did:btco (the final layer) every authorship append is a mandatory, paid Bitcoin
+inscription with no hosted fallback — phase 4 makes that cost visible up front and
+consented to.
+
+- `LifecycleManager.estimateAppendCost(asset, appendKind, opts?)` — a non-mutating
+  quote for the NEXT btco append, returning `{ satoshis, feeRate, vbytes,
+  contentBytes }`. It sizes the actual payload (`opts.content` / the in-flight new
+  media for `'update'`, the reinscribed DID doc for `'rotate'`) and reuses the same
+  fee-rate source and `MAX_REASONABLE_FEE_RATE` cap as the real inscribe path, so
+  the quote tracks reality. Zero side effects — no signing, appending, or
+  inscription. Throws `ORD_PROVIDER_REQUIRED` without an ordinalsProvider.
+- `inscribeConfirm` gate — a per-call option on `addResourceVersion` and a config
+  default on `OriginalsConfig`. `'now'` (default) is the phase-3 behavior (inscribe
+  immediately). A callback is awaited with the estimate BEFORE any log mutation:
+  `true` proceeds; `false` cleanly ABORTS the whole append — no event appended,
+  nothing inscribed, the asset left byte-identical (abort-before-mutate). A declined
+  append throws `PROVENANCE_APPEND_DECLINED` and emits the new `cel:inscribe-declined`
+  event; a subsequent append still works (no poisoned state).
+
+No defer/re-anchor path: btco is the final layer with no hosted fallback, so the
+only control is proceed-and-pay or abort. Off-btco (did:cel/did:webvh) appends are
+unaffected — they inscribe nothing, so the gate is a no-op.

--- a/docs/superpowers/plans/2026-07-15-fee-preview-confirm-phase4.md
+++ b/docs/superpowers/plans/2026-07-15-fee-preview-confirm-phase4.md
@@ -1,0 +1,75 @@
+# Plan: Fee preview + confirm (epic #407, phase 4)
+
+Implements the [phase-4 spec](../specs/2026-07-15-fee-preview-confirm-phase4-design.md).
+Stacks on #411 (phase-3 append-inscribe path). Branch `work-fee-preview-phase4`
+off `origin/work-per-event-phase3c`.
+
+## Goal
+
+Make the unavoidable on-chain cost of a did:btco authorship append **visible up
+front** (a non-mutating preview) and **consented to** (a confirm gate that cleanly
+aborts a declined paid append). No defer path — btco is the final layer with no
+hosted fallback.
+
+## Key facts established by code reading
+
+- The bound controller appender (`OriginalsAsset.#celAppender`) is reached ONLY
+  from `addResourceVersion` with `type: 'update'`. It routes to
+  `LifecycleManager.appendCelEventAndMaybeInscribe(asset, type, data)` — the
+  phase-3 entry point that (1) `appendCelEventOrSkip` **mutates the log**, then
+  (2) `inscribeCelAppend` does the paid broadcast.
+- **Critical abort constraint:** in `#addResourceVersionCritical`, after the
+  appender returns, `this.resources.push(newResource)` runs **unconditionally**
+  (both appended and degraded cases, OriginalsAsset.ts:744). So a declined append
+  that merely *returned* would still advance `resources` — NOT byte-identical.
+  Therefore decline must **throw** so the throw propagates before line 744 (the
+  `pendingHeadMedia` `finally` still clears, log never mutated → clean no-op).
+- `bitcoinManager.estimateFeeRate()` (= `resolveFeeRate`) uses the SAME
+  feeOracle → ordinalsProvider → `MAX_REASONABLE_FEE_RATE` cap chain as
+  `estimateCost` / `capEstimatedFeeRate`, and is exactly what the real inscribe
+  path's `emitInscribeCost` already uses (`vsize = ceil(bytes/4)+200`,
+  `sats = ceil(feeRate*vsize)`). Mirroring it makes the quote track the actual cost.
+- At gate time (before `appendCelEventOrSkip`), the new media for an `update`
+  lives in `asset.pendingHeadMedia` (set by `addResourceVersion` before it calls
+  the appender). `tryResolveHeadMedia` matches by the LOG head, which has NOT
+  advanced yet at gate time, so the gate reads `pendingHeadMedia` directly.
+
+## Steps (commit after each)
+
+1. **Plan** (this file). COMMIT.
+2. **Types** (`types/common.ts`): add `AppendKind = 'update' | 'rotate'`,
+   `AppendCostEstimate = { satoshis; feeRate; vbytes; contentBytes }`,
+   `InscribeConfirm = 'now' | ((e: AppendCostEstimate) => boolean | Promise<boolean>)`;
+   add `inscribeConfirm?: InscribeConfirm` to `OriginalsConfig`. COMMIT.
+3. **Preview** (`LifecycleManager.estimateAppendCost`): non-mutating quote for the
+   next btco append. `ORD_PROVIDER_REQUIRED` without a provider. Sizes the payload
+   (opts.content → pendingHeadMedia → head media → btco-doc fallback); fee rate via
+   `bitcoinManager.estimateFeeRate()` (respects `opts.feeRate`). COMMIT.
+4. **Confirm gate**: extend the appender signature with an `opts?` carrying
+   `inscribeConfirm`; thread it from `addResourceVersion(…, opts?)` → `_bindCelAppender`
+   binding → `appendCelEventAndMaybeInscribe`. At the TOP of that method (before
+   `appendCelEventOrSkip`), when the append WILL inscribe (btco + provider) and the
+   effective `inscribeConfirm` (per-call ?? config ?? 'now') is a callback: compute
+   the estimate, `await callback(estimate)`; false → emit `cel:inscribe-declined` +
+   throw `PROVENANCE_APPEND_DECLINED` (clean no-op, abort-before-mutate). COMMIT.
+5. **Event** (`events/types.ts` + `utils/EventLogger.ts`): add
+   `cel:inscribe-declined` (interface, union, map, logger config/subscribe/case). COMMIT.
+6. **Tests** + `.changeset/fee-preview-confirm-phase4.md` (minor). COMMIT.
+
+## Testing spine (from spec §6)
+
+- Preview non-mutating + accurate; leaves asset/log/chain untouched; quote ≈ real cost.
+- Confirm true → phase-3 path proceeds & inscribes.
+- Confirm false → clean abort: no event, nothing inscribed, resources/log/media
+  identical; `cel:inscribe-declined` fires; a follow-up append still works.
+- Default (`'now'`/unset) preserves phase-3 behavior.
+- `estimateAppendCost` without provider → `ORD_PROVIDER_REQUIRED`.
+- Off-btco append ignores the gate (no inscription, no prompt).
+
+## Security review
+
+One fable reviewer on the gate + preview before PR: confirm `estimateAppendCost`
+is truly non-mutating; a false confirm leaves the asset byte-identical (no orphaned
+event, no `UNPROVABLE_BASE`, no half-inscribed state) and a later append still
+works; the gate sits before mutation (not between append and inscribe); the
+estimate can't be used to skip the paid inscription while still appending.

--- a/docs/superpowers/specs/2026-07-15-fee-preview-confirm-phase4-design.md
+++ b/docs/superpowers/specs/2026-07-15-fee-preview-confirm-phase4-design.md
@@ -1,0 +1,106 @@
+# Design: Fee preview + confirm (epic #407, phase 4)
+
+> Fourth increment of epic #407. Phase 3 (#411) made every did:btco authorship
+> append a **mandatory, paid** Bitcoin inscription — and that mandate is not a
+> choice: once an asset reaches did:btco (the final layer) there is **no webvh
+> host to fall back to**, so a btco append must inscribe or not happen at all.
+> Phase 4 makes that unavoidable cost **visible up front** (a preview) and
+> **consented to** (a confirm gate) — no surprise spends.
+>
+> **Stacks on #411** (the phase-3 append-inscribe path). Branch off #411 /
+> main-after-#411.
+
+## 0. Decision record
+
+- **Preview, not just post-hoc events.** Phase 3 emits `cel:inscribe-cost`
+  *after* inscribing. Phase 4 adds a **non-mutating estimate returned to the
+  caller BEFORE committing**, extending the existing `LifecycleManager.estimateCost`
+  (the "quote-only" did:btco cost path) to cover an append.
+- **Control = confirm/cancel, NOT defer.** A btco append cannot fall back to
+  hosted/webvh (final layer, no host). So the only control is: see the cost, then
+  proceed-and-pay or abort. There is no cheaper-by-deferring path.
+- **The cheaper path is a different phase.** The only way to pay *less* on-chain
+  is a weaker guarantee — the checkpoint/squash tier — which is its own later
+  increment, not this one.
+- **No re-anchor / no defer state.** Both assumed a hosted fallback that does not
+  exist for btco assets; dropped.
+
+## 1. Preview — `estimateAppendCost`
+
+A non-mutating quote for the *next* btco append:
+```
+estimateAppendCost(asset, appendKind: 'update' | 'rotate', opts?): Promise<{
+  satoshis: number;         // estimated total inscription cost
+  feeRate: number;          // the (capped) fee rate used
+  vbytes: number;           // estimated tx vsize
+  contentBytes: number;     // size of the media/content being inscribed
+}>
+```
+- Reuses `estimateCost`'s fee-oracle + `capEstimatedFeeRate` (same source/cap as
+  the real inscribe path, so the quote tracks reality).
+- Sizes the actual payload the append would inscribe (new media for an `update`;
+  event-only for a `rotate`) so the estimate reflects *this* append.
+- Requires the ordinalsProvider (a btco op); throws `ORD_PROVIDER_REQUIRED`
+  otherwise. Zero side effects — no signing, no append, no inscription.
+
+## 2. Control — the confirm gate
+
+A knob on the btco append path (`addResourceVersion`/`rotateKey`), via a per-call
+option and a config default:
+- **`inscribeConfirm: 'now'`** (default, = phase-3 behavior) — inscribe
+  immediately, no prompt.
+- **`inscribeConfirm: <callback>`** — before inscribing, call
+  `await callback(estimate)` (the §1 estimate). If it returns `true`, proceed and
+  inscribe. If it returns `false`, **abort the entire append**: no event is
+  appended, nothing is inscribed, no partial state — the operation is a clean
+  no-op that surfaces a `PROVENANCE_APPEND_DECLINED` result/signal.
+- Config-level default `inscribeConfirm` on `OriginalsConfig` sets the policy for
+  all btco appends unless a call overrides it.
+
+## 3. Abort semantics (the load-bearing detail)
+
+When the confirm callback returns false, the append is aborted **before** the log
+is mutated — the sign+append and the inscription happen together downstream of the
+gate, so declining leaves the asset exactly as it was (no orphaned event, no
+UNPROVABLE_BASE, no half-inscribed state). The gate sits *before* `appendCelEventAndMaybeInscribe`
+(the phase-3 entry point), not between append and inscribe.
+
+## 4. Surfacing / events
+
+- The §1 estimate is **returned** to the caller (and passed to the confirm
+  callback) — not only emitted as an event.
+- `cel:inscribe-cost` (phase 3) still fires on the actual inscription.
+- New `cel:inscribe-declined` signal when a confirm gate aborts an append.
+
+## 5. Boundaries / deferred
+
+- Checkpoint/squash tier (the only *cheaper on-chain* option) — its own phase.
+- Secondary-content inscription — its own phase.
+- Payment rails / who-pays / wallet integration — out of scope (this is estimate
+  + consent, not payments).
+- Off-btco appends (did:cel/did:webvh, still free/hosted) — unaffected; the
+  preview/confirm apply only to btco appends that actually inscribe.
+
+## 6. Testing spine
+
+- **Preview non-mutating + accurate:** `estimateAppendCost` returns a plausible
+  quote and leaves the asset/log/chain untouched; the quote ≈ the actual cost the
+  subsequent real append incurs (same fee-rate source).
+- **Confirm true:** append proceeds and inscribes normally (phase-3 path).
+- **Confirm false → clean abort:** no event appended, nothing inscribed, asset
+  unchanged (log head, resources, current media all identical to before);
+  `cel:inscribe-declined` fires; a follow-up append still works (no poisoned
+  state).
+- **Default preserved:** with no `inscribeConfirm` (or `'now'`), btco appends
+  behave exactly as phase 3.
+- **Provider required:** `estimateAppendCost` without an ordinalsProvider →
+  `ORD_PROVIDER_REQUIRED`.
+- **Off-btco unaffected:** a did:cel/did:webvh append ignores the gate (no
+  inscription, no prompt).
+
+## 7. Changeset
+
+`@originals/sdk` **minor** — `estimateAppendCost` previews a did:btco append's
+inscription cost without committing; a per-call / config `inscribeConfirm` gate
+lets callers approve or cleanly abort a paid append after seeing the estimate.
+Informed consent on the unavoidable cost of appending to a btco asset (#407).

--- a/packages/sdk/src/events/types.ts
+++ b/packages/sdk/src/events/types.ts
@@ -416,6 +416,26 @@ export interface CelInscribeCostEvent extends BaseEvent {
 }
 
 /**
+ * Emitted (#407 phase 4) when an `inscribeConfirm` callback returns false and a
+ * paid did:btco authorship append is cleanly ABORTED before any log mutation:
+ * no event appended, nothing inscribed, the asset left byte-identical. Carries
+ * the estimate the caller declined.
+ */
+export interface CelInscribeDeclinedEvent extends BaseEvent {
+  type: 'cel:inscribe-declined';
+  asset: { id: string };
+  /** Which append kind was declined. */
+  appendKind: 'update' | 'rotate';
+  /** The cost estimate presented to (and rejected by) the confirm callback. */
+  estimate: {
+    satoshis: number;
+    feeRate: number;
+    vbytes: number;
+    contentBytes: number;
+  };
+}
+
+/**
  * Emitted (#407 phase 3) after a did:btco authorship append is inscribed on the
  * anchoring sat, making the on-chain log current for that event.
  */
@@ -456,6 +476,7 @@ export type OriginalsEvent =
   | CelAppendSkippedEvent
   | CelAppendInscribeSkippedEvent
   | CelInscribeCostEvent
+  | CelInscribeDeclinedEvent
   | ResourceInscribedEvent
   | CelHostFailedEvent
   | KeyRotatedEvent;
@@ -495,6 +516,7 @@ export interface EventTypeMap {
   'cel:append-skipped': CelAppendSkippedEvent;
   'cel:append-inscribe-skipped': CelAppendInscribeSkippedEvent;
   'cel:inscribe-cost': CelInscribeCostEvent;
+  'cel:inscribe-declined': CelInscribeDeclinedEvent;
   'resource:inscribed': ResourceInscribedEvent;
   'cel:host-failed': CelHostFailedEvent;
   'key:rotated': KeyRotatedEvent;

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -3909,6 +3909,13 @@ export class LifecycleManager {
    * caller-supplied content → in-flight new media (`pendingHeadMedia`, the
    * confirm-gate case, since the log head has not advanced yet) → current head
    * media → the DID document (pure-reference-head fallback). Pure/read-only.
+   *
+   * For `'rotate'`, this deliberately sizes the head MEDIA (when present), NOT the
+   * rotated DID doc: `reinscribeRotatedDoc` inscribes `headMedia.content` as the
+   * ordinal CONTENT and carries the rotated doc in METADATA, falling back to the
+   * DID doc as content only for a pure-reference head. So media size IS the paid
+   * cost of a rotation on an asset with media; the DID-doc fallback below applies
+   * to both kinds only when there is no inline media.
    */
   private resolveAppendPayloadBytes(
     asset: OriginalsAsset,
@@ -3922,6 +3929,8 @@ export class LifecycleManager {
     if (appendKind === 'update' && asset.pendingHeadMedia) {
       return Buffer.from(asset.pendingHeadMedia.content, 'utf8').byteLength;
     }
+    // Head media is the inscribed CONTENT for BOTH kinds when present (update:
+    // reinscribeCelAppend; rotate: reinscribeRotatedDoc) — so this is the paid size.
     const headMedia = this.tryResolveHeadMedia(asset);
     if (headMedia) return headMedia.content.byteLength;
     // Pure-reference head → the inscribe path falls back to the DID document as

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -6,7 +6,10 @@ import {
   ExternalSigner,
   VerifiableCredential,
   LayerType,
-  DIDDocument
+  DIDDocument,
+  AppendKind,
+  AppendCostEstimate,
+  InscribeConfirm
 } from '../types/index.js';
 import { BitcoinManager, MAX_REASONABLE_FEE_RATE } from '../bitcoin/BitcoinManager.js';
 import { DIDManager } from '../did/DIDManager.js';
@@ -3787,8 +3790,87 @@ export class LifecycleManager {
   }
 
   /**
+   * Non-mutating cost preview for the NEXT did:btco authorship append (#407 phase
+   * 4). Returns `{ satoshis, feeRate, vbytes, contentBytes }` for an `'update'`
+   * (new media) or `'rotate'` (event-only reinscription) without signing,
+   * appending, or inscribing anything — pure quote.
+   *
+   * Fee rate comes from the SAME source/cap as the real inscribe path
+   * (`bitcoinManager.estimateFeeRate` → feeOracle→provider, `MAX_REASONABLE_FEE_RATE`
+   * cap; an explicit `opts.feeRate` wins). The vsize ballpark mirrors
+   * `emitInscribeCost` (content/4 witness discount + ~200 vB overhead), so the
+   * quote tracks the cost the subsequent real append incurs.
+   *
+   * @throws StructuredError('ORD_PROVIDER_REQUIRED') when no ordinalsProvider is
+   *   configured — a btco op cannot be quoted without one.
+   */
+  async estimateAppendCost(
+    asset: OriginalsAsset,
+    appendKind: AppendKind,
+    opts?: { content?: string | Buffer; contentType?: string; feeRate?: number }
+  ): Promise<AppendCostEstimate> {
+    const provider = this.config.ordinalsProvider ?? this.deps?.bitcoinManager?.ordinalsProvider;
+    if (!provider) {
+      throw new StructuredError(
+        'ORD_PROVIDER_REQUIRED',
+        'An ordinalsProvider must be configured to estimate a did:btco append cost.'
+      );
+    }
+    const bitcoinManager = this.deps?.bitcoinManager ?? new BitcoinManager(this.config);
+    // Same resolveFeeRate chain the real inscription uses (explicit override wins,
+    // else feeOracle→provider, capped). Conservative default when nothing resolves,
+    // so the quote is always a usable number for the confirm callback (matches
+    // estimateCost's fallback).
+    const resolved = await bitcoinManager.estimateFeeRate();
+    const feeRate = (typeof opts?.feeRate === 'number' && Number.isFinite(opts.feeRate) && opts.feeRate > 0)
+      ? opts.feeRate
+      : (typeof resolved === 'number' && resolved > 0 ? resolved : 10);
+    const contentBytes = this.resolveAppendPayloadBytes(asset, appendKind, opts);
+    // Ballpark commit+reveal vsize (mirrors emitInscribeCost): a cost-awareness
+    // figure, not a billing number.
+    const vbytes = Math.ceil(contentBytes / 4) + 200;
+    const satoshis = Math.ceil(feeRate * vbytes);
+    return { satoshis, feeRate, vbytes, contentBytes };
+  }
+
+  /**
+   * Byte size of the content the next btco append would inscribe (#407 phase 4).
+   * Mirrors the real inscribe path's content selection so the estimate matches:
+   * caller-supplied content → in-flight new media (`pendingHeadMedia`, the
+   * confirm-gate case, since the log head has not advanced yet) → current head
+   * media → the DID document (pure-reference-head fallback). Pure/read-only.
+   */
+  private resolveAppendPayloadBytes(
+    asset: OriginalsAsset,
+    appendKind: AppendKind,
+    opts?: { content?: string | Buffer }
+  ): number {
+    if (opts?.content !== undefined) {
+      const buf = Buffer.isBuffer(opts.content) ? opts.content : Buffer.from(String(opts.content), 'utf8');
+      return buf.byteLength;
+    }
+    if (appendKind === 'update' && asset.pendingHeadMedia) {
+      return Buffer.from(asset.pendingHeadMedia.content, 'utf8').byteLength;
+    }
+    const headMedia = this.tryResolveHeadMedia(asset);
+    if (headMedia) return headMedia.content.byteLength;
+    // Pure-reference head → the inscribe path falls back to the DID document as
+    // content; size the current btco doc (rebuilt with the current controller key).
+    const log = asset.celLog;
+    const btcoDid = asset.bindings?.['did:btco'];
+    if (log && btcoDid) {
+      const satoshi = btcoDid.split(':').pop()!;
+      const vm = currentControllerVm(log);
+      const controllerPubMb = vm.split('#')[0].slice('did:key:'.length);
+      const btcoDoc = this.buildRotatedBtcoDoc(asset, satoshi, btcoDid, controllerPubMb);
+      return Buffer.from(JSON.stringify(btcoDoc)).byteLength;
+    }
+    return 0;
+  }
+
+  /**
    * Estimate the cost of migrating an asset to a target layer
-   * 
+   *
    * Returns a detailed breakdown of expected costs for Bitcoin operations.
    * For did:webvh migrations, costs are minimal (only hosting).
    * 

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -3144,7 +3144,8 @@ export class LifecycleManager {
   async rotateBtcoKeys(
     asset: OriginalsAsset,
     newVerificationMethod: { publicKeyMultibase: string; privateKey?: string },
-    feeRate?: number
+    feeRate?: number,
+    opts?: { inscribeConfirm?: InscribeConfirm }
   ): Promise<{ inscriptionId: string; did: string }> {
     if (asset.currentLayer !== 'did:btco') {
       throw new StructuredError('INVALID_STATE', 'Key rotation requires the asset to be on the did:btco layer.');
@@ -3170,6 +3171,31 @@ export class LifecycleManager {
     const satoshi = btcoDid.split(':').pop()!;
     // Shared rotated-doc build (backLinks + manifest + NETWORK_MISMATCH guard).
     const rotatedDoc = this.buildRotatedBtcoDoc(asset, satoshi, btcoDid, newVerificationMethod.publicKeyMultibase);
+
+    // Confirm gate (#407 phase 4): a cooperative rotation reinscribes on-chain
+    // (paid), so consent to the cost BEFORE any mutation (log OR keyStore) — same
+    // abort-before-mutate contract as the update path. A provider is guaranteed
+    // here (btco asset). On decline, throw before the rotateKey append and before
+    // registering the incoming key; the finally releases the concurrency claim,
+    // leaving the asset byte-identical.
+    const rotateConfirm = opts?.inscribeConfirm ?? this.config.inscribeConfirm ?? 'now';
+    if (typeof rotateConfirm === 'function') {
+      const estimate = await this.estimateAppendCost(asset, 'rotate', { feeRate });
+      const approved = await rotateConfirm(estimate);
+      if (!approved) {
+        await this.eventEmitter.emit({
+          type: 'cel:inscribe-declined',
+          timestamp: new Date().toISOString(),
+          asset: { id: asset.id },
+          appendKind: 'rotate',
+          estimate
+        });
+        throw new StructuredError(
+          'PROVENANCE_APPEND_DECLINED',
+          'The inscribeConfirm gate declined the paid did:btco key rotation; nothing was appended or inscribed.'
+        );
+      }
+    }
 
     // Append-first (#365): rotateKey signed by the CURRENT controller — the
     // cooperative-rotation contract (the verifier only accepts rotations
@@ -3828,9 +3854,10 @@ export class LifecycleManager {
    * (new media) or `'rotate'` (event-only reinscription) without signing,
    * appending, or inscribing anything — pure quote.
    *
-   * Fee rate comes from the SAME source/cap as the real inscribe path
-   * (`bitcoinManager.estimateFeeRate` → feeOracle→provider, `MAX_REASONABLE_FEE_RATE`
-   * cap; an explicit `opts.feeRate` wins). The vsize ballpark mirrors
+   * Fee rate comes from the SAME resolver the real inscribe path uses
+   * (`bitcoinManager.estimateFeeRate` → feeOracle→provider, absurd
+   * >`MAX_REASONABLE_FEE_RATE` sources skipped; an explicit `opts.feeRate` wins).
+   * The vsize ballpark mirrors
    * `emitInscribeCost` (content/4 witness discount + ~200 vB overhead), so the
    * quote tracks the cost the subsequent real append incurs.
    *
@@ -3851,7 +3878,7 @@ export class LifecycleManager {
     }
     const bitcoinManager = this.deps?.bitcoinManager ?? new BitcoinManager(this.config);
     // Same resolveFeeRate chain the real inscription uses (explicit override wins,
-    // else feeOracle→provider, capped). Conservative default when nothing resolves,
+    // else feeOracle→provider, absurd sources skipped). Conservative default when nothing resolves,
     // so the quote is always a usable number for the confirm callback (matches
     // estimateCost's fallback).
     const resolved = await bitcoinManager.estimateFeeRate();

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -3861,6 +3861,12 @@ export class LifecycleManager {
    * `emitInscribeCost` (content/4 witness discount + ~200 vB overhead), so the
    * quote tracks the cost the subsequent real append incurs.
    *
+   * For a STANDALONE `'update'` quote (not driven by the confirm gate), pass the
+   * intended new bytes as `opts.content` — otherwise the estimate is
+   * content-agnostic: with no in-flight `pendingHeadMedia` it sizes the CURRENT
+   * head media as a proxy and will underquote a larger upgrade. The confirm gate
+   * always sizes correctly (pendingHeadMedia is set before it runs).
+   *
    * @throws StructuredError('ORD_PROVIDER_REQUIRED') when no ordinalsProvider is
    *   configured — a btco op cannot be quoted without one.
    */
@@ -3876,15 +3882,19 @@ export class LifecycleManager {
         'An ordinalsProvider must be configured to estimate a did:btco append cost.'
       );
     }
-    const bitcoinManager = this.deps?.bitcoinManager ?? new BitcoinManager(this.config);
     // Same resolveFeeRate chain the real inscription uses (explicit override wins,
-    // else feeOracle→provider, absurd sources skipped). Conservative default when nothing resolves,
-    // so the quote is always a usable number for the confirm callback (matches
-    // estimateCost's fallback).
-    const resolved = await bitcoinManager.estimateFeeRate();
-    const feeRate = (typeof opts?.feeRate === 'number' && Number.isFinite(opts.feeRate) && opts.feeRate > 0)
-      ? opts.feeRate
-      : (typeof resolved === 'number' && resolved > 0 ? resolved : 10);
+    // else feeOracle→provider, absurd sources skipped). Conservative default when
+    // nothing resolves, so the quote is always a usable number for the confirm
+    // callback (matches estimateCost's fallback). Short-circuit an explicit
+    // opts.feeRate so we skip the fee-oracle round-trip it would only override.
+    let feeRate: number;
+    if (typeof opts?.feeRate === 'number' && Number.isFinite(opts.feeRate) && opts.feeRate > 0) {
+      feeRate = opts.feeRate;
+    } else {
+      const bitcoinManager = this.deps?.bitcoinManager ?? new BitcoinManager(this.config);
+      const resolved = await bitcoinManager.estimateFeeRate();
+      feeRate = (typeof resolved === 'number' && resolved > 0) ? resolved : 10;
+    }
     const contentBytes = this.resolveAppendPayloadBytes(asset, appendKind, opts);
     // Ballpark commit+reveal vsize (mirrors emitInscribeCost): a cost-awareness
     // figure, not a billing number.

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -343,7 +343,7 @@ export class LifecycleManager {
     const asset = new OriginalsAsset(resources, didDoc, [], log);
     // Bind the controller append path so addResourceVersion can write signed
     // `update` events with the same degrade contract as the other authorship ops.
-    asset._bindCelAppender((type, data) => this.appendCelEventAndMaybeInscribe(asset, type, data));
+    asset._bindCelAppender((type, data, opts) => this.appendCelEventAndMaybeInscribe(asset, type, data, opts));
 
     // Persist the genesis CEL at the conventional cel/<suffix>.json key so
     // the did:cel resolves from storage immediately (best-effort, never gates).
@@ -745,7 +745,7 @@ export class LifecycleManager {
       log,
       { currentLayer: folded.currentLayer, bindings: folded.bindings, provenance }
     );
-    asset._bindCelAppender((type, data) => this.appendCelEventAndMaybeInscribe(asset, type, data));
+    asset._bindCelAppender((type, data, opts) => this.appendCelEventAndMaybeInscribe(asset, type, data, opts));
 
     // Repopulate captured DID docs so re-serializing a loaded asset is
     // lossless. Only for layers cross-checked against the fold in step 5
@@ -2277,8 +2277,41 @@ export class LifecycleManager {
   private async appendCelEventAndMaybeInscribe(
     asset: OriginalsAsset,
     type: 'migrate' | 'rotateKey' | 'update',
-    data: unknown
+    data: unknown,
+    opts?: { inscribeConfirm?: InscribeConfirm }
   ): Promise<string | null> {
+    // Confirm gate (#407 phase 4): consent to the unavoidable on-chain cost BEFORE
+    // any log mutation. Only paid appends prompt — a btco asset WITH a provider (the
+    // ones that actually inscribe below). Off-btco / provider-absent appends inscribe
+    // nothing, so there is no cost to consent to and the gate is a no-op.
+    const gateProvider = this.config.ordinalsProvider ?? this.deps?.bitcoinManager?.ordinalsProvider;
+    const willInscribe = asset.currentLayer === 'did:btco' && !!gateProvider;
+    const confirm = opts?.inscribeConfirm ?? this.config.inscribeConfirm ?? 'now';
+    if (willInscribe && typeof confirm === 'function') {
+      const appendKind: AppendKind = type === 'rotateKey' ? 'rotate' : 'update';
+      // Estimate reflects THIS append (for 'update', pendingHeadMedia is already set
+      // by addResourceVersion and the log head has not advanced yet → sized correctly).
+      const estimate = await this.estimateAppendCost(asset, appendKind);
+      const approved = await confirm(estimate);
+      if (!approved) {
+        // Abort-before-mutate (spec §3): nothing was appended or inscribed, so the
+        // asset is byte-identical. THROW rather than return null — addResourceVersion
+        // pushes the new resource version unconditionally once the appender RETURNS
+        // (OriginalsAsset.ts), so only a throw guarantees a clean no-op.
+        await this.eventEmitter.emit({
+          type: 'cel:inscribe-declined',
+          timestamp: new Date().toISOString(),
+          asset: { id: asset.id },
+          appendKind,
+          estimate
+        });
+        throw new StructuredError(
+          'PROVENANCE_APPEND_DECLINED',
+          'The inscribeConfirm gate declined the paid did:btco append; nothing was appended or inscribed.'
+        );
+      }
+    }
+
     // Snapshot the pre-append log BEFORE appendCelEventOrSkip advances it — the
     // inscribe-failure rollback restores THIS (capturing after the append would
     // restore the log to itself, leaving it permanently ahead of the chain and

--- a/packages/sdk/src/lifecycle/OriginalsAsset.ts
+++ b/packages/sdk/src/lifecycle/OriginalsAsset.ts
@@ -1,8 +1,9 @@
-import { 
-  AssetResource, 
-  DIDDocument, 
-  VerifiableCredential, 
-  LayerType 
+import {
+  AssetResource,
+  DIDDocument,
+  VerifiableCredential,
+  LayerType,
+  InscribeConfirm
 } from '../types/index.js';
 import { validateDIDDocument, validateCredential, hashResource } from '../utils/validation.js';
 import { StructuredError } from '../utils/telemetry.js';
@@ -72,7 +73,11 @@ export class OriginalsAsset {
   // event via the manager's degrade-aware path and returns the new head digest,
   // or null when the append was skipped (no keyStore / no signing key). Undefined
   // for assets constructed outside the lifecycle (they degrade in-memory only).
-  #celAppender?: (type: 'migrate' | 'rotateKey' | 'update', data: unknown) => Promise<string | null>;
+  #celAppender?: (
+    type: 'migrate' | 'rotateKey' | 'update',
+    data: unknown,
+    opts?: { inscribeConfirm?: InscribeConfirm }
+  ) => Promise<string | null>;
   // Per-asset serialization for addResourceVersion: the sync→async cutover made
   // the shared #celLog read-modify-write span await points, so concurrent calls
   // raced (a later _replaceCelLog clobbered an earlier signed append, or landed
@@ -195,7 +200,11 @@ export class OriginalsAsset {
    * contract (cel:append-skipped) as the other authorship ops.
    */
   _bindCelAppender(
-    fn: (type: 'migrate' | 'rotateKey' | 'update', data: unknown) => Promise<string | null>
+    fn: (
+      type: 'migrate' | 'rotateKey' | 'update',
+      data: unknown,
+      opts?: { inscribeConfirm?: InscribeConfirm }
+    ) => Promise<string | null>
   ): void {
     this.#celAppender = fn;
   }
@@ -597,7 +606,8 @@ export class OriginalsAsset {
     resourceId: string,
     newContent: string,
     contentType: string,
-    changes?: string
+    changes?: string,
+    opts?: { inscribeConfirm?: InscribeConfirm }
   ): Promise<AssetResource> {
     // AssetResource.content is a string; a Buffer used to be silently dropped
     // (only its hash was stored), unrecoverably losing the binary content
@@ -617,7 +627,7 @@ export class OriginalsAsset {
     // second queued call re-reads the head INSIDE its turn, so it chains from
     // the first call's committed result rather than a stale snapshot (Finding 2).
     const run = this.#appendChain.then(() =>
-      this.#addResourceVersionCritical(resourceId, newContent, contentType, changes)
+      this.#addResourceVersionCritical(resourceId, newContent, contentType, changes, opts)
     );
     // Keep the chain alive across a rejected turn without swallowing it for the caller.
     this.#appendChain = run.catch(() => {});
@@ -649,7 +659,8 @@ export class OriginalsAsset {
     resourceId: string,
     newContent: string,
     contentType: string,
-    changes?: string
+    changes?: string,
+    opts?: { inscribeConfirm?: InscribeConfirm }
   ): Promise<AssetResource> {
     // RE-READ the current head inside the turn (a prior queued call may have
     // just committed a new version).
@@ -723,7 +734,7 @@ export class OriginalsAsset {
             previousVersionHash: currentResource.hash,
             toHash: newHash,
             toVersion: newVersion
-          });
+          }, opts);
         } finally {
           this.#pendingHeadMedia = undefined;
         }

--- a/packages/sdk/src/types/common.ts
+++ b/packages/sdk/src/types/common.ts
@@ -9,6 +9,41 @@ import type { OperationLock } from '../utils/OperationLock.js';
 // Base types for the Originals protocol
 export type LayerType = 'did:cel' | 'did:webvh' | 'did:btco';
 
+/**
+ * Which kind of did:btco authorship append a cost preview is for (#407 phase 4):
+ * `'update'` sizes the new media (a resource-version inscription); `'rotate'`
+ * sizes the event-only reinscription (the rotated DID document).
+ */
+export type AppendKind = 'update' | 'rotate';
+
+/**
+ * Non-mutating cost quote for the NEXT did:btco authorship append (#407 phase 4).
+ * Same fee-rate source/cap as the real inscribe path, so it tracks reality; a
+ * ballpark for cost-awareness/consent, not a billing figure.
+ */
+export interface AppendCostEstimate {
+  /** Estimated total inscription cost (sats) = feeRate × vbytes. */
+  satoshis: number;
+  /** The (capped) fee rate used (sat/vB). */
+  feeRate: number;
+  /** Estimated commit+reveal virtual size (vB). */
+  vbytes: number;
+  /** Size of the media/content being inscribed (bytes). */
+  contentBytes: number;
+}
+
+/**
+ * Confirm-gate policy for a paid did:btco authorship append (#407 phase 4).
+ * `'now'` (default) inscribes immediately (phase-3 behavior). A callback is
+ * awaited with the {@link AppendCostEstimate} BEFORE any log mutation: `true`
+ * proceeds and inscribes; `false` cleanly ABORTS the whole append (no event
+ * appended, nothing inscribed — a byte-identical no-op that throws
+ * `PROVENANCE_APPEND_DECLINED` and emits `cel:inscribe-declined`).
+ */
+export type InscribeConfirm =
+  | 'now'
+  | ((estimate: AppendCostEstimate) => boolean | Promise<boolean>);
+
 export interface OriginalsConfig {
   network: 'mainnet' | 'regtest' | 'signet';
   bitcoinRpcUrl?: string;
@@ -23,6 +58,11 @@ export interface OriginalsConfig {
   didCache?: DIDCacheConfig;
   feeOracle?: FeeOracleAdapter;
   ordinalsProvider?: OrdinalsProvider;
+  // Default confirm-gate policy for paid did:btco authorship appends (#407 phase
+  // 4). Omitted/'now' = inscribe immediately (phase-3 behavior); a callback is
+  // consulted before each btco append and can cleanly abort it. Overridable per
+  // call (e.g. addResourceVersion's opts.inscribeConfirm).
+  inscribeConfirm?: InscribeConfirm;
   // Shared keyed lock coordinating money-spending inscriptions across managers
   // (issue #303). OriginalsSDK injects one instance so all managers share it.
   operationLock?: OperationLock;

--- a/packages/sdk/src/types/common.ts
+++ b/packages/sdk/src/types/common.ts
@@ -24,7 +24,9 @@ export type AppendKind = 'update' | 'rotate';
 export interface AppendCostEstimate {
   /** Estimated total inscription cost (sats) = feeRate × vbytes. */
   satoshis: number;
-  /** The (capped) fee rate used (sat/vB). */
+  /** The fee rate used (sat/vB), from the same resolver the real inscribe path
+   * uses (feeOracle→provider, absurd >MAX_REASONABLE_FEE_RATE sources skipped; an
+   * explicit override passes through). */
   feeRate: number;
   /** Estimated commit+reveal virtual size (vB). */
   vbytes: number;
@@ -39,6 +41,10 @@ export interface AppendCostEstimate {
  * proceeds and inscribes; `false` cleanly ABORTS the whole append (no event
  * appended, nothing inscribed — a byte-identical no-op that throws
  * `PROVENANCE_APPEND_DECLINED` and emits `cel:inscribe-declined`).
+ *
+ * The callback runs INSIDE the asset's append turn; it must not call another
+ * mutating op on the SAME asset (e.g. `addResourceVersion`/`rotateBtcoKeys`),
+ * which would queue behind its own turn and deadlock. Inspect and decide only.
  */
 export type InscribeConfirm =
   | 'now'
@@ -60,8 +66,9 @@ export interface OriginalsConfig {
   ordinalsProvider?: OrdinalsProvider;
   // Default confirm-gate policy for paid did:btco authorship appends (#407 phase
   // 4). Omitted/'now' = inscribe immediately (phase-3 behavior); a callback is
-  // consulted before each btco append and can cleanly abort it. Overridable per
-  // call (e.g. addResourceVersion's opts.inscribeConfirm).
+  // consulted before each gated paid btco append (addResourceVersion,
+  // rotateBtcoKeys) and can cleanly abort it. Overridable per call (their
+  // opts.inscribeConfirm).
   inscribeConfirm?: InscribeConfirm;
   // Shared keyed lock coordinating money-spending inscriptions across managers
   // (issue #303). OriginalsSDK injects one instance so all managers share it.

--- a/packages/sdk/src/utils/EventLogger.ts
+++ b/packages/sdk/src/utils/EventLogger.ts
@@ -43,6 +43,7 @@ export interface EventLoggingConfig {
   'cel:append-skipped'?: LogLevel | false;
   'cel:append-inscribe-skipped'?: LogLevel | false;
   'cel:inscribe-cost'?: LogLevel | false;
+  'cel:inscribe-declined'?: LogLevel | false;
   'resource:inscribed'?: LogLevel | false;
   'cel:host-failed'?: LogLevel | false;
   'key:rotated'?: LogLevel | false;
@@ -78,6 +79,7 @@ const DEFAULT_EVENT_CONFIG: EventLoggingConfig = {
   'cel:append-skipped': 'warn',
   'cel:append-inscribe-skipped': 'warn',
   'cel:inscribe-cost': 'info',
+  'cel:inscribe-declined': 'warn',
   'resource:inscribed': 'info',
   'cel:host-failed': 'warn',
   'key:rotated': 'info'
@@ -132,6 +134,7 @@ export class EventLogger {
       'cel:append-skipped',
       'cel:append-inscribe-skipped',
       'cel:inscribe-cost',
+      'cel:inscribe-declined',
       'resource:inscribed',
       'cel:host-failed',
       'key:rotated'
@@ -255,6 +258,15 @@ export class EventLogger {
         data = {
           assetId: event.asset.id,
           reason: event.reason
+        };
+        break;
+
+      case 'cel:inscribe-declined':
+        message = 'Paid btco append declined at confirm gate';
+        data = {
+          assetId: event.asset.id,
+          appendKind: event.appendKind,
+          estimate: event.estimate
         };
         break;
 

--- a/packages/sdk/tests/integration/FeePreviewConfirm.e2e.test.ts
+++ b/packages/sdk/tests/integration/FeePreviewConfirm.e2e.test.ts
@@ -10,6 +10,7 @@ import { OriginalsSDK } from '../../src';
 import { OrdMockProvider } from '../../src/adapters/providers/OrdMockProvider';
 import { MemoryStorageAdapter } from '../../src/storage/MemoryStorageAdapter';
 import { MockKeyStore } from '../mocks/MockKeyStore';
+import { KeyManager } from '../../src/did/KeyManager';
 import { hashResource } from '../../src/utils/validation';
 import type { AppendCostEstimate } from '../../src/types';
 
@@ -163,6 +164,42 @@ describe('fee preview + confirm (#407 phase 4)', () => {
     const before = inssOnSat(ordinalsProvider, sat)!.length;
     await asset.addResourceVersion('art', 'v2', 'image/png', 'to v2');
     expect(inssOnSat(ordinalsProvider, sat)!.length).toBe(before + 1);
+  });
+
+  test('rotateBtcoKeys is gated: decline aborts cleanly; a subsequent rotation with true inscribes', async () => {
+    const { sdk, ordinalsProvider } = makeSDK();
+    const { asset, sat } = await btcoAsset(sdk);
+    const eventsBefore = asset.celLog!.events.length;
+    const inssBefore = inssOnSat(ordinalsProvider, sat)!.length;
+
+    let declined: any;
+    sdk.lifecycle.on('cel:inscribe-declined', (e: any) => { declined = e; });
+
+    const k1 = await new KeyManager().generateKeyPair('Ed25519');
+    await expect(
+      sdk.lifecycle.rotateBtcoKeys(
+        asset,
+        { publicKeyMultibase: k1.publicKey, privateKey: k1.privateKey },
+        5,
+        { inscribeConfirm: () => false }
+      )
+    ).rejects.toMatchObject({ code: 'PROVENANCE_APPEND_DECLINED' });
+
+    // Byte-identical: no rotateKey event appended, no reinscription.
+    expect(asset.celLog!.events.length).toBe(eventsBefore);
+    expect(inssOnSat(ordinalsProvider, sat)!.length).toBe(inssBefore);
+    expect(declined?.appendKind).toBe('rotate');
+
+    // A subsequent rotation proceeds (concurrency claim was released on abort).
+    const k2 = await new KeyManager().generateKeyPair('Ed25519');
+    const res = await sdk.lifecycle.rotateBtcoKeys(
+      asset,
+      { publicKeyMultibase: k2.publicKey, privateKey: k2.privateKey },
+      5,
+      { inscribeConfirm: () => true }
+    );
+    expect(res.inscriptionId).toBeDefined();
+    expect(inssOnSat(ordinalsProvider, sat)!.length).toBe(inssBefore + 1);
   });
 
   test('off-btco append IGNORES the gate (no inscription, callback never consulted)', async () => {

--- a/packages/sdk/tests/integration/FeePreviewConfirm.e2e.test.ts
+++ b/packages/sdk/tests/integration/FeePreviewConfirm.e2e.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Fee preview + confirm for did:btco appends (#407 phase 4). estimateAppendCost
+ * previews the unavoidable inscription cost without committing; an inscribeConfirm
+ * gate lets a caller approve or CLEANLY ABORT a paid append after seeing the
+ * estimate. A declined append is a byte-identical no-op — no event, nothing
+ * inscribed, a follow-up append still works.
+ */
+import { describe, test, expect } from 'bun:test';
+import { OriginalsSDK } from '../../src';
+import { OrdMockProvider } from '../../src/adapters/providers/OrdMockProvider';
+import { MemoryStorageAdapter } from '../../src/storage/MemoryStorageAdapter';
+import { MockKeyStore } from '../mocks/MockKeyStore';
+import { hashResource } from '../../src/utils/validation';
+import type { AppendCostEstimate } from '../../src/types';
+
+const contentHash = (s: string) => hashResource(Buffer.from(s, 'utf8'));
+
+function makeSDK(extra: Record<string, unknown> = {}) {
+  const ordinalsProvider = new OrdMockProvider();
+  const sdk = OriginalsSDK.create({
+    network: 'regtest',
+    defaultKeyType: 'Ed25519',
+    ordinalsProvider,
+    storageAdapter: new MemoryStorageAdapter(),
+    keyStore: new MockKeyStore(),
+    ...extra
+  });
+  return { sdk, ordinalsProvider };
+}
+
+const inssOnSat = (p: OrdMockProvider, sat: string) =>
+  (p as any)['state'].inscriptionsBySatoshi.get(sat) as string[] | undefined;
+
+async function btcoAsset(sdk: OriginalsSDK, seed = 'v1') {
+  const asset = await sdk.lifecycle.createAsset([
+    { id: 'art', type: 'image', contentType: 'image/png', hash: contentHash(seed), content: seed }
+  ]);
+  await sdk.lifecycle.inscribeOnBitcoin(asset, 5);
+  const sat = asset.bindings!['did:btco'].split(':').pop()!;
+  return { asset, sat };
+}
+
+describe('fee preview + confirm (#407 phase 4)', () => {
+  test('estimateAppendCost previews a plausible quote and mutates NOTHING', async () => {
+    const { sdk, ordinalsProvider } = makeSDK();
+    const { asset, sat } = await btcoAsset(sdk);
+
+    const eventsBefore = asset.celLog!.events.length;
+    const resourcesBefore = asset.resources.length;
+    const inssBefore = inssOnSat(ordinalsProvider, sat)!.length;
+    const logHeadBefore = JSON.stringify(asset.celLog!.events);
+
+    const estimate = await sdk.lifecycle.estimateAppendCost(asset, 'update', { content: 'v2-media' });
+    expect(estimate.satoshis).toBeGreaterThan(0);
+    expect(estimate.feeRate).toBeGreaterThan(0);
+    expect(estimate.vbytes).toBeGreaterThan(0);
+    expect(estimate.contentBytes).toBe(Buffer.from('v2-media', 'utf8').byteLength);
+    // satoshis = feeRate × vbytes, vbytes = ceil(contentBytes/4)+200.
+    expect(estimate.vbytes).toBe(Math.ceil(estimate.contentBytes / 4) + 200);
+    expect(estimate.satoshis).toBe(Math.ceil(estimate.feeRate * estimate.vbytes));
+
+    // Zero side effects: log, resources, and the chain are untouched.
+    expect(asset.celLog!.events.length).toBe(eventsBefore);
+    expect(asset.resources.length).toBe(resourcesBefore);
+    expect(inssOnSat(ordinalsProvider, sat)!.length).toBe(inssBefore);
+    expect(JSON.stringify(asset.celLog!.events)).toBe(logHeadBefore);
+  });
+
+  test('estimateAppendCost without an ordinalsProvider throws ORD_PROVIDER_REQUIRED', async () => {
+    // Build a btco asset WITH a provider, then quote via a provider-less SDK.
+    const { sdk } = makeSDK();
+    const { asset } = await btcoAsset(sdk);
+    const noProvider = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519' });
+    await expect(noProvider.lifecycle.estimateAppendCost(asset, 'update', { content: 'x' }))
+      .rejects.toMatchObject({ code: 'ORD_PROVIDER_REQUIRED' });
+  });
+
+  test('the preview quote ≈ the actual cost the real append incurs (same fee source)', async () => {
+    const { sdk } = makeSDK();
+    const { asset } = await btcoAsset(sdk);
+
+    const preview = await sdk.lifecycle.estimateAppendCost(asset, 'update', { content: 'v2' });
+    let cost: { feeRate?: number; estVsize: number; estSats?: number } | undefined;
+    sdk.lifecycle.on('cel:inscribe-cost', (e: any) => { cost = e; });
+
+    await asset.addResourceVersion('art', 'v2', 'image/png', 'to v2');
+    expect(cost).toBeDefined();
+    expect(cost!.feeRate).toBe(preview.feeRate);
+    expect(cost!.estVsize).toBe(preview.vbytes);
+    expect(cost!.estSats).toBe(preview.satoshis);
+  });
+
+  test('inscribeConfirm callback → true proceeds and inscribes (phase-3 path)', async () => {
+    const { sdk, ordinalsProvider } = makeSDK();
+    const { asset, sat } = await btcoAsset(sdk);
+    const before = inssOnSat(ordinalsProvider, sat)!.length;
+
+    let seen: AppendCostEstimate | undefined;
+    await asset.addResourceVersion('art', 'v2', 'image/png', 'to v2', {
+      inscribeConfirm: (est) => { seen = est; return true; }
+    });
+
+    expect(seen).toBeDefined();
+    expect(seen!.contentBytes).toBe(Buffer.from('v2', 'utf8').byteLength);
+    expect(inssOnSat(ordinalsProvider, sat)!.length).toBe(before + 1);
+    expect(asset.resources.find(r => r.hash === contentHash('v2'))?.content).toBe('v2');
+  });
+
+  test('inscribeConfirm → false ABORTS cleanly: no event, nothing inscribed, byte-identical; a follow-up still works', async () => {
+    const { sdk, ordinalsProvider } = makeSDK();
+    const { asset, sat } = await btcoAsset(sdk);
+
+    const eventsBefore = asset.celLog!.events.length;
+    const resourcesBefore = asset.resources.length;
+    const inssBefore = inssOnSat(ordinalsProvider, sat)!.length;
+    const logBefore = JSON.stringify(asset.celLog!.events);
+
+    let declined: any;
+    sdk.lifecycle.on('cel:inscribe-declined', (e: any) => { declined = e; });
+
+    await expect(
+      asset.addResourceVersion('art', 'v2', 'image/png', 'to v2', { inscribeConfirm: () => false })
+    ).rejects.toMatchObject({ code: 'PROVENANCE_APPEND_DECLINED' });
+
+    // Byte-identical: no event appended, nothing inscribed, no new resource version.
+    expect(asset.celLog!.events.length).toBe(eventsBefore);
+    expect(asset.resources.length).toBe(resourcesBefore);
+    expect(inssOnSat(ordinalsProvider, sat)!.length).toBe(inssBefore);
+    expect(JSON.stringify(asset.celLog!.events)).toBe(logBefore);
+    expect(asset.resources.find(r => r.hash === contentHash('v2'))).toBeUndefined();
+    // The declined event carries the estimate the caller rejected.
+    expect(declined).toBeDefined();
+    expect(declined.appendKind).toBe('update');
+    expect(declined.estimate.satoshis).toBeGreaterThan(0);
+
+    // No poisoned state: a subsequent append proceeds and inscribes normally.
+    await asset.addResourceVersion('art', 'v2b', 'image/png', 'to v2b');
+    expect(inssOnSat(ordinalsProvider, sat)!.length).toBe(inssBefore + 1);
+    expect(asset.resources.find(r => r.hash === contentHash('v2b'))?.content).toBe('v2b');
+  });
+
+  test('config-level inscribeConfirm default gates all btco appends unless overridden', async () => {
+    let calls = 0;
+    const { sdk, ordinalsProvider } = makeSDK({ inscribeConfirm: () => { calls++; return false; } });
+    const { asset, sat } = await btcoAsset(sdk);
+    const before = inssOnSat(ordinalsProvider, sat)!.length;
+
+    // Config default declines.
+    await expect(asset.addResourceVersion('art', 'v2', 'image/png', 'to v2'))
+      .rejects.toMatchObject({ code: 'PROVENANCE_APPEND_DECLINED' });
+    expect(calls).toBe(1);
+    expect(inssOnSat(ordinalsProvider, sat)!.length).toBe(before);
+
+    // Per-call override wins over the config default.
+    await asset.addResourceVersion('art', 'v2', 'image/png', 'to v2', { inscribeConfirm: 'now' });
+    expect(calls).toBe(1); // config callback not consulted for the overridden call
+    expect(inssOnSat(ordinalsProvider, sat)!.length).toBe(before + 1);
+  });
+
+  test("default (no inscribeConfirm) preserves phase-3 behavior — append inscribes, no prompt", async () => {
+    const { sdk, ordinalsProvider } = makeSDK();
+    const { asset, sat } = await btcoAsset(sdk);
+    const before = inssOnSat(ordinalsProvider, sat)!.length;
+    await asset.addResourceVersion('art', 'v2', 'image/png', 'to v2');
+    expect(inssOnSat(ordinalsProvider, sat)!.length).toBe(before + 1);
+  });
+
+  test('off-btco append IGNORES the gate (no inscription, callback never consulted)', async () => {
+    const { sdk } = makeSDK();
+    // Stay on did:webvh — not the final layer, no inscription, so no cost to consent to.
+    const asset = await sdk.lifecycle.createAsset([
+      { id: 'art', type: 'image', contentType: 'image/png', hash: contentHash('v1'), content: 'v1' }
+    ]);
+    await sdk.lifecycle.publishToWeb(asset, 'example.com');
+
+    let consulted = false;
+    const res = await asset.addResourceVersion('art', 'v2', 'image/png', 'to v2', {
+      inscribeConfirm: () => { consulted = true; return false; }
+    });
+    expect(consulted).toBe(false);
+    expect(res.content).toBe('v2');
+    expect(asset.resources.find(r => r.hash === contentHash('v2'))?.content).toBe('v2');
+  });
+});

--- a/packages/sdk/tests/integration/FeePreviewConfirm.e2e.test.ts
+++ b/packages/sdk/tests/integration/FeePreviewConfirm.e2e.test.ts
@@ -166,6 +166,18 @@ describe('fee preview + confirm (#407 phase 4)', () => {
     expect(inssOnSat(ordinalsProvider, sat)!.length).toBe(before + 1);
   });
 
+  test("rotate estimate sizes the PAID content (head media), matching reinscribeRotatedDoc — not the DID doc", async () => {
+    const { sdk } = makeSDK();
+    // Media large enough that DID-doc size and media size are unambiguously different.
+    const media = 'M'.repeat(4096);
+    const { asset } = await btcoAsset(sdk, media);
+
+    const est = await sdk.lifecycle.estimateAppendCost(asset, 'rotate');
+    // reinscribeRotatedDoc inscribes headMedia.content as CONTENT (doc rides in
+    // metadata), so the paid content size IS the head media — not the DID doc.
+    expect(est.contentBytes).toBe(Buffer.from(media, 'utf8').byteLength);
+  });
+
   test('rotateBtcoKeys is gated: decline aborts cleanly; a subsequent rotation with true inscribes', async () => {
     const { sdk, ordinalsProvider } = makeSDK();
     const { asset, sat } = await btcoAsset(sdk);


### PR DESCRIPTION
Fourth increment of epic #407. Phase 3 (#411) made every did:btco authorship append a mandatory, paid Bitcoin inscription (btco is the final layer — no hosted host to fall back to). Phase 4 makes that unavoidable cost **visible up front** (a preview) and **consented to** (a confirm gate).

**Stacks on #411** (the phase-3 append-inscribe path). Base is `work-per-event-phase3c` since #411 is not yet merged.

## What's here

- **`LifecycleManager.estimateAppendCost(asset, appendKind, opts?)`** — a **non-mutating** quote for the NEXT btco append, returning `{ satoshis, feeRate, vbytes, contentBytes }`. Sizes the actual payload (`opts.content` / in-flight new media for `'update'`; the reinscribed DID doc for `'rotate'`) and reuses the **same fee-rate resolver** the real inscribe path uses, so the quote tracks reality. Zero side effects. Throws `ORD_PROVIDER_REQUIRED` without an ordinalsProvider.
- **`inscribeConfirm` gate** — a per-call option on `addResourceVersion` and `rotateBtcoKeys`, plus a config default on `OriginalsConfig`. `'now'` (default) = phase-3 behavior. A callback is awaited with the estimate **before any log mutation**: `true` proceeds; `false` **cleanly aborts** the whole append — no event appended, nothing inscribed, the asset left byte-identical (abort-before-mutate), throwing `PROVENANCE_APPEND_DECLINED` and emitting the new **`cel:inscribe-declined`** event. A subsequent append still works (no poisoned state).

**No defer path:** btco has no hosted fallback, so the only control is proceed-and-pay or abort. Off-btco (did:cel/did:webvh) appends are unaffected — they inscribe nothing, so the gate is a no-op.

## Load-bearing detail

`OriginalsAsset.#addResourceVersionCritical` pushes the new resource version **unconditionally** once the appender returns, so a mere `return null` on decline would still mutate `resources`. The gate therefore **throws** (before that push, before any log mutation) to guarantee a byte-identical no-op.

## Security review

One fable reviewer on the gate + preview before opening this PR. Verdict after fixes: the preview is truly non-mutating; a false confirm leaves the asset byte-identical (no orphaned event, no `UNPROVABLE_BASE`, no half-inscribed state) with a working follow-up append; the gate sits before mutation; the estimate can't be used to append-without-paying. Its one **Important** finding (paid `rotateBtcoKeys` reinscriptions bypassed the gate, contradicting spec §2 and the config doc) is fixed here by gating rotation too; the Minor/Nit doc findings (reentrancy warning, fee-rate "cap" wording) are addressed.

## Verification

- `bun run build` clean; `bunx tsc --noEmit` clean.
- `bun test`: 3800 pass, 0 fail, 249 skip. New spine: `tests/integration/FeePreviewConfirm.e2e.test.ts` (9 tests) covers non-mutating preview, quote ≈ actual cost, `ORD_PROVIDER_REQUIRED`, confirm true/false, clean abort + working follow-up, rotate gating, config default + per-call override, and off-btco no-op.

Closes part of #407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add fee preview and confirm gate for did:btco authorship appends
> - Adds `LifecycleManager.estimateAppendCost` to return a non-mutating cost estimate (`satoshis`, `feeRate`, `vbytes`, `contentBytes`) for the next `did:btco` append (update or rotate).
> - Adds an `inscribeConfirm` gate (callback or `'now'`) to `addResourceVersion` and `rotateBtcoKeys`; if the callback returns `false`, the append is aborted before any mutation, a `cel:inscribe-declined` event is emitted, and a `PROVENANCE_APPEND_DECLINED` error is thrown.
> - Adds `InscribeConfirm` as an optional default in `OriginalsConfig` for a config-level gate policy.
> - `EventLogger` subscribes to `cel:inscribe-declined` and logs it at `warn` level with asset ID, append kind, and cost estimate.
> - Integration tests cover estimate accuracy, true/false confirm paths for update and rotate, config-level defaults, and off-btco no-op behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85fe076.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->