### PR TITLE
fix(stress): correct memory-leak assertion direction and increase warmup

### DIFF
--- a/packages/sdk/tests/stress/batch-operations-stress.test.ts
+++ b/packages/sdk/tests/stress/batch-operations-stress.test.ts
@@ -388,7 +388,10 @@ describe('Batch Operations Stress Tests', () => {
 
   describe('6. Memory and Resource Tests', () => {
     it('should not leak memory during repeated batch operations', async () => {
-      const warmupIterations = 5; // allow JIT to settle before measuring
+      // Longer warmup so GC from prior heavy stress tests (1000-asset migrations)
+      // fully settles before we start measuring — without this, mid-measurement GC
+      // can make firstHalf >> secondHalf and cause the growth check to false-fire.
+      const warmupIterations = 15;
       const measuredIterations = 10;
       const batchSize = 100;
 
@@ -427,7 +430,9 @@ describe('Batch Operations Stress Tests', () => {
       const growth = ((secondHalf - firstHalf) / firstHalf) * 100;
 
       console.log(`[STRESS] Memory growth: ${growth.toFixed(2)}%`);
-      expect(Math.abs(growth)).toBeLessThan(50); // Memory shouldn't grow > 50%
+      // A memory leak manifests as POSITIVE growth. GC-driven shrinkage between
+      // halves is normal and not a leak, so we only check the positive direction.
+      expect(growth).toBeLessThan(50); // Memory shouldn't grow > 50%
     }, 180000);
 
     it('should handle resource cleanup after timeout', async () => {


### PR DESCRIPTION
## What was red

`Batch Operations Stress Tests > 6. Memory and Resource Tests > should not leak memory during repeated batch operations` failed deterministically when the full stress suite ran, but passed 3/3 times in isolation.

**Real failure** (not flaky in the isolation-vs-suite sense — it failed consistently when the preceding 1000-asset migration tests ran first).

## Root cause

The assertion was:
```ts
expect(Math.abs(growth)).toBeLessThan(50); // Memory shouldn't grow > 50%
```

`Math.abs` makes this fire in *both* directions — if memory **decreases** by >50% between the first and second measurement half, it also fails.

The preceding stress tests (1000-asset migrations) leave a large heap. GC hadn't finished clearing it by the time the 5-iteration warmup completed. So the first half of the measurement window saw declining memory (GC still running), and the second half saw a settled, lower baseline — producing a `growth` value of e.g. −60%. `Math.abs(−60) = 60 > 50` → false failure.

A memory **leak** shows as **positive** growth (second half > first half). GC-driven shrinkage between halves is normal and not a defect.

## Fix

1. **Corrected the assertion direction**: `expect(Math.abs(growth)).toBeLessThan(50)` → `expect(growth).toBeLessThan(50)`. Memory leaks are positive growth; we only need to guard that direction.

2. **Increased warmup iterations**: 5 → 15, so GC from prior heavy tests has more time to settle before the measurement window opens.

## Verification — green invariant output

```
Tasks:    4 successful, 4 total
@originals/sdk:test:  18 pass  0 fail   (stress)
@originals/auth:test: 238 pass  0 fail
@originals/sdk:test: 3753 pass  0 fail   (integration + unit + security + stress)
```

- `bunx tsc --noEmit`: 0 errors
- `bun run build`: succeeded

## Self-check

- (a) Root cause fixed: yes — assertion now only catches positive heap growth
- (b) No test skipped/deleted/weakened/masked: the assertion still catches ≥50% heap growth under repeated load
- (c) No cryptographic or provenance guarantee loosened: change is entirely in a stress test timing heuristic

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPfoMUHUaNP1pk5MbK7nwU)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix memory-leak assertion in batch operations stress test and increase warmup
> - Fixes the assertion in the memory-leak test in [batch-operations-stress.test.ts](https://github.com/onionoriginals/sdk/pull/425/files#diff-697571f6952f931f3b6d5b5e48df116050df238b6e494e863d48630e05326593) by replacing `expect(Math.abs(growth)).toBeLessThan(50)` with `expect(growth).toBeLessThan(50)`, so GC-driven memory shrinkage no longer causes a false failure.
> - Increases `warmupIterations` from 5 to 15 to give the runtime more time to stabilize before measurements are taken.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 43b0114.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->