### PR TITLE
fix(sdk): noble-init must not throw at import when @noble namespace is frozen (browser)

### DIFF
--- a/.changeset/noble-init-browser-hardening.md
+++ b/.changeset/noble-init-browser-hardening.md
@@ -1,0 +1,5 @@
+---
+"@originals/sdk": patch
+---
+
+Harden `noble-init` so importing the SDK never white-screens a browser app. Under some ESM bundlers the `@noble/ed25519` / `@noble/secp256k1` module namespace is frozen (non-configurable, `hashes` reads `undefined`); the previous init did a raw `Object.defineProperty(mod, 'hashes', …)` that threw `Cannot redefine property: hashes` at import time. Initialization now routes `hashes` creation through the existing `safeSetProperty` (which cannot throw) and skips with a one-time `console.warn` when the namespace can't be configured, instead of crashing every consumer that merely imports the SDK.

--- a/packages/sdk/src/crypto/noble-init.ts
+++ b/packages/sdk/src/crypto/noble-init.ts
@@ -12,6 +12,10 @@
  * 1. Libraries are configured before any crypto operations
  * 2. Configuration is consistent across the SDK
  * 3. Readonly property issues (Bun) are handled gracefully
+ * 4. It never throws at import time — under some browser ESM bundlers the noble
+ *    module namespace is frozen (non-configurable, `hashes` reads undefined), so
+ *    configuration is impossible; we warn and skip rather than crash every
+ *    consumer that merely imports the SDK (browser white-screen reports).
  *
  * This should be imported at the SDK entry point (index.ts) to ensure it runs first.
  */
@@ -36,9 +40,10 @@ const hmacSha256Impl = (key: Uint8Array, ...msgs: Uint8Array[]) =>
   hmac(sha256, key, concatBytes(...msgs));
 
 /**
- * Safely set a property on an object, handling readonly properties
+ * Safely set a property on an object, handling readonly properties.
+ * Never throws — returns false if the property cannot be set.
  */
- 
+
 function safeSetProperty(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   obj: any,
@@ -55,7 +60,7 @@ function safeSetProperty(
     // Property might be readonly, try defineProperty
     try {
       Object.defineProperty(obj, prop, {
-         
+
         value,
         writable: options?.writable ?? true,
         configurable: options?.configurable ?? true,
@@ -69,71 +74,83 @@ function safeSetProperty(
 }
 
 /**
+ * Return the module's mutable `hashes` object, creating it if absent.
+ *
+ * Returns `null` when the module namespace is frozen and `hashes` cannot be
+ * attached — e.g. a strict-ESM browser bundle where the namespace is
+ * non-extensible and `hashes` exists only as a non-configurable binding whose
+ * value is `undefined`. In that case configuration is impossible and callers
+ * must skip rather than dereference `hashes` (which would throw and, at import
+ * time, white-screen the consuming app).
+ */
+function ensureHashesObject(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mod: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Record<string, any> | null {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  if (mod && typeof mod.hashes === 'object' && mod.hashes !== null) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
+    return mod.hashes;
+  }
+  // safeSetProperty never throws (frozen namespace → both assign and
+  // defineProperty are caught), so this is safe at import time.
+  safeSetProperty(mod, 'hashes', {});
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  return mod && typeof mod.hashes === 'object' && mod.hashes !== null ? mod.hashes : null;
+}
+
+let warnedFrozen = false;
+function warnFrozen(lib: string): void {
+  if (warnedFrozen) return;
+  warnedFrozen = true;
+  console.warn(
+    `[noble-init] Could not configure @noble/${lib} sync hashes: the module namespace is frozen ` +
+      `(non-configurable). Sync crypto ops may be unavailable in this environment. This is usually a ` +
+      `bundler dedupe/pre-bundle issue — ensure a single @noble instance is served as ESM.`
+  );
+}
+
+/**
  * Initialize @noble/secp256k1 with sync hash utilities (v3.x `hashes` object).
  *
- * Note: v3.x freezes the legacy v2.x `utils` object, so it is no longer
- * possible (nor necessary) to inject `utils.hmacSha256Sync` for backward
- * compatibility - all sync signing/verification now reads from `hashes`.
+ * The optional `mod` parameter exists for testing (inject a frozen/mutable mock);
+ * production always configures the real imported module.
  */
-function initSecp256k1(): void {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
-  const sAny: any = secp256k1 as any;
-
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  if (!sAny?.hashes) {
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      sAny.hashes = {};
-    } catch {
-      Object.defineProperty(sAny, 'hashes', {
-        value: {},
-        writable: true,
-        configurable: true,
-      });
-    }
+export function initSecp256k1(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mod: any = secp256k1
+): void {
+  const hashes = ensureHashesObject(mod);
+  if (!hashes) {
+    warnFrozen('secp256k1');
+    return;
   }
-
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  if (typeof sAny.hashes.sha256 !== 'function') {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    safeSetProperty(sAny.hashes, 'sha256', sha256Impl);
+  if (typeof hashes.sha256 !== 'function') {
+    safeSetProperty(hashes, 'sha256', sha256Impl);
   }
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  if (typeof sAny.hashes.hmacSha256 !== 'function') {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    safeSetProperty(sAny.hashes, 'hmacSha256', hmacSha256Impl);
+  if (typeof hashes.hmacSha256 !== 'function') {
+    safeSetProperty(hashes, 'hmacSha256', hmacSha256Impl);
   }
 }
 
 /**
  * Initialize @noble/ed25519 with sync sha512 utility (v3.x `hashes.sha512`).
  *
- * Note: v3.x freezes the legacy v2.x `utils` / `etc` objects, so it is no
- * longer possible (nor necessary) to inject `utils.sha512Sync` /
- * `etc.sha512Sync` for backward compatibility - all sync signing/verification
- * now reads from `hashes`.
+ * The optional `mod` parameter exists for testing (inject a frozen/mutable mock);
+ * production always configures the real imported module.
  */
-function initEd25519(): void {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
-  const eAny: any = ed25519 as any;
-
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  if (!eAny?.hashes) {
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      eAny.hashes = {};
-    } catch {
-      Object.defineProperty(eAny, 'hashes', {
-        value: {},
-        writable: true,
-        configurable: true,
-      });
-    }
+export function initEd25519(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mod: any = ed25519
+): void {
+  const hashes = ensureHashesObject(mod);
+  if (!hashes) {
+    warnFrozen('ed25519');
+    return;
   }
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  if (typeof eAny.hashes.sha512 !== 'function') {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    safeSetProperty(eAny.hashes, 'sha512', sha512Impl);
+  if (typeof hashes.sha512 !== 'function') {
+    safeSetProperty(hashes, 'sha512', sha512Impl);
   }
 }
 
@@ -148,4 +165,3 @@ export function initNobleCrypto(): void {
 
 // Auto-initialize when this module is imported
 initNobleCrypto();
-

--- a/packages/sdk/src/crypto/noble-init.ts
+++ b/packages/sdk/src/crypto/noble-init.ts
@@ -100,10 +100,12 @@ function ensureHashesObject(
   return mod && typeof mod.hashes === 'object' && mod.hashes !== null ? mod.hashes : null;
 }
 
-let warnedFrozen = false;
+// Per-library so a frozen ed25519 namespace still warns even after secp256k1
+// already warned (both are frozen together in the Vite pre-bundle scenario).
+const warnedFrozen = new Set<string>();
 function warnFrozen(lib: string): void {
-  if (warnedFrozen) return;
-  warnedFrozen = true;
+  if (warnedFrozen.has(lib)) return;
+  warnedFrozen.add(lib);
   console.warn(
     `[noble-init] Could not configure @noble/${lib} sync hashes: the module namespace is frozen ` +
       `(non-configurable). Sync crypto ops may be unavailable in this environment. This is usually a ` +

--- a/packages/sdk/tests/unit/crypto/noble-init.test.ts
+++ b/packages/sdk/tests/unit/crypto/noble-init.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect } from 'bun:test';
+import { initEd25519, initSecp256k1, initNobleCrypto } from '../../../src/crypto/noble-init';
+
+/**
+ * Simulate a strict-ESM browser bundle namespace: `hashes` exists only as a
+ * non-configurable binding whose value is `undefined`, and the object is
+ * non-extensible. Before the fix, initEd25519/initSecp256k1 did a raw
+ * `Object.defineProperty(mod, 'hashes', …)` here and threw
+ * "Cannot redefine property: hashes" — white-screening any browser app that
+ * merely imported the SDK.
+ */
+function frozenNamespace(): unknown {
+  const ns: Record<string, unknown> = {};
+  Object.defineProperty(ns, 'hashes', {
+    value: undefined,
+    writable: false,
+    configurable: false,
+    enumerable: true,
+  });
+  Object.preventExtensions(ns);
+  return ns;
+}
+
+describe('noble-init browser hardening', () => {
+  test('initEd25519 does not throw on a frozen module namespace', () => {
+    expect(() => initEd25519(frozenNamespace())).not.toThrow();
+  });
+
+  test('initSecp256k1 does not throw on a frozen module namespace', () => {
+    expect(() => initSecp256k1(frozenNamespace())).not.toThrow();
+  });
+
+  test('initEd25519 configures hashes.sha512 on a normal mutable module', () => {
+    const mod: { hashes?: Record<string, unknown> } = {};
+    initEd25519(mod);
+    expect(typeof mod.hashes?.sha512).toBe('function');
+  });
+
+  test('initSecp256k1 configures hashes.sha256 + hmacSha256 on a normal module', () => {
+    const mod: { hashes?: Record<string, unknown> } = {};
+    initSecp256k1(mod);
+    expect(typeof mod.hashes?.sha256).toBe('function');
+    expect(typeof mod.hashes?.hmacSha256).toBe('function');
+  });
+
+  test('does not clobber a hash impl that is already set', () => {
+    const existing = (msg: Uint8Array) => msg;
+    const mod = { hashes: { sha512: existing } as Record<string, unknown> };
+    initEd25519(mod);
+    expect(mod.hashes.sha512).toBe(existing);
+  });
+
+  test('initNobleCrypto (real modules) is idempotent and does not throw', () => {
+    expect(() => initNobleCrypto()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What

`packages/sdk/src/crypto/noble-init.ts` auto-runs on import to configure `@noble/ed25519` / `@noble/secp256k1` sync hashes. Its fallback for creating the `hashes` object used a raw `Object.defineProperty(mod, 'hashes', …)` that **throws** when the module namespace is frozen — then blindly dereferenced `hashes.sha512`.

Under some browser ESM bundlers (e.g. Vite dep pre-bundling with two `@noble/ed25519` representations), the namespace is non-extensible and `hashes` exists only as a **non-configurable binding whose value is `undefined`**. Import-time init then threw `Cannot redefine property: hashes` — **white-screening any browser app that merely imports the SDK**.

## Why

This is a robustness bug, not a correctness one: it never triggers in Node (mutable module object), so the SDK's own test suite never hit it — but it takes down browser consumers at import time. Reported from the landing app; the app-side workaround (Vite dedupe/exclude) fixes that one consumer, but the root cause belongs in the SDK.

## How

- Route `hashes` creation through the existing `safeSetProperty` (try-assign → try-defineProperty → **swallow**), which cannot throw.
- New `ensureHashesObject(mod)` returns the mutable `hashes` object or `null` when the namespace can't be configured; `initEd25519`/`initSecp256k1` then **skip with a one-time `console.warn`** instead of dereferencing `undefined`.
- `initEd25519`/`initSecp256k1` gain an optional injected-module parameter (defaulting to the real import) purely for testability.
- No behavior change in the normal (Node / mutable module) path.

## Testing

New `tests/unit/crypto/noble-init.test.ts` (6 tests):
- `initEd25519` / `initSecp256k1` **do not throw** on a simulated frozen ESM namespace (the exact repro: `hashes` non-configurable + value `undefined` + non-extensible object) — this is the regression that white-screened the browser.
- normal mutable module still gets `hashes.sha512` / `hashes.sha256` / `hmacSha256`;
- an already-set hash impl is not clobbered;
- `initNobleCrypto()` on the real modules stays idempotent and throw-free.

Full SDK unit suite: **3566 pass / 0 fail**; `tsc` + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `noble-init` to not throw when `@noble` module namespaces are frozen in browsers
> - `initSecp256k1` and `initEd25519` previously threw when the `@noble` module namespaces were frozen (e.g. in certain browser bundler environments), causing white-screens on import.
> - Introduces `ensureHashesObject` to safely obtain or create the `hashes` object, returning `null` instead of throwing when the namespace is frozen.
> - Adds `warnFrozen` to emit a one-time `console.warn` per library when configuration is skipped due to a frozen namespace.
> - Both initializers are now exported and accept an optional module parameter to support testing with mock modules.
> - Unit tests in [`noble-init.test.ts`](https://github.com/onionoriginals/sdk/pull/416/files#diff-e1e61ee5ab2ff33bd2866b292b40299a075af6de6f4dacb0316b0cfe0c54052d) cover frozen namespaces, mutable configuration, pre-existing hash preservation, and idempotent behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 62c28ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->