### PR TITLE
fix(auth): pass Uint8Array not Buffer to multibase encode (TS strict build)

### DIFF
--- a/.changeset/auth-buffer-uint8array.md
+++ b/.changeset/auth-buffer-uint8array.md
@@ -1,0 +1,5 @@
+---
+"@originals/auth": patch
+---
+
+Pass a plain `Uint8Array` (not a `Buffer`) to multibase encoding in the Turnkey signers. Under stricter Node/Bun typings `Buffer` is a `Buffer<ArrayBufferLike>` that TypeScript will not assign to a `Uint8Array<ArrayBufferLike>` parameter, breaking the build (`TS2345`). `Uint8Array.from(Buffer.from(hex, 'hex'))` is equivalent at runtime and type-clean.

--- a/packages/auth/src/client/turnkey-did-signer.ts
+++ b/packages/auth/src/client/turnkey-did-signer.ts
@@ -78,7 +78,7 @@ export class TurnkeyDIDSigner {
         const cleanS = s.startsWith('0x') ? s.slice(2) : s;
         const combinedHex = cleanR + cleanS;
 
-        const signatureBytes = Buffer.from(combinedHex, 'hex');
+        const signatureBytes = Uint8Array.from(Buffer.from(combinedHex, 'hex'));
 
         if (signatureBytes.length !== 64) {
           throw new Error(

--- a/packages/auth/src/server/turnkey-signer.ts
+++ b/packages/auth/src/server/turnkey-signer.ts
@@ -99,7 +99,7 @@ export class TurnkeyWebVHSigner implements ExternalSigner, ExternalVerifier {
       const cleanR = r.startsWith('0x') ? r.slice(2) : r;
       const cleanS = s.startsWith('0x') ? s.slice(2) : s;
       const cleanSig = cleanR + cleanS;
-      const signatureBytes = Buffer.from(cleanSig, 'hex');
+      const signatureBytes = Uint8Array.from(Buffer.from(cleanSig, 'hex'));
 
       // Ed25519 signatures must be exactly 64 bytes (32-byte r + 32-byte s).
       // Never truncate: a 65-byte value is not a valid Ed25519 signature with a


### PR DESCRIPTION
## What

`@originals/auth`'s Turnkey signers decode the signature with `Buffer.from(hex, 'hex')` and pass that `Buffer` straight into multibase encoding:
- `src/client/turnkey-did-signer.ts:89` → `encoding.multibase.encode(signatureBytes, 'base58btc')`
- `src/server/turnkey-signer.ts:117` → `multikey.encodeMultibase(signatureBytes)`

Under stricter Node/Bun typings `Buffer` is `Buffer<ArrayBufferLike>`, which TypeScript will **not** assign to a `Uint8Array<ArrayBufferLike>` parameter — so the build fails:

```
src/client/turnkey-did-signer.ts(89,54): error TS2345:
  Argument of type 'Buffer<ArrayBufferLike>' is not assignable to parameter of type 'Uint8Array<ArrayBufferLike>'.
```

## Fix

Wrap the hex-decoded bytes in `Uint8Array.from(Buffer.from(hex, 'hex'))` at both sites. Equivalent at runtime (a `Buffer` *is* a `Uint8Array`), and type-clean under strict typings. No behavior change — the length checks and encoding are unchanged.

## Testing

- Real turbo build (SDK → auth, `--force`, no cache): **2 successful, 2 total**, no TS errors.
- Only the two signer files change.

Fixes the `main` build regression reported when building `@originals/auth` on a fresh/strict install (surfaced while setting up the landing Railway deploy, #330).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Turnkey signers to pass `Uint8Array` instead of `Buffer` to multibase encode
> Wraps the hex-decoded `Buffer` in `Uint8Array.from(...)` before passing to `multibase.encode` in both [`turnkey-did-signer.ts`](https://github.com/onionoriginals/sdk/pull/420/files#diff-733521f2c747d425cf13428332a1c8f7d4e891d3a787d6a6b546332954ae32c3) and [`turnkey-signer.ts`](https://github.com/onionoriginals/sdk/pull/420/files#diff-0bc85aff7b742649b9aba1d2c34caeed85c94a77c9bb195720f1a397ce93d323). This satisfies stricter Node/Bun TypeScript typings that do not accept `Buffer` where `Uint8Array` is expected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bec4ab8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->