### PR TITLE
fix(landing): serve.ts mounts /api auth routes (env-gated) + clean 404

### DIFF
--- a/.changeset/landing-serve-unified-api.md
+++ b/.changeset/landing-serve-unified-api.md
@@ -1,0 +1,5 @@
+---
+"@originals/landing": patch
+---
+
+Landing production server (`apps/landing/serve.ts`) now serves the SPA **and** mounts the `/api` auth routes in the same process when Turnkey env (`TURNKEY_*` + `JWT_SECRET`) is set, so the Railway deploy supports Sign-in same-origin. Without that env it serves static only and `/api/*` returns a clear JSON 404 instead of SPA-falling-back to `index.html` (which made the client parse HTML as JSON — "Unexpected token '<'").

--- a/apps/landing/serve.ts
+++ b/apps/landing/serve.ts
@@ -1,16 +1,38 @@
 /**
- * Production static server for the built landing SPA (Railway).
+ * Production server for the landing app (Railway) — single service.
  *
- * Serves `apps/landing/dist` on $PORT with SPA fallback (unknown non-asset
- * routes → index.html). Static-only: the auth API (`server/index.ts`) is a
- * separate service that needs Turnkey creds — deploy it alongside and point the
- * proxy/`VITE_*` at it if you want the Sign-in / did:webvh features live.
+ * Serves the built SPA (`apps/landing/dist`) on `$PORT`, and — when the Turnkey
+ * auth env is present — ALSO mounts the `/api` auth routes in the SAME process,
+ * so Sign-in / session work same-origin (no CORS, httpOnly cookie). Without that
+ * env it serves the static site only and `/api/*` returns a clear JSON 404.
+ *
+ * Enable the auth API by setting on the Railway service:
+ *   TURNKEY_API_PUBLIC_KEY, TURNKEY_API_PRIVATE_KEY, TURNKEY_ORGANIZATION_ID, JWT_SECRET
+ * Sessions are in-memory (fine for a single instance; use a shared store if you
+ * scale to multiple).
  */
 import { file } from 'bun';
 import { normalize } from 'node:path';
+import { createInMemorySessionStorage } from '@originals/auth/server';
+import { route, json, type Handler } from './server/router';
+import { buildRoutes } from './server/index';
+import { getTurnkey } from './server/turnkey';
 
 const DIST = new URL('./dist/', import.meta.url).pathname;
 const port = Number(process.env.PORT ?? 3000);
+
+function buildApiRoutes(): Record<string, Handler> | null {
+  const jwtSecret = process.env.JWT_SECRET;
+  const configured =
+    jwtSecret &&
+    process.env.TURNKEY_API_PUBLIC_KEY &&
+    process.env.TURNKEY_API_PRIVATE_KEY &&
+    process.env.TURNKEY_ORGANIZATION_ID;
+  if (!configured) return null;
+  return buildRoutes({ turnkey: getTurnkey(), sessions: createInMemorySessionStorage(), jwtSecret });
+}
+
+const apiRoutes = buildApiRoutes();
 
 async function serveFile(relPath: string): Promise<Response> {
   const f = file(DIST + relPath);
@@ -26,6 +48,15 @@ const server = Bun.serve({
   hostname: '0.0.0.0',
   async fetch(req) {
     const url = new URL(req.url);
+    // Auth API: dispatch when configured, else a clear JSON 404 (never
+    // SPA-fallback /api/* to index.html — the client would parse HTML as JSON).
+    if (url.pathname === '/api' || url.pathname.startsWith('/api/')) {
+      if (apiRoutes) return route(req, apiRoutes);
+      return json(
+        { error: 'Auth API not configured — set TURNKEY_* + JWT_SECRET on this service to enable Sign-in.' },
+        404
+      );
+    }
     // Strip leading slashes, normalize, and reject path traversal.
     const rel = normalize(decodeURIComponent(url.pathname)).replace(/^(\.\.(\/|\\|$))+/, '').replace(/^\/+/, '');
     if (rel.includes('..')) return new Response('Bad request', { status: 400 });
@@ -33,4 +64,6 @@ const server = Bun.serve({
   },
 });
 
-console.log(`[landing] serving ${DIST} on http://0.0.0.0:${server.port}`);
+console.log(
+  `[landing] serving ${DIST} on http://0.0.0.0:${server.port} (auth API: ${apiRoutes ? 'enabled' : 'static-only'})`
+);


### PR DESCRIPTION
## What

Follow-up to #419. The `serve.ts` that merged in #419 was the original static server: it SPA-fell-back **`/api/*` → `index.html`**, so on the deployed site (no auth backend) the Sign-in client parsed an HTML page as JSON — **"Unexpected token '<'"**.

This makes `apps/landing/serve.ts` a single unified service:

- Always serves the static SPA (`dist/`, SPA fallback, path-traversal guard, `0.0.0.0:$PORT`).
- **Mounts the `/api` auth routes in the same process when the Turnkey env is present** (`TURNKEY_API_PUBLIC_KEY`, `TURNKEY_API_PRIVATE_KEY`, `TURNKEY_ORGANIZATION_ID`, `JWT_SECRET`) — Sign-in works **same-origin** (no CORS, httpOnly cookie).
- Without that env: static-only, and `/api/*` returns a clear **JSON 404** (never HTML).

## Why not in #419

#419 was squash-merged before this revision was pushed to the branch, so main still has the original `serve.ts`. This PR carries the pending fix.

## Testing

Verified against current `main`:
- build chain succeeds; `serve.ts` runs.
- **auth-enabled** (env set): startup logs `auth API: enabled`, `/api/health` → 200 `{status:ok}`, `/api/me` (no cookie) → 401 JSON.
- **static-only** (no env): `auth API: static-only`, `/api/*` → 404 JSON, `/` → 200 html, SPA routes fall back to index.html, encoded `../` traversal does not escape `dist/`.

Enables Sign-in on the Railway deploy by setting the four env vars; leave unset for a static marketing deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mount /api auth routes in landing `serve.ts` when Turnkey env vars are present
> - [serve.ts](https://github.com/onionoriginals/sdk/pull/421/files#diff-2a9b68a554de991b63b27f025f9dac1146c11e7f26168242518e22521d4148bb) now checks for `JWT_SECRET` and `TURNKEY_*` env vars at startup; if all are present, it builds and mounts `/api` route handlers via `buildApiRoutes`.
> - `/api` and `/api/*` requests are dispatched to these handlers when configured, or return a JSON 404 when env vars are missing — they no longer fall back to serving `index.html`.
> - Startup log now reports `(auth API: enabled)` or `(auth API: static-only)` to reflect the active mode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8dfb5e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->