### PR TITLE
feat(landing): real on-chain demo — did:webvh hosting + testnet4 inscription (#417)

### DIFF
--- a/.changeset/testnet4-network-support.md
+++ b/.changeset/testnet4-network-support.md
@@ -1,0 +1,5 @@
+---
+"@originals/sdk": minor
+---
+
+Add first-class `network: 'testnet'` (testnet4) support. A testnet-configured SDK mints `did:btco:test:<sat>` identifiers and validates `tb1` testnet addresses; the config/DID-identity network unions and prefix maps accept `'testnet'` across `types`, `btcoDid`, `createBtcoDidDocument`, `DIDManager`, `LifecycleManager`, `BitcoinManager`, `BtcoCelManager`, and `bitcoin-address`. The Bitcoin transaction layer already mapped `testnet` → `TEST_NETWORK`. `QuickNodeProvider` accepts `expectedNetwork: 'testnet'` for testnet4 reads/broadcast.

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -20,11 +20,16 @@
   "dependencies": {
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource/jetbrains-mono": "^5.2.8",
+    "@noble/curves": "^2.2.0",
     "@noble/ed25519": "^3.1.0",
     "@noble/hashes": "^2.0.1",
     "@originals/auth": "workspace:*",
     "@originals/sdk": "workspace:*",
+    "@scure/base": "^2.2.0",
+    "@scure/btc-signer": "^2.2.0",
+    "@turnkey/api-key-stamper": "^0.6.7",
     "@turnkey/crypto": "^2.10.0",
+    "@turnkey/sdk-browser": "^6.1.1",
     "didwebvh-ts": "^2.8.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"

--- a/apps/landing/serve.ts
+++ b/apps/landing/serve.ts
@@ -59,7 +59,10 @@ function buildApiRoutes(): Record<string, Handler> | null {
       faucet: { walletId: process.env.BTC_FAUCET_WALLET_ID!, address: process.env.BTC_FAUCET_ADDRESS! },
       faucetSats: Number(process.env.BTC_FAUCET_SATS ?? 20_000),
     });
-    console.log('[landing] testnet4 inscription configured — /api/btc/* live');
+    console.warn(
+      '[landing] /api/btc/* mounted, but the faucet WILL return 502 until getSpendableUtxos ' +
+        'is wired in createFaucetProviderFromEnv (serve.ts) for your QuickNode add-on / bitcoind.'
+    );
   } else {
     console.warn('[landing] testnet4 inscription disabled (QUICKNODE_ENDPOINT/BTC_FAUCET_* absent) — inscribe stays mock');
   }

--- a/apps/landing/serve.ts
+++ b/apps/landing/serve.ts
@@ -1,25 +1,45 @@
 /**
  * Production server for the landing app (Railway) — single service.
  *
- * Serves the built SPA (`apps/landing/dist`) on `$PORT`, and — when the Turnkey
- * auth env is present — ALSO mounts the `/api` auth routes in the SAME process,
- * so Sign-in / session work same-origin (no CORS, httpOnly cookie). Without that
- * env it serves the static site only and `/api/*` returns a clear JSON 404.
+ * Serves the built SPA (`apps/landing/dist`) on `$PORT`, hosts the real
+ * did:webvh logs at `/api/host/*` + the resolver URLs (Track A — no secrets
+ * needed), and — when the Turnkey auth env is present — ALSO mounts the `/api`
+ * auth routes (and, when a testnet4 faucet is configured, `/api/btc/*` for real
+ * inscription) in the SAME process, so everything is same-origin. Without the
+ * auth env, `/api/*` (except the host store) returns a clear JSON 404.
  *
- * Enable the auth API by setting on the Railway service:
- *   TURNKEY_API_PUBLIC_KEY, TURNKEY_API_PRIVATE_KEY, TURNKEY_ORGANIZATION_ID, JWT_SECRET
- * Sessions are in-memory (fine for a single instance; use a shared store if you
- * scale to multiple).
+ * Enable the auth API by setting: TURNKEY_API_PUBLIC_KEY, TURNKEY_API_PRIVATE_KEY,
+ * TURNKEY_ORGANIZATION_ID, JWT_SECRET. Enable real testnet4 inscription by ALSO
+ * setting QUICKNODE_ENDPOINT + BTC_FAUCET_WALLET_ID + BTC_FAUCET_ADDRESS.
  */
-import { file } from 'bun';
-import { normalize } from 'node:path';
 import { createInMemorySessionStorage } from '@originals/auth/server';
-import { route, json, type Handler } from './server/router';
+import { QuickNodeProvider } from '@originals/sdk';
+import { buildFetch } from './server/app';
+import { createWebvhHostStore } from './server/webvh-host';
 import { buildRoutes } from './server/index';
 import { getTurnkey } from './server/turnkey';
+import { createBitcoinRoutes, isBitcoinConfigured, type FaucetProvider } from './server/bitcoin';
+import type { Handler } from './server/router';
 
 const DIST = new URL('./dist/', import.meta.url).pathname;
 const port = Number(process.env.PORT ?? 3000);
+const hostStore = createWebvhHostStore();
+
+// QuickNodeProvider + a faucet UTXO lookup. getSpendableUtxos uses the Ordinals
+// add-on's address index / bitcoind scantxoutset — an explicit throw-until-wired
+// operational gap (fails loudly; never fabricates), filled per-deploy.
+function createFaucetProviderFromEnv(): FaucetProvider {
+  const provider = new QuickNodeProvider({
+    endpoint: process.env.QUICKNODE_ENDPOINT!,
+    expectedNetwork: 'testnet',
+  }) as unknown as FaucetProvider;
+  provider.getSpendableUtxos = async (address: string) => {
+    throw new Error(
+      `getSpendableUtxos not wired for ${address}: implement against the QuickNode Ordinals add-on address index or bitcoind scantxoutset before enabling the faucet.`
+    );
+  };
+  return provider;
+}
 
 function buildApiRoutes(): Record<string, Handler> | null {
   const jwtSecret = process.env.JWT_SECRET;
@@ -29,39 +49,29 @@ function buildApiRoutes(): Record<string, Handler> | null {
     process.env.TURNKEY_API_PRIVATE_KEY &&
     process.env.TURNKEY_ORGANIZATION_ID;
   if (!configured) return null;
-  return buildRoutes({ turnkey: getTurnkey(), sessions: createInMemorySessionStorage(), jwtSecret });
+  const turnkey = getTurnkey();
+  let bitcoin;
+  if (isBitcoinConfigured()) {
+    bitcoin = createBitcoinRoutes({
+      turnkey,
+      jwtSecret,
+      provider: createFaucetProviderFromEnv(),
+      faucet: { walletId: process.env.BTC_FAUCET_WALLET_ID!, address: process.env.BTC_FAUCET_ADDRESS! },
+      faucetSats: Number(process.env.BTC_FAUCET_SATS ?? 20_000),
+    });
+    console.log('[landing] testnet4 inscription configured — /api/btc/* live');
+  } else {
+    console.warn('[landing] testnet4 inscription disabled (QUICKNODE_ENDPOINT/BTC_FAUCET_* absent) — inscribe stays mock');
+  }
+  return buildRoutes({ turnkey, sessions: createInMemorySessionStorage(), jwtSecret, bitcoin });
 }
 
 const apiRoutes = buildApiRoutes();
 
-async function serveFile(relPath: string): Promise<Response> {
-  const f = file(DIST + relPath);
-  if (await f.exists()) return new Response(f);
-  // SPA fallback: client-side routes have no file on disk.
-  return new Response(file(DIST + 'index.html'), {
-    headers: { 'content-type': 'text/html; charset=utf-8' },
-  });
-}
-
 const server = Bun.serve({
   port,
   hostname: '0.0.0.0',
-  async fetch(req) {
-    const url = new URL(req.url);
-    // Auth API: dispatch when configured, else a clear JSON 404 (never
-    // SPA-fallback /api/* to index.html — the client would parse HTML as JSON).
-    if (url.pathname === '/api' || url.pathname.startsWith('/api/')) {
-      if (apiRoutes) return route(req, apiRoutes);
-      return json(
-        { error: 'Auth API not configured — set TURNKEY_* + JWT_SECRET on this service to enable Sign-in.' },
-        404
-      );
-    }
-    // Strip leading slashes, normalize, and reject path traversal.
-    const rel = normalize(decodeURIComponent(url.pathname)).replace(/^(\.\.(\/|\\|$))+/, '').replace(/^\/+/, '');
-    if (rel.includes('..')) return new Response('Bad request', { status: 400 });
-    return serveFile(rel === '' ? 'index.html' : rel);
-  },
+  fetch: buildFetch({ apiRoutes, hostStore, distDir: DIST }),
 });
 
 console.log(

--- a/apps/landing/server/app.ts
+++ b/apps/landing/server/app.ts
@@ -1,0 +1,90 @@
+import { file } from 'bun';
+import { normalize } from 'node:path';
+import { route, json, type Handler } from './router';
+
+// Minimal surface buildFetch depends on; the real store (webvh-host.ts)
+// implements exactly these two methods. `handlePut` takes the resolved,
+// trustworthy client IP (Bun socket peer) for rate-limit keying — never a
+// client-supplied header, which is spoofable.
+export interface WebvhHostStore {
+  handlePut(req: Request, url: URL, clientIp: string): Promise<Response>;
+  read(url: URL): Response;
+  serve(req: Request, url: URL): Response | null;
+}
+
+// Just the slice of Bun's Server we use: the real peer IP of the connection.
+interface BunServerLike {
+  requestIP?(req: Request): { address: string } | null;
+}
+
+// The rate-limit key: the actual socket peer IP, which a client cannot spoof.
+// (Behind a proxy this is the proxy's IP — coarse but fail-safe: a spoofed
+// X-Forwarded-For can no longer mint unlimited buckets.)
+function resolveClientIp(req: Request, server?: BunServerLike): string {
+  return server?.requestIP?.(req)?.address || 'local';
+}
+
+async function serveStatic(url: URL, distDir: string): Promise<Response> {
+  // Reject traversal on the DECODED path before normalize collapses `..`
+  // segments (e.g. `%2f..%2f` → `/../` would otherwise normalize past root and
+  // slip through). Any `..` segment in the requested path is rejected outright.
+  const decoded = decodeURIComponent(url.pathname);
+  if (decoded.split(/[/\\]/).includes('..')) {
+    return new Response('Bad request', { status: 400 });
+  }
+  const rel = normalize(decoded)
+    .replace(/^(\.\.(\/|\\|$))+/, '')
+    .replace(/^\/+/, '');
+  if (rel.includes('..')) return new Response('Bad request', { status: 400 });
+  const target = rel === '' ? 'index.html' : rel;
+  const f = file(distDir + target);
+  if (await f.exists()) return new Response(f);
+  // SPA fallback: client-side routes have no file on disk.
+  return new Response(file(distDir + 'index.html'), {
+    headers: { 'content-type': 'text/html; charset=utf-8' },
+  });
+}
+
+export function buildFetch(deps: {
+  // The exact-match API route map (auth + optional /api/btc/*), or null when the
+  // Turnkey/JWT env is absent — then /api/* returns a clean JSON 404 (never
+  // SPA-fallback /api/* to index.html). The WebVH host store below is always on:
+  // Track A (did:webvh hosting) must run without any secrets.
+  apiRoutes: Record<string, Handler> | null;
+  hostStore: WebvhHostStore;
+  distDir: string;
+}): (req: Request, server?: BunServerLike) => Promise<Response> {
+  const { apiRoutes, hostStore, distDir } = deps;
+  // Bun calls this with (request, server); server exposes the real peer IP.
+  return async (req, server?: BunServerLike) => {
+    const url = new URL(req.url);
+    const path = url.pathname;
+
+    // 1. WebVH host store (wildcard path — not expressible in the exact route
+    // map). GET/HEAD read an object by key (adapter.get); PUT writes. Always
+    // available (no auth required — Track A runs without secrets).
+    if (path.startsWith('/api/host/')) {
+      if (req.method === 'GET' || req.method === 'HEAD') return hostStore.read(url);
+      return hostStore.handlePut(req, url, resolveClientIp(req, server));
+    }
+
+    // 2. All other /api/* — dispatch when configured, else a clear JSON 404
+    // (matches main's behavior; never SPA-fallback /api/* to index.html).
+    if (path === '/api' || path.startsWith('/api/')) {
+      if (apiRoutes) return route(req, apiRoutes);
+      return json(
+        { error: 'Auth API not configured — set TURNKEY_* + JWT_SECRET on this service to enable Sign-in.' },
+        404
+      );
+    }
+
+    // 3. WebVH log/resource GETs served at the resolver's exact URLs.
+    if (req.method === 'GET' || req.method === 'HEAD') {
+      const served = hostStore.serve(req, url);
+      if (served) return served;
+    }
+
+    // 4. Static SPA + fallback (with traversal guard).
+    return serveStatic(url, distDir);
+  };
+}

--- a/apps/landing/server/auth-routes.ts
+++ b/apps/landing/server/auth-routes.ts
@@ -65,8 +65,19 @@ export function createAuthRoutes(deps: {
       }
       const token = signToken(result.subOrgId, result.email, undefined, { secret: deps.jwtSecret });
       const cookie = serializeCookie(getAuthCookieConfig(token));
+      // Surface the Turnkey verificationToken + the P-256 pubkey it is bound to
+      // so the browser can run OTP_LOGIN and install its own session credential
+      // (Track B, testnet4 signing). The token is client-bound — useless without
+      // the browser-held P-256 private key — so returning it is safe. The
+      // httpOnly session JWT cookie is UNCHANGED.
       return json(
-        { verified: true, email: result.email, subOrgId: result.subOrgId },
+        {
+          verified: true,
+          email: result.email,
+          subOrgId: result.subOrgId,
+          verificationToken: result.verificationToken,
+          publicKey: result.publicKey,
+        },
         200,
         { 'Set-Cookie': cookie }
       );

--- a/apps/landing/server/bitcoin.ts
+++ b/apps/landing/server/bitcoin.ts
@@ -1,0 +1,243 @@
+/**
+ * Server Bitcoin routes: a Turnkey-org faucet + thin QuickNode proxies.
+ *
+ * NO raw private key on the server: the faucet is a Turnkey-org wallet, signed
+ * with the SAME Turnkey API creds auth already uses. The user's inscription is
+ * signed in the browser by the user's own Turnkey session key. Every route is
+ * auth-gated (JWT cookie) + rate-limited. The faucet signs ONLY its own funding
+ * tx to a logged-in user's testnet address — never a general signing oracle.
+ */
+import * as btc from '@scure/btc-signer';
+import { hex, base64 } from '@scure/base';
+import type { Turnkey } from '@turnkey/sdk-server';
+import { verifyToken } from '@originals/auth/server';
+import type { OrdinalsProvider } from '@originals/sdk';
+import { isValidBitcoinAddress } from '@originals/sdk';
+import { json, type Handler } from './router';
+import { extractToken } from './cookies';
+import { createRateLimiter } from './rate-limit';
+
+export function isBitcoinConfigured(): boolean {
+  return (
+    !!process.env.QUICKNODE_ENDPOINT &&
+    !!process.env.BTC_FAUCET_WALLET_ID &&
+    !!process.env.BTC_FAUCET_ADDRESS
+  );
+}
+
+// Provider surface these routes use (a superset of OrdinalsProvider — the
+// faucet also needs the faucet wallet's spendable UTXOs). Production wires a
+// QuickNodeProvider whose getSpendableUtxos lists the faucet address's UTXOs.
+export interface FaucetProvider extends OrdinalsProvider {
+  getSpendableUtxos(address: string): Promise<
+    Array<{ txid: string; vout: number; value: number; scriptPubKey: string }>
+  >;
+}
+
+export function createBitcoinRoutes(deps: {
+  turnkey: Turnkey;
+  jwtSecret: string;
+  provider: OrdinalsProvider | FaucetProvider;
+  faucet: { walletId: string; address: string };
+  faucetSats?: number;
+  now?: () => number;
+}): { funding: Handler; sat: Handler; fee: Handler; broadcast: Handler } {
+  const faucetSats = deps.faucetSats ?? 20_000;
+  const ipLimiter = createRateLimiter({ limit: 30, windowMs: 60_000 });
+  const userLimiter = createRateLimiter({ limit: 5, windowMs: 60 * 60_000 }); // 5 fundings / user / hour
+  const provider = deps.provider as FaucetProvider;
+
+  // Best-effort IP key (behind the auth gate + per-user cap, which are the real
+  // protection). X-Forwarded-For is spoofable, so the per-user limiter keyed on
+  // the JWT `sub` — not this — is what bounds faucet abuse.
+  function clientIp(req: Request): string {
+    return req.headers.get('x-forwarded-for')?.split(',')[0].trim() || 'local';
+  }
+
+  /** Returns the authenticated subOrgId, or null (→ 401). */
+  function authSub(req: Request): string | null {
+    const token = extractToken(req);
+    if (!token) return null;
+    try {
+      return verifyToken(token, { secret: deps.jwtSecret }).sub;
+    } catch {
+      return null;
+    }
+  }
+
+  function rateLimited(req: Request): Response | null {
+    const rl = ipLimiter.check(clientIp(req));
+    if (!rl.allowed) {
+      return json({ error: 'rate_limited' }, 429, {
+        'Retry-After': String(Math.ceil(rl.retryAfterMs / 1000)),
+      });
+    }
+    return null;
+  }
+
+  const sat: Handler = async (req) => {
+    if (!authSub(req)) return json({ error: 'unauthorized' }, 401);
+    const limited = rateLimited(req);
+    if (limited) return limited;
+    const { txid, vout } = (await req.json().catch(() => ({}))) as { txid?: string; vout?: number };
+    if (typeof txid !== 'string' || typeof vout !== 'number') return json({ error: 'bad_request' }, 400);
+    if (typeof provider.getFirstSatOfOutput !== 'function') return json({ error: 'sat_index_unsupported' }, 501);
+    try {
+      const satoshi = await provider.getFirstSatOfOutput({ txid, vout });
+      return json({ satoshi });
+    } catch (e) {
+      return json({ error: 'sat_lookup_failed', message: (e as Error).message }, 502);
+    }
+  };
+
+  const fee: Handler = async (req) => {
+    if (!authSub(req)) return json({ error: 'unauthorized' }, 401);
+    const limited = rateLimited(req);
+    if (limited) return limited;
+    const { blocks } = (await req.json().catch(() => ({}))) as { blocks?: number };
+    try {
+      const feeRate = await provider.estimateFee(typeof blocks === 'number' ? blocks : 1);
+      return json({ feeRate });
+    } catch (e) {
+      return json({ error: 'fee_estimate_failed', message: (e as Error).message }, 502);
+    }
+  };
+
+  const broadcast: Handler = async (req) => {
+    if (!authSub(req)) return json({ error: 'unauthorized' }, 401);
+    const limited = rateLimited(req);
+    if (limited) return limited;
+    const { txHex } = (await req.json().catch(() => ({}))) as { txHex?: string };
+    if (typeof txHex !== 'string' || !/^(?:[0-9a-fA-F]{2})+$/.test(txHex)) return json({ error: 'bad_tx_hex' }, 400);
+    try {
+      const txid = await provider.broadcastTransaction(txHex);
+      return json({ txid });
+    } catch (e) {
+      return json({ error: 'broadcast_failed', message: (e as Error).message }, 502);
+    }
+  };
+
+  const funding: Handler = async (req) => {
+    const sub = authSub(req);
+    if (!sub) return json({ error: 'unauthorized' }, 401);
+    const limited = rateLimited(req);
+    if (limited) return limited;
+
+    // Validate the address BEFORE consuming a per-user faucet slot — otherwise
+    // repeated bad-address requests would exhaust a user's hourly cap for free.
+    const { address } = (await req.json().catch(() => ({}))) as { address?: string };
+    if (!address || !isValidBitcoinAddress(address, 'testnet')) {
+      return json({ error: 'bad_address', message: 'A testnet4 P2WPKH (tb1) address is required.' }, 400);
+    }
+
+    const perUser = userLimiter.check(sub);
+    if (!perUser.allowed) {
+      return json({ error: 'faucet_user_cap', message: 'Per-user faucet limit reached; try again later.' }, 429, {
+        'Retry-After': String(Math.ceil(perUser.retryAfterMs / 1000)),
+      });
+    }
+
+    // 1) Gather the faucet's spendable UTXOs; pick enough to cover fundingSats +
+    //    a fixed fee floor. Empty faucet → 507.
+    let faucetUtxos: Array<{ txid: string; vout: number; value: number; scriptPubKey: string }>;
+    try {
+      faucetUtxos = await provider.getSpendableUtxos(deps.faucet.address);
+    } catch (e) {
+      return json({ error: 'faucet_unavailable', message: (e as Error).message }, 502);
+    }
+    const totalAvail = faucetUtxos.reduce((n, u) => n + u.value, 0);
+    if (faucetUtxos.length === 0 || totalAvail < faucetSats + 500) {
+      return json({ error: 'faucet_empty', message: 'The testnet4 faucet is out of funds. Try again later.' }, 507);
+    }
+
+    // 2) Build the funding tx: faucet UTXOs in, fundingSats to the user, change
+    //    back to the faucet. Fee = feeRate * estimated vsize (simple P2WPKH).
+    let feeRate = 1;
+    try { feeRate = Math.max(1, Math.ceil(await provider.estimateFee(1))); } catch { /* floor */ }
+    const selected: typeof faucetUtxos = [];
+    let inSats = 0;
+    for (const u of faucetUtxos) {
+      selected.push(u);
+      inSats += u.value;
+      if (inSats >= faucetSats + 200) break;
+    }
+    // vsize ~ 10.5 + 68*inputs + 31*2 outputs (P2WPKH), rounded up.
+    const vsize = Math.ceil(10.5 + 68 * selected.length + 31 * 2);
+    const fee = feeRate * vsize;
+    const change = inSats - faucetSats - fee;
+    if (change < 0) return json({ error: 'faucet_empty', message: 'Faucet UTXOs too small for the fee.' }, 507);
+
+    const tx = new btc.Transaction();
+    for (const u of selected) {
+      tx.addInput({
+        txid: hex.decode(u.txid),
+        index: u.vout,
+        witnessUtxo: { script: hex.decode(u.scriptPubKey), amount: BigInt(u.value) },
+      });
+    }
+    tx.addOutputAddress(address, BigInt(faucetSats), btc.TEST_NETWORK);
+    if (change > 330) tx.addOutputAddress(deps.faucet.address, BigInt(change), btc.TEST_NETWORK);
+
+    // 3) Sign with the faucet Turnkey-org wallet (unsigned PSBT hex → Turnkey →
+    //    broadcast-ready hex). NO raw key: Turnkey holds the faucet key.
+    const unsignedHex = hex.encode(tx.toPSBT());
+    let signedTxHex: string;
+    try {
+      const result = await deps.turnkey.apiClient().signTransaction({
+        organizationId: process.env.TURNKEY_ORGANIZATION_ID!,
+        signWith: deps.faucet.address,
+        unsignedTransaction: unsignedHex,
+        type: 'TRANSACTION_TYPE_BITCOIN',
+      } as never);
+      // Turnkey returns either broadcast-ready hex or a partially-signed PSBT.
+      const signed =
+        (result as { activity?: { result?: { signTransactionResult?: { signedTransaction?: string } } } })
+          .activity?.result?.signTransactionResult?.signedTransaction;
+      if (!signed) throw new Error('Turnkey signTransaction returned no signedTransaction');
+      // If Turnkey returned a PSBT, finalize it; if already raw hex, pass through.
+      signedTxHex = maybeFinalize(signed);
+    } catch (e) {
+      return json({ error: 'faucet_sign_failed', message: (e as Error).message }, 502);
+    }
+
+    // The funded outpoint is vout 0 (the user output). Capture its scriptPubKey
+    // now — the SDK's createCommitTransaction REQUIRES it on the fundingUtxo to
+    // set the segwit witnessUtxo (it throws "missing scriptPubKey" otherwise).
+    const userScript = tx.getOutput(0).script;
+    if (!userScript) return json({ error: 'funding_build_failed', message: 'No user output script.' }, 500);
+    const scriptPubKey = hex.encode(userScript);
+
+    // 4) Broadcast.
+    let txid: string;
+    try {
+      txid = await provider.broadcastTransaction(signedTxHex);
+    } catch (e) {
+      return json({ error: 'faucet_broadcast_failed', message: (e as Error).message }, 502);
+    }
+
+    return json({
+      fundingUtxo: { txid, vout: 0, value: faucetSats, scriptPubKey },
+      changeAddress: address, // the user's own address is the inscription change/reveal dest
+    });
+  };
+
+  return { funding, sat, fee, broadcast };
+}
+
+export type BitcoinRoutes = ReturnType<typeof createBitcoinRoutes>;
+
+/** Pass raw tx hex through; finalize a PSBT (base64 or hex) into raw hex. */
+function maybeFinalize(signed: string): string {
+  // A finalized raw tx parses via fromRaw and re-serializes unchanged.
+  try {
+    const asRaw = btc.Transaction.fromRaw(hex.decode(signed), {
+      allowUnknownInputs: true,
+      allowUnknownOutputs: true,
+    });
+    return hex.encode(asRaw.extract());
+  } catch { /* not raw hex — try PSBT below */ }
+  const bytes = /^[0-9a-fA-F]+$/.test(signed) ? hex.decode(signed) : base64.decode(signed);
+  const tx = btc.Transaction.fromPSBT(bytes, { allowUnknownInputs: true, allowUnknownOutputs: true });
+  tx.finalize();
+  return hex.encode(tx.extract());
+}

--- a/apps/landing/server/index.ts
+++ b/apps/landing/server/index.ts
@@ -1,38 +1,54 @@
 import { createInMemorySessionStorage, type SessionStorage } from '@originals/auth/server';
 import type { Turnkey } from '@turnkey/sdk-server';
-import { json, route, type Handler } from './router';
+import { json, type Handler } from './router';
 import { getTurnkey } from './turnkey';
 import { createAuthRoutes } from './auth-routes';
+import { buildFetch } from './app';
+import { createWebvhHostStore } from './webvh-host';
+import type { BitcoinRoutes } from './bitcoin';
 
 // did:webvh creation is client-side (browser Ed25519 key, see src/auth/webvh.ts):
 // the parent Turnkey key can't sign for a credential-less sub-org, so there is
-// no server DID route.
+// no server DID route. Optional `bitcoin` mounts the Track B /api/btc/* routes
+// (testnet4 inscription) when the deploy provides a QuickNode endpoint + faucet.
 export function buildRoutes(deps: {
   turnkey: Turnkey;
   sessions: SessionStorage;
   jwtSecret: string;
+  bitcoin?: BitcoinRoutes;
 }): Record<string, Handler> {
   const auth = createAuthRoutes(deps);
-  return {
+  const routes: Record<string, Handler> = {
     'GET /api/health': () => json({ status: 'ok' }),
     'POST /api/auth/send-otp': auth.sendOtp,
     'POST /api/auth/verify-otp': auth.verifyOtp,
     'GET /api/me': auth.me,
     'POST /api/auth/logout': auth.logout,
   };
+  if (deps.bitcoin) {
+    routes['POST /api/btc/funding'] = deps.bitcoin.funding;
+    routes['POST /api/btc/sat'] = deps.bitcoin.sat;
+    routes['POST /api/btc/fee'] = deps.bitcoin.fee;
+    routes['POST /api/btc/broadcast'] = deps.bitcoin.broadcast;
+  }
+  return routes;
 }
 
+// Standalone dev API server (Vite proxies /api → here). Routes through the same
+// buildFetch as prod so /api/host/* (webvh hosting) works in dev too.
 if (import.meta.main) {
   const jwtSecret = process.env.JWT_SECRET;
   if (!jwtSecret) throw new Error('JWT_SECRET environment variable is required');
-  const routes = buildRoutes({
+  const apiRoutes = buildRoutes({
     turnkey: getTurnkey(),
     sessions: createInMemorySessionStorage(),
     jwtSecret,
   });
+  const hostStore = createWebvhHostStore();
+  const distDir = new URL('../dist/', import.meta.url).pathname;
   const server = Bun.serve({
     port: Number(process.env.PORT ?? 8787),
-    fetch: (req) => route(req, routes),
+    fetch: buildFetch({ apiRoutes, hostStore, distDir }),
   });
   console.log(`[auth-server] listening on http://localhost:${server.port}`);
 }

--- a/apps/landing/server/tests/app.test.ts
+++ b/apps/landing/server/tests/app.test.ts
@@ -1,0 +1,111 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildFetch } from '../app';
+import { json, type Handler } from '../router';
+
+// A no-op host store matching the WebvhHostStore surface buildFetch depends on.
+const noopHostStore = {
+  async handlePut() {
+    return json({ error: 'not_implemented' }, 501);
+  },
+  read() {
+    return json({ error: 'not_found' }, 404);
+  },
+  serve() {
+    return null as Response | null;
+  },
+};
+
+// A minimal "configured" API route map (auth present).
+const configuredRoutes: Record<string, Handler> = {
+  'GET /api/health': () => json({ status: 'ok' }),
+  'POST /api/auth/send-otp': () => json({ ok: true }),
+};
+
+let distDir: string;
+
+beforeAll(() => {
+  const dir = mkdtempSync(join(tmpdir(), 'landing-dist-'));
+  writeFileSync(join(dir, 'index.html'), '<!doctype html><title>spa</title>');
+  writeFileSync(join(dir, 'app.js'), 'console.log("asset")');
+  distDir = dir + '/';
+});
+
+afterAll(() => rmSync(distDir, { recursive: true, force: true }));
+
+function makeFetch(apiRoutes: Record<string, Handler> | null) {
+  return buildFetch({ apiRoutes, hostStore: noopHostStore, distDir });
+}
+
+describe('unified server buildFetch', () => {
+  test('serves a real static asset from dist', async () => {
+    const res = await makeFetch(null)(new Request('http://x/app.js'));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('asset');
+  });
+
+  test('SPA fallback: unknown non-file path returns index.html', async () => {
+    const res = await makeFetch(null)(new Request('http://x/some/client/route'));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('spa');
+  });
+
+  test('rejects path traversal', async () => {
+    const res = await makeFetch(null)(new Request('http://x/..%2f..%2fetc%2fpasswd'));
+    expect(res.status).toBe(400);
+  });
+
+  test('GET /api/health returns ok when configured', async () => {
+    const res = await makeFetch(configuredRoutes)(new Request('http://x/api/health'));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: 'ok' });
+  });
+
+  test('/api/* returns a clean JSON 404 when unconfigured (not SPA HTML)', async () => {
+    const res = await makeFetch(null)(
+      new Request('http://x/api/auth/send-otp', { method: 'POST' })
+    );
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toContain('not configured');
+  });
+
+  test('POST /api/host/* is routed to the host store, not static (works without auth)', async () => {
+    const res = await makeFetch(null)(
+      new Request('http://x/api/host/whatever', { method: 'PUT' })
+    );
+    expect(res.status).toBe(501); // noopHostStore.handlePut
+  });
+
+  test('host writes get the real socket IP (server.requestIP), not a client header', async () => {
+    let seenIp: string | undefined;
+    const recordingStore = {
+      async handlePut(_req: Request, _url: URL, clientIp: string) {
+        seenIp = clientIp;
+        return json({ ok: true }, 200);
+      },
+      read: () => json({ error: 'not_found' }, 404),
+      serve: () => null as Response | null,
+    };
+    const fetchFn = buildFetch({ apiRoutes: null, hostStore: recordingStore, distDir });
+    const fakeServer = { requestIP: () => ({ address: '203.0.113.7' }) };
+    await fetchFn(
+      new Request('http://x/api/host/k', {
+        method: 'PUT',
+        headers: { 'x-forwarded-for': '9.9.9.9' }, // spoofed — must be ignored
+      }),
+      fakeServer
+    );
+    expect(seenIp).toBe('203.0.113.7');
+
+    // No server object available → falls back to 'local', never the header.
+    await fetchFn(
+      new Request('http://x/api/host/k2', {
+        method: 'PUT',
+        headers: { 'x-forwarded-for': '9.9.9.9' },
+      })
+    );
+    expect(seenIp).toBe('local');
+  });
+});

--- a/apps/landing/server/tests/auth-verify-token.test.ts
+++ b/apps/landing/server/tests/auth-verify-token.test.ts
@@ -1,0 +1,75 @@
+import { describe, test, expect, mock, afterAll } from 'bun:test';
+import * as realAuthServer from '@originals/auth/server';
+
+// Stub the auth/server module so verify-otp's success path is deterministic
+// without real OTP crypto. verifyEmailAuth returns the client-bound token; the
+// other exports are minimal real-shaped stubs (serializeCookie from ./cookies
+// is real and consumes getAuthCookieConfig's output). RESTORED in afterAll so
+// the mock doesn't leak into sibling test files (bun shares the module registry
+// across a run).
+const realExports = { ...realAuthServer };
+afterAll(() => {
+  mock.module('@originals/auth/server', () => realExports);
+});
+mock.module('@originals/auth/server', () => ({
+  initiateEmailAuth: async () => ({ sessionId: 's1', message: 'sent' }),
+  verifyEmailAuth: async (
+    _sessionId: string,
+    _code: string,
+    _turnkey: unknown,
+    _sessions: unknown,
+    opts?: { publicKey?: string }
+  ) => ({
+    verified: true,
+    subOrgId: 'sub-1',
+    email: 'a@b.com',
+    verificationToken: 'vtoken-123',
+    publicKey: opts?.publicKey,
+  }),
+  signToken: () => 'jwt-token',
+  verifyToken: () => ({ sub: 'sub-1', email: 'a@b.com' }),
+  getAuthCookieConfig: (token: string) => ({
+    name: 'auth_token',
+    value: token,
+    options: { httpOnly: true, path: '/' },
+  }),
+  getClearAuthCookieConfig: () => ({
+    name: 'auth_token',
+    value: '',
+    options: { maxAge: 0, path: '/' },
+  }),
+}));
+
+const { createAuthRoutes } = await import('../auth-routes');
+
+function deps() {
+  return {
+    turnkey: {} as unknown as Parameters<typeof createAuthRoutes>[0]['turnkey'],
+    sessions: {
+      get: () => undefined,
+      set: () => {},
+      delete: () => {},
+      cleanup: () => {},
+    } as unknown as Parameters<typeof createAuthRoutes>[0]['sessions'],
+    jwtSecret: 'test-secret-at-least-32-chars-long!!',
+  };
+}
+
+describe('verify-otp surfaces the client-bound verificationToken', () => {
+  test('response body carries verificationToken + publicKey alongside subOrgId', async () => {
+    const routes = createAuthRoutes(deps());
+    const req = new Request('http://x/api/auth/verify-otp', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ sessionId: 's1', code: '123456', publicKey: '02'.padEnd(66, 'a') }),
+    });
+    const res = await routes.verifyOtp(req, new URL(req.url));
+    expect(res.status).toBe(200);
+    // The httpOnly JWT cookie is still set; the body now also returns the token.
+    expect(res.headers.get('set-cookie')).toBeTruthy();
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.subOrgId).toBe('sub-1');
+    expect(body.verificationToken).toBe('vtoken-123');
+    expect(body.publicKey).toBe('02'.padEnd(66, 'a'));
+  });
+});

--- a/apps/landing/server/tests/bitcoin.test.ts
+++ b/apps/landing/server/tests/bitcoin.test.ts
@@ -1,0 +1,124 @@
+import { describe, test, expect } from 'bun:test';
+import * as btc from '@scure/btc-signer';
+import { hex } from '@scure/base';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { signToken, getAuthCookieConfig } from '@originals/auth/server';
+import { serializeCookie } from '../cookies';
+import { createBitcoinRoutes } from '../bitcoin';
+
+const JWT = 'test-secret-at-least-32-chars-long!!';
+
+function authedReq(path: string, body: unknown) {
+  const token = signToken('sub-1', 'a@b.com', undefined, { secret: JWT });
+  const cookie = serializeCookie(getAuthCookieConfig(token));
+  return new Request(`http://host${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify(body),
+  });
+}
+
+// A real, fully-signed-but-not-finalized P2WPKH PSBT (hex) — the shape Turnkey
+// signTransaction returns, which the funding route finalizes before broadcast.
+function signedFaucetPsbtHex(): string {
+  const priv = hex.decode('2222222222222222222222222222222222222222222222222222222222222222');
+  const pub = secp256k1.getPublicKey(priv, true);
+  const p2wpkh = btc.p2wpkh(pub, btc.TEST_NETWORK);
+  const tx = new btc.Transaction();
+  tx.addInput({ txid: hex.decode('c'.repeat(64)), index: 0, witnessUtxo: { script: p2wpkh.script, amount: 100_000n } });
+  tx.addOutputAddress('tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx', 20_000n, btc.TEST_NETWORK);
+  tx.sign(priv); // signs, does NOT finalize
+  return hex.encode(tx.toPSBT());
+}
+
+function fakeProvider() {
+  return {
+    async getFirstSatOfOutput() { return '5000000000'; },
+    async estimateFee() { return 3; },
+    async broadcastTransaction() { return 'f'.repeat(64); },
+    async getSpendableUtxos() {
+      return [{ txid: 'a'.repeat(64), vout: 0, value: 100_000, scriptPubKey: '0014' + '0'.repeat(40) }];
+    },
+  } as unknown as Parameters<typeof createBitcoinRoutes>[0]['provider'];
+}
+
+function fakeTurnkey() {
+  const signedTransaction = signedFaucetPsbtHex();
+  return {
+    apiClient: () => ({
+      signTransaction: async () => ({ activity: { result: { signTransactionResult: { signedTransaction } } } }),
+    }),
+  } as unknown as Parameters<typeof createBitcoinRoutes>[0]['turnkey'];
+}
+
+// A real (valid-checksum) testnet4 P2WPKH faucet address — the change output
+// is sent here, so it must decode.
+const FAUCET_ADDRESS = btc.p2wpkh(
+  secp256k1.getPublicKey(hex.decode('3'.repeat(64)), true),
+  btc.TEST_NETWORK
+).address!;
+
+const deps = () => ({
+  turnkey: fakeTurnkey(),
+  jwtSecret: JWT,
+  provider: fakeProvider(),
+  faucet: { walletId: 'w-faucet', address: FAUCET_ADDRESS },
+  faucetSats: 20_000,
+});
+
+describe('bitcoin routes', () => {
+  test('POST /api/btc/sat proxies getFirstSatOfOutput', async () => {
+    const r = createBitcoinRoutes(deps());
+    const req = authedReq('/api/btc/sat', { txid: 'a'.repeat(64), vout: 0 });
+    const res = await r.sat(req, new URL(req.url));
+    expect(res.status).toBe(200);
+    expect((await res.json()).satoshi).toBe('5000000000');
+  });
+
+  test('POST /api/btc/fee proxies estimateFee', async () => {
+    const r = createBitcoinRoutes(deps());
+    const req = authedReq('/api/btc/fee', { blocks: 1 });
+    const res = await r.fee(req, new URL(req.url));
+    expect((await res.json()).feeRate).toBe(3);
+  });
+
+  test('POST /api/btc/broadcast proxies broadcastTransaction', async () => {
+    const r = createBitcoinRoutes(deps());
+    const req = authedReq('/api/btc/broadcast', { txHex: '0200000000' });
+    const res = await r.broadcast(req, new URL(req.url));
+    expect((await res.json()).txid).toBe('f'.repeat(64));
+  });
+
+  test('anonymous request is rejected 401', async () => {
+    const r = createBitcoinRoutes(deps());
+    const req = new Request('http://host/api/btc/sat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ txid: 'a'.repeat(64), vout: 0 }),
+    });
+    const res = await r.sat(req, new URL(req.url));
+    expect(res.status).toBe(401);
+  });
+
+  test("POST /api/btc/funding returns the user's funded outpoint + change address", async () => {
+    const r = createBitcoinRoutes(deps());
+    const userAddr = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx';
+    const req = authedReq('/api/btc/funding', { address: userAddr });
+    const res = await r.funding(req, new URL(req.url));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { fundingUtxo: { txid: string; vout: number; value: number; scriptPubKey: string }; changeAddress: string };
+    expect(body.changeAddress).toBe(userAddr);
+    expect(body.fundingUtxo.txid).toMatch(/^[0-9a-f]{64}$/);
+    expect(body.fundingUtxo.value).toBe(20_000);
+    // scriptPubKey is REQUIRED by the SDK's commit builder — must be the user
+    // output's P2WPKH script (0014 + 20-byte hash).
+    expect(body.fundingUtxo.scriptPubKey).toMatch(/^0014[0-9a-f]{40}$/);
+  });
+
+  test('funding rejects a non-testnet address 400', async () => {
+    const r = createBitcoinRoutes(deps());
+    const req = authedReq('/api/btc/funding', { address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4' });
+    const res = await r.funding(req, new URL(req.url));
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/landing/server/tests/webvh-host.test.ts
+++ b/apps/landing/server/tests/webvh-host.test.ts
@@ -43,6 +43,21 @@ describe('webvh-host store', () => {
     expect(served.headers.get('content-disposition')).toBe('attachment');
   });
 
+  test('read() (GET /api/host/*) also carries the anti-XSS headers', async () => {
+    const store = createWebvhHostStore();
+    const key = 'victim.example.com/evil/did.jsonl';
+    await store.handlePut(
+      putReq(key, '<script>alert(1)</script>', 'text/html'),
+      new URL(`http://host/api/host/${encodeURIComponent(key)}`)
+    );
+    const url = new URL(`http://host/api/host/${encodeURIComponent(key)}`);
+    const res = store.read(url);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+    expect(res.headers.get('content-security-policy')).toContain('sandbox');
+    expect(res.headers.get('content-disposition')).toBe('attachment');
+  });
+
   test('serve returns null for unknown key', () => {
     const store = createWebvhHostStore();
     const url = new URL('http://demo.example.com/nope/did.jsonl');

--- a/apps/landing/server/tests/webvh-host.test.ts
+++ b/apps/landing/server/tests/webvh-host.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect } from 'bun:test';
+import { createWebvhHostStore } from '../webvh-host';
+
+function putReq(key: string, body: string, contentType: string) {
+  return new Request(`http://host/api/host/${encodeURIComponent(key)}`, {
+    method: 'PUT',
+    headers: { 'content-type': contentType },
+    body,
+  });
+}
+
+describe('webvh-host store', () => {
+  test('put → serve roundtrip at the resolver URL', async () => {
+    const store = createWebvhHostStore();
+    const key = 'demo.example.com/studio/you/did.jsonl';
+    const putRes = await store.handlePut(
+      putReq(key, '{"v":1}\n{"v":2}', 'application/jsonl'),
+      new URL(`http://host/api/host/${encodeURIComponent(key)}`)
+    );
+    expect(putRes.status).toBe(200);
+
+    // Resolver GETs https://demo.example.com/studio/you/did.jsonl → host+pathname key.
+    const getUrl = new URL('http://demo.example.com/studio/you/did.jsonl');
+    const served = store.serve(new Request(getUrl), getUrl);
+    expect(served).not.toBeNull();
+    expect(served!.status).toBe(200);
+    expect(served!.headers.get('content-type')).toBe('application/jsonl');
+    expect(await served!.text()).toBe('{"v":1}\n{"v":2}');
+  });
+
+  test('served content is neutralized against stored XSS', async () => {
+    const store = createWebvhHostStore();
+    // An attacker PUTs active HTML with an arbitrary content-type.
+    const key = 'victim.example.com/evil/did.jsonl';
+    await store.handlePut(
+      putReq(key, '<script>alert(document.cookie)</script>', 'text/html'),
+      new URL(`http://host/api/host/${encodeURIComponent(key)}`)
+    );
+    const url = new URL('http://victim.example.com/evil/did.jsonl');
+    const served = store.serve(new Request(url), url)!;
+    expect(served.headers.get('x-content-type-options')).toBe('nosniff');
+    expect(served.headers.get('content-security-policy')).toContain('sandbox');
+    expect(served.headers.get('content-disposition')).toBe('attachment');
+  });
+
+  test('serve returns null for unknown key', () => {
+    const store = createWebvhHostStore();
+    const url = new URL('http://demo.example.com/nope/did.jsonl');
+    expect(store.serve(new Request(url), url)).toBeNull();
+  });
+
+  test('TTL expiry: serve returns null after ttl elapses', async () => {
+    let clock = 1000;
+    const store = createWebvhHostStore({ ttlMs: 500, now: () => clock });
+    const key = 'demo.example.com/.well-known/did.jsonl';
+    await store.handlePut(
+      putReq(key, 'x', 'application/jsonl'),
+      new URL(`http://host/api/host/${encodeURIComponent(key)}`)
+    );
+    const url = new URL('http://demo.example.com/.well-known/did.jsonl');
+    expect(store.serve(new Request(url), url)).not.toBeNull();
+    clock += 501; // past TTL
+    expect(store.serve(new Request(url), url)).toBeNull();
+  });
+
+  test('size cap: body over maxObjectBytes is rejected 413', async () => {
+    const store = createWebvhHostStore({ maxObjectBytes: 8 });
+    const key = 'd/x/did.jsonl';
+    const res = await store.handlePut(
+      putReq(key, 'this body is longer than eight bytes', 'application/jsonl'),
+      new URL(`http://host/api/host/${encodeURIComponent(key)}`)
+    );
+    expect(res.status).toBe(413);
+  });
+
+  test('entry cap: rejects a new key when full (507)', async () => {
+    const store = createWebvhHostStore({ maxEntries: 1 });
+    await store.handlePut(
+      putReq('a/x/did.jsonl', 'a', 'application/jsonl'),
+      new URL(`http://host/api/host/${encodeURIComponent('a/x/did.jsonl')}`)
+    );
+    const res = await store.handlePut(
+      putReq('b/x/did.jsonl', 'b', 'application/jsonl'),
+      new URL(`http://host/api/host/${encodeURIComponent('b/x/did.jsonl')}`)
+    );
+    expect(res.status).toBe(507);
+  });
+
+  test('rate limit keys on the passed socket IP, not a spoofable X-Forwarded-For', async () => {
+    const store = createWebvhHostStore({ limit: 1, windowMs: 60_000 });
+    const mk = (k: string, xff: string) =>
+      new Request(`http://host/api/host/${encodeURIComponent(k)}`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/jsonl', 'x-forwarded-for': xff },
+        body: 'x',
+      });
+    const u = (k: string) => new URL(`http://host/api/host/${encodeURIComponent(k)}`);
+
+    const first = await store.handlePut(mk('a/x/did.jsonl', '9.9.9.9'), u('a/x/did.jsonl'), '1.1.1.1');
+    expect(first.status).toBe(200);
+    // Same real IP, a DIFFERENT spoofed X-Forwarded-For → still the same bucket → limited.
+    const second = await store.handlePut(mk('b/x/did.jsonl', '8.8.8.8'), u('b/x/did.jsonl'), '1.1.1.1');
+    expect(second.status).toBe(429);
+    // A genuinely different socket IP gets its own bucket.
+    const other = await store.handlePut(mk('c/x/did.jsonl', '7.7.7.7'), u('c/x/did.jsonl'), '2.2.2.2');
+    expect(other.status).toBe(200);
+  });
+
+  test('non-PUT method is rejected 405', async () => {
+    const store = createWebvhHostStore();
+    const url = new URL('http://host/api/host/whatever');
+    const res = await store.handlePut(new Request(url, { method: 'POST' }), url);
+    expect(res.status).toBe(405);
+  });
+});

--- a/apps/landing/server/webvh-host.ts
+++ b/apps/landing/server/webvh-host.ts
@@ -1,0 +1,117 @@
+/**
+ * In-memory WebVH host: receives the SDK's hosting writes at PUT /api/host/<key>
+ * and serves them back at the EXACT URLs didwebvh-ts's resolver GETs.
+ *
+ * The put key is `${domain}/${relativePath}` (LifecycleManager). The resolver
+ * GETs https://${domain}/${relativePath}, so on serve the lookup key is
+ * `${url.host}${url.pathname}` — byte-identical to the put key. Bounded by a
+ * per-object size cap, a total-entry cap, and a TTL; PUTs are rate-limited.
+ */
+import { json } from './router';
+import { createRateLimiter } from './rate-limit';
+
+interface Entry {
+  body: Uint8Array;
+  contentType: string;
+  expiresAt: number;
+}
+
+const HOST_PREFIX = '/api/host/';
+
+export function createWebvhHostStore(opts?: {
+  maxObjectBytes?: number;
+  maxEntries?: number;
+  ttlMs?: number;
+  now?: () => number;
+  limit?: number;
+  windowMs?: number;
+}) {
+  const maxObjectBytes = opts?.maxObjectBytes ?? 256 * 1024; // 256 KiB per object
+  const maxEntries = opts?.maxEntries ?? 500;
+  const ttlMs = opts?.ttlMs ?? 30 * 60 * 1000; // 30 minutes
+  const now = opts?.now ?? Date.now;
+  const limiter = createRateLimiter({
+    limit: opts?.limit ?? 120,
+    windowMs: opts?.windowMs ?? 60_000,
+  });
+
+  const map = new Map<string, Entry>();
+
+  function sweep(): void {
+    const t = now();
+    for (const [k, e] of map) if (e.expiresAt <= t) map.delete(k);
+  }
+
+  // `clientIp` is the resolved socket peer IP supplied by the server layer
+  // (app.ts `resolveClientIp`), NOT a client-supplied header — an X-Forwarded-For
+  // value is spoofable and would let one client mint unlimited rate-limit buckets.
+  async function handlePut(req: Request, url: URL, clientIp = 'local'): Promise<Response> {
+    if (req.method !== 'PUT') return json({ error: 'method_not_allowed' }, 405);
+
+    const rl = limiter.check(clientIp);
+    if (!rl.allowed) {
+      return json({ error: 'rate_limited' }, 429, {
+        'Retry-After': String(Math.ceil(rl.retryAfterMs / 1000)),
+      });
+    }
+
+    const key = decodeURIComponent(url.pathname.slice(HOST_PREFIX.length));
+    if (!key) return json({ error: 'missing_key' }, 400);
+
+    const body = new Uint8Array(await req.arrayBuffer());
+    if (body.byteLength > maxObjectBytes) {
+      return json({ error: 'too_large', maxObjectBytes }, 413);
+    }
+
+    sweep();
+    if (!map.has(key) && map.size >= maxEntries) {
+      return json({ error: 'store_full', maxEntries }, 507);
+    }
+
+    map.set(key, {
+      body,
+      contentType: req.headers.get('content-type') ?? 'application/octet-stream',
+      expiresAt: now() + ttlMs,
+    });
+    return json({ ok: true }, 200);
+  }
+
+  // Read by object key — the counterpart to handlePut, for the StorageAdapter's
+  // GET /api/host/<key> (adapter.get). Keyed by the decoded object key (same as
+  // the put key), NOT the resolver host+pathname form that `serve` uses. Returns
+  // 404 JSON on a miss so the adapter maps it to null.
+  function read(url: URL): Response {
+    sweep();
+    const key = decodeURIComponent(url.pathname.slice(HOST_PREFIX.length));
+    const entry = map.get(key);
+    if (!entry) return json({ error: 'not_found' }, 404);
+    return new Response(entry.body.slice(), {
+      status: 200,
+      headers: { 'content-type': entry.contentType, 'x-content-type-options': 'nosniff' },
+    });
+  }
+
+  function serve(_req: Request, url: URL): Response | null {
+    sweep();
+    const key = `${url.host}${url.pathname}`;
+    const entry = map.get(key);
+    if (!entry) return null;
+    // Copy so the caller can't mutate stored bytes.
+    // The store is unauthenticated (public demo — must run without secrets), so
+    // content is untrusted. Neutralize stored-XSS: nosniff + a sandbox CSP +
+    // attachment disposition mean a browser never executes served bytes as a
+    // page regardless of their content-type. did:webvh resolution is unaffected
+    // — it reads the log via fetch(), where these headers don't apply.
+    return new Response(entry.body.slice(), {
+      status: 200,
+      headers: {
+        'content-type': entry.contentType,
+        'x-content-type-options': 'nosniff',
+        'content-security-policy': "default-src 'none'; sandbox",
+        'content-disposition': 'attachment',
+      },
+    });
+  }
+
+  return { handlePut, read, serve, size: () => map.size };
+}

--- a/apps/landing/server/webvh-host.ts
+++ b/apps/landing/server/webvh-host.ts
@@ -85,10 +85,8 @@ export function createWebvhHostStore(opts?: {
     const key = decodeURIComponent(url.pathname.slice(HOST_PREFIX.length));
     const entry = map.get(key);
     if (!entry) return json({ error: 'not_found' }, 404);
-    return new Response(entry.body.slice(), {
-      status: 200,
-      headers: { 'content-type': entry.contentType, 'x-content-type-options': 'nosniff' },
-    });
+    // Copy so the caller can't mutate stored bytes.
+    return new Response(entry.body.slice(), { status: 200, headers: untrustedHeaders(entry.contentType) });
   }
 
   function serve(_req: Request, url: URL): Response | null {
@@ -97,21 +95,23 @@ export function createWebvhHostStore(opts?: {
     const entry = map.get(key);
     if (!entry) return null;
     // Copy so the caller can't mutate stored bytes.
-    // The store is unauthenticated (public demo — must run without secrets), so
-    // content is untrusted. Neutralize stored-XSS: nosniff + a sandbox CSP +
-    // attachment disposition mean a browser never executes served bytes as a
-    // page regardless of their content-type. did:webvh resolution is unaffected
-    // — it reads the log via fetch(), where these headers don't apply.
-    return new Response(entry.body.slice(), {
-      status: 200,
-      headers: {
-        'content-type': entry.contentType,
-        'x-content-type-options': 'nosniff',
-        'content-security-policy': "default-src 'none'; sandbox",
-        'content-disposition': 'attachment',
-      },
-    });
+    return new Response(entry.body.slice(), { status: 200, headers: untrustedHeaders(entry.contentType) });
   }
 
   return { handlePut, read, serve, size: () => map.size };
+}
+
+// The store is unauthenticated (public demo — must run without secrets), so ALL
+// served content is untrusted. Both serve() and read() return stored bytes to a
+// browser, so both MUST neutralize stored-XSS: nosniff + a sandbox CSP +
+// attachment disposition mean a browser never executes served bytes as a page
+// regardless of their content-type. did:webvh resolution is unaffected — it
+// reads the log via fetch(), where these headers don't apply.
+function untrustedHeaders(contentType: string): Record<string, string> {
+  return {
+    'content-type': contentType,
+    'x-content-type-options': 'nosniff',
+    'content-security-policy': "default-src 'none'; sandbox",
+    'content-disposition': 'attachment',
+  };
 }

--- a/apps/landing/src/App.tsx
+++ b/apps/landing/src/App.tsx
@@ -46,7 +46,7 @@ function SmokeTest() {
       const art = generateArtwork('Smoke Test', 'Artwork', 1);
       const s1 = await engine.create('Smoke Test', 'Artwork', art.svg);
       const s2 = await engine.publish();
-      const s3 = await engine.inscribe(7);
+      const s3 = await engine.inscribe({ feeRate: 7 });
       setOut(
         JSON.stringify(
           { l1: s1.layer, l2: s2.layer, l3: s3.layer, events, tx: s3.inscription?.txid },

--- a/apps/landing/src/auth/api.ts
+++ b/apps/landing/src/auth/api.ts
@@ -10,15 +10,31 @@ export async function startOtp(email: string): Promise<{ sessionId: string; mess
   return sendOtp(email); // POST /api/auth/send-otp (default endpoint)
 }
 
-export async function completeOtp(
-  sessionId: string,
-  code: string
-): Promise<{ verified: boolean; email: string; subOrgId: string }> {
+export interface CompleteOtpResult {
+  verified: boolean;
+  email: string;
+  subOrgId: string;
+  /** Turnkey verificationToken (bound to the P-256 pubkey below), for OTP_LOGIN. */
+  verificationToken?: string;
+  /** The browser P-256 keypair (hex). Private key NEVER leaves the browser. */
+  p256PublicKey: string;
+  p256PrivateKey: string;
+}
+
+export async function completeOtp(sessionId: string, code: string): Promise<CompleteOtpResult> {
   // Generate the P-256 keypair in the browser so the verification-token
-  // private key never transits HTTP (2.0 token binding).
+  // private key never transits HTTP (2.0 token binding). Track B (testnet4
+  // signing) reuses this exact keypair as the Turnkey session credential.
   const keyPair = generateP256KeyPair();
   const result = await verifyOtp(sessionId, code, undefined, { publicKey: keyPair.publicKey });
-  return { verified: result.verified, email: result.email!, subOrgId: result.subOrgId! };
+  return {
+    verified: result.verified,
+    email: result.email!,
+    subOrgId: result.subOrgId!,
+    verificationToken: result.verificationToken,
+    p256PublicKey: keyPair.publicKey,
+    p256PrivateKey: keyPair.privateKey,
+  };
 }
 
 export async function fetchMe(): Promise<AuthUser | null> {

--- a/apps/landing/src/auth/turnkey-browser-client.ts
+++ b/apps/landing/src/auth/turnkey-browser-client.ts
@@ -1,0 +1,31 @@
+/**
+ * The concrete browser Turnkey client for Track B signing. Isolated from
+ * ./turnkey-session (which stays pure/testable) because @turnkey/sdk-browser
+ * pulls a browser-only dependency graph that must not load under `bun test`.
+ *
+ * The stamper reuses the SAME P-256 keypair the OTP flow generated, so no new
+ * credential is minted — OTP_LOGIN already installed that key on the sub-org.
+ */
+import { ApiKeyStamper } from '@turnkey/api-key-stamper';
+import { TurnkeyBrowserClient } from '@turnkey/sdk-browser';
+import type { TurnkeyBitcoinClient } from './turnkey-session';
+
+export function buildBrowserSigningClient(opts: {
+  subOrgId: string;
+  p256PublicKey: string;
+  p256PrivateKey: string;
+  apiBaseUrl?: string;
+}): TurnkeyBitcoinClient {
+  const stamper = new ApiKeyStamper({
+    apiPublicKey: opts.p256PublicKey,
+    apiPrivateKey: opts.p256PrivateKey,
+  });
+  const client = new TurnkeyBrowserClient({
+    stamper,
+    apiBaseUrl: opts.apiBaseUrl ?? 'https://api.turnkey.com',
+    organizationId: opts.subOrgId,
+  } as unknown as ConstructorParameters<typeof TurnkeyBrowserClient>[0]);
+  // TurnkeyBrowserClient exposes signTransaction / createWalletAccounts /
+  // getWallets / otpLogin with these shapes; the cast pins the narrow surface.
+  return client as unknown as TurnkeyBitcoinClient;
+}

--- a/apps/landing/src/auth/turnkey-session.test.ts
+++ b/apps/landing/src/auth/turnkey-session.test.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  otpLoginToSession,
+  ensureBitcoinFundingAccount,
+  type TurnkeyBitcoinClient,
+  type TurnkeySessionApi,
+} from './turnkey-session';
+
+describe('turnkey-session helpers', () => {
+  test('otpLoginToSession calls otpLogin with a client signature and returns the session', async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const turnkey: TurnkeySessionApi = {
+      async otpLogin(params) {
+        calls.push(params);
+        return { session: 'session-jwt-xyz' };
+      },
+    };
+    const { session } = await otpLoginToSession({
+      turnkey,
+      subOrgId: 'sub-1',
+      verificationToken: 'vtoken',
+      // A valid P-256 keypair: private key = 32 bytes of 0x02, any 33-byte pub hex.
+      p256PublicKey: '02'.padEnd(66, 'a'),
+      p256PrivateKey: '02'.repeat(32),
+    });
+    expect(session).toBe('session-jwt-xyz');
+    expect(calls[0].organizationId).toBe('sub-1');
+    expect(calls[0].verificationToken).toBe('vtoken');
+    expect(typeof calls[0].clientSignature).toBe('string');
+    expect((calls[0].clientSignature as string).length).toBeGreaterThan(0);
+  });
+
+  test('ensureBitcoinFundingAccount adds a testnet P2WPKH account and returns its tb1 address (idempotent)', async () => {
+    let existing: Array<{ address: string; path: string }> = [];
+    const client: TurnkeyBitcoinClient = {
+      async getWallets() {
+        return { wallets: [{ walletId: 'w1', accounts: existing }] };
+      },
+      async createWalletAccounts(params) {
+        const address = 'tb1qexampleuseraddr000000000000000000000000';
+        existing = [{ address, path: params.accounts[0].path }];
+        return { addresses: [address] };
+      },
+      async signTransaction() {
+        throw new Error('not used here');
+      },
+    };
+    const addr = await ensureBitcoinFundingAccount(client, 'sub-1');
+    expect(addr.startsWith('tb1q')).toBe(true);
+    // Second call must NOT create a duplicate account — returns the cached one.
+    const addr2 = await ensureBitcoinFundingAccount(client, 'sub-1');
+    expect(addr2).toBe(addr);
+  });
+});

--- a/apps/landing/src/auth/turnkey-session.ts
+++ b/apps/landing/src/auth/turnkey-session.ts
@@ -1,0 +1,110 @@
+/**
+ * Turnkey session helpers for Track B (testnet4 signing).
+ *
+ * After OTP verify, the sub-org is credential-less: the parent Turnkey key
+ * can't sign for it and there is no passkey. OTP_LOGIN installs the browser's
+ * P-256 key as the session credential, after which the user's Bitcoin signing
+ * (signTransaction) is silent within the session window. These helpers are
+ * pure (no @turnkey/sdk-browser import) so they run under `bun test`; the
+ * concrete browser client lives in ./turnkey-browser-client.
+ */
+import { p256 } from '@noble/curves/nist.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { hex } from '@scure/base';
+
+/** The single OTP_LOGIN activity the session bootstrap needs. */
+export interface TurnkeySessionApi {
+  otpLogin(params: {
+    organizationId: string;
+    verificationToken: string;
+    publicKey: string;
+    clientSignature: string;
+    expirationSeconds?: string;
+  }): Promise<{ session: string }>;
+}
+
+/** The Bitcoin-signing + account surface the rest of Track B consumes. */
+export interface TurnkeyBitcoinClient {
+  signTransaction(params: {
+    signWith: string;
+    unsignedTransaction: string;
+    type: 'TRANSACTION_TYPE_BITCOIN';
+  }): Promise<{ signedTransaction: string }>;
+  createWalletAccounts(params: {
+    walletId: string;
+    organizationId: string;
+    accounts: Array<{
+      curve: 'CURVE_SECP256K1';
+      pathFormat: 'PATH_FORMAT_BIP32';
+      path: string;
+      addressFormat: 'ADDRESS_FORMAT_BITCOIN_TESTNET_P2WPKH';
+    }>;
+  }): Promise<{ addresses: string[] }>;
+  getWallets(params: { organizationId: string }): Promise<{
+    wallets: Array<{ walletId: string; accounts?: Array<{ address: string; path?: string }> }>;
+  }>;
+}
+
+const TESTNET_P2WPKH_PATH = "m/84'/1'/0'/0/0";
+
+/**
+ * Run OTP_LOGIN: sign the login challenge (the verificationToken) with the
+ * browser P-256 key and exchange it for a session credential. We sign SHA-256
+ * of the verificationToken bytes with the API-P256 scheme (low-S DER), the
+ * encoding ApiKeyStamper uses. NOTE: the exact challenge Turnkey expects is a
+ * manual-smoke verification point (Resolved fact #7); the automated test only
+ * asserts a non-empty clientSignature is produced and passed through.
+ */
+export async function otpLoginToSession(deps: {
+  turnkey: TurnkeySessionApi;
+  subOrgId: string;
+  verificationToken: string;
+  p256PublicKey: string;
+  p256PrivateKey: string;
+  expirationSeconds?: number;
+}): Promise<{ session: string }> {
+  const challenge = sha256(new TextEncoder().encode(deps.verificationToken));
+  const sig = p256.sign(challenge, hex.decode(deps.p256PrivateKey), { lowS: true, format: 'der' });
+  const clientSignature = hex.encode(sig);
+  const { session } = await deps.turnkey.otpLogin({
+    organizationId: deps.subOrgId,
+    verificationToken: deps.verificationToken,
+    publicKey: deps.p256PublicKey,
+    clientSignature,
+    expirationSeconds: String(deps.expirationSeconds ?? 900),
+  });
+  return { session };
+}
+
+/**
+ * Ensure the user's wallet has a testnet4 P2WPKH account and return its tb1
+ * address. Idempotent: if the path already exists, the cached address wins —
+ * re-creating would waste an activity and could error on a duplicate path.
+ */
+export async function ensureBitcoinFundingAccount(
+  client: TurnkeyBitcoinClient,
+  subOrgId: string
+): Promise<string> {
+  const { wallets } = await client.getWallets({ organizationId: subOrgId });
+  const wallet = wallets[0];
+  if (!wallet) throw new Error('No Turnkey wallet found for the sub-organization.');
+  const existing = wallet.accounts?.find((a) => a.path === TESTNET_P2WPKH_PATH);
+  if (existing?.address) return existing.address;
+  const { addresses } = await client.createWalletAccounts({
+    walletId: wallet.walletId,
+    organizationId: subOrgId,
+    accounts: [
+      {
+        curve: 'CURVE_SECP256K1',
+        pathFormat: 'PATH_FORMAT_BIP32',
+        path: TESTNET_P2WPKH_PATH,
+        addressFormat: 'ADDRESS_FORMAT_BITCOIN_TESTNET_P2WPKH',
+      },
+    ],
+  });
+  const address = addresses[0];
+  if (!address || !address.startsWith('tb1')) {
+    throw new Error(`Turnkey returned an unexpected funding address: ${String(address)}`);
+  }
+  return address;
+}

--- a/apps/landing/src/auth/useAuth.tsx
+++ b/apps/landing/src/auth/useAuth.tsx
@@ -2,12 +2,26 @@ import { createContext, useContext, useEffect, useState, useCallback, type React
 import * as api from './api';
 import type { AuthUser } from './api';
 import { createUserWebVHDid } from './webvh';
+import {
+  otpLoginToSession,
+  ensureBitcoinFundingAccount,
+  type TurnkeyBitcoinClient,
+  type TurnkeySessionApi,
+} from './turnkey-session';
+import { btcTestnetEnabled } from '../sdk/testnet-flag';
+
+export interface BitcoinSession {
+  fundingAddress: string;
+  signingClient: TurnkeyBitcoinClient;
+}
 
 interface AuthContextValue {
   user: AuthUser | null;
   isAuthenticated: boolean;
   isLoading: boolean;
   sessionId: string | null;
+  /** Track B: the user's testnet4 signing client + funding address (null until ready / when disabled). */
+  bitcoin: BitcoinSession | null;
   startOtp: (email: string) => Promise<void>;
   verify: (code: string) => Promise<void>;
   createIdentity: () => Promise<string>;
@@ -20,6 +34,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [sessionId, setSessionId] = useState<string | null>(null);
+  const [bitcoin, setBitcoin] = useState<BitcoinSession | null>(null);
 
   useEffect(() => {
     api.fetchMe().then(setUser).finally(() => setIsLoading(false));
@@ -35,6 +50,35 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const result = await api.completeOtp(sessionId, code);
     setUser({ subOrgId: result.subOrgId, email: result.email });
     setSessionId(null);
+
+    // Track B bootstrap: install the P-256 session credential (OTP_LOGIN), then
+    // build the signing client + ensure the testnet4 funding account. Best-
+    // effort: a failure here must NOT block login — the demo simply falls back
+    // to the mock inscribe path. Only runs when the deploy enabled testnet4.
+    if (!btcTestnetEnabled() || !result.verificationToken) return;
+    try {
+      // Lazy-load the browser Turnkey client so its browser-only dependency
+      // graph never loads unless Track B is actually active.
+      const { buildBrowserSigningClient } = await import('./turnkey-browser-client');
+      const signingClient = buildBrowserSigningClient({
+        subOrgId: result.subOrgId,
+        p256PublicKey: result.p256PublicKey,
+        p256PrivateKey: result.p256PrivateKey,
+      });
+      await otpLoginToSession({
+        turnkey: signingClient as unknown as TurnkeySessionApi,
+        subOrgId: result.subOrgId,
+        verificationToken: result.verificationToken,
+        p256PublicKey: result.p256PublicKey,
+        p256PrivateKey: result.p256PrivateKey,
+      });
+      const fundingAddress = await ensureBitcoinFundingAccount(signingClient, result.subOrgId);
+      setBitcoin({ fundingAddress, signingClient });
+    } catch (err) {
+      // Non-fatal: log for the console-visible demo narrative; UI stays on mock.
+      console.warn('[originals-demo] testnet4 session bootstrap failed; inscribe stays on mock', err);
+      setBitcoin(null);
+    }
   }, [sessionId]);
 
   const createIdentity = useCallback(async () => {
@@ -48,11 +92,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const signOut = useCallback(async () => {
     await api.logout();
     setUser(null);
+    setBitcoin(null);
   }, []);
 
   return (
     <AuthContext.Provider
-      value={{ user, isAuthenticated: !!user, isLoading, sessionId, startOtp, verify, createIdentity, signOut }}
+      value={{ user, isAuthenticated: !!user, isLoading, sessionId, bitcoin, startOtp, verify, createIdentity, signOut }}
     >
       {children}
     </AuthContext.Provider>

--- a/apps/landing/src/components/Demo.tsx
+++ b/apps/landing/src/components/Demo.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { demo } from '../content';
 import type { DemoAssetState, DemoEngine, DemoEvent } from '../sdk/engine';
+import { btcTestnetEnabled } from '../sdk/testnet-flag';
+import { useAuth } from '../auth/useAuth';
 import { generateArtwork } from '../sdk/artwork';
 import { getArtSeed, setArtSeed } from '../sdk/artwork-sync';
 import { Pipeline } from './Pipeline';
@@ -30,6 +32,7 @@ const eventColors: Record<string, string> = {
   'asset:created': 'var(--cel)',
   'did:webvh:created': 'var(--webvh)',
   'resource:published': 'var(--webvh)',
+  'did:webvh:resolved': 'var(--webvh)',
   'asset:migrated': 'var(--webvh)',
   'credential:issued': 'var(--ok)',
   'asset:inscribed': 'var(--btco)'
@@ -63,6 +66,8 @@ function useEngine() {
 
 export function Demo() {
   const [phase, setPhase] = useState<Phase>('idle');
+  const { isAuthenticated, bitcoin } = useAuth();
+  const testnet = btcTestnetEnabled();
   const [title, setTitle] = useState(demo.form.defaultTitle);
   const [medium, setMedium] = useState(demo.form.mediums[0]);
   const [nonce, setNonce] = useState(() => getArtSeed().nonce);
@@ -146,7 +151,31 @@ export function Demo() {
   const publish = () =>
     run('created', 'publishing', 'published', (engine) => engine.publish());
   const inscribe = () =>
-    run('published', 'inscribing', 'inscribed', (engine) => engine.inscribe(7));
+    run('published', 'inscribing', 'inscribed', async (engine) => {
+      // Mock path (testnet disabled): unchanged bare inscribe.
+      if (!testnet) return engine.inscribe();
+      // Real path: must be signed in with a provisioned testnet4 session.
+      if (!isAuthenticated || !bitcoin) {
+        throw new Error(demo.inscribeGate.signInPrompt);
+      }
+      // Ask the server faucet to fund the user's address, then inscribe with the
+      // user's Turnkey key. faucet_empty (507) surfaces a friendly message.
+      const res = await fetch('/api/btc/funding', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({ address: bitcoin.fundingAddress }),
+      });
+      if (res.status === 507) throw new Error(demo.inscribeGate.faucetEmpty);
+      if (!res.ok) throw new Error(`Funding failed (${res.status})`);
+      const { fundingUtxo, changeAddress } = (await res.json()) as {
+        fundingUtxo: { txid: string; vout: number; value: number; scriptPubKey: string };
+        changeAddress: string;
+      };
+      return engine.inscribe({
+        funding: { fundingUtxo, changeAddress, signingClient: bitcoin.signingClient },
+      });
+    });
 
   const reset = () => {
     unsubscribe.current?.();
@@ -304,6 +333,43 @@ export function Demo() {
 
                 {error && <p className="demo-error" role="alert">{error}</p>}
 
+                {phase === 'published' && (
+                  <p className="demo-inscribe-note">
+                    {testnet
+                      ? isAuthenticated && bitcoin
+                        ? demo.inscribeGate.yourKeyNote
+                        : demo.inscribeGate.signInPrompt
+                      : demo.inscribeGate.mockNote}
+                  </p>
+                )}
+
+                {(phase === 'published' || phase === 'inscribing' || phase === 'inscribed') &&
+                  asset?.webvhLogUrl && (
+                    <div className="demo-resolved">
+                      <div className="demo-resolved-head">
+                        <span>{demo.resolved.heading}</span>
+                        <span
+                          className="demo-resolved-badge"
+                          data-ok={asset.webvhResolved || undefined}
+                        >
+                          {asset.webvhResolved
+                            ? demo.resolved.resolvedBadge
+                            : demo.resolved.pendingBadge}
+                        </span>
+                      </div>
+                      <a
+                        className="demo-resolved-link"
+                        href={asset.webvhLogUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        {demo.resolved.linkLabel}
+                        <code>{asset.webvhLogUrl}</code>
+                      </a>
+                      <p className="demo-resolved-note">{demo.resolved.note}</p>
+                    </div>
+                  )}
+
                 {phase === 'inscribed' && asset && (
                   <div className="demo-done">
                     <p>
@@ -311,6 +377,16 @@ export function Demo() {
                       <code>{asset.inscription?.satoshi}</code> {demo.done.beforeTx}{' '}
                       <code>{asset.inscription?.txid}</code>. {demo.done.after}
                     </p>
+                    {asset.inscription?.explorerUrl && (
+                      <a
+                        className="demo-explorer-link"
+                        href={asset.inscription.explorerUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        {demo.inscribeGate.explorerLabel}
+                      </a>
+                    )}
                     <button type="button" className="demo-reset" onClick={reset}>
                       {demo.reset}
                     </button>

--- a/apps/landing/src/components/demo-content.test.ts
+++ b/apps/landing/src/components/demo-content.test.ts
@@ -1,0 +1,13 @@
+import { describe, test, expect } from 'bun:test';
+import { demo } from '../content';
+
+describe('demo resolved-DID copy', () => {
+  test('has a resolved-DID label block', () => {
+    expect(demo.resolved).toBeDefined();
+    expect(typeof demo.resolved.heading).toBe('string');
+    expect(demo.resolved.heading.length).toBeGreaterThan(0);
+    expect(typeof demo.resolved.resolvedBadge).toBe('string');
+    expect(typeof demo.resolved.pendingBadge).toBe('string');
+    expect(typeof demo.resolved.linkLabel).toBe('string');
+  });
+});

--- a/apps/landing/src/components/demo-inscribe-content.test.ts
+++ b/apps/landing/src/components/demo-inscribe-content.test.ts
@@ -1,0 +1,14 @@
+import { describe, test, expect } from 'bun:test';
+import { demo } from '../content';
+
+describe('demo inscribe-gate copy', () => {
+  test('has an inscribeGate copy block', () => {
+    expect(demo.inscribeGate).toBeDefined();
+    expect(typeof demo.inscribeGate.signInPrompt).toBe('string');
+    expect(demo.inscribeGate.signInPrompt.length).toBeGreaterThan(0);
+    expect(typeof demo.inscribeGate.yourKeyNote).toBe('string');
+    expect(typeof demo.inscribeGate.explorerLabel).toBe('string');
+    expect(typeof demo.inscribeGate.faucetEmpty).toBe('string');
+    expect(typeof demo.inscribeGate.mockNote).toBe('string');
+  });
+});

--- a/apps/landing/src/content.ts
+++ b/apps/landing/src/content.ts
@@ -118,7 +118,7 @@ export const demo = {
       title: 'Create',
       layer: 'did:cel',
       description:
-        'Hashes the artwork’s bytes and mints a did:cel identity — a signed event log, entirely in this tab, no server involved.'
+        'Hashes the artwork’s bytes and mints its did:cel genesis — a signed event log, entirely in this tab, no server involved.'
     },
     {
       id: 'publish',
@@ -127,7 +127,7 @@ export const demo = {
       title: 'Publish',
       layer: 'did:webvh',
       description:
-        'Migrates the asset to did:webvh, publishes its resources, and signs a publication credential.'
+        'Migrates the asset to did:webvh and hosts the signed DID log at this origin — the SDK’s real resolver then fetches it back over HTTP(S).'
     },
     {
       id: 'inscribe',
@@ -156,6 +156,22 @@ export const demo = {
     beforeSatoshi: 'Inscribed on satoshi',
     beforeTx: 'in tx',
     after: 'The full history is in the Provenance tab.'
+  },
+  resolved: {
+    heading: 'did:webvh log — live at this origin',
+    resolvedBadge: 'resolved ✓',
+    pendingBadge: 'resolves in production',
+    linkLabel: 'Open the signed DID log',
+    note: 'The SDK’s real resolver fetched this over HTTP(S) — no mock. Open it: it’s the signed version history.'
+  },
+  inscribeGate: {
+    signInPrompt: 'Sign in to inscribe on Bitcoin testnet4 — your own key signs it.',
+    yourKeyNote: 'Your Turnkey key signs this inscription in your browser. The server never sees a private key; funding comes from a testnet4 faucet (worthless tBTC).',
+    fundingLabel: 'Requesting testnet4 funding…',
+    signingLabel: 'Signing the commit with your key…',
+    explorerLabel: 'View the real transaction on mempool.space',
+    faucetEmpty: 'The testnet4 faucet is temporarily out of funds — try again in a bit.',
+    mockNote: 'Bitcoin inscription runs against a mock provider in this environment (no wallet, no chain). Deploy with a testnet4 endpoint + faucet to make it real.'
   },
   reset: 'Start over with a new asset'
 };

--- a/apps/landing/src/sdk/engine.inscribe.test.ts
+++ b/apps/landing/src/sdk/engine.inscribe.test.ts
@@ -1,0 +1,66 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { DemoEngine, btcoExplorerUrl } from './engine';
+import { createWebvhHostStore } from '../../server/webvh-host';
+
+// publish() hosts the did:webvh log via relative /api/host/* fetches, which are
+// invalid without a browser origin — route them through an in-process store so
+// create→publish works, then inscribe runs against OrdMockProvider (mock path).
+function installHostFetch(host = 'demo.test') {
+  const store = createWebvhHostStore();
+  const real = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(typeof input === 'string' ? input : input.toString(), `http://${host}`);
+    if (url.pathname.startsWith('/api/host/')) {
+      const req = new Request(url, { method: (init?.method ?? 'GET'), headers: init?.headers as HeadersInit, body: init?.body as BodyInit });
+      return store.handlePut(req, url);
+    }
+    const served = store.serve(new Request(url), url);
+    return served ?? new Response('nf', { status: 404 });
+  }) as unknown as typeof fetch;
+  return () => { globalThis.fetch = real; };
+}
+
+describe('engine inscribe wiring', () => {
+  let restore: () => void;
+  beforeEach(() => { restore = installHostFetch(); });
+  afterEach(() => restore());
+
+  test('btcoExplorerUrl builds a testnet4 mempool link', () => {
+    // Only meaningful when testnet is enabled; the helper is pure.
+    const url = btcoExplorerUrl('f'.repeat(64));
+    // In the default (mock) test env VITE_BTC_TESTNET is unset → undefined.
+    expect(url === undefined || url === `https://mempool.space/testnet4/tx/${'f'.repeat(64)}`).toBe(true);
+  });
+
+  test('inscribe() without funding runs the mock path and still yields an inscription', async () => {
+    const engine = new DemoEngine();
+    await engine.create('T', 'Artwork', '<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+    await engine.publish();
+    const state = await engine.inscribe(); // mock path (no funding) — OrdMockProvider/regtest
+    expect(state.layer).toBe('did:btco');
+    expect(state.inscription?.txid).toBeTruthy();
+  });
+
+  test('inscribe() with funding but a broken signer surfaces the failure (real path is attempted)', async () => {
+    const engine = new DemoEngine();
+    await engine.create('T', 'Artwork', '<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+    await engine.publish();
+    const brokenClient = {
+      async signTransaction() { throw new Error('turnkey down'); },
+      async createWalletAccounts() { throw new Error('x'); },
+      async getWallets() { throw new Error('x'); },
+    };
+    // With funding provided, the engine takes the sat-selected path; the broken
+    // signer makes the SDK throw (COMMIT signing fails) — proving the real path
+    // is wired, not the mock.
+    await expect(
+      engine.inscribe({
+        funding: {
+          fundingUtxo: { txid: 'a'.repeat(64), vout: 0, value: 20_000 },
+          changeAddress: 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx',
+          signingClient: brokenClient as never,
+        },
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/apps/landing/src/sdk/engine.publish-resolve.test.ts
+++ b/apps/landing/src/sdk/engine.publish-resolve.test.ts
@@ -1,0 +1,70 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { DemoEngine } from './engine';
+import { createWebvhHostStore } from '../../server/webvh-host';
+
+// Route the browser adapter's PUT /api/host/* AND the resolver's https GETs
+// through one in-process host store, so publish → resolve is deterministic
+// without a live HTTPS origin (Resolved fact #4).
+function installHostFetch(host: string) {
+  const store = createWebvhHostStore();
+  const real = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const raw = typeof input === 'string' ? input : input.toString();
+    const method = (init?.method ?? 'GET').toUpperCase();
+    const url = new URL(raw, `http://${host}`);
+    if (url.pathname.startsWith('/api/host/')) {
+      const req = new Request(url, {
+        method,
+        headers: init?.headers as HeadersInit,
+        body: init?.body as BodyInit,
+      });
+      return store.handlePut(req, url);
+    }
+    // Resolver GET https://<host>/<path>/did.jsonl → serve from the store.
+    const served = store.serve(new Request(url), url);
+    if (served) return served;
+    return new Response('not found', { status: 404 });
+  }) as unknown as typeof fetch;
+  return () => {
+    globalThis.fetch = real;
+  };
+}
+
+describe('publish → resolve roundtrip', () => {
+  const host = 'demo.test';
+  let restore: () => void;
+
+  beforeEach(() => {
+    (import.meta as unknown as { env: Record<string, string> }).env ??= {};
+    (import.meta as unknown as { env: Record<string, string> }).env.VITE_WEBVH_HOST = host;
+    restore = installHostFetch(host);
+  });
+  afterEach(() => restore());
+
+  test('publishes the DID log and resolves it back over (mocked) HTTPS', async () => {
+    const engine = new DemoEngine();
+    const resolvedEvents: Array<{ logUrl: string; resolved: boolean }> = [];
+    engine.on((e) => {
+      if (e.type === 'did:webvh:resolved') {
+        resolvedEvents.push(e.payload as { logUrl: string; resolved: boolean });
+      }
+    });
+
+    await engine.create('Roundtrip', 'Artwork', '<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+    const state = await engine.publish();
+
+    // publishToWeb hosts the ASSET's did:webvh log (content-addressed slug path),
+    // not the publisher's — derive the expected resolvable URL from that did.
+    const parts = state.webvhDid!.split(':'); // did:webvh:<SCID>:<host>:<slug>
+    const expectedUrl = `https://${host}/${parts.slice(4).join('/')}/did.jsonl`;
+
+    expect(state.layer).toBe('did:webvh');
+    expect(state.webvhDid).toContain(`:${host}:`);
+    expect(state.webvhLogUrl).toBe(expectedUrl);
+    expect(state.webvhResolved).toBe(true);
+
+    expect(resolvedEvents.length).toBe(1);
+    expect(resolvedEvents[0].logUrl).toBe(expectedUrl);
+    expect(resolvedEvents[0].resolved).toBe(true);
+  });
+});

--- a/apps/landing/src/sdk/engine.summary.test.ts
+++ b/apps/landing/src/sdk/engine.summary.test.ts
@@ -1,0 +1,26 @@
+import { describe, test, expect } from 'bun:test';
+import { DemoEngine } from './engine';
+import { demo } from '../content';
+
+describe('honesty labels', () => {
+  test('content: create step no longer claims a did:peer identity', () => {
+    expect(demo.steps[0].description).toContain('did:cel');
+    expect(demo.steps[0].description).not.toContain('did:peer identity');
+  });
+
+  test('content: publish step describes real hosting/resolution', () => {
+    expect(demo.steps[1].description.toLowerCase()).toMatch(/host|resolv/);
+  });
+
+  test('asset:created summary says did:cel, not "a private did:peer identity"', async () => {
+    const engine = new DemoEngine();
+    const summaries: string[] = [];
+    engine.on((e) => {
+      if (e.type === 'asset:created') summaries.push(e.summary);
+    });
+    await engine.create('Test Piece', 'Artwork', '<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+    expect(summaries.length).toBe(1);
+    expect(summaries[0]).toContain('did:cel');
+    expect(summaries[0]).not.toContain('did:peer identity');
+  });
+});

--- a/apps/landing/src/sdk/engine.ts
+++ b/apps/landing/src/sdk/engine.ts
@@ -4,8 +4,9 @@
  * Everything here calls the real @originals/sdk — the same package a
  * developer gets from `npm install @originals/sdk`. Nothing is canned:
  * DIDs, hashes, credentials, events and provenance all come back from
- * actual SDK calls. Bitcoin operations run against OrdMockProvider, the
- * SDK's own in-memory Ordinals provider, so no wallet or node is needed.
+ * actual SDK calls. Publishing hosts the signed did:webvh log at this origin
+ * over real HTTP(S) and the SDK's real resolver fetches it back. Bitcoin
+ * operations still run against OrdMockProvider (no wallet or node needed).
  *
  * Every SDK event is mirrored to the browser console (prefixed
  * "[originals-sdk]") so anyone can open devtools and watch the protocol
@@ -17,10 +18,16 @@ export { short };
 import {
   OriginalsSDK,
   OrdMockProvider,
-  MemoryStorageAdapter,
   type OriginalsAsset
 } from '@originals/sdk';
+import { HttpHostingStorageAdapter } from './http-hosting-adapter';
+import { HttpOrdinalsProvider } from './http-ordinals-provider';
+import { TurnkeySatSigner } from './turnkey-sat-signer';
+import { btcTestnetEnabled } from './testnet-flag';
+import type { TurnkeyBitcoinClient } from '../auth/turnkey-session';
 import { sha256 } from '@noble/hashes/sha2.js';
+
+export { btcTestnetEnabled } from './testnet-flag';
 
 export type LayerId = 'did:cel' | 'did:webvh' | 'did:btco';
 
@@ -39,6 +46,8 @@ export interface DemoAssetState {
   layer: LayerId;
   did: string;
   webvhDid?: string;
+  webvhLogUrl?: string;
+  webvhResolved?: boolean;
   btcoDid?: string;
   resource: {
     id: string;
@@ -57,6 +66,7 @@ export interface DemoAssetState {
     inscriptionId: string;
     satoshi: string;
     feeRate?: number;
+    explorerUrl?: string;
   };
   provenance: unknown;
 }
@@ -77,6 +87,8 @@ export class DemoEngine {
   private keys = new Map<string, string>();
   private listeners = new Set<Listener>();
   private publisherDid: string | null = null;
+  private webvhLogUrl: string | null = null;
+  private webvhResolved = false;
   asset: OriginalsAsset | null = null;
 
   constructor() {
@@ -85,12 +97,18 @@ export class DemoEngine {
     // construction so it always points at the engine currently driving the UI.
     (globalThis as Record<string, unknown>).__originalsDemo = this;
     const keys = this.keys;
+    // Track B: when the deploy enables testnet4 signing, inscribe for real over
+    // the /api/btc/* QuickNode proxies on Bitcoin testnet4; otherwise keep the
+    // self-contained OrdMockProvider mock (regtest) unchanged.
+    const testnet = btcTestnetEnabled();
     this.sdk = OriginalsSDK.create({
-      network: 'regtest',
+      network: testnet ? 'testnet' : 'regtest',
       webvhNetwork: 'magby',
       defaultKeyType: 'Ed25519',
-      ordinalsProvider: new OrdMockProvider(),
-      storageAdapter: new MemoryStorageAdapter(),
+      ordinalsProvider: testnet ? new HttpOrdinalsProvider() : new OrdMockProvider(),
+      // Real HTTP hosting at this origin — the SDK's did:webvh log becomes
+      // resolvable over HTTP(S) (see http-hosting-adapter.ts).
+      storageAdapter: new HttpHostingStorageAdapter(),
       enableLogging: false,
       keyStore: {
         async getPrivateKey(id: string) {
@@ -115,12 +133,12 @@ export class DemoEngine {
     };
 
     forward('asset:created', (e: { asset: { id: string } }) =>
-      `Asset created as ${short(e.asset.id)} — a private did:cel identity, generated entirely offline`
+      `Asset created as ${short(e.asset.id)} — a did:cel genesis (a signed event log), generated entirely offline in this tab`
     );
     forward(
       'resource:published',
       (e: { resource: { id: string } }) =>
-        `Resource "${e.resource.id}" published to hosted storage`
+        `Resource "${e.resource.id}" hosted over HTTP at this origin — its did:webvh log is now resolvable`
     );
     forward(
       'credential:issued',
@@ -212,6 +230,7 @@ export class DemoEngine {
 
     if (!this.publisherDid) {
       const webvh = await this.sdk.did.createDIDWebVH({
+        domain: demoHost(),
         paths: ['studio', 'you']
       });
       const result = webvh as unknown as {
@@ -240,13 +259,73 @@ export class DemoEngine {
     }
 
     await this.sdk.lifecycle.publishToWeb(this.asset, this.publisherDid);
+
+    // Prove REAL resolution: publishToWeb hosts the ASSET's did:webvh log (+ cel
+    // + resources) at this origin. Fetch that log back over the network via the
+    // SDK's real resolver. skipCache forces a network read (not the in-memory
+    // cache). Best-effort in dev (http origin can't satisfy the resolver's
+    // hard-coded https), authoritative in prod. resolved=false still shows the
+    // link, just no "resolved ✓" tick.
+    const assetWebvhDid = ((this.asset.bindings ?? {}) as Record<string, string>)['did:webvh'];
+    const logUrl = assetWebvhDid ? webvhLogUrl(assetWebvhDid) : '';
+    let resolvedDoc: unknown = null;
+    let resolved = false;
+    if (assetWebvhDid) {
+      try {
+        resolvedDoc = await this.sdk.did.resolveDID(assetWebvhDid, { skipCache: true });
+        resolved = !!resolvedDoc;
+      } catch (err) {
+        log('did:webvh:resolve-failed', err);
+      }
+    }
+    this.webvhLogUrl = logUrl;
+    this.webvhResolved = resolved;
+    this.emit(
+      'did:webvh:resolved',
+      resolved
+        ? `did:webvh log resolved over HTTPS — ${logUrl}`
+        : `did:webvh log hosted at ${logUrl} (resolves over HTTPS in production)`,
+      { logUrl, resolved, doc: resolvedDoc }
+    );
+
     return this.snapshot();
   }
 
-  /** Step 3 — inscribe on Bitcoin (OrdMockProvider; regtest semantics). */
-  async inscribe(feeRate = 7): Promise<DemoAssetState> {
+  /**
+   * Step 3 — inscribe on Bitcoin.
+   *
+   * With `funding` (Track B, login-gated): a REAL testnet4 inscription. The
+   * server-funded UTXO's first sat becomes the did:btco identity, the user's
+   * Turnkey session key signs the commit, the reveal is self-signed by the SDK,
+   * and both broadcast via the /api/btc/* QuickNode proxies. Without `funding`:
+   * the self-contained OrdMockProvider mock (regtest).
+   */
+  async inscribe(opts?: {
+    feeRate?: number;
+    funding?: {
+      fundingUtxo: { txid: string; vout: number; value: number; scriptPubKey?: string; address?: string };
+      changeAddress: string;
+      signingClient: TurnkeyBitcoinClient;
+    };
+  }): Promise<DemoAssetState> {
     if (!this.asset) throw new Error('Create an asset first');
-    await this.sdk.lifecycle.inscribeOnBitcoin(this.asset, feeRate);
+    const feeRate = opts?.feeRate ?? 7;
+    if (opts?.funding) {
+      // Real sat-selected path: the user's Turnkey key signs the commit.
+      const satSigner = new TurnkeySatSigner({
+        client: opts.funding.signingClient,
+        signWith: opts.funding.changeAddress, // the user's tb1q funding address IS signWith
+      });
+      await this.sdk.lifecycle.inscribeOnBitcoin(this.asset, {
+        fundingUtxo: opts.funding.fundingUtxo,
+        satSigner,
+        changeAddress: opts.funding.changeAddress,
+        feeRate,
+      });
+    } else {
+      // Mock path (unchanged): bare feeRate against OrdMockProvider.
+      await this.sdk.lifecycle.inscribeOnBitcoin(this.asset, feeRate);
+    }
     const state = this.snapshot();
     if (state.inscription) {
       this.emit(
@@ -278,6 +357,8 @@ export class DemoEngine {
       layer: asset.currentLayer as LayerId,
       did: asset.id,
       webvhDid: bindings['did:webvh'],
+      webvhLogUrl: this.webvhLogUrl ?? undefined,
+      webvhResolved: this.webvhResolved,
       btcoDid: bindings['did:btco'],
       resource: {
         id: res.id,
@@ -295,7 +376,8 @@ export class DemoEngine {
               txid: last.transactionId,
               inscriptionId: last.inscriptionId ?? '',
               satoshi: last.satoshi ?? '',
-              feeRate: last.feeRate
+              feeRate: last.feeRate,
+              explorerUrl: btcoExplorerUrl(last.transactionId)
             }
           : undefined,
       provenance
@@ -306,4 +388,31 @@ export class DemoEngine {
 
 function toHex(bytes: Uint8Array): string {
   return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+// The testnet4 block explorer link for a real inscription's reveal txid. Only
+// produced when testnet is enabled — a mock/regtest txid has no public explorer.
+export function btcoExplorerUrl(txid: string): string | undefined {
+  if (!btcTestnetEnabled() || !txid) return undefined;
+  return `https://mempool.space/testnet4/tx/${txid}`;
+}
+
+// The origin host we host did:webvh logs under. In the browser this is the
+// live origin; VITE_WEBVH_HOST overrides it for the deployed host or tests.
+function demoHost(): string {
+  const envHost = (import.meta as unknown as { env?: Record<string, string> }).env?.VITE_WEBVH_HOST;
+  if (envHost) return envHost;
+  if (typeof window !== 'undefined' && window.location?.host) return window.location.host;
+  return 'localhost';
+}
+
+// Mirrors didwebvh-ts getFileUrl: pathed DID → https://<host>/<segs>/did.jsonl,
+// domain-root DID → https://<host>/.well-known/did.jsonl. This is the exact URL
+// the resolver GETs (protocol is always https).
+function webvhLogUrl(did: string): string {
+  const parts = did.split(':'); // did:webvh:<SCID>:<domain>[:<seg>…]
+  const domain = decodeURIComponent(parts[3] ?? '');
+  const segs = parts.slice(4).map((s) => decodeURIComponent(s));
+  const base = `https://${domain}`;
+  return segs.length ? `${base}/${segs.join('/')}/did.jsonl` : `${base}/.well-known/did.jsonl`;
 }

--- a/apps/landing/src/sdk/finalize-psbt.spike.test.ts
+++ b/apps/landing/src/sdk/finalize-psbt.spike.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect } from 'bun:test';
+import * as btc from '@scure/btc-signer';
+import { hex, base64 } from '@scure/base';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { finalizeSignedPsbt } from './finalize-psbt';
+
+// A deterministic P2WPKH key on testnet (TEST_NETWORK params).
+const priv = hex.decode('1111111111111111111111111111111111111111111111111111111111111111');
+const pub = secp256k1.getPublicKey(priv, true);
+
+// Build a partially-signed (NOT finalized) P2WPKH PSBT — the exact shape
+// Turnkey signTransaction returns. We stand in for Turnkey by signing locally.
+function turnkeyLikePartiallySignedPsbt(): string {
+  const p2wpkh = btc.p2wpkh(pub, btc.TEST_NETWORK);
+  const tx = new btc.Transaction();
+  // A synthetic funding input (segwit → witnessUtxo carries amount + script).
+  tx.addInput({
+    txid: hex.decode('a'.repeat(64)),
+    index: 0,
+    witnessUtxo: { script: p2wpkh.script, amount: 20_000n },
+  });
+  tx.addOutputAddress(
+    'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx',
+    12_000n,
+    btc.TEST_NETWORK
+  );
+  tx.sign(priv); // signs but does NOT finalize
+  return base64.encode(tx.toPSBT());
+}
+
+describe('SPIKE: Turnkey signTransaction → scure finalize (P2WPKH testnet4)', () => {
+  test('finalizeSignedPsbt turns a partially-signed P2WPKH PSBT into broadcast-ready hex with a witness', () => {
+    const partiallySigned = turnkeyLikePartiallySignedPsbt();
+    const rawHex = finalizeSignedPsbt(partiallySigned);
+
+    // Broadcast-ready hex must parse as a raw (non-PSBT) transaction...
+    const parsed = btc.Transaction.fromRaw(hex.decode(rawHex));
+    expect(parsed.inputsLength).toBe(1);
+    // ...and the single P2WPKH input must carry a finalized witness.
+    const input = parsed.getInput(0);
+    expect(input.finalScriptWitness).toBeDefined();
+    expect((input.finalScriptWitness as Uint8Array[]).length).toBeGreaterThan(0);
+  });
+
+  test('finalizeSignedPsbt throws on an unsigned PSBT', () => {
+    const p2wpkh = btc.p2wpkh(pub, btc.TEST_NETWORK);
+    const tx = new btc.Transaction();
+    tx.addInput({ txid: hex.decode('b'.repeat(64)), index: 0, witnessUtxo: { script: p2wpkh.script, amount: 20_000n } });
+    tx.addOutputAddress('tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx', 12_000n, btc.TEST_NETWORK);
+    const unsigned = base64.encode(tx.toPSBT());
+    expect(() => finalizeSignedPsbt(unsigned)).toThrow();
+  });
+});

--- a/apps/landing/src/sdk/finalize-psbt.ts
+++ b/apps/landing/src/sdk/finalize-psbt.ts
@@ -1,0 +1,46 @@
+/**
+ * Finalize a partially-signed PSBT into broadcast-ready raw tx hex.
+ *
+ * This is the second half of the recommended Turnkey signing path: Turnkey
+ * signTransaction({ type: 'TRANSACTION_TYPE_BITCOIN' }) returns a PSBT with
+ * signatures attached but NOT finalized (it owns sighash/DER/low-S). @scure/
+ * btc-signer assembles the final witness and serializes the network tx. The
+ * SDK's inscribe-on-sat path expects raw hex from the BitcoinSigner, never a
+ * PSBT, so finalization MUST happen here.
+ */
+import * as btc from '@scure/btc-signer';
+import { base64, hex } from '@scure/base';
+
+export class FinalizePsbtError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'FinalizePsbtError';
+  }
+}
+
+export function finalizeSignedPsbt(partiallySignedPsbtBase64: string): string {
+  let tx: btc.Transaction;
+  try {
+    tx = btc.Transaction.fromPSBT(base64.decode(partiallySignedPsbtBase64), {
+      allowUnknownInputs: true,
+      allowUnknownOutputs: true,
+    });
+  } catch (e) {
+    throw new FinalizePsbtError(
+      `Could not parse the signed PSBT returned by the signer: ${e instanceof Error ? e.message : String(e)}`,
+      { cause: e }
+    );
+  }
+  try {
+    // Finalize EVERY input — an input still missing its signature (Turnkey did
+    // not sign it) throws here, which is the correct fail-closed behavior: a
+    // partially-finalized tx must never reach broadcast.
+    tx.finalize();
+  } catch (e) {
+    throw new FinalizePsbtError(
+      `Signed PSBT could not be finalized (an input is unsigned or non-standard): ${e instanceof Error ? e.message : String(e)}`,
+      { cause: e }
+    );
+  }
+  return hex.encode(tx.extract());
+}

--- a/apps/landing/src/sdk/http-hosting-adapter.integration.test.ts
+++ b/apps/landing/src/sdk/http-hosting-adapter.integration.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from 'bun:test';
+import { HttpHostingStorageAdapter } from './http-hosting-adapter';
+import { buildFetch } from '../../server/app';
+import { createWebvhHostStore } from '../../server/webvh-host';
+
+// Exercises the REAL server dispatch (buildFetch + createWebvhHostStore), not a
+// hand-mocked fetch — this is the path that a unit-level mock hides. Regression
+// for: GET /api/host/* was routed to handlePut (PUT-only → 405), so adapter.get
+// threw against the real server instead of returning content / null.
+function adapterOverRealServer() {
+  const store = createWebvhHostStore();
+  const fetchFn = buildFetch({ apiRoutes: null, hostStore: store, distDir: '/nonexistent/' });
+  // The adapter uses same-origin relative URLs (as in the browser); resolve
+  // them against a base origin so Request can be constructed in the test env.
+  const fetchImpl = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const raw = typeof input === 'string' ? input : input.toString();
+    return fetchFn(new Request(new URL(raw, 'http://demo.local'), init));
+  }) as unknown as typeof fetch;
+  return new HttpHostingStorageAdapter({ baseUrl: '', fetchImpl });
+}
+
+describe('HttpHostingStorageAdapter against the real server', () => {
+  test('put then get roundtrips (get does not throw)', async () => {
+    const adapter = adapterOverRealServer();
+    const key = 'demo.example.com/studio/you/did.jsonl';
+    await adapter.put(key, '{"v":1}', { contentType: 'application/jsonl' });
+    const got = await adapter.get(key);
+    expect(got).not.toBeNull();
+    expect(got!.content.toString()).toBe('{"v":1}');
+    expect(got!.contentType).toBe('application/jsonl');
+  });
+
+  test('get returns null on a miss (404, not a throw)', async () => {
+    const adapter = adapterOverRealServer();
+    expect(await adapter.get('demo.example.com/never/did.jsonl')).toBeNull();
+  });
+});

--- a/apps/landing/src/sdk/http-hosting-adapter.test.ts
+++ b/apps/landing/src/sdk/http-hosting-adapter.test.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect } from 'bun:test';
+import { HttpHostingStorageAdapter } from './http-hosting-adapter';
+
+function mockFetch() {
+  const store = new Map<string, { body: Uint8Array; contentType: string }>();
+  const calls: Array<{ method: string; url: string }> = [];
+  const impl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const method = (init?.method ?? 'GET').toUpperCase();
+    calls.push({ method, url });
+    if (method === 'PUT') {
+      const buf = new Uint8Array(init!.body as ArrayBuffer);
+      const ct = (init!.headers as Record<string, string>)['content-type'] ?? 'application/octet-stream';
+      store.set(url, { body: buf, contentType: ct });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }
+    const hit = store.get(url);
+    if (!hit) return new Response('not found', { status: 404 });
+    return new Response(hit.body, { status: 200, headers: { 'content-type': hit.contentType } });
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+describe('HttpHostingStorageAdapter', () => {
+  test('put encodes the key, PUTs the bytes, and returns a resolvable URL', async () => {
+    const { impl, calls } = mockFetch();
+    const adapter = new HttpHostingStorageAdapter({ baseUrl: '', fetchImpl: impl });
+    const key = 'demo.example.com/studio/you/did.jsonl';
+    const url = await adapter.put(key, Buffer.from('{"a":1}\n{"b":2}'), {
+      contentType: 'application/jsonl',
+    });
+    expect(calls[0].method).toBe('PUT');
+    expect(calls[0].url).toBe('/api/host/' + encodeURIComponent(key));
+    expect(url).toBe('https://' + key);
+  });
+
+  test('get returns content + contentType, null on miss', async () => {
+    const { impl } = mockFetch();
+    const adapter = new HttpHostingStorageAdapter({ baseUrl: '', fetchImpl: impl });
+    const key = 'demo.example.com/.well-known/did.jsonl';
+    await adapter.put(key, 'hello', { contentType: 'application/jsonl' });
+    const got = await adapter.get(key);
+    expect(got).not.toBeNull();
+    expect(got!.content.toString()).toBe('hello');
+    expect(got!.contentType).toBe('application/jsonl');
+    expect(await adapter.get('nope/missing')).toBeNull();
+  });
+
+  test('put throws on a non-ok, non-2xx response', async () => {
+    const failing = (async () => new Response('too big', { status: 413 })) as unknown as typeof fetch;
+    const adapter = new HttpHostingStorageAdapter({ baseUrl: '', fetchImpl: failing });
+    await expect(adapter.put('k', 'x', { contentType: 'text/plain' })).rejects.toThrow();
+  });
+});

--- a/apps/landing/src/sdk/http-hosting-adapter.ts
+++ b/apps/landing/src/sdk/http-hosting-adapter.ts
@@ -1,0 +1,57 @@
+/**
+ * SDK StorageAdapter (interface A: put/get) backed by this origin's HTTP host.
+ *
+ * The lifecycle's hosting writes (did.jsonl, cel.json, resources) call
+ * put(`${domain}/${relativePath}`, bytes, { contentType }); we forward each to
+ * PUT /api/host/<encoded key>. The returned URL is the resolvable HTTPS URL for
+ * that key — for did.jsonl keys it is exactly what didwebvh-ts's resolver GETs.
+ */
+function toBytes(data: Buffer | Uint8Array | string): Uint8Array {
+  if (typeof data === 'string') return new TextEncoder().encode(data);
+  if (data instanceof Uint8Array) return data;
+  return new Uint8Array(data);
+}
+
+export class HttpHostingStorageAdapter {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts?: { baseUrl?: string; fetchImpl?: typeof fetch }) {
+    // '' → same-origin relative URLs (correct in the browser).
+    this.baseUrl = opts?.baseUrl ?? '';
+    this.fetchImpl = opts?.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  }
+
+  private endpoint(objectKey: string): string {
+    return `${this.baseUrl}/api/host/${encodeURIComponent(objectKey)}`;
+  }
+
+  async put(
+    objectKey: string,
+    data: Buffer | Uint8Array | string,
+    options?: { contentType?: string; cacheControl?: string }
+  ): Promise<string> {
+    const bytes = toBytes(data);
+    const res = await this.fetchImpl(this.endpoint(objectKey), {
+      method: 'PUT',
+      headers: { 'content-type': options?.contentType ?? 'application/octet-stream' },
+      // Copy into a fresh ArrayBuffer so the body is a plain BodyInit.
+      body: bytes.slice().buffer,
+    });
+    if (!res.ok) {
+      throw new Error(`HttpHostingStorageAdapter.put failed: ${res.status} for ${objectKey}`);
+    }
+    // The public, resolvable URL for this key (https — matches didwebvh-ts).
+    return `https://${objectKey}`;
+  }
+
+  async get(objectKey: string): Promise<{ content: Buffer; contentType: string } | null> {
+    const res = await this.fetchImpl(this.endpoint(objectKey), { method: 'GET' });
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      throw new Error(`HttpHostingStorageAdapter.get failed: ${res.status} for ${objectKey}`);
+    }
+    const buf = Buffer.from(await res.arrayBuffer());
+    return { content: buf, contentType: res.headers.get('content-type') ?? 'application/octet-stream' };
+  }
+}

--- a/apps/landing/src/sdk/http-ordinals-provider.test.ts
+++ b/apps/landing/src/sdk/http-ordinals-provider.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect } from 'bun:test';
+import { HttpOrdinalsProvider } from './http-ordinals-provider';
+
+function mockFetch(routes: Record<string, unknown>) {
+  const calls: Array<{ url: string; body: unknown }> = [];
+  const impl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const body = init?.body ? JSON.parse(init.body as string) : undefined;
+    calls.push({ url, body });
+    const key = new URL(url, 'http://x').pathname;
+    if (!(key in routes)) return new Response('nope', { status: 404 });
+    return new Response(JSON.stringify(routes[key]), { status: 200, headers: { 'content-type': 'application/json' } });
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+describe('HttpOrdinalsProvider', () => {
+  test('getFirstSatOfOutput hits /api/btc/sat and returns the sat', async () => {
+    const { impl, calls } = mockFetch({ '/api/btc/sat': { satoshi: '5000000000' } });
+    const p = new HttpOrdinalsProvider({ baseUrl: '', fetchImpl: impl });
+    const sat = await p.getFirstSatOfOutput({ txid: 'a'.repeat(64), vout: 0 });
+    expect(sat).toBe('5000000000');
+    expect(calls[0].url).toBe('/api/btc/sat');
+    expect(calls[0].body).toEqual({ txid: 'a'.repeat(64), vout: 0 });
+  });
+
+  test('estimateFee hits /api/btc/fee', async () => {
+    const { impl } = mockFetch({ '/api/btc/fee': { feeRate: 4 } });
+    const p = new HttpOrdinalsProvider({ baseUrl: '', fetchImpl: impl });
+    expect(await p.estimateFee(1)).toBe(4);
+  });
+
+  test('broadcastTransaction hits /api/btc/broadcast and returns txid', async () => {
+    const { impl, calls } = mockFetch({ '/api/btc/broadcast': { txid: 'f'.repeat(64) } });
+    const p = new HttpOrdinalsProvider({ baseUrl: '', fetchImpl: impl });
+    expect(await p.broadcastTransaction('0200000000')).toBe('f'.repeat(64));
+    expect(calls[0].body).toEqual({ txHex: '0200000000' });
+  });
+
+  test('createInscription rejects by design (tx built locally)', async () => {
+    const { impl } = mockFetch({});
+    const p = new HttpOrdinalsProvider({ baseUrl: '', fetchImpl: impl });
+    await expect(p.createInscription({ contentType: 'text/plain' })).rejects.toThrow();
+  });
+
+  test('broadcast surfaces a server error as a throw', async () => {
+    const failing = (async () => new Response(JSON.stringify({ error: 'broadcast_failed' }), { status: 502 })) as unknown as typeof fetch;
+    const p = new HttpOrdinalsProvider({ baseUrl: '', fetchImpl: failing });
+    await expect(p.broadcastTransaction('0200000000')).rejects.toThrow();
+  });
+});

--- a/apps/landing/src/sdk/http-ordinals-provider.ts
+++ b/apps/landing/src/sdk/http-ordinals-provider.ts
@@ -1,0 +1,71 @@
+/**
+ * SDK OrdinalsProvider backed by this origin's /api/btc/* QuickNode proxies.
+ *
+ * The SDK's sat-selected inscribe path (inscribe-on-sat.ts) uses ONLY
+ * getFirstSatOfOutput, estimateFee and broadcastTransaction; the commit/reveal
+ * are built and self-signed locally (the reveal with an ephemeral key). Every
+ * other OrdinalsProvider method therefore rejects by design — mirroring
+ * QuickNodeProvider's "does not build/sign" contract — so a mislabeled read can
+ * never silently fabricate on-chain data in the browser.
+ */
+import type { OrdinalsProvider } from '@originals/sdk';
+
+export class HttpOrdinalsProvider implements OrdinalsProvider {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts?: { baseUrl?: string; fetchImpl?: typeof fetch }) {
+    this.baseUrl = opts?.baseUrl ?? '';
+    this.fetchImpl = opts?.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  }
+
+  private async post<T>(path: string, body: unknown): Promise<T> {
+    const res = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      credentials: 'same-origin',
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      let detail = '';
+      try { detail = JSON.stringify(await res.json()); } catch { /* ignore */ }
+      throw new Error(`HttpOrdinalsProvider ${path} failed: ${res.status} ${detail}`);
+    }
+    return (await res.json()) as T;
+  }
+
+  async getFirstSatOfOutput(outpoint: { txid: string; vout: number }): Promise<string> {
+    const { satoshi } = await this.post<{ satoshi: string }>('/api/btc/sat', outpoint);
+    return satoshi;
+  }
+
+  async estimateFee(blocks = 1): Promise<number> {
+    const { feeRate } = await this.post<{ feeRate: number }>('/api/btc/fee', { blocks });
+    return feeRate;
+  }
+
+  async broadcastTransaction(txHexOrObj: unknown): Promise<string> {
+    if (typeof txHexOrObj !== 'string') {
+      throw new Error('HttpOrdinalsProvider.broadcastTransaction requires raw tx hex');
+    }
+    const { txid } = await this.post<{ txid: string }>('/api/btc/broadcast', { txHex: txHexOrObj });
+    return txid;
+  }
+
+  // --- Not implemented (the sat-selected inscribe path never calls these). ---
+  getInscriptionById(): Promise<never> {
+    return Promise.reject(new Error('HttpOrdinalsProvider.getInscriptionById is not implemented in the browser demo.'));
+  }
+  getInscriptionsBySatoshi(): Promise<never> {
+    return Promise.reject(new Error('HttpOrdinalsProvider.getInscriptionsBySatoshi is not implemented in the browser demo.'));
+  }
+  getTransactionStatus(): Promise<never> {
+    return Promise.reject(new Error('HttpOrdinalsProvider.getTransactionStatus is not implemented in the browser demo.'));
+  }
+  createInscription(): Promise<never> {
+    return Promise.reject(new Error('HttpOrdinalsProvider.createInscription is not implemented: the commit/reveal are built and signed locally, then broadcast via broadcastTransaction.'));
+  }
+  transferInscription(): Promise<never> {
+    return Promise.reject(new Error('HttpOrdinalsProvider.transferInscription is not implemented in the browser demo.'));
+  }
+}

--- a/apps/landing/src/sdk/testnet-flag.ts
+++ b/apps/landing/src/sdk/testnet-flag.ts
@@ -1,0 +1,12 @@
+/**
+ * Track B enablement flag — a standalone, dependency-free module so components
+ * (e.g. Demo.tsx) can read it WITHOUT statically importing the heavy engine
+ * module, which would defeat the engine chunk's lazy-loading (first-paint perf).
+ *
+ * Enabled only when the deploy sets VITE_BTC_TESTNET=1 (server has
+ * QUICKNODE_ENDPOINT + a faucet Turnkey wallet). Absent → the inscribe step is
+ * the self-contained OrdMockProvider mock.
+ */
+export function btcTestnetEnabled(): boolean {
+  return (import.meta as unknown as { env?: Record<string, string> }).env?.VITE_BTC_TESTNET === '1';
+}

--- a/apps/landing/src/sdk/turnkey-sat-signer.test.ts
+++ b/apps/landing/src/sdk/turnkey-sat-signer.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect } from 'bun:test';
+import * as btc from '@scure/btc-signer';
+import { hex, base64 } from '@scure/base';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { TurnkeySatSigner } from './turnkey-sat-signer';
+import type { TurnkeyBitcoinClient } from '../auth/turnkey-session';
+
+const priv = hex.decode('2222222222222222222222222222222222222222222222222222222222222222');
+const pub = secp256k1.getPublicKey(priv, true);
+const p2wpkh = btc.p2wpkh(pub, btc.TEST_NETWORK);
+
+// Build the UNSIGNED commit PSBT the SDK would hand the signer (base64).
+function unsignedCommitPsbtBase64(): string {
+  const tx = new btc.Transaction();
+  tx.addInput({ txid: hex.decode('c'.repeat(64)), index: 0, witnessUtxo: { script: p2wpkh.script, amount: 30_000n } });
+  tx.addOutputAddress('tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx', 20_000n, btc.TEST_NETWORK);
+  return base64.encode(tx.toPSBT());
+}
+
+// Mock Turnkey: signs the given unsigned PSBT (hex) locally and returns a
+// partially-signed PSBT — exactly Turnkey signTransaction's shape.
+const mockClient: TurnkeyBitcoinClient = {
+  async signTransaction({ unsignedTransaction, type }) {
+    expect(type).toBe('TRANSACTION_TYPE_BITCOIN');
+    const tx = btc.Transaction.fromPSBT(hex.decode(unsignedTransaction), { allowUnknownInputs: true, allowUnknownOutputs: true });
+    tx.sign(priv); // partially-signed, NOT finalized
+    return { signedTransaction: hex.encode(tx.toPSBT()) };
+  },
+  async createWalletAccounts() { throw new Error('not used'); },
+  async getWallets() { throw new Error('not used'); },
+};
+
+describe('TurnkeySatSigner', () => {
+  test('signAndFinalizeCommitPsbt returns broadcast-ready hex with a witness', async () => {
+    const signer = new TurnkeySatSigner({ client: mockClient, signWith: 'tb1quseraddr' });
+    const rawHex = await signer.signAndFinalizeCommitPsbt(unsignedCommitPsbtBase64());
+    const parsed = btc.Transaction.fromRaw(hex.decode(rawHex));
+    expect(parsed.inputsLength).toBe(1);
+    expect(parsed.getInput(0).finalScriptWitness).toBeDefined();
+  });
+
+  test('rejects when Turnkey returns nothing signable', async () => {
+    const bad: TurnkeyBitcoinClient = {
+      async signTransaction() { return { signedTransaction: '' }; },
+      async createWalletAccounts() { throw new Error('x'); },
+      async getWallets() { throw new Error('x'); },
+    };
+    const signer = new TurnkeySatSigner({ client: bad, signWith: 'tb1quseraddr' });
+    await expect(signer.signAndFinalizeCommitPsbt(unsignedCommitPsbtBase64())).rejects.toThrow();
+  });
+});

--- a/apps/landing/src/sdk/turnkey-sat-signer.ts
+++ b/apps/landing/src/sdk/turnkey-sat-signer.ts
@@ -1,0 +1,47 @@
+/**
+ * SDK BitcoinSigner backed by the user's Turnkey session key.
+ *
+ * The SDK's inscribe-on-sat path builds the commit PSBT and hands it here as
+ * base64; we convert to hex, sign the P2WPKH funding input via Turnkey
+ * signTransaction (SIGHASH_ALL; Turnkey owns sighash/DER/low-S), then finalize
+ * with @scure/btc-signer into broadcast-ready hex (the SDK rejects a returned
+ * PSBT). Only the COMMIT is signed here — the reveal is self-signed by the SDK's
+ * ephemeral key. Signing is silent within the Turnkey session window.
+ */
+import type { BitcoinSigner } from '@originals/sdk';
+import { base64, hex } from '@scure/base';
+import * as btc from '@scure/btc-signer';
+import { finalizeSignedPsbt } from './finalize-psbt';
+import type { TurnkeyBitcoinClient } from '../auth/turnkey-session';
+
+export class TurnkeySatSigner implements BitcoinSigner {
+  private readonly client: TurnkeyBitcoinClient;
+  private readonly signWith: string;
+
+  constructor(opts: { client: TurnkeyBitcoinClient; signWith: string }) {
+    this.client = opts.client;
+    this.signWith = opts.signWith;
+  }
+
+  async signAndFinalizeCommitPsbt(psbtBase64: string): Promise<string> {
+    const unsignedHex = hex.encode(base64.decode(psbtBase64));
+    const result = await this.client.signTransaction({
+      signWith: this.signWith,
+      unsignedTransaction: unsignedHex,
+      type: 'TRANSACTION_TYPE_BITCOIN',
+    });
+    const signed = result?.signedTransaction;
+    if (!signed) {
+      throw new Error('TurnkeySatSigner: Turnkey signTransaction returned no signedTransaction.');
+    }
+    // Turnkey may return raw hex (already finalized) or a partially-signed PSBT.
+    // Raw hex round-trips through Transaction.fromRaw; anything else is a PSBT
+    // (hex or base64) that finalizeSignedPsbt assembles into broadcast-ready hex.
+    try {
+      const raw = btc.Transaction.fromRaw(hex.decode(signed), { allowUnknownInputs: true, allowUnknownOutputs: true });
+      if (raw.getInput(0).finalScriptWitness) return hex.encode(raw.extract());
+    } catch { /* not raw finalized hex — treat as PSBT below */ }
+    const psbtBase64Out = /^[0-9a-fA-F]+$/.test(signed) ? base64.encode(hex.decode(signed)) : signed;
+    return finalizeSignedPsbt(psbtBase64Out);
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -15,11 +15,16 @@
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",
+        "@noble/curves": "^2.2.0",
         "@noble/ed25519": "^3.1.0",
         "@noble/hashes": "^2.0.1",
         "@originals/auth": "workspace:*",
         "@originals/sdk": "workspace:*",
+        "@scure/base": "^2.2.0",
+        "@scure/btc-signer": "^2.2.0",
+        "@turnkey/api-key-stamper": "^0.6.7",
         "@turnkey/crypto": "^2.10.0",
+        "@turnkey/sdk-browser": "^6.1.1",
         "didwebvh-ts": "^2.8.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -182,6 +187,16 @@
 
     "@fontsource/jetbrains-mono": ["@fontsource/jetbrains-mono@5.2.8", "", {}, "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ=="],
 
+    "@hpke/chacha20poly1305": ["@hpke/chacha20poly1305@1.8.0", "", { "dependencies": { "@hpke/common": "^1.10.0" } }, "sha512-FcBfAQ+Y99vMNJP2yrZ9wpL8V0GOwp1+zMyzvc6alasrBygfFjFm1yeUtyADJCu/27C3Lm5mJzx6u7pwg+cX5w=="],
+
+    "@hpke/common": ["@hpke/common@1.10.1", "", {}, "sha512-moJwhmtLtuxiUzzNp1jpfBfx8yefKoO9D/RCR9dmwrnc7qjJqId1rEtQz+lSlU5cabX8daToMSx/7HayXOiaFw=="],
+
+    "@hpke/core": ["@hpke/core@1.9.0", "", { "dependencies": { "@hpke/common": "^1.10.0" } }, "sha512-pFxWl1nNJeQCSUFs7+GAblHvXBCjn9EPN65vdKlYQil2aURaRxfGMO6vBKGqm1YHTKwiAxJQNEI70PbSowMP9Q=="],
+
+    "@hpke/dhkem-x25519": ["@hpke/dhkem-x25519@1.8.0", "", { "dependencies": { "@hpke/common": "^1.10.0" } }, "sha512-S1MWWkAfu+TFxySgv5+2P3O4Mx/jk7BsoplzQaA1s3sfUJVJ2UsZsSzSsMc+FXJumLXncoJFlO6mK6mDGspfmA=="],
+
+    "@hpke/dhkem-x448": ["@hpke/dhkem-x448@1.8.0", "", { "dependencies": { "@hpke/common": "^1.10.0" } }, "sha512-mFfnZfgp4OKkUIS/FKikfUgdnDKRy25ytCKBQiV+N+HbYy3I4v4ZCPBQ69QL+TYmKmCZJeUEnYeS5K+OBRP+Eg=="],
+
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.8", "", { "dependencies": { "@humanfs/core": "^0.19.2", "@humanfs/types": "^0.15.0", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ=="],
@@ -307,6 +322,12 @@
     "@turnkey/encoding": ["@turnkey/encoding@0.6.0", "", { "dependencies": { "bs58": "6.0.0", "bs58check": "4.0.0" } }, "sha512-IC8qXvy36+iGAeiaVIuJvB35uU2Ld/RAWI/DRTKS+ttBej0GXhOn48Ouu5mlca4jt8ZEuwXmDVv74A8uBQclsA=="],
 
     "@turnkey/http": ["@turnkey/http@4.1.1", "", { "dependencies": { "@turnkey/api-key-stamper": "0.6.7", "@turnkey/encoding": "0.6.0", "@turnkey/webauthn-stamper": "0.6.0", "cross-fetch": "^3.1.5" } }, "sha512-Cw5qUSH0OHOagcyJeRsKlGbhvQPm5dw5pPb8x/V2SmqcP7zMT7TQ+ug9UOtHixkvhVC/VaGJYRIcbMBGrpIOrg=="],
+
+    "@turnkey/iframe-stamper": ["@turnkey/iframe-stamper@2.11.1", "", {}, "sha512-S9BoAIyVBH1BurTKsX/YzjVrEhW6Zn0A/9WPfhhC9YA/9RDELP4wNL3jUcijJWgT9OO6BRbRDUs81FrC0ruLww=="],
+
+    "@turnkey/indexed-db-stamper": ["@turnkey/indexed-db-stamper@1.3.1", "", { "dependencies": { "@turnkey/encoding": "0.6.0", "@turnkey/sdk-types": "1.1.0" } }, "sha512-e5wYbXXa93XDKWaciFpf69vm97rJr98LhjsGUH7Iiwejgz05y+4Jf5CRXVl5xmno8fU1qCi6GvO/W6ZEGz5Xjg=="],
+
+    "@turnkey/sdk-browser": ["@turnkey/sdk-browser@6.1.1", "", { "dependencies": { "@turnkey/api-key-stamper": "0.6.7", "@turnkey/crypto": "2.10.0", "@turnkey/encoding": "0.6.0", "@turnkey/http": "4.1.1", "@turnkey/iframe-stamper": "2.11.1", "@turnkey/indexed-db-stamper": "1.3.1", "@turnkey/sdk-types": "1.1.0", "@turnkey/wallet-stamper": "1.1.19", "@turnkey/webauthn-stamper": "0.6.0", "buffer": "^6.0.3", "cross-fetch": "^3.1.5", "hpke-js": "^1.6.5" } }, "sha512-CnCv4luYI/dQ62eVOPrcymb9UVR4sQbBnInBIa/EoM2axoiTOuxV+E6OiV/uldrm07W3Vvmm8MTghts35rhQlA=="],
 
     "@turnkey/sdk-server": ["@turnkey/sdk-server@6.1.1", "", { "dependencies": { "@turnkey/api-key-stamper": "0.6.7", "@turnkey/http": "4.1.1", "@turnkey/sdk-types": "1.1.0", "@turnkey/wallet-stamper": "1.1.19", "buffer": "^6.0.3", "cross-fetch": "^3.1.5" } }, "sha512-BMg21s5jVHlFzMlrM9jnaOFSzkas7qSiSN/gHcK3pSqjMQzUaSRLonEbBb76tLx/jnX2vgCK7bBpOe+g/P/K0w=="],
 
@@ -575,6 +596,8 @@
     "globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "hpke-js": ["hpke-js@1.8.0", "", { "dependencies": { "@hpke/chacha20poly1305": "^1.8.0", "@hpke/common": "^1.10.0", "@hpke/core": "^1.9.0", "@hpke/dhkem-x25519": "^1.8.0", "@hpke/dhkem-x448": "^1.8.0" } }, "sha512-N0PFQlUQsIPS9++nUNn2ZsxTPSv8pONyyrXIGZl0iiherRfS0XW1SvTd+RmepD0TN1S9zzTJkEutMIWWYt0/4w=="],
 
     "human-id": ["human-id@4.1.1", "", { "bin": { "human-id": "dist/cli.js" } }, "sha512-3gKm/gCSUipeLsRYZbbdA1BD83lBoWUkZ7G9VFrhWPAU76KwYo5KR8V28bpoPm/ygy0x5/GCbpRQdY7VLYCoIg=="],
 

--- a/docs/superpowers/plans/2026-07-16-landing-real-webvh-hosting.md
+++ b/docs/superpowers/plans/2026-07-16-landing-real-webvh-hosting.md
@@ -1,0 +1,1320 @@
+# Landing Demo — Real did:webvh Hosting (Phase 0 + Track A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the landing demo's "Publish" step do REAL did:webvh hosting — the signed DID log (+ CEL log + resources) is uploaded to the demo's own origin over HTTP(S), the SDK's real resolver fetches it back, and the UI proves it resolved — plus fold the split static/API servers into one Bun entry and fix the did:peer→did:cel / mock-hosting mislabels.
+
+**Architecture:** One Bun server (rewritten `apps/landing/serve.ts`) serves the static SPA (with SPA fallback + path-traversal guard), the existing `/api/auth/*` routes (only when `JWT_SECRET` + `TURNKEY_*` env are present; otherwise 503 stubs so the SPA and Track A run WITHOUT secrets), a new `PUT /api/host/*` write endpoint, and GETs of the hosted DID logs at the EXACT URLs `didwebvh-ts`'s resolver requests. In the browser, a new `HttpHostingStorageAdapter` (SDK `StorageAdapter` interface A: `put`/`get`) routes all lifecycle hosting writes through `PUT /api/host/*`; after `publishToWeb` the engine calls `sdk.did.resolveDID(publisherDid, { skipCache: true })` to prove real network resolution and emits a `did:webvh:resolved` event carrying the resolvable log URL.
+
+**Tech Stack:** Bun (runtime + test runner), TypeScript, `@originals/sdk`, `didwebvh-ts` v2.8.0, Vite 8 / React 19, `@originals/auth`.
+
+## Global Constraints
+
+- **Runtime & tests:** Bun only. Server tests live in `apps/landing/server/tests/*.test.ts`; browser/SDK tests in `apps/landing/src/**/*.test.ts`. Run with `cd apps/landing && bun test <path>`. Import test primitives from `bun:test` (`import { describe, test, expect } from 'bun:test'`). Follow the style of `apps/landing/server/tests/router.test.ts`.
+- **Absolute imports inside the SDK package only** — inside `apps/landing` use the existing relative-import style already present in the files you touch.
+- **Noble imports:** `@noble/hashes/sha2.js` (never `/sha256`).
+- **Multikey encoding only** — never JWK. (Not touched by this plan, but do not introduce JWK.)
+- **Track B is OUT OF SCOPE.** This plan is Phase 0 + Phase 1/Track A only. Do NOT touch Bitcoin inscription, `OrdMockProvider`, `HttpOrdinalsProvider`, `TurnkeySatSigner`, faucet, or QuickNode. The `inscribe()` step stays exactly as-is (mock). Leave all inscription/Bitcoin copy in `content.ts` unchanged.
+- **`content.ts` reconciliation is out of scope** except the specific create/publish/hosting step strings named in Task 2.
+- **No raw private keys anywhere on the server.** (Track A introduces none; keep it that way.)
+- **Honesty rule:** every step's UI/badge copy must state exactly what is real vs. simulated. Create = real crypto, offline. Publish = real HTTP(S) did:webvh hosting + resolution. Inscribe = still mock (unchanged).
+
+---
+
+## Resolved facts (locked in Task 0 — read before coding)
+
+Confirmed by reading `node_modules/.bun/didwebvh-ts@2.8.0/node_modules/didwebvh-ts/dist/esm/index.js` (the version `apps/landing` resolves) and `packages/sdk/src/lifecycle/LifecycleManager.ts`.
+
+**1. The resolver's GET URL (`getFileUrl` → `resolveDID` → `fetch`).** For a DID `did:webvh:<SCID>:<domain>[:<segA>:<segB>…]`:
+- **Pathed DID** (has segments after the domain): `getFileUrl` returns
+  `https://<host>[:<port>]/<segA>/<segB>/did.jsonl`.
+- **Domain-root DID** (no segments): `https://<host>[:<port>]/.well-known/did.jsonl`.
+- **Protocol is hard-coded `https`** (`const protocol = "https"` in `getBaseUrl`). There is no http fallback — see dev caveat below.
+- The resolver ALSO best-effort fetches the witness proofs at the same URL with `did.jsonl` → `did-witness.json` (`fetchWitnessProofs`); a `404` there is harmless (returns `[]`). The host store therefore only strictly needs to serve `did.jsonl`; a missing `did-witness.json` is fine.
+- `resolveDID` fetches ONLY the log (`fetchLogFromIdentifier` → `fetch(getFileUrl(did))`). It does not fetch `cel.json` or resources — those are hosted for the demo/provenance but the resolver never requests them.
+
+**2. What the SDK writes (`LifecycleManager`, via storage adapter `put`).** `webvhStorageLocation(did, filename)` splits the DID: `domain = decodeURIComponent(parts[3])`, `pathParts = parts.slice(4)`, and
+`relativePath = pathParts.length ? \`${pathParts.join('/')}/${filename}\` : \`.well-known/${filename}\``.
+When the adapter has `.put`, the SDK calls `put(\`${domain}/${relativePath}\`, Buffer.from(bytes), { contentType })`:
+- DID log → key `\`${domain}/${relativePath}\`` with `filename = did.jsonl`, contentType `application/jsonl`.
+- CEL log (webvh sibling) → same shape, `filename = cel.json`, contentType `application/json`.
+- Resources → key `\`${domain}/${userPath ? userPath + '/' : ''}resources/${multibase}\``, contentType = the resource's contentType.
+- CEL demo-copy (`persistCelArtifacts`) → key `\`cel/${suffix}.json\`` (NO domain prefix), contentType `application/json`. The resolver never fetches this; it just occupies a store slot.
+
+**3. The exact mapping (this is the whole point).** The storage `put` key is `\`${domain}/${relativePath}\``. The resolver GETs `https://${domain}/${relativePath}` (domain in the DID = the origin host; `relativePath` = `<segs>/did.jsonl` or `.well-known/did.jsonl`). So on an incoming GET, the store's lookup key is exactly **`\`${url.host}${url.pathname}\``** (host header includes the port; `url.pathname` starts with `/` and equals `/${relativePath}`). This is byte-identical to the `put` key. The host GET routing MUST serve on that reconstruction — do not invent a different path scheme.
+
+Worked example (paths `['studio','you']`, origin host `demo.example.com`):
+- DID `did:webvh:<SCID>:demo.example.com:studio:you`
+- `put` key = `demo.example.com/studio/you/did.jsonl`
+- resolver GET = `https://demo.example.com/studio/you/did.jsonl` → store key `demo.example.com/studio/you/did.jsonl` ✓
+
+Port example (dev origin host `localhost:5173`): the DID encodes the port colon as `%3A` (`did:webvh:<SCID>:localhost%3A5173:studio:you`); the SDK's `decodeURIComponent(parts[3])` gives `localhost:5173`, so `put` key = `localhost:5173/studio/you/did.jsonl`, and `url.host` on the served request = `localhost:5173`. Still identical.
+
+**4. Dev caveat (protocol forced to https).** Because `getBaseUrl` hard-codes `https`, a localhost dev origin served over `http` cannot be resolved by `didwebvh-ts` (it will `fetch('https://localhost:5173/...')` and fail). Therefore the post-publish `resolveDID` step is **best-effort in dev (failure is expected and non-fatal) and authoritative in production** (real HTTPS origin). The `did:webvh:resolved` event carries `resolved: boolean` so the UI shows the link always and the "resolved ✓" tick only when resolution actually succeeded. Integration tests (Task 5) stub `globalThis.fetch` so resolution is deterministic without a live HTTPS origin.
+
+---
+
+## Task 1: Unified Bun server (static + SPA + `/api` + host mounts)
+
+**Files:**
+- Create: `apps/landing/server/app.ts`
+- Modify: `apps/landing/server/index.ts` (add `buildStubRoutes`)
+- Modify: `apps/landing/serve.ts` (rewrite as the unified prod entry)
+- Modify: `railway.json` (confirm `startCommand`)
+- Modify: `apps/landing/vite.config.ts` (confirm dev proxy comment)
+- Test: `apps/landing/server/tests/app.test.ts`
+
+**Interfaces:**
+- Consumes: `route`, `json`, `type Handler` from `./router`; `type WebvhHostStore` from `./webvh-host` (Task 4 — for Task 1, use the minimal stub host store defined in Step 3 below so Task 1 stands alone).
+- Produces:
+  - `buildFetch(deps: { routes: Record<string, Handler>; hostStore: WebvhHostStore; distDir: string }): (req: Request) => Promise<Response>`
+  - `buildStubRoutes(): Record<string, Handler>` (503 for auth routes, ok for health).
+  - `WebvhHostStore` shape used here: `{ handlePut(req: Request, url: URL): Promise<Response>; serve(req: Request, url: URL): Response | null }`. Task 4 implements the real one with the SAME two-method surface.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/landing/server/tests/app.test.ts`:
+
+```typescript
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildFetch } from '../app';
+import { buildStubRoutes } from '../index';
+import { json, type Handler } from '../router';
+
+// A no-op host store matching the WebvhHostStore surface buildFetch depends on.
+const noopHostStore = {
+  async handlePut() {
+    return json({ error: 'not_implemented' }, 501);
+  },
+  serve() {
+    return null as Response | null;
+  },
+};
+
+let distDir: string;
+
+beforeAll(() => {
+  const dir = mkdtempSync(join(tmpdir(), 'landing-dist-'));
+  writeFileSync(join(dir, 'index.html'), '<!doctype html><title>spa</title>');
+  writeFileSync(join(dir, 'app.js'), 'console.log("asset")');
+  distDir = dir + '/';
+});
+
+afterAll(() => rmSync(distDir, { recursive: true, force: true }));
+
+function makeFetch(routes: Record<string, Handler>) {
+  return buildFetch({ routes, hostStore: noopHostStore, distDir });
+}
+
+describe('unified server buildFetch', () => {
+  test('serves a real static asset from dist', async () => {
+    const res = await makeFetch(buildStubRoutes())(new Request('http://x/app.js'));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('asset');
+  });
+
+  test('SPA fallback: unknown non-file path returns index.html', async () => {
+    const res = await makeFetch(buildStubRoutes())(new Request('http://x/some/client/route'));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('spa');
+  });
+
+  test('rejects path traversal', async () => {
+    const res = await makeFetch(buildStubRoutes())(
+      new Request('http://x/..%2f..%2fetc%2fpasswd')
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test('GET /api/health returns ok', async () => {
+    const res = await makeFetch(buildStubRoutes())(new Request('http://x/api/health'));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: 'ok' });
+  });
+
+  test('auth route returns 503 when unconfigured', async () => {
+    const res = await makeFetch(buildStubRoutes())(
+      new Request('http://x/api/auth/send-otp', { method: 'POST' })
+    );
+    expect(res.status).toBe(503);
+  });
+
+  test('POST /api/host/* is routed to the host store, not static', async () => {
+    const res = await makeFetch(buildStubRoutes())(
+      new Request('http://x/api/host/whatever', { method: 'PUT' })
+    );
+    expect(res.status).toBe(501); // noopHostStore.handlePut
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/landing && bun test server/tests/app.test.ts`
+Expected: FAIL — `Cannot find module '../app'` (and `buildStubRoutes` is not exported from `../index`).
+
+- [ ] **Step 3: Implement `buildFetch` in `apps/landing/server/app.ts`**
+
+```typescript
+import { file } from 'bun';
+import { normalize } from 'node:path';
+import { route, type Handler } from './router';
+
+// Minimal surface buildFetch depends on; the real store (webvh-host.ts, Task 4)
+// implements exactly these two methods.
+export interface WebvhHostStore {
+  handlePut(req: Request, url: URL): Promise<Response>;
+  serve(req: Request, url: URL): Response | null;
+}
+
+async function serveStatic(url: URL, distDir: string): Promise<Response> {
+  // Strip leading slashes, normalize, reject path traversal (moved from serve.ts).
+  const rel = normalize(decodeURIComponent(url.pathname))
+    .replace(/^(\.\.(\/|\\|$))+/, '')
+    .replace(/^\/+/, '');
+  if (rel.includes('..')) return new Response('Bad request', { status: 400 });
+  const target = rel === '' ? 'index.html' : rel;
+  const f = file(distDir + target);
+  if (await f.exists()) return new Response(f);
+  // SPA fallback: client-side routes have no file on disk.
+  return new Response(file(distDir + 'index.html'), {
+    headers: { 'content-type': 'text/html; charset=utf-8' },
+  });
+}
+
+export function buildFetch(deps: {
+  routes: Record<string, Handler>;
+  hostStore: WebvhHostStore;
+  distDir: string;
+}): (req: Request) => Promise<Response> {
+  const { routes, hostStore, distDir } = deps;
+  return async (req) => {
+    const url = new URL(req.url);
+    const path = url.pathname;
+
+    // 1. WebVH host writes (wildcard path — not expressible in the exact route map).
+    if (path.startsWith('/api/host/')) return hostStore.handlePut(req, url);
+
+    // 2. All other /api/* — exact-match route map (auth routes or 503 stubs + health).
+    if (path.startsWith('/api/')) return route(req, routes);
+
+    // 3. WebVH log/resource GETs served at the resolver's exact URLs.
+    if (req.method === 'GET' || req.method === 'HEAD') {
+      const served = hostStore.serve(req, url);
+      if (served) return served;
+    }
+
+    // 4. Static SPA + fallback (with traversal guard).
+    return serveStatic(url, distDir);
+  };
+}
+```
+
+- [ ] **Step 4: Add `buildStubRoutes` to `apps/landing/server/index.ts`**
+
+Add this exported function (leave `buildRoutes` and the `if (import.meta.main)` block untouched — the block is now dead in prod because `serve.ts` is the entry, but keep it for standalone `bun run server/index.ts` dev use):
+
+```typescript
+// Routes for when Turnkey/JWT env is absent: health works, auth returns 503 so
+// the SPA + Track A (real webvh hosting) run WITHOUT any secrets.
+export function buildStubRoutes(): Record<string, Handler> {
+  const unavailable: Handler = () =>
+    json(
+      { error: 'auth_unconfigured', message: 'Authentication is not configured on this server.' },
+      503
+    );
+  return {
+    'GET /api/health': () => json({ status: 'ok' }),
+    'POST /api/auth/send-otp': unavailable,
+    'POST /api/auth/verify-otp': unavailable,
+    'GET /api/me': unavailable,
+    'POST /api/auth/logout': unavailable,
+  };
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd apps/landing && bun test server/tests/app.test.ts`
+Expected: PASS — 6 tests pass.
+
+- [ ] **Step 6: Rewrite `apps/landing/serve.ts` as the unified prod entry**
+
+Replace the entire file with:
+
+```typescript
+/**
+ * Unified production server for the landing app (Railway entry).
+ *
+ * One origin serves: the built SPA (with SPA fallback + traversal guard), the
+ * auth API (only when JWT_SECRET + TURNKEY_* are present; otherwise 503 stubs),
+ * the WebVH host write endpoint (PUT /api/host/*), and the hosted did:webvh logs
+ * at the exact URLs didwebvh-ts's resolver GETs. No secrets are required to run
+ * the SPA and the real did:webvh hosting demo (Track A).
+ */
+import { createInMemorySessionStorage } from '@originals/auth/server';
+import { buildFetch } from './server/app';
+import { createWebvhHostStore } from './server/webvh-host';
+import { buildRoutes, buildStubRoutes } from './server/index';
+import { getTurnkey } from './server/turnkey';
+
+const distDir = new URL('./dist/', import.meta.url).pathname;
+const hostStore = createWebvhHostStore();
+
+const jwtSecret = process.env.JWT_SECRET;
+const turnkeyConfigured =
+  !!process.env.TURNKEY_API_PUBLIC_KEY &&
+  !!process.env.TURNKEY_API_PRIVATE_KEY &&
+  !!process.env.TURNKEY_ORGANIZATION_ID;
+
+let routes;
+if (jwtSecret && turnkeyConfigured) {
+  routes = buildRoutes({
+    turnkey: getTurnkey(),
+    sessions: createInMemorySessionStorage(),
+    jwtSecret,
+  });
+  console.log('[landing] auth configured — /api/auth/* live');
+} else {
+  console.warn(
+    '[landing] auth unconfigured (JWT_SECRET/TURNKEY_* absent) — /api/auth/* returns 503; SPA + did:webvh hosting still work'
+  );
+  routes = buildStubRoutes();
+}
+
+const server = Bun.serve({
+  port: Number(process.env.PORT ?? 8787),
+  hostname: '0.0.0.0',
+  fetch: buildFetch({ routes, hostStore, distDir }),
+});
+
+console.log(`[landing] unified server on http://0.0.0.0:${server.port}`);
+```
+
+Note: this file imports `createWebvhHostStore` from `./server/webvh-host` (Task 4). Until Task 4 lands, `bun run apps/landing/serve.ts` will fail to import — that is expected; Task 1's deliverable is verified by `app.test.ts`, not by booting `serve.ts`. Do NOT create a placeholder `webvh-host.ts` here; Task 4 owns it. Sequence Task 4 before manually booting `serve.ts`.
+
+- [ ] **Step 7: Confirm `railway.json` `startCommand` targets the unified entry**
+
+Read `railway.json`. It already reads `"startCommand": "bun run apps/landing/serve.ts"`. `serve.ts` is now the unified entry, so this line is correct and needs **no change**. Verify it reads exactly `bun run apps/landing/serve.ts` and leave it. (The `buildCommand` also stays unchanged.)
+
+- [ ] **Step 8: Confirm the Vite dev proxy still targets the unified server port**
+
+Read `apps/landing/vite.config.ts`. The dev proxy is `server.proxy = { '/api': 'http://localhost:8787' }`. The unified server defaults to `PORT ?? 8787`, so dev (`bun run apps/landing/serve.ts` with no `PORT`) listens on 8787 and the proxy is already correct. Update ONLY the proxy comment (lines ~72-73) to reflect the unified server:
+
+Replace:
+```typescript
+  // Same-origin proxy so the browser reaches the standalone auth server
+  // (server/index.ts on :8787) without CORS and the httpOnly cookie works.
+```
+with:
+```typescript
+  // Same-origin proxy so the browser reaches the unified Bun server
+  // (serve.ts on :8787: auth + PUT /api/host/*) without CORS and cookies work.
+```
+
+- [ ] **Step 9: Run the test once more and commit**
+
+Run: `cd apps/landing && bun test server/tests/app.test.ts`
+Expected: PASS — 6 tests pass.
+
+```bash
+git add apps/landing/server/app.ts apps/landing/server/index.ts apps/landing/serve.ts apps/landing/vite.config.ts apps/landing/server/tests/app.test.ts railway.json
+git commit -m "feat(landing): unified Bun server (static + SPA + /api + host mounts)"
+```
+
+---
+
+## Task 2: Honesty labels (did:peer→did:cel, real hosting wording)
+
+**Files:**
+- Modify: `apps/landing/src/sdk/engine.ts` (lines ~117-124: `asset:created` + `resource:published` summaries; lines 1-13 header comment)
+- Modify: `apps/landing/src/content.ts` (lines ~120-121 create description; lines ~129-130 publish description)
+- Test: `apps/landing/src/sdk/engine.summary.test.ts`
+
+**Interfaces:**
+- Consumes: `DemoEngine` from `./engine`; `demo` from `../content`.
+- Produces: no new exports; asserts observable summary/content strings.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/landing/src/sdk/engine.summary.test.ts`:
+
+```typescript
+import { describe, test, expect } from 'bun:test';
+import { DemoEngine } from './engine';
+import { demo } from '../content';
+
+describe('honesty labels', () => {
+  test('content: create step no longer claims a did:peer identity', () => {
+    expect(demo.steps[0].description).toContain('did:cel');
+    expect(demo.steps[0].description).not.toContain('did:peer identity');
+  });
+
+  test('content: publish step describes real hosting/resolution', () => {
+    expect(demo.steps[1].description.toLowerCase()).toMatch(/host|resolv/);
+  });
+
+  test('asset:created summary says did:cel, not "a private did:peer identity"', async () => {
+    const engine = new DemoEngine();
+    const summaries: string[] = [];
+    engine.on((e) => {
+      if (e.type === 'asset:created') summaries.push(e.summary);
+    });
+    await engine.create('Test Piece', 'Artwork', '<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+    expect(summaries.length).toBe(1);
+    expect(summaries[0]).toContain('did:cel');
+    expect(summaries[0]).not.toContain('did:peer identity');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/landing && bun test src/sdk/engine.summary.test.ts`
+Expected: FAIL — `demo.steps[0].description` still contains `did:peer identity`; `asset:created` summary still says `a private did:peer identity`.
+
+- [ ] **Step 3: Fix the `asset:created` summary in `apps/landing/src/sdk/engine.ts`**
+
+Replace:
+```typescript
+    forward('asset:created', (e: { asset: { id: string } }) =>
+      `Asset created as ${short(e.asset.id)} — a private did:peer identity, generated entirely offline`
+    );
+```
+with:
+```typescript
+    forward('asset:created', (e: { asset: { id: string } }) =>
+      `Asset created as ${short(e.asset.id)} — a did:cel genesis (a signed event log), generated entirely offline in this tab`
+    );
+```
+
+- [ ] **Step 4: Fix the `resource:published` summary in `apps/landing/src/sdk/engine.ts`**
+
+Replace:
+```typescript
+    forward(
+      'resource:published',
+      (e: { resource: { id: string } }) =>
+        `Resource "${e.resource.id}" published to hosted storage`
+    );
+```
+with:
+```typescript
+    forward(
+      'resource:published',
+      (e: { resource: { id: string } }) =>
+        `Resource "${e.resource.id}" hosted over HTTP at this origin — its did:webvh log is now resolvable`
+    );
+```
+
+- [ ] **Step 5: Fix the header comment in `apps/landing/src/sdk/engine.ts`**
+
+Replace the header sentence (lines ~5-8):
+```typescript
+ * DIDs, hashes, credentials, events and provenance all come back from
+ * actual SDK calls. Bitcoin operations run against OrdMockProvider, the
+ * SDK's own in-memory Ordinals provider, so no wallet or node is needed.
+```
+with:
+```typescript
+ * DIDs, hashes, credentials, events and provenance all come back from
+ * actual SDK calls. Publishing hosts the signed did:webvh log at this origin
+ * over real HTTP(S) and the SDK's real resolver fetches it back. Bitcoin
+ * operations still run against OrdMockProvider (no wallet or node needed).
+```
+
+- [ ] **Step 6: Fix the create + publish step copy in `apps/landing/src/content.ts`**
+
+Replace the create description (lines ~120-121):
+```typescript
+      description:
+        'Hashes the artwork’s bytes and mints a did:peer identity — entirely in this tab, no server involved.'
+```
+with:
+```typescript
+      description:
+        'Hashes the artwork’s bytes and mints its did:cel genesis — a signed event log, entirely in this tab, no server involved.'
+```
+
+Replace the publish description (lines ~129-130):
+```typescript
+      description:
+        'Migrates the asset to did:webvh, publishes its resources, and signs a publication credential.'
+```
+with:
+```typescript
+      description:
+        'Migrates the asset to did:webvh and hosts the signed DID log at this origin — the SDK’s real resolver then fetches it back over HTTP(S).'
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `cd apps/landing && bun test src/sdk/engine.summary.test.ts`
+Expected: PASS — 3 tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/landing/src/sdk/engine.ts apps/landing/src/content.ts apps/landing/src/sdk/engine.summary.test.ts
+git commit -m "fix(landing): honest did:cel + real-hosting copy for create/publish"
+```
+
+---
+
+## Task 3: `HttpHostingStorageAdapter` (browser, SDK StorageAdapter interface A)
+
+**Files:**
+- Create: `apps/landing/src/sdk/http-hosting-adapter.ts`
+- Test: `apps/landing/src/sdk/http-hosting-adapter.test.ts`
+
+**Interfaces:**
+- Consumes: `globalThis.fetch`.
+- Produces:
+  - `class HttpHostingStorageAdapter` implementing SDK `StorageAdapter` interface A:
+    - `put(objectKey: string, data: Buffer | Uint8Array | string, options?: { contentType?: string; cacheControl?: string }): Promise<string>` — PUTs to `\`${baseUrl}/api/host/${encodeURIComponent(objectKey)}\`` with the bytes as the body and `content-type` header; returns the public URL `\`${origin}/${objectKey}\`` (`https` scheme; this is the resolvable URL for did.jsonl keys).
+    - `get(objectKey: string): Promise<{ content: Buffer; contentType: string } | null>` — GETs `\`${baseUrl}/api/host/${encodeURIComponent(objectKey)}\``; `null` on 404.
+  - `constructor(opts?: { baseUrl?: string; fetchImpl?: typeof fetch })` — `baseUrl` defaults to `''` (same-origin relative URLs, correct in the browser); `fetchImpl` defaults to `globalThis.fetch` (injectable for tests).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/landing/src/sdk/http-hosting-adapter.test.ts`:
+
+```typescript
+import { describe, test, expect } from 'bun:test';
+import { HttpHostingStorageAdapter } from './http-hosting-adapter';
+
+function mockFetch() {
+  const store = new Map<string, { body: Uint8Array; contentType: string }>();
+  const calls: Array<{ method: string; url: string }> = [];
+  const impl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const method = (init?.method ?? 'GET').toUpperCase();
+    calls.push({ method, url });
+    if (method === 'PUT') {
+      const buf = new Uint8Array(init!.body as ArrayBuffer);
+      const ct = (init!.headers as Record<string, string>)['content-type'] ?? 'application/octet-stream';
+      store.set(url, { body: buf, contentType: ct });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }
+    const hit = store.get(url);
+    if (!hit) return new Response('not found', { status: 404 });
+    return new Response(hit.body, { status: 200, headers: { 'content-type': hit.contentType } });
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+describe('HttpHostingStorageAdapter', () => {
+  test('put encodes the key, PUTs the bytes, and returns a resolvable URL', async () => {
+    const { impl, calls } = mockFetch();
+    const adapter = new HttpHostingStorageAdapter({ baseUrl: '', fetchImpl: impl });
+    const key = 'demo.example.com/studio/you/did.jsonl';
+    const url = await adapter.put(key, Buffer.from('{"a":1}\n{"b":2}'), {
+      contentType: 'application/jsonl',
+    });
+    expect(calls[0].method).toBe('PUT');
+    expect(calls[0].url).toBe('/api/host/' + encodeURIComponent(key));
+    expect(url).toBe('https://' + key);
+  });
+
+  test('get returns content + contentType, null on miss', async () => {
+    const { impl } = mockFetch();
+    const adapter = new HttpHostingStorageAdapter({ baseUrl: '', fetchImpl: impl });
+    const key = 'demo.example.com/.well-known/did.jsonl';
+    await adapter.put(key, 'hello', { contentType: 'application/jsonl' });
+    const got = await adapter.get(key);
+    expect(got).not.toBeNull();
+    expect(got!.content.toString()).toBe('hello');
+    expect(got!.contentType).toBe('application/jsonl');
+    expect(await adapter.get('nope/missing')).toBeNull();
+  });
+
+  test('put throws on a non-ok, non-2xx response', async () => {
+    const failing = (async () => new Response('too big', { status: 413 })) as unknown as typeof fetch;
+    const adapter = new HttpHostingStorageAdapter({ baseUrl: '', fetchImpl: failing });
+    await expect(adapter.put('k', 'x', { contentType: 'text/plain' })).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/landing && bun test src/sdk/http-hosting-adapter.test.ts`
+Expected: FAIL — `Cannot find module './http-hosting-adapter'`.
+
+- [ ] **Step 3: Implement `apps/landing/src/sdk/http-hosting-adapter.ts`**
+
+```typescript
+/**
+ * SDK StorageAdapter (interface A: put/get) backed by this origin's HTTP host.
+ *
+ * The lifecycle's hosting writes (did.jsonl, cel.json, resources) call
+ * put(`${domain}/${relativePath}`, bytes, { contentType }); we forward each to
+ * PUT /api/host/<encoded key>. The returned URL is the resolvable HTTPS URL for
+ * that key — for did.jsonl keys it is exactly what didwebvh-ts's resolver GETs.
+ */
+function toBytes(data: Buffer | Uint8Array | string): Uint8Array {
+  if (typeof data === 'string') return new TextEncoder().encode(data);
+  if (data instanceof Uint8Array) return data;
+  return new Uint8Array(data);
+}
+
+export class HttpHostingStorageAdapter {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts?: { baseUrl?: string; fetchImpl?: typeof fetch }) {
+    // '' → same-origin relative URLs (correct in the browser).
+    this.baseUrl = opts?.baseUrl ?? '';
+    this.fetchImpl = opts?.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  }
+
+  private endpoint(objectKey: string): string {
+    return `${this.baseUrl}/api/host/${encodeURIComponent(objectKey)}`;
+  }
+
+  async put(
+    objectKey: string,
+    data: Buffer | Uint8Array | string,
+    options?: { contentType?: string; cacheControl?: string }
+  ): Promise<string> {
+    const bytes = toBytes(data);
+    const res = await this.fetchImpl(this.endpoint(objectKey), {
+      method: 'PUT',
+      headers: { 'content-type': options?.contentType ?? 'application/octet-stream' },
+      // Copy into a fresh ArrayBuffer so the body is a plain BodyInit.
+      body: bytes.slice().buffer,
+    });
+    if (!res.ok) {
+      throw new Error(`HttpHostingStorageAdapter.put failed: ${res.status} for ${objectKey}`);
+    }
+    // The public, resolvable URL for this key (https — matches didwebvh-ts).
+    return `https://${objectKey}`;
+  }
+
+  async get(objectKey: string): Promise<{ content: Buffer; contentType: string } | null> {
+    const res = await this.fetchImpl(this.endpoint(objectKey), { method: 'GET' });
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      throw new Error(`HttpHostingStorageAdapter.get failed: ${res.status} for ${objectKey}`);
+    }
+    const buf = Buffer.from(await res.arrayBuffer());
+    return { content: buf, contentType: res.headers.get('content-type') ?? 'application/octet-stream' };
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/landing && bun test src/sdk/http-hosting-adapter.test.ts`
+Expected: PASS — 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/landing/src/sdk/http-hosting-adapter.ts apps/landing/src/sdk/http-hosting-adapter.test.ts
+git commit -m "feat(landing): HttpHostingStorageAdapter over PUT/GET /api/host/*"
+```
+
+---
+
+## Task 4: `webvh-host.ts` server module (store + serve at resolver URLs)
+
+**Files:**
+- Create: `apps/landing/server/webvh-host.ts`
+- Test: `apps/landing/server/tests/webvh-host.test.ts`
+
+**Interfaces:**
+- Consumes: `json` from `./router`; `createRateLimiter` from `./rate-limit`; `WebvhHostStore` shape from `./app` (Task 1).
+- Produces:
+  - `createWebvhHostStore(opts?: { maxObjectBytes?: number; maxEntries?: number; ttlMs?: number; now?: () => number; limit?: number; windowMs?: number }): WebvhHostStore & { size(): number }` where `WebvhHostStore = { handlePut(req, url): Promise<Response>; serve(req, url): Response | null }`.
+  - `handlePut` — `PUT /api/host/<encoded key>` only (else 405). Rate-limited per client IP. Rejects bodies over `maxObjectBytes` (413). Rejects new keys when the store is full after sweeping expired entries (507). Stores `{ body, contentType, expiresAt }`; 200 on success.
+  - `serve` — reconstructs key `\`${url.host}${url.pathname}\`` (Resolved fact #3), returns a `Response` (200 with stored `content-type`) or `null` (unknown/expired → caller falls through to static/404). Sweeps expired entries first.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/landing/server/tests/webvh-host.test.ts`:
+
+```typescript
+import { describe, test, expect } from 'bun:test';
+import { createWebvhHostStore } from '../webvh-host';
+
+function putReq(key: string, body: string, contentType: string) {
+  return new Request(`http://host/api/host/${encodeURIComponent(key)}`, {
+    method: 'PUT',
+    headers: { 'content-type': contentType },
+    body,
+  });
+}
+
+describe('webvh-host store', () => {
+  test('put → serve roundtrip at the resolver URL', async () => {
+    const store = createWebvhHostStore();
+    const key = 'demo.example.com/studio/you/did.jsonl';
+    const putRes = await store.handlePut(
+      putReq(key, '{"v":1}\n{"v":2}', 'application/jsonl'),
+      new URL(`http://host/api/host/${encodeURIComponent(key)}`)
+    );
+    expect(putRes.status).toBe(200);
+
+    // Resolver GETs https://demo.example.com/studio/you/did.jsonl → host+pathname key.
+    const getUrl = new URL('http://demo.example.com/studio/you/did.jsonl');
+    const served = store.serve(new Request(getUrl), getUrl);
+    expect(served).not.toBeNull();
+    expect(served!.status).toBe(200);
+    expect(served!.headers.get('content-type')).toBe('application/jsonl');
+    expect(await served!.text()).toBe('{"v":1}\n{"v":2}');
+  });
+
+  test('serve returns null for unknown key', () => {
+    const store = createWebvhHostStore();
+    const url = new URL('http://demo.example.com/nope/did.jsonl');
+    expect(store.serve(new Request(url), url)).toBeNull();
+  });
+
+  test('TTL expiry: serve returns null after ttl elapses', async () => {
+    let clock = 1000;
+    const store = createWebvhHostStore({ ttlMs: 500, now: () => clock });
+    const key = 'demo.example.com/.well-known/did.jsonl';
+    await store.handlePut(
+      putReq(key, 'x', 'application/jsonl'),
+      new URL(`http://host/api/host/${encodeURIComponent(key)}`)
+    );
+    const url = new URL('http://demo.example.com/.well-known/did.jsonl');
+    expect(store.serve(new Request(url), url)).not.toBeNull();
+    clock += 501; // past TTL
+    expect(store.serve(new Request(url), url)).toBeNull();
+  });
+
+  test('size cap: body over maxObjectBytes is rejected 413', async () => {
+    const store = createWebvhHostStore({ maxObjectBytes: 8 });
+    const key = 'd/x/did.jsonl';
+    const res = await store.handlePut(
+      putReq(key, 'this body is longer than eight bytes', 'application/jsonl'),
+      new URL(`http://host/api/host/${encodeURIComponent(key)}`)
+    );
+    expect(res.status).toBe(413);
+  });
+
+  test('entry cap: rejects a new key when full (507)', async () => {
+    const store = createWebvhHostStore({ maxEntries: 1 });
+    await store.handlePut(
+      putReq('a/x/did.jsonl', 'a', 'application/jsonl'),
+      new URL(`http://host/api/host/${encodeURIComponent('a/x/did.jsonl')}`)
+    );
+    const res = await store.handlePut(
+      putReq('b/x/did.jsonl', 'b', 'application/jsonl'),
+      new URL(`http://host/api/host/${encodeURIComponent('b/x/did.jsonl')}`)
+    );
+    expect(res.status).toBe(507);
+  });
+
+  test('non-PUT method is rejected 405', async () => {
+    const store = createWebvhHostStore();
+    const url = new URL('http://host/api/host/whatever');
+    const res = await store.handlePut(new Request(url, { method: 'POST' }), url);
+    expect(res.status).toBe(405);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/landing && bun test server/tests/webvh-host.test.ts`
+Expected: FAIL — `Cannot find module '../webvh-host'`.
+
+- [ ] **Step 3: Implement `apps/landing/server/webvh-host.ts`**
+
+```typescript
+/**
+ * In-memory WebVH host: receives the SDK's hosting writes at PUT /api/host/<key>
+ * and serves them back at the EXACT URLs didwebvh-ts's resolver GETs.
+ *
+ * The put key is `${domain}/${relativePath}` (LifecycleManager). The resolver
+ * GETs https://${domain}/${relativePath}, so on serve the lookup key is
+ * `${url.host}${url.pathname}` — byte-identical to the put key. Bounded by a
+ * per-object size cap, a total-entry cap, and a TTL; PUTs are rate-limited.
+ */
+import { json } from './router';
+import { createRateLimiter } from './rate-limit';
+
+interface Entry {
+  body: Uint8Array;
+  contentType: string;
+  expiresAt: number;
+}
+
+const HOST_PREFIX = '/api/host/';
+
+export function createWebvhHostStore(opts?: {
+  maxObjectBytes?: number;
+  maxEntries?: number;
+  ttlMs?: number;
+  now?: () => number;
+  limit?: number;
+  windowMs?: number;
+}) {
+  const maxObjectBytes = opts?.maxObjectBytes ?? 256 * 1024; // 256 KiB per object
+  const maxEntries = opts?.maxEntries ?? 500;
+  const ttlMs = opts?.ttlMs ?? 30 * 60 * 1000; // 30 minutes
+  const now = opts?.now ?? Date.now;
+  const limiter = createRateLimiter({
+    limit: opts?.limit ?? 120,
+    windowMs: opts?.windowMs ?? 60_000,
+  });
+
+  const map = new Map<string, Entry>();
+
+  function sweep(): void {
+    const t = now();
+    for (const [k, e] of map) if (e.expiresAt <= t) map.delete(k);
+  }
+
+  function clientIp(req: Request): string {
+    return req.headers.get('x-forwarded-for')?.split(',')[0].trim() || 'local';
+  }
+
+  async function handlePut(req: Request, url: URL): Promise<Response> {
+    if (req.method !== 'PUT') return json({ error: 'method_not_allowed' }, 405);
+
+    const rl = limiter.check(clientIp(req));
+    if (!rl.allowed) {
+      return json({ error: 'rate_limited' }, 429, {
+        'Retry-After': String(Math.ceil(rl.retryAfterMs / 1000)),
+      });
+    }
+
+    const key = decodeURIComponent(url.pathname.slice(HOST_PREFIX.length));
+    if (!key) return json({ error: 'missing_key' }, 400);
+
+    const body = new Uint8Array(await req.arrayBuffer());
+    if (body.byteLength > maxObjectBytes) {
+      return json({ error: 'too_large', maxObjectBytes }, 413);
+    }
+
+    sweep();
+    if (!map.has(key) && map.size >= maxEntries) {
+      return json({ error: 'store_full', maxEntries }, 507);
+    }
+
+    map.set(key, {
+      body,
+      contentType: req.headers.get('content-type') ?? 'application/octet-stream',
+      expiresAt: now() + ttlMs,
+    });
+    return json({ ok: true }, 200);
+  }
+
+  function serve(_req: Request, url: URL): Response | null {
+    sweep();
+    const key = `${url.host}${url.pathname}`;
+    const entry = map.get(key);
+    if (!entry) return null;
+    // Copy so the caller can't mutate stored bytes.
+    return new Response(entry.body.slice(), {
+      status: 200,
+      headers: { 'content-type': entry.contentType },
+    });
+  }
+
+  return { handlePut, serve, size: () => map.size };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/landing && bun test server/tests/webvh-host.test.ts`
+Expected: PASS — 6 tests pass.
+
+- [ ] **Step 5: Verify the unified server boots with the real host store wired**
+
+The `serve.ts` written in Task 1 already imports `createWebvhHostStore` from `./server/webvh-host`. Confirm the whole server test suite still passes:
+
+Run: `cd apps/landing && bun test server/tests/app.test.ts server/tests/webvh-host.test.ts`
+Expected: PASS — 12 tests pass (6 + 6).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/landing/server/webvh-host.ts apps/landing/server/tests/webvh-host.test.ts
+git commit -m "feat(landing): webvh-host store — serve DID logs at resolver URLs, bounded by TTL/caps"
+```
+
+---
+
+## Task 5: Engine wiring (real hosting adapter + post-publish resolve)
+
+**Files:**
+- Modify: `apps/landing/src/sdk/engine.ts` (imports, constructor `storageAdapter`, `network`, `publish()`, new `webvhLogUrl` helper, `DemoAssetState`)
+- Test: `apps/landing/src/sdk/engine.publish-resolve.test.ts`
+
+**Interfaces:**
+- Consumes: `HttpHostingStorageAdapter` from `./http-hosting-adapter` (Task 3); `createWebvhHostStore` from `../../server/webvh-host` (Task 4, test only).
+- Produces:
+  - `DemoEngine.publish()` now: passes an explicit webvh `domain` to `createDIDWebVH`, and after `publishToWeb` calls `sdk.did.resolveDID(this.publisherDid, { skipCache: true })`, emitting a `did:webvh:resolved` event with payload `{ logUrl: string; resolved: boolean; doc: unknown }`.
+  - `DemoAssetState` gains `webvhLogUrl?: string` and `webvhResolved?: boolean`.
+  - Module helper `webvhLogUrl(did: string): string` mirroring `getFileUrl` (https; `<segs>/did.jsonl` vs `.well-known/did.jsonl`).
+  - `demoHost(): string` — the origin host the engine hosts under: `import.meta.env?.VITE_WEBVH_HOST` if set, else `window.location.host`, else `'localhost'` (SSR/test guard).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/landing/src/sdk/engine.publish-resolve.test.ts`:
+
+```typescript
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { DemoEngine } from './engine';
+import { createWebvhHostStore } from '../../server/webvh-host';
+
+// Route the browser adapter's PUT /api/host/* AND the resolver's https GETs
+// through one in-process host store, so publish → resolve is deterministic
+// without a live HTTPS origin (Resolved fact #4).
+function installHostFetch(host: string) {
+  const store = createWebvhHostStore();
+  const real = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const raw = typeof input === 'string' ? input : input.toString();
+    const method = (init?.method ?? 'GET').toUpperCase();
+    const url = new URL(raw, `http://${host}`);
+    if (url.pathname.startsWith('/api/host/')) {
+      const req = new Request(url, {
+        method,
+        headers: init?.headers as HeadersInit,
+        body: init?.body as BodyInit,
+      });
+      return store.handlePut(req, url);
+    }
+    // Resolver GET https://<host>/<path>/did.jsonl → serve from the store.
+    const served = store.serve(new Request(url), url);
+    if (served) return served;
+    return new Response('not found', { status: 404 });
+  }) as unknown as typeof fetch;
+  return () => {
+    globalThis.fetch = real;
+  };
+}
+
+describe('publish → resolve roundtrip', () => {
+  const host = 'demo.test';
+  let restore: () => void;
+
+  beforeEach(() => {
+    (import.meta as unknown as { env: Record<string, string> }).env ??= {};
+    (import.meta as unknown as { env: Record<string, string> }).env.VITE_WEBVH_HOST = host;
+    restore = installHostFetch(host);
+  });
+  afterEach(() => restore());
+
+  test('publishes the DID log and resolves it back over (mocked) HTTPS', async () => {
+    const engine = new DemoEngine();
+    const resolvedEvents: Array<{ logUrl: string; resolved: boolean }> = [];
+    engine.on((e) => {
+      if (e.type === 'did:webvh:resolved') {
+        resolvedEvents.push(e.payload as { logUrl: string; resolved: boolean });
+      }
+    });
+
+    await engine.create('Roundtrip', 'Artwork', '<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+    const state = await engine.publish();
+
+    expect(state.layer).toBe('did:webvh');
+    expect(state.webvhLogUrl).toBe(`https://${host}/studio/you/did.jsonl`);
+    expect(state.webvhResolved).toBe(true);
+
+    expect(resolvedEvents.length).toBe(1);
+    expect(resolvedEvents[0].logUrl).toBe(`https://${host}/studio/you/did.jsonl`);
+    expect(resolvedEvents[0].resolved).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/landing && bun test src/sdk/engine.publish-resolve.test.ts`
+Expected: FAIL — `state.webvhLogUrl` is `undefined` (engine still uses `MemoryStorageAdapter`, passes no domain, emits no `did:webvh:resolved`).
+
+- [ ] **Step 3: Swap the storage adapter + network in the engine constructor**
+
+In `apps/landing/src/sdk/engine.ts`, replace the import:
+```typescript
+import {
+  OriginalsSDK,
+  OrdMockProvider,
+  MemoryStorageAdapter,
+  type OriginalsAsset
+} from '@originals/sdk';
+```
+with:
+```typescript
+import {
+  OriginalsSDK,
+  OrdMockProvider,
+  type OriginalsAsset
+} from '@originals/sdk';
+import { HttpHostingStorageAdapter } from './http-hosting-adapter';
+```
+
+Replace the `storageAdapter` line in the `OriginalsSDK.create({ ... })` call:
+```typescript
+      storageAdapter: new MemoryStorageAdapter(),
+```
+with:
+```typescript
+      // Real HTTP hosting at this origin — the SDK's did:webvh log becomes
+      // resolvable over HTTP(S) (see http-hosting-adapter.ts).
+      storageAdapter: new HttpHostingStorageAdapter(),
+```
+
+Leave `network: 'regtest'` and the OrdMockProvider unchanged — Bitcoin/network changes are Track B (Plan 2).
+
+- [ ] **Step 4: Add the `demoHost` + `webvhLogUrl` helpers**
+
+At the bottom of `apps/landing/src/sdk/engine.ts` (next to `toHex`), add:
+
+```typescript
+// The origin host we host did:webvh logs under. In the browser this is the
+// live origin; VITE_WEBVH_HOST overrides it for the deployed host or tests.
+function demoHost(): string {
+  const envHost = (import.meta as unknown as { env?: Record<string, string> }).env?.VITE_WEBVH_HOST;
+  if (envHost) return envHost;
+  if (typeof window !== 'undefined' && window.location?.host) return window.location.host;
+  return 'localhost';
+}
+
+// Mirrors didwebvh-ts getFileUrl: pathed DID → https://<host>/<segs>/did.jsonl,
+// domain-root DID → https://<host>/.well-known/did.jsonl. This is the exact URL
+// the resolver GETs (protocol is always https).
+function webvhLogUrl(did: string): string {
+  const parts = did.split(':'); // did:webvh:<SCID>:<domain>[:<seg>…]
+  const domain = decodeURIComponent(parts[3] ?? '');
+  const segs = parts.slice(4).map((s) => decodeURIComponent(s));
+  const base = `https://${domain}`;
+  return segs.length ? `${base}/${segs.join('/')}/did.jsonl` : `${base}/.well-known/did.jsonl`;
+}
+```
+
+- [ ] **Step 5: Pass the explicit domain to `createDIDWebVH` and resolve after publish**
+
+In `publish()`, change the `createDIDWebVH` call to pass the demo host as `domain`:
+```typescript
+      const webvh = await this.sdk.did.createDIDWebVH({
+        paths: ['studio', 'you']
+      });
+```
+becomes:
+```typescript
+      const webvh = await this.sdk.did.createDIDWebVH({
+        domain: demoHost(),
+        paths: ['studio', 'you']
+      });
+```
+
+Then replace the tail of `publish()`:
+```typescript
+    await this.sdk.lifecycle.publishToWeb(this.asset, this.publisherDid);
+    return this.snapshot();
+  }
+```
+with:
+```typescript
+    await this.sdk.lifecycle.publishToWeb(this.asset, this.publisherDid);
+
+    // Prove REAL resolution: fetch the just-hosted log back over the network via
+    // the SDK's real resolver. skipCache forces a network read (the publisher
+    // doc is cached above for offline credential signing). Best-effort in dev
+    // (http origin can't satisfy the resolver's hard-coded https), authoritative
+    // in prod. resolved=false still shows the link, just no "resolved ✓" tick.
+    const logUrl = webvhLogUrl(this.publisherDid);
+    let resolvedDoc: unknown = null;
+    let resolved = false;
+    try {
+      resolvedDoc = await this.sdk.did.resolveDID(this.publisherDid, { skipCache: true });
+      resolved = !!resolvedDoc;
+    } catch (err) {
+      log('did:webvh:resolve-failed', err);
+    }
+    this.webvhLogUrl = logUrl;
+    this.webvhResolved = resolved;
+    this.emit(
+      'did:webvh:resolved',
+      resolved
+        ? `did:webvh log resolved over HTTPS — ${logUrl}`
+        : `did:webvh log hosted at ${logUrl} (resolves over HTTPS in production)`,
+      { logUrl, resolved, doc: resolvedDoc }
+    );
+
+    return this.snapshot();
+  }
+```
+
+- [ ] **Step 6: Track the resolution state on the engine and surface it in the snapshot**
+
+Add two fields to the `DemoEngine` class (next to `publisherDid`):
+```typescript
+  private publisherDid: string | null = null;
+```
+becomes:
+```typescript
+  private publisherDid: string | null = null;
+  private webvhLogUrl: string | null = null;
+  private webvhResolved = false;
+```
+
+Extend the `DemoAssetState` interface — add after `btcoDid?: string;`:
+```typescript
+  webvhDid?: string;
+  btcoDid?: string;
+```
+becomes:
+```typescript
+  webvhDid?: string;
+  webvhLogUrl?: string;
+  webvhResolved?: boolean;
+  btcoDid?: string;
+```
+
+In `snapshot()`, add the two fields to the returned object — after `webvhDid: bindings['did:webvh'],`:
+```typescript
+      webvhDid: bindings['did:webvh'],
+      btcoDid: bindings['did:btco'],
+```
+becomes:
+```typescript
+      webvhDid: bindings['did:webvh'],
+      webvhLogUrl: this.webvhLogUrl ?? undefined,
+      webvhResolved: this.webvhResolved,
+      btcoDid: bindings['did:btco'],
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `cd apps/landing && bun test src/sdk/engine.publish-resolve.test.ts`
+Expected: PASS — 1 test passes.
+
+- [ ] **Step 8: Re-run the honesty test to confirm no regression**
+
+Run: `cd apps/landing && bun test src/sdk/engine.summary.test.ts`
+Expected: PASS — 3 tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/landing/src/sdk/engine.ts apps/landing/src/sdk/engine.publish-resolve.test.ts
+git commit -m "feat(landing): engine hosts did:webvh over HTTP + proves real resolution"
+```
+
+---
+
+## Task 6: Demo UI — resolvable link + "resolved ✓" + honest badges
+
+**Files:**
+- Modify: `apps/landing/src/content.ts` (add `demo.resolved` copy block)
+- Modify: `apps/landing/src/components/Demo.tsx` (render the resolvable link + tick; register the `did:webvh:resolved` event color)
+- Modify: `apps/landing/src/components/demo.css` (styles for the new block)
+- Test: `apps/landing/src/components/demo-content.test.ts`
+
+**Interfaces:**
+- Consumes: `demo` from `../content`; `DemoAssetState` (`webvhLogUrl`, `webvhResolved`) from `../sdk/engine` (Task 5).
+- Produces: no new exports; a resolvable-DID panel in the published state.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/landing/src/components/demo-content.test.ts`:
+
+```typescript
+import { describe, test, expect } from 'bun:test';
+import { demo } from '../content';
+
+describe('demo resolved-DID copy', () => {
+  test('has a resolved-DID label block', () => {
+    expect(demo.resolved).toBeDefined();
+    expect(typeof demo.resolved.heading).toBe('string');
+    expect(demo.resolved.heading.length).toBeGreaterThan(0);
+    expect(typeof demo.resolved.resolvedBadge).toBe('string');
+    expect(typeof demo.resolved.pendingBadge).toBe('string');
+    expect(typeof demo.resolved.linkLabel).toBe('string');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/landing && bun test src/components/demo-content.test.ts`
+Expected: FAIL — `demo.resolved` is `undefined`.
+
+- [ ] **Step 3: Add the `resolved` copy block to `apps/landing/src/content.ts`**
+
+Inside the `demo` object, add after the `done: { … }` block and before the closing `reset: …`:
+```typescript
+  done: {
+    lead: 'Anchored.',
+    beforeSatoshi: 'Inscribed on satoshi',
+    beforeTx: 'in tx',
+    after: 'The full history is in the Provenance tab.'
+  },
+```
+becomes:
+```typescript
+  done: {
+    lead: 'Anchored.',
+    beforeSatoshi: 'Inscribed on satoshi',
+    beforeTx: 'in tx',
+    after: 'The full history is in the Provenance tab.'
+  },
+  resolved: {
+    heading: 'did:webvh log — live at this origin',
+    resolvedBadge: 'resolved ✓',
+    pendingBadge: 'resolves in production',
+    linkLabel: 'Open the signed DID log',
+    note: 'The SDK’s real resolver fetched this over HTTP(S) — no mock. Open it: it’s the signed version history.'
+  },
+```
+
+- [ ] **Step 4: Register the new event color in `Demo.tsx`**
+
+In `apps/landing/src/components/Demo.tsx`, extend `eventColors`:
+```typescript
+const eventColors: Record<string, string> = {
+  'asset:created': 'var(--peer)',
+  'did:webvh:created': 'var(--webvh)',
+  'resource:published': 'var(--webvh)',
+  'asset:migrated': 'var(--webvh)',
+  'credential:issued': 'var(--ok)',
+  'asset:inscribed': 'var(--btco)'
+};
+```
+becomes:
+```typescript
+const eventColors: Record<string, string> = {
+  'asset:created': 'var(--peer)',
+  'did:webvh:created': 'var(--webvh)',
+  'resource:published': 'var(--webvh)',
+  'did:webvh:resolved': 'var(--webvh)',
+  'asset:migrated': 'var(--webvh)',
+  'credential:issued': 'var(--ok)',
+  'asset:inscribed': 'var(--btco)'
+};
+```
+
+- [ ] **Step 5: Render the resolvable-DID panel in the published state**
+
+In `Demo.tsx`, immediately AFTER the `{error && …}` line and BEFORE the `{phase === 'inscribed' && asset && ( … )}` block, insert:
+
+```tsx
+                {(phase === 'published' || phase === 'inscribing' || phase === 'inscribed') &&
+                  asset?.webvhLogUrl && (
+                    <div className="demo-resolved">
+                      <div className="demo-resolved-head">
+                        <span>{demo.resolved.heading}</span>
+                        <span
+                          className="demo-resolved-badge"
+                          data-ok={asset.webvhResolved || undefined}
+                        >
+                          {asset.webvhResolved
+                            ? demo.resolved.resolvedBadge
+                            : demo.resolved.pendingBadge}
+                        </span>
+                      </div>
+                      <a
+                        className="demo-resolved-link"
+                        href={asset.webvhLogUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        {demo.resolved.linkLabel}
+                        <code>{asset.webvhLogUrl}</code>
+                      </a>
+                      <p className="demo-resolved-note">{demo.resolved.note}</p>
+                    </div>
+                  )}
+```
+
+- [ ] **Step 6: Add styles to `apps/landing/src/components/demo.css`**
+
+Append to the end of `apps/landing/src/components/demo.css`:
+
+```css
+.demo-resolved {
+  margin-top: 1rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--border, rgba(128, 128, 128, 0.25));
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--webvh) 6%, transparent);
+}
+.demo-resolved-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+.demo-resolved-badge {
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  color: var(--text-tertiary, #888);
+  background: color-mix(in srgb, currentColor 12%, transparent);
+}
+.demo-resolved-badge[data-ok] {
+  color: var(--ok, #1a8f4a);
+}
+.demo-resolved-link {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  text-decoration: none;
+}
+.demo-resolved-link code {
+  font-size: 0.75rem;
+  word-break: break-all;
+  color: var(--webvh);
+}
+.demo-resolved-note {
+  margin-top: 0.5rem;
+  font-size: 0.78rem;
+  color: var(--text-tertiary, #888);
+}
+```
+
+- [ ] **Step 7: Run the content test to verify it passes**
+
+Run: `cd apps/landing && bun test src/components/demo-content.test.ts`
+Expected: PASS — 1 test passes.
+
+- [ ] **Step 8: Full app + engine test sweep (no regressions)**
+
+Run: `cd apps/landing && bun test server/tests/app.test.ts server/tests/webvh-host.test.ts server/tests/router.test.ts src/sdk/http-hosting-adapter.test.ts src/sdk/engine.summary.test.ts src/sdk/engine.publish-resolve.test.ts src/components/demo-content.test.ts`
+Expected: PASS — all suites green.
+
+- [ ] **Step 9: Manual smoke (dev)**
+
+Run in one terminal: `cd apps/landing && bun run serve.ts` (unified server on :8787; logs "auth unconfigured" — expected without secrets). In another: `cd apps/landing && bun run dev` (Vite). Open the demo, click Create → Publish. Confirm: the event log shows `did:webvh:resolved`; the resolvable-DID panel renders with the `https://localhost:5173/studio/you/did.jsonl` link and the "resolves in production" badge (dev is http, so resolution is best-effort — the badge NOT showing "resolved ✓" in dev is correct per Resolved fact #4). Confirm no console errors from the hosting PUTs (they should 200 via the Vite `/api` proxy).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add apps/landing/src/content.ts apps/landing/src/components/Demo.tsx apps/landing/src/components/demo.css apps/landing/src/components/demo-content.test.ts
+git commit -m "feat(landing): show resolvable did:webvh log + resolved indicator"
+```
+
+---
+
+## Self-review notes (done before saving)
+
+- **Spec coverage (Phase 0 + Track A):**
+  - Unified server (SPA + SPA-fallback + traversal guard + `/api/*` + conditional auth + `/api/host/*` + webvh GET mounts) → Task 1. Railway `startCommand` → Task 1 Step 7. Dev proxy kept → Task 1 Step 8.
+  - Auth mounting conditional on `JWT_SECRET` + `TURNKEY_*`, no throw when absent, 503 stubs → Task 1 (`buildStubRoutes`) + `serve.ts`.
+  - did:peer→did:cel + hosted-storage wording, plus create/publish `content.ts` copy → Task 2.
+  - `HttpHostingStorageAdapter` (interface A `put`/`get`) over `PUT`/`GET /api/host/*` → Task 3.
+  - `webvh-host.ts` in-memory Map + size cap + entry cap + TTL + rate limit, serves at resolver URLs → Task 4.
+  - Engine: swap adapter, explicit `domain`, post-publish `resolveDID`, new `did:webvh:resolved` event with log URL + doc → Task 5.
+  - UI: resolvable link + "resolved ✓" + honest badges → Task 6.
+  - Testing plan (server units, adapter mock-fetch, engine publish→resolve integration) → Tasks 1/3/4/5.
+- **Explicitly out of scope (Track B / Plan 2), untouched here:** `HttpOrdinalsProvider`, `TurnkeySatSigner`, `bitcoin.ts` faucet/QuickNode proxy, user Bitcoin-account provisioning, `network: 'testnet'`, inscription copy. `OrdMockProvider` and `inscribe()` left as-is.
+- **Placeholder scan:** every code step contains complete code; no TODO/TBD/"add error handling"; all test commands are exact `cd apps/landing && bun test <path>` with expected PASS/FAIL.
+- **Type/name consistency:** `WebvhHostStore` two-method surface (`handlePut`/`serve`) is identical in Task 1 (`app.ts`) and Task 4 (`webvh-host.ts`). `createWebvhHostStore` name matches across `serve.ts` (Task 1), `webvh-host.ts` (Task 4), and the engine integration test (Task 5). `HttpHostingStorageAdapter` (`put`/`get`) matches across Tasks 3 and 5. `webvhLogUrl`/`demoHost` defined and used only within Task 5. `did:webvh:resolved` event payload `{ logUrl, resolved, doc }` matches between the emit (Task 5), the integration test (Task 5), and the UI consumption via `DemoAssetState.webvhLogUrl`/`webvhResolved` (Tasks 5 + 6). `buildStubRoutes` exported from `server/index.ts` (Task 1) and imported by `serve.ts` (Task 1) and `app.test.ts` (Task 1).

--- a/docs/superpowers/plans/2026-07-16-landing-testnet4-inscription.md
+++ b/docs/superpowers/plans/2026-07-16-landing-testnet4-inscription.md
@@ -1,0 +1,2282 @@
+# Landing Demo — Real testnet4 Inscription (Track B) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the landing demo's "Inscribe" step do a REAL Bitcoin **testnet4** inscription, login-gated: the logged-in user's OWN Turnkey key signs the commit in the browser, funding comes from a **Turnkey-org faucet** (the server signs the faucet's own funding tx via its Turnkey API creds — NO raw private key anywhere on the server), the commit/reveal broadcast through QuickNode, and the UI surfaces the real txid + a testnet4 explorer link. Everything is gated on env (`QUICKNODE_ENDPOINT` + a faucet Turnkey wallet id); when absent the demo falls back to the existing `OrdMockProvider` mock path unchanged.
+
+**Plan 2 of 2 for issue #417.** Plan 1 (`2026-07-16-landing-real-webvh-hosting.md`) delivered real did:webvh hosting + the unified Bun server and is **merged/available** — this plan does NOT re-do it. It builds on the same unified server (`apps/landing/serve.ts` + `apps/landing/server/*`) and the same engine (`apps/landing/src/sdk/engine.ts`, which already hosts did:webvh and proves resolution).
+
+**Architecture:** A small SDK change adds first-class `'testnet'` support (testnet4 shares signet's `tb1` address encoding; the did:btco network prefix is `test` — already parsed by `BtcoDidResolver`). The browser drives a real sat-selected inscription via the SDK's merged `inscribeOnBitcoin(asset, { fundingUtxo, satSigner, changeAddress, feeRate })` path (PR #414): an `HttpOrdinalsProvider` (SDK `OrdinalsProvider` over `POST /api/btc/{sat,fee,broadcast}` QuickNode proxies) supplies sat-lookup/fee/broadcast, and a `TurnkeySatSigner` (SDK `BitcoinSigner`) signs the commit with the user's Turnkey session key via Turnkey `signTransaction` (P2WPKH, SIGHASH_ALL) → `@scure/btc-signer` finalize. Funding is a new authenticated `POST /api/btc/funding`: the server builds+signs a faucet funding tx from a **Turnkey-org faucet wallet** to the user's testnet4 P2WPKH address and broadcasts it, returning `{ fundingUtxo, changeAddress }` (the user's own address). The auth layer gains the missing Turnkey **OTP_LOGIN** step (installing the browser P-256 key as the session credential) so the credential-less sub-org can sign silently, plus a dedicated testnet4 P2WPKH wallet account.
+
+**Tech Stack:** Bun (runtime + test runner), TypeScript, `@originals/sdk` (rebuilt with testnet support), `@scure/btc-signer`, `@turnkey/sdk-server` (server faucet), `@turnkey/sdk-browser` + `@turnkey/api-key-stamper` + `@turnkey/crypto` (browser session signing), `QuickNodeProvider`, Vite 8 / React 19, `@originals/auth`.
+
+## Global Constraints
+
+- **Runtime & tests:** Bun only. SDK tests live in `packages/sdk/tests/unit/**/*.test.ts` (run from `packages/sdk`). Landing server tests in `apps/landing/server/tests/*.test.ts`; landing browser/SDK tests in `apps/landing/src/**/*.test.ts`. Run landing tests with `cd apps/landing && bun test <path>`; run SDK tests with `cd packages/sdk && bun test <path>`. Import test primitives from `bun:test`.
+- **The SDK must be rebuilt** (`bun run build` at repo root) after Task 1 and BEFORE the landing app imports the new `network: 'testnet'` support — the landing app consumes the built `packages/sdk/dist`, not `src`.
+- **Absolute imports inside the SDK package only.** Inside `apps/landing` use the existing relative-import style already present in the files you touch.
+- **Noble imports:** `@noble/hashes/sha2.js` (never `/sha256`).
+- **Multikey encoding only** — never JWK.
+- **No raw private keys anywhere on the server.** The faucet is a Turnkey-org wallet; the server authorizes its funding tx with the SAME Turnkey API credentials it already uses for auth (`getTurnkey()`). The user's inscription is signed by the user's own Turnkey session key in the browser. The browser never sees any private key except its own ephemeral P-256 session key (generated in-browser, already the case in `auth/api.ts`).
+- **Login-gated + rate-limited.** Every `/api/btc/*` route is auth-gated (reject anonymous) and rate-limited (reuse `server/rate-limit.ts` + the auth JWT cookie via `server/cookies.ts`). The faucet signs ONLY its own funding tx to a logged-in user's address — never a general signing oracle. Small fixed funding amount, per-user cap, graceful "faucet empty" state.
+- **Env-gated with mock fallback.** Track B activates only when `QUICKNODE_ENDPOINT` (testnet4) AND `BTC_FAUCET_WALLET_ID` are present on the server, surfaced to the browser via `VITE_BTC_TESTNET=1`. Absent → the `inscribe()` step stays EXACTLY the current `OrdMockProvider` mock (`network: 'regtest'`), untouched.
+- **Honesty rule:** the inscribe step's UI/badge copy must state exactly what is real (testnet4, user-signed, worthless tBTC) vs. mock. Track A copy (create/publish) is unchanged.
+- **Live end-to-end is a MANUAL SMOKE, gated on provisioned env.** Every automated test in this plan runs offline against mocked Turnkey clients + mocked QuickNode/fetch. The real login→fund→inscribe→broadcast path is verified by a manual smoke once the operational prerequisites are provisioned (see below). Task 2 (the signing spike) de-risks the load-bearing Turnkey→finalize step BEFORE the faucet/provider/UI are built.
+
+## Operational prerequisites (user-provided, NOT built by this plan)
+
+- A QuickNode **testnet4** endpoint with the Ordinals & Runes add-on → `QUICKNODE_ENDPOINT`; set `BITCOIN_NETWORK=testnet`.
+- A **testnet4 faucet as a Turnkey-org wallet** (P2WPKH), funded with a pool of small confirmed UTXOs. Its wallet id → `BTC_FAUCET_WALLET_ID`; its tb1q funding address → `BTC_FAUCET_ADDRESS`. Reached with the existing `TURNKEY_*` API creds — no raw key.
+- The user wallet provisioning gains a testnet4 P2WPKH secp256k1 account (Task 3). Turnkey environment reachable from the deployed server (already true for auth).
+
+---
+
+## Resolved facts (read before coding)
+
+Confirmed by reading `packages/sdk/src/lifecycle/LifecycleManager.ts`, `bitcoin/inscribe-on-sat.ts`, `bitcoin/transactions/commit.ts`, `bitcoin/transfer.ts`, `types/common.ts`, `types/network.ts`, `did/DIDManager.ts`, `did/createBtcoDidDocument.ts`, `did/BtcoDidResolver.ts`, `cel/btcoDid.ts`, `utils/bitcoin-address.ts`, `adapters/providers/QuickNodeProvider.ts`, `adapters/types.ts`, and the `apps/landing` auth stack.
+
+**1. The SDK's Bitcoin transaction layer ALREADY supports testnet.** `bitcoin/transactions/commit.ts` and `bitcoin/transfer.ts` both define `type BitcoinNetwork = 'mainnet' | 'testnet' | 'regtest' | 'signet'` and map `'testnet'` → `btc.TEST_NETWORK` in `getScureNetwork`; they internally translate `testnet` → `signet` before calling `validateBitcoinAddress` (commit.ts lines ~193, ~377). `inscribe-on-sat.ts`'s `InscribeOnSatParams.network` is already `'mainnet' | 'testnet' | 'regtest' | 'signet'`. So NO change is needed in the tx-building/scure layer.
+
+**2. The testnet gap is the config/DID-identity layer** — several exhaustive switches + literal unions that do NOT yet accept `'testnet'` and will throw or fail to typecheck:
+- `types/common.ts` `OriginalsConfig.network` is the literal union `'mainnet' | 'regtest' | 'signet'`.
+- `types/network.ts` `BitcoinNetworkName` is `'mainnet' | 'regtest' | 'signet'`.
+- `cel/btcoDid.ts` `btcoDidPrefix(network)` — `default:` throws `Unsupported Bitcoin network`. Needs `'testnet'` → `'did:btco:test'`.
+- `did/createBtcoDidDocument.ts` `getDidPrefix` — exhaustive over mainnet/regtest/signet. Needs `'testnet'` → `'did:btco:test'`.
+- `did/DIDManager.ts` `getConfiguredBitcoinNetwork()` return type (line ~245), `migrateToDIDBTCO` local `network` type (line ~275) and its inline prefix map (line ~314: `network === 'regtest' ? 'did:btco:reg:' : 'did:btco:sig:'`). Needs `'testnet'` → `'did:btco:test:'`.
+- `lifecycle/LifecycleManager.ts` `getConfiguredBitcoinNetwork()` return type (line ~3608).
+- `utils/bitcoin-address.ts` `type BitcoinNetwork` + `getNetwork` (exhaustive). Needs `'testnet'` → `bitcoin.networks.testnet` (`tb1`).
+- `bitcoin/BitcoinManager.ts` read-side prefix guard (lines ~421-426): `this.config.network === 'regtest' ? 'reg' : this.config.network === 'signet' ? 'sig' : null`. Needs a `'testnet'` → `'test'` arm so a testnet-configured SDK does not treat a `did:btco:test:N` as mainnet.
+
+**3. `BtcoDidResolver` already resolves the `test` prefix.** `parseBtcoDid` regex is `/^did:btco(?::(reg|sig|test))?:([0-9]+)(?:\/(.+))?$/`; `getDidPrefix` maps `test`/`testnet` → `did:btco:test`. No resolver change.
+
+**4. `inscribeOnBitcoin` contract (PR #414, merged).** `inscribeOnBitcoin(asset, opts?: number | InscribeOnBitcoinOptions)` where `InscribeOnBitcoinOptions = { feeRate?; fundingUtxo?: Utxo; satSigner?: BitcoinSigner; changeAddress?: string }`.
+- `Utxo = { txid: string; vout: number; value: number; scriptPubKey?: string; address?: string; ... }`.
+- `BitcoinSigner = { signAndFinalizeCommitPsbt(psbtBase64: string): Promise<string> }` — MUST return broadcast-ready **raw tx hex** (NOT a PSBT). A returned PSBT → `COMMIT_TX_INVALID`.
+- Providing `fundingUtxo` WITHOUT both `satSigner` and `changeAddress` throws `INVALID_INPUT`. A missing fee with no oracle throws `FEE_RATE_REQUIRED`/`INVALID_INPUT`.
+- Flow (`inscribe-on-sat.ts`): `provider.getFirstSatOfOutput(fundingUtxo)` derives the DID sat → build commit locally → `satSigner.signAndFinalizeCommitPsbt` → parse+invariant-check the signed commit (input[0]==fundingUtxo, output[0]==built commit output, ≤2 outputs) → build+self-sign the reveal with an ephemeral key → `provider.broadcastTransaction(commit)` then `(reveal)`. Provider is used ONLY for `getFirstSatOfOutput`, `estimateFee` (when no explicit feeRate), `broadcastTransaction`. A post-commit reveal failure throws `REVEAL_BROADCAST_FAILED` carrying `revealTxHex` for recovery.
+
+**5. `QuickNodeProvider`.** `new QuickNodeProvider({ endpoint, expectedNetwork: 'testnet' })`. Real `getFirstSatOfOutput` (`ord_getOutput.sat_ranges[0][0]`), `estimateFee` (`estimatesmartfee`, sat/vB), `broadcastTransaction` (`sendrawtransaction`, returns 64-hex txid). `createInscription`/`transferInscription` REJECT by design. On first RPC it verifies `getblockchaininfo.chain === 'test'` (issue #350) — a mismatched endpoint fails loudly.
+
+**6. Turnkey OTP → session (the currently-MISSING step).** The OTP flow today: `initOtp` → `verifyOtp` returns a `verificationToken` (JWT) bound to the browser P-256 pubkey generated by `generateP256KeyPair()` in `apps/landing/src/auth/api.ts`. `verifyEmailAuth` (`packages/auth/src/server/email-auth.ts`) ALREADY returns `verificationToken` + the bound `publicKey`, but `apps/landing/server/auth-routes.ts` verify-otp DROPS them and just mints its own JWT cookie. The missing activity is **OTP_LOGIN** (`turnkey.apiClient().otpLogin({ organizationId: subOrgId, verificationToken, publicKey, clientSignature, expirationSeconds })` → a `session` JWT), where `clientSignature` is a P-256 signature (scheme `CLIENT_SIGNATURE_SCHEME_API_P256`) over the login challenge made with the browser's P-256 private key. This installs the P-256 key as the session credential on the credential-less sub-org — signing is then silent within the session window (request a generous `expirationSeconds`, e.g. `900`).
+
+**7. Browser signer.** After `otpLogin`, build an `ApiKeyStamper({ apiPublicKey: p256PubHex, apiPrivateKey: p256PrivHex })` (from `@turnkey/api-key-stamper`) wrapped in a `@turnkey/sdk-browser` client scoped to `subOrgId`; reuse the existing `@turnkey/crypto` keypair. (Canonical alternative: `sdk.indexedDbClient()` + `loginWithSession(session)`; noted, but ApiKeyStamper is primary — minimal refactor over the existing keypair.) To keep this plan's automated tests deterministic and to isolate the load-bearing unknown, the Bitcoin-signing surface the `TurnkeySatSigner` consumes is a narrow injectable interface `TurnkeyBitcoinClient = { signTransaction(params: { signWith: string; unsignedTransaction: string; type: 'TRANSACTION_TYPE_BITCOIN' }): Promise<{ signedTransaction: string }> }`; the concrete browser client is built in the auth layer and the live wiring is a manual smoke.
+
+**8. Bitcoin signing (RECOMMENDED path).** `signAndFinalizeCommitPsbt(psbtBase64)` = base64→hex PSBT → Turnkey `signTransaction({ signWith, unsignedTransaction: <hex>, type: 'TRANSACTION_TYPE_BITCOIN' })` (Turnkey supports P2WPKH, SIGHASH_ALL; it owns sighash/DER/low-S) → Turnkey returns a **partially-signed, NOT finalized** PSBT → load into `@scure/btc-signer` `Transaction.fromPSBT()`, `.finalize()`, return `.hex`. (Fallback: `signRawPayload` secp256k1 + manual DER/low-S witness assembly — noted; `signTransaction` is primary.) Task 2 proves the finalize half in isolation.
+
+**9. User testnet4 P2WPKH address.** The default wallet's secp256k1 account is `ADDRESS_FORMAT_ETHEREUM` (`turnkey-client.ts` `DEFAULT_WALLET_ACCOUNTS`), not a testnet P2WPKH. Add a dedicated account via `createWalletAccounts({ walletId, organizationId: subOrgId, accounts: [{ curve: 'CURVE_SECP256K1', pathFormat: 'PATH_FORMAT_BIP32', path: "m/84'/1'/0'/0/0", addressFormat: 'ADDRESS_FORMAT_BITCOIN_TESTNET_P2WPKH' }] })` using the SESSION-stamped browser client (the sub-org is credential-less until `otpLogin` installs the P-256 key). The returned account `address` (tb1q…) IS the `signWith` for `signTransaction` AND the user's funding/change address. Cache it.
+
+**10. Server plumbing already present (Plan 1).** `server/router.ts` (`json(data, status?, headers?)`, `route(req, routes)`, `type Handler = (req, url) => Response | Promise<Response>`), `server/rate-limit.ts` (`createRateLimiter({ limit, windowMs }).check(key) → { allowed, retryAfterMs }`), `server/cookies.ts` (`extractToken(req)`), `server/turnkey.ts` (`getTurnkey()`), `server/index.ts` (`buildRoutes(deps)` exact-match route map + `buildStubRoutes()`), `server/app.ts` (`buildFetch` routes `/api/host/*` to the host store and all other `/api/*` through `route(req, routes)`). `/api/btc/*` are exact paths, so they slot into the `buildRoutes` map — no wildcard needed. `verifyToken(token, { secret })` from `@originals/auth/server` reads the JWT `sub` (subOrgId).
+
+---
+
+## Task 1: SDK — first-class `network: 'testnet'` (testnet4) support
+
+**Files:**
+- Modify: `packages/sdk/src/types/network.ts` (`BitcoinNetworkName` union)
+- Modify: `packages/sdk/src/types/common.ts` (`OriginalsConfig.network` union)
+- Modify: `packages/sdk/src/cel/btcoDid.ts` (`btcoDidPrefix`)
+- Modify: `packages/sdk/src/did/createBtcoDidDocument.ts` (`BitcoinNetwork` + `getDidPrefix`)
+- Modify: `packages/sdk/src/did/DIDManager.ts` (`getConfiguredBitcoinNetwork` return type, `migrateToDIDBTCO` network type + prefix map)
+- Modify: `packages/sdk/src/lifecycle/LifecycleManager.ts` (`getConfiguredBitcoinNetwork` return type, line ~3608)
+- Modify: `packages/sdk/src/utils/bitcoin-address.ts` (`BitcoinNetwork` + `getNetwork`)
+- Modify: `packages/sdk/src/bitcoin/BitcoinManager.ts` (read-side prefix guard, lines ~421-426)
+- Test: `packages/sdk/tests/unit/testnet-support.test.ts`
+
+**Interfaces:**
+- Consumes: existing SDK internals.
+- Produces: `network: 'testnet'` accepted end-to-end; `did:btco:test:<sat>` minted for a testnet-configured SDK; `tb1`/testnet addresses validated under `'testnet'`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/sdk/tests/unit/testnet-support.test.ts`:
+
+```typescript
+import { describe, test, expect } from 'bun:test';
+import { btcoDidPrefix, btcoDidFromSatoshi } from '../../src/cel/btcoDid.js';
+import { createBtcoDidDocument } from '../../src/did/createBtcoDidDocument.js';
+import { validateBitcoinAddress, isValidBitcoinAddress } from '../../src/utils/bitcoin-address.js';
+
+describe('SDK testnet (testnet4) support', () => {
+  test('btcoDidPrefix maps testnet to did:btco:test', () => {
+    expect(btcoDidPrefix('testnet')).toBe('did:btco:test');
+    expect(btcoDidFromSatoshi('123456', 'testnet')).toBe('did:btco:test:123456');
+  });
+
+  test('createBtcoDidDocument mints a did:btco:test id on testnet', () => {
+    const doc = createBtcoDidDocument('123456', 'testnet', {
+      publicKey: '02'.padEnd(66, '0'),
+      keyType: 'ES256K',
+    });
+    expect(doc.id).toBe('did:btco:test:123456');
+  });
+
+  test('validateBitcoinAddress accepts a testnet4 tb1 P2WPKH address under "testnet"', () => {
+    // Canonical BIP-173 testnet P2WPKH vector (tb1 prefix; testnet4 shares it).
+    const tb1 = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx';
+    expect(isValidBitcoinAddress(tb1, 'testnet')).toBe(true);
+    // A mainnet bc1 address must NOT validate as testnet.
+    expect(isValidBitcoinAddress('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4', 'testnet')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/sdk && bun test tests/unit/testnet-support.test.ts`
+Expected: FAIL — `btcoDidPrefix('testnet')` throws `Unsupported Bitcoin network`; `createBtcoDidDocument(..., 'testnet', ...)` is a type error / throws; `validateBitcoinAddress(tb1, 'testnet')` throws (`'testnet'` not a valid `BitcoinNetwork`).
+
+- [ ] **Step 3: Widen the two type unions**
+
+In `packages/sdk/src/types/network.ts`, replace:
+```typescript
+export type BitcoinNetworkName = 'mainnet' | 'regtest' | 'signet';
+```
+with:
+```typescript
+export type BitcoinNetworkName = 'mainnet' | 'testnet' | 'regtest' | 'signet';
+```
+
+In `packages/sdk/src/types/common.ts`, replace:
+```typescript
+export interface OriginalsConfig {
+  network: 'mainnet' | 'regtest' | 'signet';
+```
+with:
+```typescript
+export interface OriginalsConfig {
+  network: 'mainnet' | 'testnet' | 'regtest' | 'signet';
+```
+
+- [ ] **Step 4: Add the `testnet` → `did:btco:test` prefix in the two DID-identity sites**
+
+In `packages/sdk/src/cel/btcoDid.ts`, in `btcoDidPrefix`, add the case BEFORE `default:`:
+```typescript
+    case 'regtest':
+      return 'did:btco:reg';
+```
+becomes:
+```typescript
+    case 'regtest':
+      return 'did:btco:reg';
+    case 'testnet':
+      return 'did:btco:test';
+```
+
+In `packages/sdk/src/did/createBtcoDidDocument.ts`, replace:
+```typescript
+export type BitcoinNetwork = 'mainnet' | 'regtest' | 'signet';
+```
+with:
+```typescript
+export type BitcoinNetwork = 'mainnet' | 'testnet' | 'regtest' | 'signet';
+```
+and in `getDidPrefix`, add after the regtest arm:
+```typescript
+	if (network === 'regtest') return 'did:btco:reg';
+```
+becomes:
+```typescript
+	if (network === 'regtest') return 'did:btco:reg';
+	if (network === 'testnet') return 'did:btco:test';
+```
+
+- [ ] **Step 5: Widen the two `getConfiguredBitcoinNetwork` return types + DIDManager prefix map**
+
+In `packages/sdk/src/did/DIDManager.ts`, replace the `getConfiguredBitcoinNetwork` signature (line ~245):
+```typescript
+  private getConfiguredBitcoinNetwork(): 'mainnet' | 'regtest' | 'signet' | undefined {
+```
+with:
+```typescript
+  private getConfiguredBitcoinNetwork(): 'mainnet' | 'testnet' | 'regtest' | 'signet' | undefined {
+```
+Replace the `migrateToDIDBTCO` local network type (line ~275):
+```typescript
+    const network: 'mainnet' | 'regtest' | 'signet' = this.getConfiguredBitcoinNetwork() ?? 'mainnet';
+```
+with:
+```typescript
+    const network: 'mainnet' | 'testnet' | 'regtest' | 'signet' = this.getConfiguredBitcoinNetwork() ?? 'mainnet';
+```
+Replace the inline prefix map (line ~314):
+```typescript
+      const prefix = network === 'mainnet' ? 'did:btco:' : network === 'regtest' ? 'did:btco:reg:' : 'did:btco:sig:';
+```
+with:
+```typescript
+      const prefix =
+        network === 'mainnet' ? 'did:btco:'
+        : network === 'regtest' ? 'did:btco:reg:'
+        : network === 'testnet' ? 'did:btco:test:'
+        : 'did:btco:sig:';
+```
+
+In `packages/sdk/src/lifecycle/LifecycleManager.ts`, replace (line ~3608):
+```typescript
+  private getConfiguredBitcoinNetwork(): 'mainnet' | 'regtest' | 'signet' {
+```
+with:
+```typescript
+  private getConfiguredBitcoinNetwork(): 'mainnet' | 'testnet' | 'regtest' | 'signet' {
+```
+
+- [ ] **Step 6: Accept `testnet` in address validation**
+
+In `packages/sdk/src/utils/bitcoin-address.ts`, replace:
+```typescript
+export type BitcoinNetwork = 'mainnet' | 'regtest' | 'signet';
+```
+with:
+```typescript
+export type BitcoinNetwork = 'mainnet' | 'testnet' | 'regtest' | 'signet';
+```
+and in `getNetwork`, add the testnet arm after `mainnet`:
+```typescript
+    case 'mainnet':
+      return bitcoin.networks.bitcoin;
+```
+becomes:
+```typescript
+    case 'mainnet':
+      return bitcoin.networks.bitcoin;
+    case 'testnet':
+      // testnet4 shares testnet3's bech32 params (tb1) — same as signet below.
+      return bitcoin.networks.testnet;
+```
+
+- [ ] **Step 7: Fix the BitcoinManager read-side prefix guard**
+
+In `packages/sdk/src/bitcoin/BitcoinManager.ts`, replace the prefix expression (lines ~423-425):
+```typescript
+      this.config.network === 'regtest' ? 'reg'
+        : this.config.network === 'signet' ? 'sig'
+          : null; // mainnet DIDs have no network prefix (did:btco:<sat>)
+```
+with:
+```typescript
+      this.config.network === 'regtest' ? 'reg'
+        : this.config.network === 'signet' ? 'sig'
+          : this.config.network === 'testnet' ? 'test'
+            : null; // mainnet DIDs have no network prefix (did:btco:<sat>)
+```
+
+- [ ] **Step 8: Run the test to verify it passes**
+
+Run: `cd packages/sdk && bun test tests/unit/testnet-support.test.ts`
+Expected: PASS — 3 tests pass.
+
+- [ ] **Step 9: Guard against regressions across the SDK network switches**
+
+Run: `cd packages/sdk && bun test tests/unit/bitcoin tests/unit/did tests/unit/cel`
+Expected: PASS — existing regtest/signet/mainnet DID + address + inscription unit suites stay green (the change only ADDS a `testnet` arm to each switch; no existing arm moved).
+
+- [ ] **Step 10: Rebuild the SDK so the landing app can import testnet support**
+
+Run: `cd /Users/brian/Projects/onionoriginals/sdk && bun run build`
+Expected: `packages/sdk/dist` recompiles with no TypeScript errors. This is REQUIRED before Tasks 2-8 (the landing app imports `packages/sdk/dist`).
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add packages/sdk/src/types/network.ts packages/sdk/src/types/common.ts packages/sdk/src/cel/btcoDid.ts packages/sdk/src/did/createBtcoDidDocument.ts packages/sdk/src/did/DIDManager.ts packages/sdk/src/lifecycle/LifecycleManager.ts packages/sdk/src/utils/bitcoin-address.ts packages/sdk/src/bitcoin/BitcoinManager.ts packages/sdk/tests/unit/testnet-support.test.ts
+git commit -m "feat(sdk): first-class network:'testnet' (testnet4) support — did:btco:test + tb1 validation"
+```
+
+---
+
+## Task 2: Signing spike — Turnkey `signTransaction` → `@scure/btc-signer` finalize
+
+**This task de-risks the load-bearing unknown for the whole plan.** It proves that a partially-signed P2WPKH PSBT (the shape Turnkey `signTransaction` returns) can be finalized with `@scure/btc-signer` into a valid, broadcast-ready testnet4 transaction. The finalize helper it produces is reused verbatim by the `TurnkeySatSigner` (Task 6).
+
+**Files:**
+- Add dep: `apps/landing/package.json` (`@scure/btc-signer` as an explicit dependency)
+- Create: `apps/landing/src/sdk/finalize-psbt.ts`
+- Test: `apps/landing/src/sdk/finalize-psbt.spike.test.ts`
+
+**Interfaces:**
+- Consumes: `@scure/btc-signer`.
+- Produces: `finalizeSignedPsbt(partiallySignedPsbtBase64: string): string` — loads a partially-signed PSBT, finalizes all inputs, returns broadcast-ready raw tx hex; throws `FinalizePsbtError` if any input is unsigned/unfinalizable.
+
+- [ ] **Step 1: Add `@scure/btc-signer` as an explicit landing dependency**
+
+`@scure/btc-signer` is resolvable transitively via `@originals/sdk`, but the browser bundle must import it directly, so pin it explicitly. In `apps/landing/package.json`, add to `dependencies` (keep alphabetical near the other `@` scopes):
+```json
+    "@scure/btc-signer": "^2.2.0",
+```
+Then run: `cd /Users/brian/Projects/onionoriginals/sdk && bun install`
+Expected: lockfile updated; `apps/landing/node_modules/@scure/btc-signer` resolves.
+
+- [ ] **Step 2: Write the failing spike test**
+
+Create `apps/landing/src/sdk/finalize-psbt.spike.test.ts`. It stands in for Turnkey by building a P2WPKH-input PSBT and signing it locally with a known key (exactly the "partially-signed, not finalized" PSBT Turnkey `signTransaction` returns), then asserts `finalizeSignedPsbt` yields a parseable tx with a non-empty witness on the input:
+
+```typescript
+import { describe, test, expect } from 'bun:test';
+import * as btc from '@scure/btc-signer';
+import { hex, base64 } from '@scure/base';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { finalizeSignedPsbt } from './finalize-psbt';
+
+// A deterministic P2WPKH key on testnet (TEST_NETWORK params).
+const priv = hex.decode('1111111111111111111111111111111111111111111111111111111111111111');
+const pub = secp256k1.getPublicKey(priv, true);
+
+// Build a partially-signed (NOT finalized) P2WPKH PSBT — the exact shape
+// Turnkey signTransaction returns. We stand in for Turnkey by signing locally.
+function turnkeyLikePartiallySignedPsbt(): string {
+  const p2wpkh = btc.p2wpkh(pub, btc.TEST_NETWORK);
+  const tx = new btc.Transaction();
+  // A synthetic funding input (segwit → witnessUtxo carries amount + script).
+  tx.addInput({
+    txid: hex.decode('a'.repeat(64)),
+    index: 0,
+    witnessUtxo: { script: p2wpkh.script, amount: 20_000n },
+  });
+  tx.addOutputAddress(
+    'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx',
+    12_000n,
+    btc.TEST_NETWORK
+  );
+  tx.sign(priv); // signs but does NOT finalize
+  return base64.encode(tx.toPSBT());
+}
+
+describe('SPIKE: Turnkey signTransaction → scure finalize (P2WPKH testnet4)', () => {
+  test('finalizeSignedPsbt turns a partially-signed P2WPKH PSBT into broadcast-ready hex with a witness', () => {
+    const partiallySigned = turnkeyLikePartiallySignedPsbt();
+    const rawHex = finalizeSignedPsbt(partiallySigned);
+
+    // Broadcast-ready hex must parse as a raw (non-PSBT) transaction...
+    const parsed = btc.Transaction.fromRaw(hex.decode(rawHex));
+    expect(parsed.inputsLength).toBe(1);
+    // ...and the single P2WPKH input must carry a finalized witness.
+    const input = parsed.getInput(0);
+    expect(input.finalScriptWitness).toBeDefined();
+    expect((input.finalScriptWitness as Uint8Array[]).length).toBeGreaterThan(0);
+  });
+
+  test('finalizeSignedPsbt throws on an unsigned PSBT', () => {
+    const p2wpkh = btc.p2wpkh(pub, btc.TEST_NETWORK);
+    const tx = new btc.Transaction();
+    tx.addInput({ txid: hex.decode('b'.repeat(64)), index: 0, witnessUtxo: { script: p2wpkh.script, amount: 20_000n } });
+    tx.addOutputAddress('tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx', 12_000n, btc.TEST_NETWORK);
+    const unsigned = base64.encode(tx.toPSBT());
+    expect(() => finalizeSignedPsbt(unsigned)).toThrow();
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd apps/landing && bun test src/sdk/finalize-psbt.spike.test.ts`
+Expected: FAIL — `Cannot find module './finalize-psbt'`.
+
+- [ ] **Step 4: Implement `apps/landing/src/sdk/finalize-psbt.ts`**
+
+```typescript
+/**
+ * Finalize a partially-signed PSBT into broadcast-ready raw tx hex.
+ *
+ * This is the second half of the recommended Turnkey signing path: Turnkey
+ * signTransaction({ type: 'TRANSACTION_TYPE_BITCOIN' }) returns a PSBT with
+ * signatures attached but NOT finalized (it owns sighash/DER/low-S). @scure/
+ * btc-signer assembles the final witness and serializes the network tx. The
+ * SDK's inscribe-on-sat path expects raw hex from the BitcoinSigner, never a
+ * PSBT, so finalization MUST happen here.
+ */
+import * as btc from '@scure/btc-signer';
+import { base64, hex } from '@scure/base';
+
+export class FinalizePsbtError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'FinalizePsbtError';
+  }
+}
+
+export function finalizeSignedPsbt(partiallySignedPsbtBase64: string): string {
+  let tx: btc.Transaction;
+  try {
+    tx = btc.Transaction.fromPSBT(base64.decode(partiallySignedPsbtBase64), {
+      allowUnknownInputs: true,
+      allowUnknownOutputs: true,
+    });
+  } catch (e) {
+    throw new FinalizePsbtError(
+      `Could not parse the signed PSBT returned by the signer: ${e instanceof Error ? e.message : String(e)}`,
+      { cause: e }
+    );
+  }
+  try {
+    // Finalize EVERY input — an input still missing its signature (Turnkey did
+    // not sign it) throws here, which is the correct fail-closed behavior: a
+    // partially-finalized tx must never reach broadcast.
+    tx.finalize();
+  } catch (e) {
+    throw new FinalizePsbtError(
+      `Signed PSBT could not be finalized (an input is unsigned or non-standard): ${e instanceof Error ? e.message : String(e)}`,
+      { cause: e }
+    );
+  }
+  return hex.encode(tx.extract());
+}
+```
+
+Note: `@scure/base` ships as a dependency of `@scure/btc-signer` (present in `node_modules/.bun/@scure+base`); if Vite/Bun cannot resolve the bare `@scure/base` import, add `"@scure/base": "^1.1.0"` to `apps/landing/package.json` dependencies and re-run `bun install`. `@noble/curves` is likewise a transitive dep of the SDK; the test imports `@noble/curves/secp256k1.js` — if unresolved, add `"@noble/curves": "^2.0.0"` to `apps/landing/package.json`.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd apps/landing && bun test src/sdk/finalize-psbt.spike.test.ts`
+Expected: PASS — 2 tests pass. **This green run is the go/no-go gate: the finalize path works, so the rest of Track B can be built. The full live path (real Turnkey signTransaction + real QuickNode broadcast) remains a MANUAL SMOKE gated on provisioned env — see Task 8 Step N.**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/landing/package.json apps/landing/src/sdk/finalize-psbt.ts apps/landing/src/sdk/finalize-psbt.spike.test.ts
+git commit -m "spike(landing): prove Turnkey-shaped PSBT → scure finalize → broadcast-ready P2WPKH hex"
+```
+
+---
+
+## Task 3: Turnkey OTP_LOGIN session + browser signing client + testnet4 funding account
+
+**Files:**
+- Modify: `apps/landing/server/auth-routes.ts` (verify-otp surfaces `verificationToken` + bound `publicKey`)
+- Create: `apps/landing/src/auth/turnkey-session.ts` (`otpLoginToSession`, `buildBrowserSigningClient`, `ensureBitcoinFundingAccount` — behind an injectable Turnkey interface)
+- Modify: `apps/landing/src/auth/api.ts` (`completeOtp` returns `verificationToken` + `publicKey` + the browser P-256 keypair)
+- Modify: `apps/landing/src/auth/useAuth.tsx` (run otpLogin, hold session + signing client + funding address; expose them)
+- Test: `apps/landing/src/auth/turnkey-session.test.ts`
+- Test: `apps/landing/server/tests/auth-verify-token.test.ts`
+
+**Interfaces:**
+- Produces:
+  - Server verify-otp response gains `verificationToken: string` and `publicKey: string` (the P-256 pubkey the token is bound to). The httpOnly JWT cookie is UNCHANGED — the returned token is client-bound and safe to hand back.
+  - `otpLoginToSession(deps: { turnkey: TurnkeySessionApi; subOrgId: string; verificationToken: string; p256PublicKey: string; p256PrivateKey: string; expirationSeconds?: number }): Promise<{ session: string }>` — computes the P-256 `clientSignature` over the login challenge and calls `otpLogin`.
+  - `buildBrowserSigningClient(opts: { subOrgId: string; p256PublicKey: string; p256PrivateKey: string }): TurnkeyBitcoinClient` — an ApiKeyStamper-backed browser client exposing `signTransaction` + `createWalletAccounts` + `getWallets`, scoped to `subOrgId`.
+  - `ensureBitcoinFundingAccount(client: TurnkeyBitcoinClient, subOrgId: string): Promise<string>` — adds (idempotently) the `m/84'/1'/0'/0/0` `ADDRESS_FORMAT_BITCOIN_TESTNET_P2WPKH` account and returns its tb1q address.
+  - `TurnkeyBitcoinClient` narrow interface (see Resolved fact #7) so `TurnkeySatSigner` (Task 6) and tests depend on it, not on the concrete browser SDK.
+  - `useAuth()` context gains `bitcoin: { fundingAddress: string; signingClient: TurnkeyBitcoinClient } | null` (null until otpLogin + provisioning complete, or when Track B is disabled).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/landing/src/auth/turnkey-session.test.ts` (drives the session helpers against a mock Turnkey API — no network):
+
+```typescript
+import { describe, test, expect } from 'bun:test';
+import {
+  otpLoginToSession,
+  ensureBitcoinFundingAccount,
+  type TurnkeyBitcoinClient,
+  type TurnkeySessionApi,
+} from './turnkey-session';
+
+describe('turnkey-session helpers', () => {
+  test('otpLoginToSession calls otpLogin with a client signature and returns the session', async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const turnkey: TurnkeySessionApi = {
+      async otpLogin(params) {
+        calls.push(params);
+        return { session: 'session-jwt-xyz' };
+      },
+    };
+    const { session } = await otpLoginToSession({
+      turnkey,
+      subOrgId: 'sub-1',
+      verificationToken: 'vtoken',
+      // 32-byte P-256 private key + its compressed pubkey (hex). Any valid pair.
+      p256PublicKey: '02'.padEnd(66, 'a'),
+      p256PrivateKey: '1'.repeat(64),
+    });
+    expect(session).toBe('session-jwt-xyz');
+    expect(calls[0].organizationId).toBe('sub-1');
+    expect(calls[0].verificationToken).toBe('vtoken');
+    expect(typeof calls[0].clientSignature).toBe('string');
+    expect((calls[0].clientSignature as string).length).toBeGreaterThan(0);
+  });
+
+  test('ensureBitcoinFundingAccount adds a testnet P2WPKH account and returns its tb1 address (idempotent)', async () => {
+    let existing: Array<{ address: string; path: string }> = [];
+    const client: TurnkeyBitcoinClient = {
+      async getWallets() {
+        return { wallets: [{ walletId: 'w1', accounts: existing }] };
+      },
+      async createWalletAccounts(params) {
+        const address = 'tb1qexampleuseraddr000000000000000000000000';
+        existing = [{ address, path: (params.accounts[0] as { path: string }).path }];
+        return { addresses: [address] };
+      },
+      async signTransaction() {
+        throw new Error('not used here');
+      },
+    };
+    const addr = await ensureBitcoinFundingAccount(client, 'sub-1');
+    expect(addr.startsWith('tb1q')).toBe(true);
+    // Second call must NOT create a duplicate account — returns the cached one.
+    const addr2 = await ensureBitcoinFundingAccount(client, 'sub-1');
+    expect(addr2).toBe(addr);
+  });
+});
+```
+
+Create `apps/landing/server/tests/auth-verify-token.test.ts` (verify-otp now surfaces the token; uses a fake Turnkey + sessions, mirroring the auth-routes convention):
+
+```typescript
+import { describe, test, expect } from 'bun:test';
+import { createAuthRoutes } from '../auth-routes';
+
+// Minimal fakes: enough of the surface createAuthRoutes touches.
+function fakeDeps() {
+  const session = {
+    email: 'a@b.com',
+    otpId: 'otp1',
+    otpEncryptionTargetBundle: 'bundle',
+    timestamp: Date.now(),
+    verified: false,
+  };
+  const sessions = {
+    get: () => session,
+    set: () => {},
+    delete: () => {},
+    cleanup: () => {},
+  };
+  const turnkey = {
+    apiClient: () => ({
+      // verifyOtp is exercised via verifyEmailAuth internals; we stub the
+      // higher-level path by making verifyEmailAuth resolve. Since auth-routes
+      // calls verifyEmailAuth(sessionId, code, turnkey, sessions), provide the
+      // sub-org + verificationToken it needs.
+      verifyOtp: async () => ({ verificationToken: 'vtoken-123' }),
+      getSubOrgIds: async () => ({ organizationIds: ['sub-1'] }),
+      getWallets: async () => ({ wallets: [{ walletId: 'w1' }] }),
+    }),
+  } as unknown as Parameters<typeof createAuthRoutes>[0]['turnkey'];
+  return { turnkey, sessions, jwtSecret: 'test-secret-at-least-32-chars-long!!' };
+}
+
+describe('verify-otp surfaces the client-bound verificationToken', () => {
+  test('response body carries verificationToken + publicKey alongside subOrgId', async () => {
+    const routes = createAuthRoutes(fakeDeps());
+    const req = new Request('http://x/api/auth/verify-otp', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ sessionId: 's1', code: '123456', publicKey: '02'.padEnd(66, 'a') }),
+    });
+    const res = await routes.verifyOtp(req, new URL(req.url));
+    // The httpOnly JWT cookie is still set; the body now also returns the token.
+    expect(res.headers.get('set-cookie')).toBeTruthy();
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.subOrgId).toBe('sub-1');
+    expect(body.verificationToken).toBe('vtoken-123');
+    expect(body.publicKey).toBe('02'.padEnd(66, 'a'));
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/landing && bun test src/auth/turnkey-session.test.ts server/tests/auth-verify-token.test.ts`
+Expected: FAIL — `Cannot find module './turnkey-session'`; verify-otp body has no `verificationToken`/`publicKey` (dropped today).
+
+- [ ] **Step 3: Surface the token in the server verify-otp handler**
+
+In `apps/landing/server/auth-routes.ts`, replace the verify-otp success block:
+```typescript
+      const token = signToken(result.subOrgId, result.email, undefined, { secret: deps.jwtSecret });
+      const cookie = serializeCookie(getAuthCookieConfig(token));
+      return json(
+        { verified: true, email: result.email, subOrgId: result.subOrgId },
+        200,
+        { 'Set-Cookie': cookie }
+      );
+```
+with:
+```typescript
+      const token = signToken(result.subOrgId, result.email, undefined, { secret: deps.jwtSecret });
+      const cookie = serializeCookie(getAuthCookieConfig(token));
+      // Surface the Turnkey verificationToken + the P-256 pubkey it is bound to
+      // so the browser can run OTP_LOGIN and install its own session credential
+      // (Track B, testnet4 signing). The token is client-bound — useless without
+      // the browser-held P-256 private key — so returning it is safe. The
+      // httpOnly session JWT cookie is UNCHANGED.
+      return json(
+        {
+          verified: true,
+          email: result.email,
+          subOrgId: result.subOrgId,
+          verificationToken: result.verificationToken,
+          publicKey: result.publicKey,
+        },
+        200,
+        { 'Set-Cookie': cookie }
+      );
+```
+
+- [ ] **Step 4: Implement the browser session helpers `apps/landing/src/auth/turnkey-session.ts`**
+
+```typescript
+/**
+ * Turnkey session helpers for Track B (testnet4 signing).
+ *
+ * After OTP verify, the sub-org is credential-less: the parent Turnkey key
+ * can't sign for it and there is no passkey. OTP_LOGIN installs the browser's
+ * P-256 key as the session credential, after which the user's Bitcoin signing
+ * (signTransaction) is silent within the session window. These helpers wrap
+ * that flow behind narrow, injectable interfaces so the app code and tests
+ * never depend on the concrete @turnkey/sdk-browser surface directly.
+ */
+import { ApiKeyStamper } from '@turnkey/api-key-stamper';
+import { TurnkeyBrowserClient } from '@turnkey/sdk-browser';
+import { secp256r1 } from '@noble/curves/nist.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { hex } from '@scure/base';
+
+/** The single OTP_LOGIN activity the session bootstrap needs. */
+export interface TurnkeySessionApi {
+  otpLogin(params: {
+    organizationId: string;
+    verificationToken: string;
+    publicKey: string;
+    clientSignature: string;
+    expirationSeconds?: string;
+  }): Promise<{ session: string }>;
+}
+
+/** The Bitcoin-signing + account surface the rest of Track B consumes. */
+export interface TurnkeyBitcoinClient {
+  signTransaction(params: {
+    signWith: string;
+    unsignedTransaction: string;
+    type: 'TRANSACTION_TYPE_BITCOIN';
+  }): Promise<{ signedTransaction: string }>;
+  createWalletAccounts(params: {
+    walletId: string;
+    organizationId: string;
+    accounts: Array<{
+      curve: 'CURVE_SECP256K1';
+      pathFormat: 'PATH_FORMAT_BIP32';
+      path: string;
+      addressFormat: 'ADDRESS_FORMAT_BITCOIN_TESTNET_P2WPKH';
+    }>;
+  }): Promise<{ addresses: string[] }>;
+  getWallets(params: { organizationId: string }): Promise<{
+    wallets: Array<{ walletId: string; accounts?: Array<{ address: string; path?: string }> }>;
+  }>;
+}
+
+const TESTNET_P2WPKH_PATH = "m/84'/1'/0'/0/0";
+
+/**
+ * Run OTP_LOGIN: sign the login challenge (the verificationToken) with the
+ * browser P-256 key and exchange it for a session credential. The exact
+ * challenge Turnkey expects is the verificationToken bytes; we sign SHA-256 of
+ * them with the API-P256 scheme (low-S DER), matching ApiKeyStamper.
+ */
+export async function otpLoginToSession(deps: {
+  turnkey: TurnkeySessionApi;
+  subOrgId: string;
+  verificationToken: string;
+  p256PublicKey: string;
+  p256PrivateKey: string;
+  expirationSeconds?: number;
+}): Promise<{ session: string }> {
+  const challenge = sha256(new TextEncoder().encode(deps.verificationToken));
+  const sig = secp256r1.sign(challenge, hex.decode(deps.p256PrivateKey), { lowS: true });
+  const clientSignature = hex.encode(sig.toDERRawBytes());
+  const { session } = await deps.turnkey.otpLogin({
+    organizationId: deps.subOrgId,
+    verificationToken: deps.verificationToken,
+    publicKey: deps.p256PublicKey,
+    clientSignature,
+    expirationSeconds: String(deps.expirationSeconds ?? 900),
+  });
+  return { session };
+}
+
+/**
+ * Build the ApiKeyStamper-backed browser client scoped to the sub-org. The
+ * stamper reuses the SAME P-256 keypair the OTP flow generated, so no new
+ * credential is minted. Returns the narrow TurnkeyBitcoinClient surface.
+ */
+export function buildBrowserSigningClient(opts: {
+  subOrgId: string;
+  p256PublicKey: string;
+  p256PrivateKey: string;
+  apiBaseUrl?: string;
+}): TurnkeyBitcoinClient {
+  const stamper = new ApiKeyStamper({
+    apiPublicKey: opts.p256PublicKey,
+    apiPrivateKey: opts.p256PrivateKey,
+  });
+  const client = new TurnkeyBrowserClient({
+    stamper,
+    apiBaseUrl: opts.apiBaseUrl ?? 'https://api.turnkey.com',
+    organizationId: opts.subOrgId,
+  });
+  // TurnkeyBrowserClient already exposes signTransaction / createWalletAccounts
+  // / getWallets with these shapes; the cast pins the narrow surface we use.
+  return client as unknown as TurnkeyBitcoinClient;
+}
+
+/**
+ * Ensure the user's wallet has a testnet4 P2WPKH account and return its tb1
+ * address. Idempotent: if the path already exists, the cached address wins —
+ * re-creating would waste an activity and could error on a duplicate path.
+ */
+export async function ensureBitcoinFundingAccount(
+  client: TurnkeyBitcoinClient,
+  subOrgId: string
+): Promise<string> {
+  const { wallets } = await client.getWallets({ organizationId: subOrgId });
+  const wallet = wallets[0];
+  if (!wallet) throw new Error('No Turnkey wallet found for the sub-organization.');
+  const existing = wallet.accounts?.find((a) => a.path === TESTNET_P2WPKH_PATH);
+  if (existing?.address) return existing.address;
+  const { addresses } = await client.createWalletAccounts({
+    walletId: wallet.walletId,
+    organizationId: subOrgId,
+    accounts: [
+      {
+        curve: 'CURVE_SECP256K1',
+        pathFormat: 'PATH_FORMAT_BIP32',
+        path: TESTNET_P2WPKH_PATH,
+        addressFormat: 'ADDRESS_FORMAT_BITCOIN_TESTNET_P2WPKH',
+      },
+    ],
+  });
+  const address = addresses[0];
+  if (!address || !address.startsWith('tb1')) {
+    throw new Error(`Turnkey returned an unexpected funding address: ${String(address)}`);
+  }
+  return address;
+}
+```
+
+Note: `@turnkey/api-key-stamper` and `@turnkey/sdk-browser` are present in `node_modules/.bun` (verified) but `@turnkey/api-key-stamper` may not be an explicit `apps/landing` dependency — add `"@turnkey/api-key-stamper": "^0.6.7"` and `"@turnkey/sdk-browser": "^6.1.1"` to `apps/landing/package.json` dependencies and re-run `bun install` if the imports fail to resolve. `@noble/curves/nist.js` exports `secp256r1` (P-256); if the subpath differs in the installed version, import from `@noble/curves/p256.js`. If `toDERRawBytes()` is unavailable on the installed `@noble/curves`, use `sig.toCompactRawBytes()` and set the otpLogin scheme accordingly — flag as a manual-smoke verification point.
+
+- [ ] **Step 5: Thread the token + keypair through `apps/landing/src/auth/api.ts`**
+
+Replace `completeOtp`:
+```typescript
+export async function completeOtp(
+  sessionId: string,
+  code: string
+): Promise<{ verified: boolean; email: string; subOrgId: string }> {
+  // Generate the P-256 keypair in the browser so the verification-token
+  // private key never transits HTTP (2.0 token binding).
+  const keyPair = generateP256KeyPair();
+  const result = await verifyOtp(sessionId, code, undefined, { publicKey: keyPair.publicKey });
+  return { verified: result.verified, email: result.email!, subOrgId: result.subOrgId! };
+}
+```
+with:
+```typescript
+export interface CompleteOtpResult {
+  verified: boolean;
+  email: string;
+  subOrgId: string;
+  /** Turnkey verificationToken (bound to the P-256 pubkey below), for OTP_LOGIN. */
+  verificationToken?: string;
+  /** The browser P-256 keypair (hex). Private key NEVER leaves the browser. */
+  p256PublicKey: string;
+  p256PrivateKey: string;
+}
+
+export async function completeOtp(sessionId: string, code: string): Promise<CompleteOtpResult> {
+  // Generate the P-256 keypair in the browser so the verification-token
+  // private key never transits HTTP (2.0 token binding). Track B (testnet4
+  // signing) reuses this exact keypair as the Turnkey session credential.
+  const keyPair = generateP256KeyPair();
+  const result = await verifyOtp(sessionId, code, undefined, { publicKey: keyPair.publicKey });
+  return {
+    verified: result.verified,
+    email: result.email!,
+    subOrgId: result.subOrgId!,
+    verificationToken: (result as { verificationToken?: string }).verificationToken,
+    p256PublicKey: keyPair.publicKey,
+    p256PrivateKey: keyPair.privateKey,
+  };
+}
+```
+
+- [ ] **Step 6: Bootstrap the session + signing client + funding address in `useAuth.tsx`**
+
+In `apps/landing/src/auth/useAuth.tsx`, extend the context and the `verify` flow. Add the imports at the top:
+```typescript
+import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from 'react';
+import * as api from './api';
+import type { AuthUser } from './api';
+import { createUserWebVHDid } from './webvh';
+```
+becomes:
+```typescript
+import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from 'react';
+import * as api from './api';
+import type { AuthUser } from './api';
+import { createUserWebVHDid } from './webvh';
+import {
+  otpLoginToSession,
+  buildBrowserSigningClient,
+  ensureBitcoinFundingAccount,
+  type TurnkeyBitcoinClient,
+} from './turnkey-session';
+
+// Track B activates only when the deploy enables testnet4 signing.
+const btcTestnetEnabled =
+  (import.meta as unknown as { env?: Record<string, string> }).env?.VITE_BTC_TESTNET === '1';
+
+export interface BitcoinSession {
+  fundingAddress: string;
+  signingClient: TurnkeyBitcoinClient;
+}
+```
+Extend the context value type:
+```typescript
+interface AuthContextValue {
+  user: AuthUser | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  sessionId: string | null;
+  startOtp: (email: string) => Promise<void>;
+  verify: (code: string) => Promise<void>;
+  createIdentity: () => Promise<string>;
+  signOut: () => Promise<void>;
+}
+```
+becomes:
+```typescript
+interface AuthContextValue {
+  user: AuthUser | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  sessionId: string | null;
+  /** Track B: the user's testnet4 signing client + funding address (null until ready / when disabled). */
+  bitcoin: BitcoinSession | null;
+  startOtp: (email: string) => Promise<void>;
+  verify: (code: string) => Promise<void>;
+  createIdentity: () => Promise<string>;
+  signOut: () => Promise<void>;
+}
+```
+Add the state + extend `verify` + reset on signOut:
+```typescript
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+```
+becomes:
+```typescript
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [bitcoin, setBitcoin] = useState<BitcoinSession | null>(null);
+```
+Replace `verify`:
+```typescript
+  const verify = useCallback(async (code: string) => {
+    if (!sessionId) throw new Error('Start the OTP flow first');
+    const result = await api.completeOtp(sessionId, code);
+    setUser({ subOrgId: result.subOrgId, email: result.email });
+    setSessionId(null);
+  }, [sessionId]);
+```
+with:
+```typescript
+  const verify = useCallback(async (code: string) => {
+    if (!sessionId) throw new Error('Start the OTP flow first');
+    const result = await api.completeOtp(sessionId, code);
+    setUser({ subOrgId: result.subOrgId, email: result.email });
+    setSessionId(null);
+
+    // Track B bootstrap: install the P-256 session credential (OTP_LOGIN), then
+    // build the signing client + ensure the testnet4 funding account. Best-
+    // effort: a failure here must NOT block login — the demo simply falls back
+    // to the mock inscribe path. Only runs when the deploy enabled testnet4.
+    if (!btcTestnetEnabled || !result.verificationToken) return;
+    try {
+      const signingClient = buildBrowserSigningClient({
+        subOrgId: result.subOrgId,
+        p256PublicKey: result.p256PublicKey,
+        p256PrivateKey: result.p256PrivateKey,
+      });
+      await otpLoginToSession({
+        turnkey: signingClient as unknown as Parameters<typeof otpLoginToSession>[0]['turnkey'],
+        subOrgId: result.subOrgId,
+        verificationToken: result.verificationToken,
+        p256PublicKey: result.p256PublicKey,
+        p256PrivateKey: result.p256PrivateKey,
+      });
+      const fundingAddress = await ensureBitcoinFundingAccount(signingClient, result.subOrgId);
+      setBitcoin({ fundingAddress, signingClient });
+    } catch (err) {
+      // Non-fatal: log for the console-visible demo narrative; UI stays on mock.
+      console.warn('[originals-demo] testnet4 session bootstrap failed; inscribe stays on mock', err);
+      setBitcoin(null);
+    }
+  }, [sessionId]);
+```
+Replace `signOut`:
+```typescript
+  const signOut = useCallback(async () => {
+    await api.logout();
+    setUser(null);
+  }, []);
+```
+with:
+```typescript
+  const signOut = useCallback(async () => {
+    await api.logout();
+    setUser(null);
+    setBitcoin(null);
+  }, []);
+```
+And add `bitcoin` to the provider value:
+```typescript
+      value={{ user, isAuthenticated: !!user, isLoading, sessionId, startOtp, verify, createIdentity, signOut }}
+```
+becomes:
+```typescript
+      value={{ user, isAuthenticated: !!user, isLoading, sessionId, bitcoin, startOtp, verify, createIdentity, signOut }}
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `cd apps/landing && bun test src/auth/turnkey-session.test.ts server/tests/auth-verify-token.test.ts`
+Expected: PASS — 3 tests pass (2 session helpers + 1 verify-otp token surface).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/landing/server/auth-routes.ts apps/landing/src/auth/turnkey-session.ts apps/landing/src/auth/api.ts apps/landing/src/auth/useAuth.tsx apps/landing/src/auth/turnkey-session.test.ts apps/landing/server/tests/auth-verify-token.test.ts apps/landing/package.json
+git commit -m "feat(landing): Turnkey OTP_LOGIN session + browser signing client + testnet4 funding account"
+```
+
+---
+
+## Task 4: Server `bitcoin.ts` — Turnkey-org faucet + QuickNode proxies
+
+**Files:**
+- Create: `apps/landing/server/bitcoin.ts`
+- Modify: `apps/landing/server/index.ts` (mount `/api/btc/*` in `buildRoutes` when configured)
+- Modify: `apps/landing/serve.ts` (pass the Bitcoin routes into the unified fetch)
+- Test: `apps/landing/server/tests/bitcoin.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `createBitcoinRoutes(deps: { turnkey; jwtSecret; provider: OrdinalsProvider; faucet: { walletId: string; address: string }; faucetSats?: number; now?: () => number }): { funding: Handler; sat: Handler; fee: Handler; broadcast: Handler }`.
+  - `POST /api/btc/funding` — authenticated. Builds a funding tx from the faucet's confirmed UTXOs (fetched via the provider) to the user's tb1q address (from the request body, validated as testnet), signs it with the **faucet Turnkey-org wallet** via `turnkey.apiClient().signTransaction`, broadcasts via `provider.broadcastTransaction`, returns `{ fundingUtxo: { txid, vout, value }, changeAddress }` (the user's own address). Per-user cap + rate-limit + "faucet empty" (507) states.
+  - `POST /api/btc/sat` `{ txid, vout }` → `{ satoshi }` via `provider.getFirstSatOfOutput`.
+  - `POST /api/btc/fee` `{ blocks? }` → `{ feeRate }` via `provider.estimateFee`.
+  - `POST /api/btc/broadcast` `{ txHex }` → `{ txid }` via `provider.broadcastTransaction`.
+  - `isBitcoinConfigured(): boolean` — `QUICKNODE_ENDPOINT` + `BTC_FAUCET_WALLET_ID` + `BTC_FAUCET_ADDRESS` present.
+  - `createOrdinalsProviderFromEnv()` (re-exported convenience from the SDK) selects `QuickNodeProvider` from env for the server.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/landing/server/tests/bitcoin.test.ts` (mock provider + mock Turnkey + a valid JWT cookie; the faucet build/sign is exercised with a mocked `signTransaction` returning a known raw hex, and broadcast is mocked):
+
+```typescript
+import { describe, test, expect } from 'bun:test';
+import { signToken, getAuthCookieConfig } from '@originals/auth/server';
+import { serializeCookie } from '../cookies';
+import { createBitcoinRoutes } from '../bitcoin';
+
+const JWT = 'test-secret-at-least-32-chars-long!!';
+
+function authedReq(path: string, body: unknown) {
+  const token = signToken('sub-1', 'a@b.com', undefined, { secret: JWT });
+  const cookie = serializeCookie(getAuthCookieConfig(token));
+  return new Request(`http://host${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify(body),
+  });
+}
+
+function fakeProvider() {
+  return {
+    async getFirstSatOfOutput() { return '5000000000'; },
+    async estimateFee() { return 3; },
+    async broadcastTransaction() { return 'f'.repeat(64); },
+    // The faucet needs the faucet's spendable UTXOs; expose a small helper.
+    async getSpendableUtxos() {
+      return [{ txid: 'a'.repeat(64), vout: 0, value: 100_000, scriptPubKey: '0014' + '0'.repeat(40) }];
+    },
+  } as unknown as Parameters<typeof createBitcoinRoutes>[0]['provider'];
+}
+
+function fakeTurnkey() {
+  return {
+    apiClient: () => ({
+      // Faucet signing: returns broadcast-ready hex (already finalized server-side).
+      signTransaction: async () => ({ activity: { result: { signTransactionResult: { signedTransaction: '0200000000' } } } }),
+    }),
+  } as unknown as Parameters<typeof createBitcoinRoutes>[0]['turnkey'];
+}
+
+const deps = () => ({
+  turnkey: fakeTurnkey(),
+  jwtSecret: JWT,
+  provider: fakeProvider(),
+  faucet: { walletId: 'w-faucet', address: 'tb1qfaucet00000000000000000000000000000000' },
+  faucetSats: 20_000,
+});
+
+describe('bitcoin routes', () => {
+  test('POST /api/btc/sat proxies getFirstSatOfOutput', async () => {
+    const r = createBitcoinRoutes(deps());
+    const req = authedReq('/api/btc/sat', { txid: 'a'.repeat(64), vout: 0 });
+    const res = await r.sat(req, new URL(req.url));
+    expect(res.status).toBe(200);
+    expect((await res.json()).satoshi).toBe('5000000000');
+  });
+
+  test('POST /api/btc/fee proxies estimateFee', async () => {
+    const r = createBitcoinRoutes(deps());
+    const req = authedReq('/api/btc/fee', { blocks: 1 });
+    const res = await r.fee(req, new URL(req.url));
+    expect((await res.json()).feeRate).toBe(3);
+  });
+
+  test('POST /api/btc/broadcast proxies broadcastTransaction', async () => {
+    const r = createBitcoinRoutes(deps());
+    const req = authedReq('/api/btc/broadcast', { txHex: '0200000000' });
+    const res = await r.broadcast(req, new URL(req.url));
+    expect((await res.json()).txid).toBe('f'.repeat(64));
+  });
+
+  test('anonymous request is rejected 401', async () => {
+    const r = createBitcoinRoutes(deps());
+    const req = new Request('http://host/api/btc/sat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ txid: 'a'.repeat(64), vout: 0 }),
+    });
+    const res = await r.sat(req, new URL(req.url));
+    expect(res.status).toBe(401);
+  });
+
+  test('POST /api/btc/funding returns the user\'s funded outpoint + change address', async () => {
+    const r = createBitcoinRoutes(deps());
+    const userAddr = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx';
+    const req = authedReq('/api/btc/funding', { address: userAddr });
+    const res = await r.funding(req, new URL(req.url));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { fundingUtxo: { txid: string; vout: number; value: number }; changeAddress: string };
+    expect(body.changeAddress).toBe(userAddr);
+    expect(body.fundingUtxo.txid).toMatch(/^[0-9a-f]{64}$/);
+    expect(body.fundingUtxo.value).toBe(20_000);
+  });
+
+  test('funding rejects a non-testnet address 400', async () => {
+    const r = createBitcoinRoutes(deps());
+    const req = authedReq('/api/btc/funding', { address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4' });
+    const res = await r.funding(req, new URL(req.url));
+    expect(res.status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/landing && bun test server/tests/bitcoin.test.ts`
+Expected: FAIL — `Cannot find module '../bitcoin'`.
+
+- [ ] **Step 3: Implement `apps/landing/server/bitcoin.ts`**
+
+```typescript
+/**
+ * Server Bitcoin routes: a Turnkey-org faucet + thin QuickNode proxies.
+ *
+ * NO raw private key on the server: the faucet is a Turnkey-org wallet, signed
+ * with the SAME Turnkey API creds auth already uses. The user's inscription is
+ * signed in the browser by the user's own Turnkey session key. Every route is
+ * auth-gated (JWT cookie) + rate-limited. The faucet signs ONLY its own funding
+ * tx to a logged-in user's testnet address — never a general signing oracle.
+ */
+import * as btc from '@scure/btc-signer';
+import { hex, base64 } from '@scure/base';
+import type { Turnkey } from '@turnkey/sdk-server';
+import { verifyToken } from '@originals/auth/server';
+import type { OrdinalsProvider } from '@originals/sdk';
+import { isValidBitcoinAddress } from '@originals/sdk';
+import { json, type Handler } from './router';
+import { extractToken } from './cookies';
+import { createRateLimiter } from './rate-limit';
+
+export function isBitcoinConfigured(): boolean {
+  return (
+    !!process.env.QUICKNODE_ENDPOINT &&
+    !!process.env.BTC_FAUCET_WALLET_ID &&
+    !!process.env.BTC_FAUCET_ADDRESS
+  );
+}
+
+// Provider surface these routes use (a superset of OrdinalsProvider — the
+// faucet also needs the faucet wallet's spendable UTXOs). Production wires a
+// QuickNodeProvider whose getSpendableUtxos lists the faucet address's UTXOs.
+export interface FaucetProvider extends OrdinalsProvider {
+  getSpendableUtxos(address: string): Promise<
+    Array<{ txid: string; vout: number; value: number; scriptPubKey: string }>
+  >;
+}
+
+export function createBitcoinRoutes(deps: {
+  turnkey: Turnkey;
+  jwtSecret: string;
+  provider: OrdinalsProvider | FaucetProvider;
+  faucet: { walletId: string; address: string };
+  faucetSats?: number;
+  now?: () => number;
+}): { funding: Handler; sat: Handler; fee: Handler; broadcast: Handler } {
+  const faucetSats = deps.faucetSats ?? 20_000;
+  const ipLimiter = createRateLimiter({ limit: 30, windowMs: 60_000 });
+  const userLimiter = createRateLimiter({ limit: 5, windowMs: 60 * 60_000 }); // 5 fundings / user / hour
+  const provider = deps.provider as FaucetProvider;
+
+  function clientIp(req: Request): string {
+    return req.headers.get('x-forwarded-for')?.split(',')[0].trim() || 'local';
+  }
+
+  /** Returns the authenticated subOrgId, or null (→ 401). */
+  function authSub(req: Request): string | null {
+    const token = extractToken(req);
+    if (!token) return null;
+    try {
+      return verifyToken(token, { secret: deps.jwtSecret }).sub;
+    } catch {
+      return null;
+    }
+  }
+
+  function rateLimited(req: Request): Response | null {
+    const rl = ipLimiter.check(clientIp(req));
+    if (!rl.allowed) {
+      return json({ error: 'rate_limited' }, 429, {
+        'Retry-After': String(Math.ceil(rl.retryAfterMs / 1000)),
+      });
+    }
+    return null;
+  }
+
+  const sat: Handler = async (req) => {
+    if (!authSub(req)) return json({ error: 'unauthorized' }, 401);
+    const limited = rateLimited(req);
+    if (limited) return limited;
+    const { txid, vout } = (await req.json().catch(() => ({}))) as { txid?: string; vout?: number };
+    if (typeof txid !== 'string' || typeof vout !== 'number') return json({ error: 'bad_request' }, 400);
+    if (typeof provider.getFirstSatOfOutput !== 'function') return json({ error: 'sat_index_unsupported' }, 501);
+    try {
+      const satoshi = await provider.getFirstSatOfOutput({ txid, vout });
+      return json({ satoshi });
+    } catch (e) {
+      return json({ error: 'sat_lookup_failed', message: (e as Error).message }, 502);
+    }
+  };
+
+  const fee: Handler = async (req) => {
+    if (!authSub(req)) return json({ error: 'unauthorized' }, 401);
+    const limited = rateLimited(req);
+    if (limited) return limited;
+    const { blocks } = (await req.json().catch(() => ({}))) as { blocks?: number };
+    try {
+      const feeRate = await provider.estimateFee(typeof blocks === 'number' ? blocks : 1);
+      return json({ feeRate });
+    } catch (e) {
+      return json({ error: 'fee_estimate_failed', message: (e as Error).message }, 502);
+    }
+  };
+
+  const broadcast: Handler = async (req) => {
+    if (!authSub(req)) return json({ error: 'unauthorized' }, 401);
+    const limited = rateLimited(req);
+    if (limited) return limited;
+    const { txHex } = (await req.json().catch(() => ({}))) as { txHex?: string };
+    if (typeof txHex !== 'string' || !/^(?:[0-9a-fA-F]{2})+$/.test(txHex)) return json({ error: 'bad_tx_hex' }, 400);
+    try {
+      const txid = await provider.broadcastTransaction(txHex);
+      return json({ txid });
+    } catch (e) {
+      return json({ error: 'broadcast_failed', message: (e as Error).message }, 502);
+    }
+  };
+
+  const funding: Handler = async (req) => {
+    const sub = authSub(req);
+    if (!sub) return json({ error: 'unauthorized' }, 401);
+    const limited = rateLimited(req);
+    if (limited) return limited;
+    const perUser = userLimiter.check(sub);
+    if (!perUser.allowed) {
+      return json({ error: 'faucet_user_cap', message: 'Per-user faucet limit reached; try again later.' }, 429, {
+        'Retry-After': String(Math.ceil(perUser.retryAfterMs / 1000)),
+      });
+    }
+
+    const { address } = (await req.json().catch(() => ({}))) as { address?: string };
+    if (!address || !isValidBitcoinAddress(address, 'testnet')) {
+      return json({ error: 'bad_address', message: 'A testnet4 P2WPKH (tb1) address is required.' }, 400);
+    }
+
+    // 1) Gather the faucet's spendable UTXOs; pick enough to cover fundingSats +
+    //    a fixed 1 sat/vB fee floor. Empty faucet → 507.
+    let faucetUtxos: Array<{ txid: string; vout: number; value: number; scriptPubKey: string }>;
+    try {
+      faucetUtxos = await provider.getSpendableUtxos(deps.faucet.address);
+    } catch (e) {
+      return json({ error: 'faucet_unavailable', message: (e as Error).message }, 502);
+    }
+    const totalAvail = faucetUtxos.reduce((n, u) => n + u.value, 0);
+    if (faucetUtxos.length === 0 || totalAvail < faucetSats + 500) {
+      return json({ error: 'faucet_empty', message: 'The testnet4 faucet is out of funds. Try again later.' }, 507);
+    }
+
+    // 2) Build the funding tx: faucet UTXOs in, fundingSats to the user, change
+    //    back to the faucet. Fee = feeRate * estimated vsize (simple P2WPKH).
+    let feeRate = 1;
+    try { feeRate = Math.max(1, Math.ceil(await provider.estimateFee(1))); } catch { /* floor */ }
+    const selected: typeof faucetUtxos = [];
+    let inSats = 0;
+    for (const u of faucetUtxos) {
+      selected.push(u);
+      inSats += u.value;
+      if (inSats >= faucetSats + 200) break;
+    }
+    // vsize ~ 10.5 + 68*inputs + 31*2 outputs (P2WPKH), rounded up.
+    const vsize = Math.ceil(10.5 + 68 * selected.length + 31 * 2);
+    const fee = feeRate * vsize;
+    const change = inSats - faucetSats - fee;
+    if (change < 0) return json({ error: 'faucet_empty', message: 'Faucet UTXOs too small for the fee.' }, 507);
+
+    const tx = new btc.Transaction();
+    for (const u of selected) {
+      tx.addInput({
+        txid: hex.decode(u.txid),
+        index: u.vout,
+        witnessUtxo: { script: hex.decode(u.scriptPubKey), amount: BigInt(u.value) },
+      });
+    }
+    tx.addOutputAddress(address, BigInt(faucetSats), btc.TEST_NETWORK);
+    if (change > 330) tx.addOutputAddress(deps.faucet.address, BigInt(change), btc.TEST_NETWORK);
+
+    // 3) Sign with the faucet Turnkey-org wallet (unsigned PSBT hex → Turnkey →
+    //    broadcast-ready hex). NO raw key: Turnkey holds the faucet key.
+    const unsignedHex = hex.encode(tx.toPSBT());
+    let signedTxHex: string;
+    try {
+      const result = await deps.turnkey.apiClient().signTransaction({
+        organizationId: process.env.TURNKEY_ORGANIZATION_ID!,
+        signWith: deps.faucet.address,
+        unsignedTransaction: unsignedHex,
+        type: 'TRANSACTION_TYPE_BITCOIN',
+      } as never);
+      // Turnkey returns either broadcast-ready hex or a partially-signed PSBT.
+      const signed =
+        (result as { activity?: { result?: { signTransactionResult?: { signedTransaction?: string } } } })
+          .activity?.result?.signTransactionResult?.signedTransaction;
+      if (!signed) throw new Error('Turnkey signTransaction returned no signedTransaction');
+      // If Turnkey returned a PSBT, finalize it; if already raw hex, pass through.
+      signedTxHex = maybeFinalize(signed);
+    } catch (e) {
+      return json({ error: 'faucet_sign_failed', message: (e as Error).message }, 502);
+    }
+
+    // 4) Broadcast; the funded outpoint is vout 0 (the user output).
+    let txid: string;
+    try {
+      txid = await provider.broadcastTransaction(signedTxHex);
+    } catch (e) {
+      return json({ error: 'faucet_broadcast_failed', message: (e as Error).message }, 502);
+    }
+
+    return json({
+      fundingUtxo: { txid, vout: 0, value: faucetSats },
+      changeAddress: address, // the user's own address is the inscription change/reveal dest
+    });
+  };
+
+  return { funding, sat, fee, broadcast };
+}
+
+/** Pass raw tx hex through; finalize a PSBT (base64 or hex) into raw hex. */
+function maybeFinalize(signed: string): string {
+  // Raw tx hex parses as a Transaction and has inputs already witnessed.
+  try {
+    const asRaw = btc.Transaction.fromRaw(hex.decode(signed), { allowUnknownInputs: true, allowUnknownOutputs: true });
+    return hex.encode(asRaw.extract());
+  } catch { /* not raw hex — try PSBT below */ }
+  const bytes = /^[0-9a-fA-F]+$/.test(signed) ? hex.decode(signed) : base64.decode(signed);
+  const tx = btc.Transaction.fromPSBT(bytes, { allowUnknownInputs: true, allowUnknownOutputs: true });
+  tx.finalize();
+  return hex.encode(tx.extract());
+}
+```
+
+Note: `getSpendableUtxos` is NOT on the base `OrdinalsProvider` interface — the production server wires a `QuickNodeProvider` subclass (or a thin wrapper) exposing it via `ord`/`scantxoutset`/an address-index RPC on the faucet address. That wrapper is a one-method extension built in `serve.ts` (Step 5); the route logic here depends only on the `FaucetProvider` shape. `signTransaction`'s exact result envelope may differ across `@turnkey/sdk-server` versions — `maybeFinalize` tolerates both raw-hex and PSBT returns, which is the manual-smoke verification point.
+
+- [ ] **Step 4: Mount the routes in `server/index.ts` when configured**
+
+In `apps/landing/server/index.ts`, extend `buildRoutes` to accept optional Bitcoin routes and mount them. Replace the `buildRoutes` signature + body:
+```typescript
+export function buildRoutes(deps: {
+  turnkey: Turnkey;
+  sessions: SessionStorage;
+  jwtSecret: string;
+}): Record<string, Handler> {
+  const auth = createAuthRoutes(deps);
+  return {
+    'GET /api/health': () => json({ status: 'ok' }),
+    'POST /api/auth/send-otp': auth.sendOtp,
+    'POST /api/auth/verify-otp': auth.verifyOtp,
+    'GET /api/me': auth.me,
+    'POST /api/auth/logout': auth.logout,
+  };
+}
+```
+with:
+```typescript
+import type { BitcoinRoutes } from './bitcoin';
+
+export function buildRoutes(deps: {
+  turnkey: Turnkey;
+  sessions: SessionStorage;
+  jwtSecret: string;
+  bitcoin?: BitcoinRoutes;
+}): Record<string, Handler> {
+  const auth = createAuthRoutes(deps);
+  const routes: Record<string, Handler> = {
+    'GET /api/health': () => json({ status: 'ok' }),
+    'POST /api/auth/send-otp': auth.sendOtp,
+    'POST /api/auth/verify-otp': auth.verifyOtp,
+    'GET /api/me': auth.me,
+    'POST /api/auth/logout': auth.logout,
+  };
+  if (deps.bitcoin) {
+    routes['POST /api/btc/funding'] = deps.bitcoin.funding;
+    routes['POST /api/btc/sat'] = deps.bitcoin.sat;
+    routes['POST /api/btc/fee'] = deps.bitcoin.fee;
+    routes['POST /api/btc/broadcast'] = deps.bitcoin.broadcast;
+  }
+  return routes;
+}
+```
+Add the `BitcoinRoutes` type export at the top of `apps/landing/server/bitcoin.ts` (so `index.ts` can import it) — add after `createBitcoinRoutes`'s return-type usage:
+```typescript
+export type BitcoinRoutes = ReturnType<typeof createBitcoinRoutes>;
+```
+
+- [ ] **Step 5: Wire the Bitcoin routes into `serve.ts` (env-gated)**
+
+In `apps/landing/serve.ts`, after the `routes` are built, construct the Bitcoin routes when configured. Replace the auth-config block:
+```typescript
+let routes;
+if (jwtSecret && turnkeyConfigured) {
+  routes = buildRoutes({
+    turnkey: getTurnkey(),
+    sessions: createInMemorySessionStorage(),
+    jwtSecret,
+  });
+  console.log('[landing] auth configured — /api/auth/* live');
+} else {
+  console.warn(
+    '[landing] auth unconfigured (JWT_SECRET/TURNKEY_* absent) — /api/auth/* returns 503; SPA + did:webvh hosting still work'
+  );
+  routes = buildStubRoutes();
+}
+```
+with:
+```typescript
+let routes;
+if (jwtSecret && turnkeyConfigured) {
+  const turnkey = getTurnkey();
+  let bitcoin: import('./server/bitcoin').BitcoinRoutes | undefined;
+  if (isBitcoinConfigured()) {
+    // QuickNodeProvider gives sat/fee/broadcast; a thin subclass adds the
+    // faucet's spendable-UTXO lookup. No raw key — the faucet is a Turnkey wallet.
+    const provider = createFaucetProviderFromEnv();
+    bitcoin = createBitcoinRoutes({
+      turnkey,
+      jwtSecret,
+      provider,
+      faucet: { walletId: process.env.BTC_FAUCET_WALLET_ID!, address: process.env.BTC_FAUCET_ADDRESS! },
+      faucetSats: Number(process.env.BTC_FAUCET_SATS ?? 20_000),
+    });
+    console.log('[landing] testnet4 inscription configured — /api/btc/* live');
+  } else {
+    console.warn('[landing] testnet4 inscription disabled (QUICKNODE_ENDPOINT/BTC_FAUCET_* absent) — inscribe stays mock');
+  }
+  routes = buildRoutes({
+    turnkey,
+    sessions: createInMemorySessionStorage(),
+    jwtSecret,
+    bitcoin,
+  });
+  console.log('[landing] auth configured — /api/auth/* live');
+} else {
+  console.warn(
+    '[landing] auth unconfigured (JWT_SECRET/TURNKEY_* absent) — /api/auth/* returns 503; SPA + did:webvh hosting still work'
+  );
+  routes = buildStubRoutes();
+}
+```
+Add the imports + the `createFaucetProviderFromEnv` helper at the top of `serve.ts`:
+```typescript
+import { QuickNodeProvider } from '@originals/sdk';
+import { createBitcoinRoutes, isBitcoinConfigured, type FaucetProvider } from './server/bitcoin';
+
+// QuickNodeProvider + a faucet UTXO lookup. getSpendableUtxos uses the Ordinals
+// add-on's address index (ord_getAddressOutputs) or bitcoind scantxoutset. The
+// exact RPC is a manual-smoke wiring point; the shape is fixed here.
+function createFaucetProviderFromEnv(): FaucetProvider {
+  const base = new QuickNodeProvider({
+    endpoint: process.env.QUICKNODE_ENDPOINT!,
+    expectedNetwork: 'testnet',
+  });
+  const provider = base as unknown as FaucetProvider;
+  provider.getSpendableUtxos = async (address: string) => {
+    // Placeholder wiring the deploy fills in against its QuickNode add-on:
+    // return confirmed P2WPKH UTXOs for `address` as { txid, vout, value, scriptPubKey }.
+    throw new Error(
+      `getSpendableUtxos not wired for ${address}: implement against the QuickNode Ordinals add-on address index or bitcoind scantxoutset before enabling the faucet.`
+    );
+  };
+  return provider;
+}
+```
+Note: this leaves `getSpendableUtxos` as an explicit throw-until-wired — the faucet route fails loudly (`faucet_unavailable`, 502) until the deploy provides the address-index call, which is a genuine operational choice (QuickNode's UTXO listing depends on the add-on/plan). The automated tests inject a fake provider, so they are unaffected. This throw is intentional, not a placeholder-in-shipping-logic: it is the honest "not configured" state.
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cd apps/landing && bun test server/tests/bitcoin.test.ts`
+Expected: PASS — 6 tests pass.
+
+- [ ] **Step 7: Confirm the server suite still passes**
+
+Run: `cd apps/landing && bun test server/tests/app.test.ts server/tests/webvh-host.test.ts server/tests/bitcoin.test.ts server/tests/auth-verify-token.test.ts`
+Expected: PASS — all server suites green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/landing/server/bitcoin.ts apps/landing/server/index.ts apps/landing/serve.ts apps/landing/server/tests/bitcoin.test.ts
+git commit -m "feat(landing): server bitcoin.ts — Turnkey-org faucet + QuickNode /api/btc/* proxies (env-gated)"
+```
+
+---
+
+## Task 5: `HttpOrdinalsProvider` (browser SDK `OrdinalsProvider` over `/api/btc/*`)
+
+**Files:**
+- Create: `apps/landing/src/sdk/http-ordinals-provider.ts`
+- Test: `apps/landing/src/sdk/http-ordinals-provider.test.ts`
+
+**Interfaces:**
+- Produces: `class HttpOrdinalsProvider implements OrdinalsProvider` where the ONLY implemented methods are `getFirstSatOfOutput` (`POST /api/btc/sat`), `estimateFee` (`POST /api/btc/fee`), `broadcastTransaction` (`POST /api/btc/broadcast`). Every other `OrdinalsProvider` method (`getInscriptionById`, `getInscriptionsBySatoshi`, `getTransactionStatus`, `createInscription`, `transferInscription`) REJECTS by design — the SDK's sat-selected inscribe path never calls them (verified in `inscribe-on-sat.ts`), and the commit/reveal are built + self-signed locally. `constructor(opts?: { baseUrl?: string; fetchImpl?: typeof fetch })`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/landing/src/sdk/http-ordinals-provider.test.ts`:
+
+```typescript
+import { describe, test, expect } from 'bun:test';
+import { HttpOrdinalsProvider } from './http-ordinals-provider';
+
+function mockFetch(routes: Record<string, unknown>) {
+  const calls: Array<{ url: string; body: unknown }> = [];
+  const impl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const body = init?.body ? JSON.parse(init.body as string) : undefined;
+    calls.push({ url, body });
+    const key = new URL(url, 'http://x').pathname;
+    if (!(key in routes)) return new Response('nope', { status: 404 });
+    return new Response(JSON.stringify(routes[key]), { status: 200, headers: { 'content-type': 'application/json' } });
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+describe('HttpOrdinalsProvider', () => {
+  test('getFirstSatOfOutput hits /api/btc/sat and returns the sat', async () => {
+    const { impl, calls } = mockFetch({ '/api/btc/sat': { satoshi: '5000000000' } });
+    const p = new HttpOrdinalsProvider({ baseUrl: '', fetchImpl: impl });
+    const sat = await p.getFirstSatOfOutput({ txid: 'a'.repeat(64), vout: 0 });
+    expect(sat).toBe('5000000000');
+    expect(calls[0].url).toBe('/api/btc/sat');
+    expect(calls[0].body).toEqual({ txid: 'a'.repeat(64), vout: 0 });
+  });
+
+  test('estimateFee hits /api/btc/fee', async () => {
+    const { impl } = mockFetch({ '/api/btc/fee': { feeRate: 4 } });
+    const p = new HttpOrdinalsProvider({ baseUrl: '', fetchImpl: impl });
+    expect(await p.estimateFee(1)).toBe(4);
+  });
+
+  test('broadcastTransaction hits /api/btc/broadcast and returns txid', async () => {
+    const { impl, calls } = mockFetch({ '/api/btc/broadcast': { txid: 'f'.repeat(64) } });
+    const p = new HttpOrdinalsProvider({ baseUrl: '', fetchImpl: impl });
+    expect(await p.broadcastTransaction('0200000000')).toBe('f'.repeat(64));
+    expect(calls[0].body).toEqual({ txHex: '0200000000' });
+  });
+
+  test('createInscription rejects by design (tx built locally)', async () => {
+    const { impl } = mockFetch({});
+    const p = new HttpOrdinalsProvider({ baseUrl: '', fetchImpl: impl });
+    await expect(p.createInscription({ contentType: 'text/plain' })).rejects.toThrow();
+  });
+
+  test('broadcast surfaces a server error as a throw', async () => {
+    const failing = (async () => new Response(JSON.stringify({ error: 'broadcast_failed' }), { status: 502 })) as unknown as typeof fetch;
+    const p = new HttpOrdinalsProvider({ baseUrl: '', fetchImpl: failing });
+    await expect(p.broadcastTransaction('0200000000')).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/landing && bun test src/sdk/http-ordinals-provider.test.ts`
+Expected: FAIL — `Cannot find module './http-ordinals-provider'`.
+
+- [ ] **Step 3: Implement `apps/landing/src/sdk/http-ordinals-provider.ts`**
+
+```typescript
+/**
+ * SDK OrdinalsProvider backed by this origin's /api/btc/* QuickNode proxies.
+ *
+ * The SDK's sat-selected inscribe path (inscribe-on-sat.ts) uses ONLY
+ * getFirstSatOfOutput, estimateFee and broadcastTransaction; the commit/reveal
+ * are built and self-signed locally (the reveal with an ephemeral key). Every
+ * other OrdinalsProvider method therefore rejects by design — mirroring
+ * QuickNodeProvider's "does not build/sign" contract — so a mislabeled read can
+ * never silently fabricate on-chain data in the browser.
+ */
+import type { OrdinalsProvider } from '@originals/sdk';
+
+export class HttpOrdinalsProvider implements OrdinalsProvider {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts?: { baseUrl?: string; fetchImpl?: typeof fetch }) {
+    this.baseUrl = opts?.baseUrl ?? '';
+    this.fetchImpl = opts?.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  }
+
+  private async post<T>(path: string, body: unknown): Promise<T> {
+    const res = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      credentials: 'same-origin',
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      let detail = '';
+      try { detail = JSON.stringify(await res.json()); } catch { /* ignore */ }
+      throw new Error(`HttpOrdinalsProvider ${path} failed: ${res.status} ${detail}`);
+    }
+    return (await res.json()) as T;
+  }
+
+  async getFirstSatOfOutput(outpoint: { txid: string; vout: number }): Promise<string> {
+    const { satoshi } = await this.post<{ satoshi: string }>('/api/btc/sat', outpoint);
+    return satoshi;
+  }
+
+  async estimateFee(blocks = 1): Promise<number> {
+    const { feeRate } = await this.post<{ feeRate: number }>('/api/btc/fee', { blocks });
+    return feeRate;
+  }
+
+  async broadcastTransaction(txHexOrObj: unknown): Promise<string> {
+    if (typeof txHexOrObj !== 'string') {
+      throw new Error('HttpOrdinalsProvider.broadcastTransaction requires raw tx hex');
+    }
+    const { txid } = await this.post<{ txid: string }>('/api/btc/broadcast', { txHex: txHexOrObj });
+    return txid;
+  }
+
+  // --- Not implemented (the sat-selected inscribe path never calls these). ---
+  getInscriptionById(): Promise<never> {
+    return Promise.reject(new Error('HttpOrdinalsProvider.getInscriptionById is not implemented in the browser demo.'));
+  }
+  getInscriptionsBySatoshi(): Promise<never> {
+    return Promise.reject(new Error('HttpOrdinalsProvider.getInscriptionsBySatoshi is not implemented in the browser demo.'));
+  }
+  getTransactionStatus(): Promise<never> {
+    return Promise.reject(new Error('HttpOrdinalsProvider.getTransactionStatus is not implemented in the browser demo.'));
+  }
+  createInscription(): Promise<never> {
+    return Promise.reject(new Error('HttpOrdinalsProvider.createInscription is not implemented: the commit/reveal are built and signed locally, then broadcast via broadcastTransaction.'));
+  }
+  transferInscription(): Promise<never> {
+    return Promise.reject(new Error('HttpOrdinalsProvider.transferInscription is not implemented in the browser demo.'));
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/landing && bun test src/sdk/http-ordinals-provider.test.ts`
+Expected: PASS — 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/landing/src/sdk/http-ordinals-provider.ts apps/landing/src/sdk/http-ordinals-provider.test.ts
+git commit -m "feat(landing): HttpOrdinalsProvider over /api/btc/{sat,fee,broadcast}"
+```
+
+---
+
+## Task 6: `TurnkeySatSigner` (browser SDK `BitcoinSigner`)
+
+**Files:**
+- Create: `apps/landing/src/sdk/turnkey-sat-signer.ts`
+- Test: `apps/landing/src/sdk/turnkey-sat-signer.test.ts`
+
+**Interfaces:**
+- Produces: `class TurnkeySatSigner implements BitcoinSigner` — `signAndFinalizeCommitPsbt(psbtBase64: string): Promise<string>` = decode base64→hex → `client.signTransaction({ signWith, unsignedTransaction, type: 'TRANSACTION_TYPE_BITCOIN' })` → extract the signed PSBT/hex from the Turnkey result → `finalizeSignedPsbt` (Task 2) → broadcast-ready hex. `constructor(opts: { client: TurnkeyBitcoinClient; signWith: string })` where `signWith` is the user's tb1q funding address.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/landing/src/sdk/turnkey-sat-signer.test.ts`. The mock Turnkey `signTransaction` stands in by signing the input PSBT locally with a known key (the "partially-signed" return), then asserts the signer produces finalized, broadcast-ready hex:
+
+```typescript
+import { describe, test, expect } from 'bun:test';
+import * as btc from '@scure/btc-signer';
+import { hex, base64 } from '@scure/base';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { TurnkeySatSigner } from './turnkey-sat-signer';
+import type { TurnkeyBitcoinClient } from '../auth/turnkey-session';
+
+const priv = hex.decode('2222222222222222222222222222222222222222222222222222222222222222');
+const pub = secp256k1.getPublicKey(priv, true);
+const p2wpkh = btc.p2wpkh(pub, btc.TEST_NETWORK);
+
+// Build the UNSIGNED commit PSBT the SDK would hand the signer (base64).
+function unsignedCommitPsbtBase64(): string {
+  const tx = new btc.Transaction();
+  tx.addInput({ txid: hex.decode('c'.repeat(64)), index: 0, witnessUtxo: { script: p2wpkh.script, amount: 30_000n } });
+  tx.addOutputAddress('tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx', 20_000n, btc.TEST_NETWORK);
+  return base64.encode(tx.toPSBT());
+}
+
+// Mock Turnkey: signs the given unsigned PSBT (hex) locally and returns a
+// partially-signed PSBT — exactly Turnkey signTransaction's shape.
+const mockClient: TurnkeyBitcoinClient = {
+  async signTransaction({ unsignedTransaction, type }) {
+    expect(type).toBe('TRANSACTION_TYPE_BITCOIN');
+    const tx = btc.Transaction.fromPSBT(hex.decode(unsignedTransaction), { allowUnknownInputs: true, allowUnknownOutputs: true });
+    tx.sign(priv); // partially-signed, NOT finalized
+    return { signedTransaction: hex.encode(tx.toPSBT()) };
+  },
+  async createWalletAccounts() { throw new Error('not used'); },
+  async getWallets() { throw new Error('not used'); },
+};
+
+describe('TurnkeySatSigner', () => {
+  test('signAndFinalizeCommitPsbt returns broadcast-ready hex with a witness', async () => {
+    const signer = new TurnkeySatSigner({ client: mockClient, signWith: 'tb1quseraddr' });
+    const rawHex = await signer.signAndFinalizeCommitPsbt(unsignedCommitPsbtBase64());
+    const parsed = btc.Transaction.fromRaw(hex.decode(rawHex));
+    expect(parsed.inputsLength).toBe(1);
+    expect(parsed.getInput(0).finalScriptWitness).toBeDefined();
+  });
+
+  test('rejects when Turnkey returns nothing signable', async () => {
+    const bad: TurnkeyBitcoinClient = {
+      async signTransaction() { return { signedTransaction: '' }; },
+      async createWalletAccounts() { throw new Error('x'); },
+      async getWallets() { throw new Error('x'); },
+    };
+    const signer = new TurnkeySatSigner({ client: bad, signWith: 'tb1quseraddr' });
+    await expect(signer.signAndFinalizeCommitPsbt(unsignedCommitPsbtBase64())).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/landing && bun test src/sdk/turnkey-sat-signer.test.ts`
+Expected: FAIL — `Cannot find module './turnkey-sat-signer'`.
+
+- [ ] **Step 3: Implement `apps/landing/src/sdk/turnkey-sat-signer.ts`**
+
+```typescript
+/**
+ * SDK BitcoinSigner backed by the user's Turnkey session key.
+ *
+ * The SDK's inscribe-on-sat path builds the commit PSBT and hands it here as
+ * base64; we convert to hex, sign the P2WPKH funding input via Turnkey
+ * signTransaction (SIGHASH_ALL; Turnkey owns sighash/DER/low-S), then finalize
+ * with @scure/btc-signer into broadcast-ready hex (the SDK rejects a returned
+ * PSBT). Only the COMMIT is signed here — the reveal is self-signed by the SDK's
+ * ephemeral key. Signing is silent within the Turnkey session window.
+ */
+import type { BitcoinSigner } from '@originals/sdk';
+import { base64, hex } from '@scure/base';
+import * as btc from '@scure/btc-signer';
+import { finalizeSignedPsbt } from './finalize-psbt';
+import type { TurnkeyBitcoinClient } from '../auth/turnkey-session';
+
+export class TurnkeySatSigner implements BitcoinSigner {
+  private readonly client: TurnkeyBitcoinClient;
+  private readonly signWith: string;
+
+  constructor(opts: { client: TurnkeyBitcoinClient; signWith: string }) {
+    this.client = opts.client;
+    this.signWith = opts.signWith;
+  }
+
+  async signAndFinalizeCommitPsbt(psbtBase64: string): Promise<string> {
+    const unsignedHex = hex.encode(base64.decode(psbtBase64));
+    const result = await this.client.signTransaction({
+      signWith: this.signWith,
+      unsignedTransaction: unsignedHex,
+      type: 'TRANSACTION_TYPE_BITCOIN',
+    });
+    const signed = result?.signedTransaction;
+    if (!signed) {
+      throw new Error('TurnkeySatSigner: Turnkey signTransaction returned no signedTransaction.');
+    }
+    // Turnkey may return raw hex (already finalized) or a partially-signed PSBT.
+    // Raw hex round-trips through Transaction.fromRaw; anything else is a PSBT
+    // (hex or base64) that finalizeSignedPsbt assembles into broadcast-ready hex.
+    try {
+      const raw = btc.Transaction.fromRaw(hex.decode(signed), { allowUnknownInputs: true, allowUnknownOutputs: true });
+      if (raw.getInput(0).finalScriptWitness) return hex.encode(raw.extract());
+    } catch { /* not raw finalized hex — treat as PSBT below */ }
+    const psbtBase64Out = /^[0-9a-fA-F]+$/.test(signed) ? base64.encode(hex.decode(signed)) : signed;
+    return finalizeSignedPsbt(psbtBase64Out);
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/landing && bun test src/sdk/turnkey-sat-signer.test.ts`
+Expected: PASS — 2 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/landing/src/sdk/turnkey-sat-signer.ts apps/landing/src/sdk/turnkey-sat-signer.test.ts
+git commit -m "feat(landing): TurnkeySatSigner — user Turnkey key signs the commit, scure finalizes"
+```
+
+---
+
+## Task 7: Engine wiring — testnet4 config, login-gated inscribe, real txid
+
+**Files:**
+- Modify: `apps/landing/src/sdk/engine.ts` (constructor provider/network selection; `inscribe()` sat-selected path; explorer helper; `DemoAssetState.inscription.explorerUrl`)
+- Test: `apps/landing/src/sdk/engine.inscribe.test.ts`
+
+**Interfaces:**
+- Consumes: `HttpOrdinalsProvider` (Task 5), `TurnkeySatSigner` (Task 6), `TurnkeyBitcoinClient` (Task 3).
+- Produces:
+  - Module helper `btcTestnetEnabled(): boolean` (`import.meta.env.VITE_BTC_TESTNET === '1'`).
+  - Constructor: when `btcTestnetEnabled()`, `network: 'testnet'` + `ordinalsProvider: new HttpOrdinalsProvider()`; else `network: 'regtest'` + `OrdMockProvider()` (unchanged mock path).
+  - `DemoEngine.inscribe(opts?: { feeRate?; funding?: { fundingUtxo; changeAddress; signingClient: TurnkeyBitcoinClient } })`. With `funding` present → sat-selected real path: build a `TurnkeySatSigner`, call `inscribeOnBitcoin(asset, { fundingUtxo, satSigner, changeAddress, feeRate })`. Without → the legacy bare-feeRate mock path.
+  - `DemoAssetState.inscription` gains `explorerUrl?: string` (`https://mempool.space/testnet4/tx/<txid>` when testnet, else undefined).
+  - Module helper `btcoExplorerUrl(txid: string): string | undefined`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/landing/src/sdk/engine.inscribe.test.ts`:
+
+```typescript
+import { describe, test, expect } from 'bun:test';
+import { DemoEngine, btcoExplorerUrl } from './engine';
+
+describe('engine inscribe wiring', () => {
+  test('btcoExplorerUrl builds a testnet4 mempool link', () => {
+    // Only meaningful when testnet is enabled; the helper is pure.
+    const url = btcoExplorerUrl('f'.repeat(64));
+    // In the default (mock) test env VITE_BTC_TESTNET is unset → undefined.
+    expect(url === undefined || url === `https://mempool.space/testnet4/tx/${'f'.repeat(64)}`).toBe(true);
+  });
+
+  test('inscribe() without funding runs the mock path and still yields an inscription', async () => {
+    const engine = new DemoEngine();
+    await engine.create('T', 'Artwork', '<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+    await engine.publish();
+    const state = await engine.inscribe(); // mock path (no funding) — OrdMockProvider/regtest
+    expect(state.layer).toBe('did:btco');
+    expect(state.inscription?.txid).toBeTruthy();
+  });
+
+  test('inscribe() with funding but a broken signer surfaces the failure (real path is attempted)', async () => {
+    const engine = new DemoEngine();
+    await engine.create('T', 'Artwork', '<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+    await engine.publish();
+    const brokenClient = {
+      async signTransaction() { throw new Error('turnkey down'); },
+      async createWalletAccounts() { throw new Error('x'); },
+      async getWallets() { throw new Error('x'); },
+    };
+    // With funding provided, the engine takes the sat-selected path; the broken
+    // signer makes the SDK throw (COMMIT signing fails) — proving the real path
+    // is wired, not the mock.
+    await expect(
+      engine.inscribe({
+        funding: {
+          fundingUtxo: { txid: 'a'.repeat(64), vout: 0, value: 20_000 },
+          changeAddress: 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx',
+          signingClient: brokenClient as never,
+        },
+      })
+    ).rejects.toThrow();
+  });
+});
+```
+
+Note: the third test attempts the real sat-selected path. Because the default engine uses `OrdMockProvider` (testnet disabled in the test env), `inscribeOnBitcoin` will attempt `getFirstSatOfOutput` on the mock provider; if the mock lacks it, the SDK throws `SAT_INDEX_UNSUPPORTED` before the signer runs — still a throw, still proving the funding branch is taken (not the mock bare-feeRate branch). Either failure mode satisfies the assertion. If `OrdMockProvider` DOES implement `getFirstSatOfOutput`, the broken signer throws instead. The assertion tolerates both.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/landing && bun test src/sdk/engine.inscribe.test.ts`
+Expected: FAIL — `btcoExplorerUrl` is not exported from `./engine`; `inscribe()` does not accept an options object with `funding`.
+
+- [ ] **Step 3: Add the testnet toggle + provider/network selection in the constructor**
+
+In `apps/landing/src/sdk/engine.ts`, extend the imports:
+```typescript
+import {
+  OriginalsSDK,
+  OrdMockProvider,
+  type OriginalsAsset
+} from '@originals/sdk';
+import { HttpHostingStorageAdapter } from './http-hosting-adapter';
+import { sha256 } from '@noble/hashes/sha2.js';
+```
+becomes:
+```typescript
+import {
+  OriginalsSDK,
+  OrdMockProvider,
+  type OriginalsAsset
+} from '@originals/sdk';
+import { HttpHostingStorageAdapter } from './http-hosting-adapter';
+import { HttpOrdinalsProvider } from './http-ordinals-provider';
+import { TurnkeySatSigner } from './turnkey-sat-signer';
+import type { TurnkeyBitcoinClient } from '../auth/turnkey-session';
+import { sha256 } from '@noble/hashes/sha2.js';
+```
+Replace the `network`/`ordinalsProvider` lines in the `OriginalsSDK.create({ ... })` call:
+```typescript
+    this.sdk = OriginalsSDK.create({
+      network: 'regtest',
+      webvhNetwork: 'magby',
+      defaultKeyType: 'Ed25519',
+      ordinalsProvider: new OrdMockProvider(),
+```
+with:
+```typescript
+    // Track B: when the deploy enables testnet4 signing, inscribe for real over
+    // the /api/btc/* QuickNode proxies on Bitcoin testnet4; otherwise keep the
+    // self-contained OrdMockProvider mock (regtest) unchanged.
+    const testnet = btcTestnetEnabled();
+    this.sdk = OriginalsSDK.create({
+      network: testnet ? 'testnet' : 'regtest',
+      webvhNetwork: 'magby',
+      defaultKeyType: 'Ed25519',
+      ordinalsProvider: testnet ? new HttpOrdinalsProvider() : new OrdMockProvider(),
+```
+
+- [ ] **Step 4: Rewrite `inscribe()` to take the sat-selected real path when funded**
+
+Replace the whole `inscribe` method:
+```typescript
+  /** Step 3 — inscribe on Bitcoin (OrdMockProvider; regtest semantics). */
+  async inscribe(feeRate = 7): Promise<DemoAssetState> {
+    if (!this.asset) throw new Error('Create an asset first');
+    await this.sdk.lifecycle.inscribeOnBitcoin(this.asset, feeRate);
+    const state = this.snapshot();
+    if (state.inscription) {
+      this.emit(
+        'asset:inscribed',
+        `Inscribed on satoshi ${state.inscription.satoshi} — tx ${state.inscription.txid}`,
+        state.inscription
+      );
+    }
+    return state;
+  }
+```
+with:
+```typescript
+  /**
+   * Step 3 — inscribe on Bitcoin.
+   *
+   * With `funding` (Track B, login-gated): a REAL testnet4 inscription. The
+   * server-funded UTXO's first sat becomes the did:btco identity, the user's
+   * Turnkey session key signs the commit, the reveal is self-signed by the SDK,
+   * and both broadcast via the /api/btc/* QuickNode proxies. Without `funding`:
+   * the self-contained OrdMockProvider mock (regtest).
+   */
+  async inscribe(opts?: {
+    feeRate?: number;
+    funding?: {
+      fundingUtxo: { txid: string; vout: number; value: number; scriptPubKey?: string; address?: string };
+      changeAddress: string;
+      signingClient: TurnkeyBitcoinClient;
+    };
+  }): Promise<DemoAssetState> {
+    if (!this.asset) throw new Error('Create an asset first');
+    const feeRate = opts?.feeRate ?? 7;
+    if (opts?.funding) {
+      // Real sat-selected path (#369): the user's Turnkey key signs the commit.
+      const satSigner = new TurnkeySatSigner({
+        client: opts.funding.signingClient,
+        signWith: opts.funding.changeAddress, // the user's tb1q funding address IS signWith
+      });
+      await this.sdk.lifecycle.inscribeOnBitcoin(this.asset, {
+        fundingUtxo: opts.funding.fundingUtxo,
+        satSigner,
+        changeAddress: opts.funding.changeAddress,
+        feeRate,
+      });
+    } else {
+      // Mock path (unchanged): bare feeRate against OrdMockProvider.
+      await this.sdk.lifecycle.inscribeOnBitcoin(this.asset, feeRate);
+    }
+    const state = this.snapshot();
+    if (state.inscription) {
+      this.emit(
+        'asset:inscribed',
+        `Inscribed on satoshi ${state.inscription.satoshi} — tx ${state.inscription.txid}`,
+        state.inscription
+      );
+    }
+    return state;
+  }
+```
+
+- [ ] **Step 5: Surface the explorer URL on the inscription snapshot**
+
+Extend the `DemoAssetState.inscription` shape:
+```typescript
+  inscription?: {
+    txid: string;
+    inscriptionId: string;
+    satoshi: string;
+    feeRate?: number;
+  };
+```
+becomes:
+```typescript
+  inscription?: {
+    txid: string;
+    inscriptionId: string;
+    satoshi: string;
+    feeRate?: number;
+    explorerUrl?: string;
+  };
+```
+In `snapshot()`, extend the inscription object:
+```typescript
+      inscription:
+        last && last.to === 'did:btco' && last.transactionId
+          ? {
+              txid: last.transactionId,
+              inscriptionId: last.inscriptionId ?? '',
+              satoshi: last.satoshi ?? '',
+              feeRate: last.feeRate
+            }
+          : undefined,
+```
+becomes:
+```typescript
+      inscription:
+        last && last.to === 'did:btco' && last.transactionId
+          ? {
+              txid: last.transactionId,
+              inscriptionId: last.inscriptionId ?? '',
+              satoshi: last.satoshi ?? '',
+              feeRate: last.feeRate,
+              explorerUrl: btcoExplorerUrl(last.transactionId)
+            }
+          : undefined,
+```
+
+- [ ] **Step 6: Add the `btcTestnetEnabled` + `btcoExplorerUrl` helpers**
+
+At the bottom of `apps/landing/src/sdk/engine.ts` (next to `demoHost`), add:
+```typescript
+// Track B is enabled only when the deploy sets VITE_BTC_TESTNET=1 (server has
+// QUICKNODE_ENDPOINT + a faucet Turnkey wallet). Absent → the inscribe step is
+// the self-contained OrdMockProvider mock.
+export function btcTestnetEnabled(): boolean {
+  return (import.meta as unknown as { env?: Record<string, string> }).env?.VITE_BTC_TESTNET === '1';
+}
+
+// The testnet4 block explorer link for a real inscription's reveal txid. Only
+// produced when testnet is enabled — a mock/regtest txid has no public explorer.
+export function btcoExplorerUrl(txid: string): string | undefined {
+  if (!btcTestnetEnabled() || !txid) return undefined;
+  return `https://mempool.space/testnet4/tx/${txid}`;
+}
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `cd apps/landing && bun test src/sdk/engine.inscribe.test.ts`
+Expected: PASS — 3 tests pass.
+
+- [ ] **Step 8: Confirm the Track A engine tests still pass (no regression)**
+
+Run: `cd apps/landing && bun test src/sdk/engine.summary.test.ts src/sdk/engine.publish-resolve.test.ts`
+Expected: PASS — Track A create/publish/resolve behavior unchanged (the constructor still defaults to the mock/regtest path when testnet is disabled, which is the test env).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/landing/src/sdk/engine.ts apps/landing/src/sdk/engine.inscribe.test.ts
+git commit -m "feat(landing): engine testnet4 wiring — login-funded real inscription + explorer link"
+```
+
+---
+
+## Task 8: Demo UI — login-gated inscribe + "your Turnkey key signs this" + explorer link
+
+**Files:**
+- Modify: `apps/landing/src/content.ts` (add a `demo.inscribeGate` copy block)
+- Modify: `apps/landing/src/components/Demo.tsx` (login gate on inscribe; fetch funding; pass to `engine.inscribe`; explorer link; error/faucet states)
+- Modify: `apps/landing/src/components/demo.css` (styles for the gate + explorer block)
+- Test: `apps/landing/src/components/demo-inscribe-content.test.ts`
+
+**Interfaces:**
+- Consumes: `demo` from `../content`; `useAuth()` (`isAuthenticated`, `bitcoin`); `DemoAssetState.inscription.explorerUrl`; `btcTestnetEnabled` from `../sdk/engine`.
+- Produces: no new exports; a login-gated inscribe control + real-tx explorer panel.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/landing/src/components/demo-inscribe-content.test.ts`:
+
+```typescript
+import { describe, test, expect } from 'bun:test';
+import { demo } from '../content';
+
+describe('demo inscribe-gate copy', () => {
+  test('has an inscribeGate copy block', () => {
+    expect(demo.inscribeGate).toBeDefined();
+    expect(typeof demo.inscribeGate.signInPrompt).toBe('string');
+    expect(demo.inscribeGate.signInPrompt.length).toBeGreaterThan(0);
+    expect(typeof demo.inscribeGate.yourKeyNote).toBe('string');
+    expect(typeof demo.inscribeGate.explorerLabel).toBe('string');
+    expect(typeof demo.inscribeGate.faucetEmpty).toBe('string');
+    expect(typeof demo.inscribeGate.mockNote).toBe('string');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/landing && bun test src/components/demo-inscribe-content.test.ts`
+Expected: FAIL — `demo.inscribeGate` is `undefined`.
+
+- [ ] **Step 3: Add the `inscribeGate` copy block to `apps/landing/src/content.ts`**
+
+Inside the `demo` object, add after the `resolved: { … }` block (added in Plan 1):
+```typescript
+  resolved: {
+    heading: 'did:webvh log — live at this origin',
+    resolvedBadge: 'resolved ✓',
+    pendingBadge: 'resolves in production',
+    linkLabel: 'Open the signed DID log',
+    note: 'The SDK’s real resolver fetched this over HTTP(S) — no mock. Open it: it’s the signed version history.'
+  },
+```
+becomes:
+```typescript
+  resolved: {
+    heading: 'did:webvh log — live at this origin',
+    resolvedBadge: 'resolved ✓',
+    pendingBadge: 'resolves in production',
+    linkLabel: 'Open the signed DID log',
+    note: 'The SDK’s real resolver fetched this over HTTP(S) — no mock. Open it: it’s the signed version history.'
+  },
+  inscribeGate: {
+    signInPrompt: 'Sign in to inscribe on Bitcoin testnet4 — your own key signs it.',
+    yourKeyNote: 'Your Turnkey key signs this inscription in your browser. The server never sees a private key; funding comes from a testnet4 faucet (worthless tBTC).',
+    fundingLabel: 'Requesting testnet4 funding…',
+    signingLabel: 'Signing the commit with your key…',
+    explorerLabel: 'View the real transaction on mempool.space',
+    faucetEmpty: 'The testnet4 faucet is temporarily out of funds — try again in a bit.',
+    mockNote: 'Bitcoin inscription runs against a mock provider in this environment (no wallet, no chain). Deploy with a testnet4 endpoint + faucet to make it real.'
+  },
+```
+
+- [ ] **Step 4: Gate + drive the inscribe step in `Demo.tsx`**
+
+In `apps/landing/src/components/Demo.tsx`, add the auth + testnet imports near the top:
+```typescript
+import { useAuth } from '../auth/useAuth';
+import { btcTestnetEnabled } from '../sdk/engine';
+```
+Inside the component, read auth + testnet state (near the other hooks, e.g. after `const [phase, setPhase] = useState<Phase>('idle');`):
+```typescript
+  const { isAuthenticated, bitcoin } = useAuth();
+  const testnet = btcTestnetEnabled();
+```
+Replace the `inscribe` action:
+```typescript
+  const inscribe = () =>
+    run('published', 'inscribing', 'inscribed', (engine) => engine.inscribe(7));
+```
+with:
+```typescript
+  const inscribe = () =>
+    run('published', 'inscribing', 'inscribed', async (engine) => {
+      // Mock path (testnet disabled): unchanged bare inscribe.
+      if (!testnet) return engine.inscribe();
+      // Real path: must be signed in with a provisioned testnet4 session.
+      if (!isAuthenticated || !bitcoin) {
+        throw new Error(demo.inscribeGate.signInPrompt);
+      }
+      // Ask the server faucet to fund the user's address, then inscribe with the
+      // user's Turnkey key. faucet_empty (507) surfaces a friendly message.
+      const res = await fetch('/api/btc/funding', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({ address: bitcoin.fundingAddress }),
+      });
+      if (res.status === 507) throw new Error(demo.inscribeGate.faucetEmpty);
+      if (!res.ok) throw new Error(`Funding failed (${res.status})`);
+      const { fundingUtxo, changeAddress } = (await res.json()) as {
+        fundingUtxo: { txid: string; vout: number; value: number };
+        changeAddress: string;
+      };
+      return engine.inscribe({
+        funding: { fundingUtxo, changeAddress, signingClient: bitcoin.signingClient },
+      });
+    });
+```
+
+- [ ] **Step 5: Render the gate note + real-tx explorer link**
+
+In `Demo.tsx`, find the `{phase === 'inscribed' && asset && ( … )}` "done" block and extend it to show the explorer link when the inscription is real. Replace:
+```tsx
+                {phase === 'inscribed' && asset && (
+                  <div className="demo-done">
+                    <p>
+                      <strong>{demo.done.lead}</strong> {demo.done.beforeSatoshi}{' '}
+                      <code>{asset.inscription?.satoshi}</code> {demo.done.beforeTx}{' '}
+                      <code>{asset.inscription?.txid}</code>. {demo.done.after}
+                    </p>
+                    <button type="button" className="demo-reset" onClick={reset}>
+                      {demo.reset}
+                    </button>
+                  </div>
+                )}
+```
+with:
+```tsx
+                {phase === 'inscribed' && asset && (
+                  <div className="demo-done">
+                    <p>
+                      <strong>{demo.done.lead}</strong> {demo.done.beforeSatoshi}{' '}
+                      <code>{asset.inscription?.satoshi}</code> {demo.done.beforeTx}{' '}
+                      <code>{asset.inscription?.txid}</code>. {demo.done.after}
+                    </p>
+                    {asset.inscription?.explorerUrl && (
+                      <a
+                        className="demo-explorer-link"
+                        href={asset.inscription.explorerUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        {demo.inscribeGate.explorerLabel}
+                      </a>
+                    )}
+                    <button type="button" className="demo-reset" onClick={reset}>
+                      {demo.reset}
+                    </button>
+                  </div>
+                )}
+```
+And immediately BEFORE the inscribe step's action button area (where the step list renders the third action), surface the honest gate note. Add, just after the `{error && …}` line (and before the `demo-resolved` block):
+```tsx
+                {phase === 'published' && (
+                  <p className="demo-inscribe-note">
+                    {testnet
+                      ? isAuthenticated && bitcoin
+                        ? demo.inscribeGate.yourKeyNote
+                        : demo.inscribeGate.signInPrompt
+                      : demo.inscribeGate.mockNote}
+                  </p>
+                )}
+```
+
+- [ ] **Step 6: Add styles to `apps/landing/src/components/demo.css`**
+
+Append to the end of `apps/landing/src/components/demo.css`:
+```css
+.demo-inscribe-note {
+  margin-top: 0.75rem;
+  font-size: 0.8rem;
+  line-height: 1.45;
+  color: var(--text-tertiary, #888);
+}
+.demo-explorer-link {
+  display: inline-block;
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--btco, #f7931a);
+  text-decoration: none;
+}
+.demo-explorer-link:hover {
+  text-decoration: underline;
+}
+```
+
+- [ ] **Step 7: Run the content test to verify it passes**
+
+Run: `cd apps/landing && bun test src/components/demo-inscribe-content.test.ts`
+Expected: PASS — 1 test passes.
+
+- [ ] **Step 8: Full Track B + regression sweep**
+
+Run: `cd apps/landing && bun test src/sdk/finalize-psbt.spike.test.ts src/auth/turnkey-session.test.ts src/sdk/http-ordinals-provider.test.ts src/sdk/turnkey-sat-signer.test.ts src/sdk/engine.inscribe.test.ts src/components/demo-inscribe-content.test.ts server/tests/bitcoin.test.ts server/tests/auth-verify-token.test.ts server/tests/app.test.ts server/tests/webvh-host.test.ts src/sdk/engine.summary.test.ts src/sdk/engine.publish-resolve.test.ts`
+Expected: PASS — all Track A + Track B suites green.
+
+- [ ] **Step 9: SDK regression sweep**
+
+Run: `cd packages/sdk && bun test tests/unit/testnet-support.test.ts tests/unit/bitcoin tests/unit/did tests/unit/lifecycle`
+Expected: PASS — testnet support plus existing Bitcoin/DID/lifecycle unit suites green.
+
+- [ ] **Step 10: Manual smoke — MOCK path (no secrets)**
+
+Build the SDK if not already done this session (`cd /Users/brian/Projects/onionoriginals/sdk && bun run build`). Then in one terminal: `cd apps/landing && bun run serve.ts` (logs "auth unconfigured" AND "testnet4 inscription disabled" — expected without secrets). In another: `cd apps/landing && bun run dev`. Open the demo, Create → Publish → Inscribe. Confirm: the inscribe step shows the honest `mockNote` copy, inscribes via OrdMockProvider, shows the done panel, and shows NO explorer link (mock txid has no explorer). No console errors.
+
+- [ ] **Step 11: Manual smoke — REAL testnet4 path (GATED ON PROVISIONED ENV; user-run)**
+
+This step is NOT part of the automated suite. With the operational prerequisites provisioned (`QUICKNODE_ENDPOINT` testnet4 + Ordinals add-on, `BTC_FAUCET_WALLET_ID` + `BTC_FAUCET_ADDRESS` funded Turnkey faucet, `TURNKEY_*`, `JWT_SECRET`, `VITE_BTC_TESTNET=1`, and `getSpendableUtxos` wired in `serve.ts`): boot `serve.ts` (logs "/api/btc/* live"), sign in via email OTP, then Create → Publish → Inscribe. Confirm: the funding request succeeds, the browser signs the commit with the user's Turnkey key (silent within the session), the commit+reveal broadcast, and the done panel shows a REAL testnet4 txid with a working `mempool.space/testnet4/tx/<txid>` link. Verify: (a) Turnkey `signTransaction`'s result envelope matches `maybeFinalize`/`TurnkeySatSigner` expectations; (b) `otpLogin`'s `clientSignature` scheme + `secp256r1` DER shape are accepted; (c) the commit spends the still-unconfirmed faucet funding UTXO without a confirmation wait. These three are the flagged load-bearing unknowns — reconcile any mismatch here.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add apps/landing/src/content.ts apps/landing/src/components/Demo.tsx apps/landing/src/components/demo.css apps/landing/src/components/demo-inscribe-content.test.ts
+git commit -m "feat(landing): login-gated testnet4 inscribe UI — your-key note + real-tx explorer link"
+```
+
+---
+
+## Self-review notes (done before saving)
+
+- **Spec coverage (Track B / Phase 2):**
+  - SDK `network: 'testnet'` (testnet4) end-to-end incl. `did:btco:test` prefix + `tb1` validation, plus SDK rebuild → Task 1 (identified the FULL exhaustive-switch surface: `common.ts`, `network.ts`, `btcoDid.ts`, `createBtcoDidDocument.ts`, `DIDManager.ts`, `LifecycleManager.ts`, `bitcoin-address.ts`, `BitcoinManager.ts`; the tx layer already handles testnet).
+  - Signing SPIKE (Turnkey-shaped PSBT → `@scure/btc-signer` finalize → broadcastable P2WPKH hex; live e2e flagged manual) → Task 2, first after the SDK task, as required.
+  - Turnkey OTP_LOGIN session + browser signing client + testnet4 P2WPKH account provisioning; verify-otp surfaces `verificationToken` → Task 3.
+  - Server `bitcoin.ts`: Turnkey-org faucet (no raw key; signs the faucet's own funding tx) + `POST /api/btc/{funding,sat,fee,broadcast}`; auth-gated + rate-limited + per-user cap + faucet-empty; env-gated with mock fallback → Task 4.
+  - `HttpOrdinalsProvider` (browser `OrdinalsProvider`; create/transfer reject) → Task 5.
+  - `TurnkeySatSigner` (`BitcoinSigner`; user Turnkey key signs commit, scure finalizes) → Task 6.
+  - Engine wiring: `network:'testnet'` + `HttpOrdinalsProvider`, login-gated `inscribe()` requesting funding then calling `inscribeOnBitcoin` sat path; real txid + testnet4 explorer link → Task 7.
+  - Login-gated inscribe UI + "your Turnkey key signs this" moment + explorer link + faucet/error states → Task 8.
+  - Testing plan (server units with mock Turnkey/QuickNode + auth-gating; browser adapters/signer vs. mock fetch/Turnkey; engine wiring; SDK unit) → Tasks 1-8. Live e2e is an explicit MANUAL SMOKE (Task 8 Step 11).
+- **Explicitly out of scope (Plan 1 / Track A, untouched here):** `HttpHostingStorageAdapter`, `webvh-host.ts`, the unified server foundation, `resolveDID` confirmation, did:peer→did:cel labels, create/publish copy. Track A `engine.create()`/`publish()` behavior is only regression-checked, never modified.
+- **No raw private keys on the server:** the faucet signs via `turnkey.apiClient().signTransaction` with the existing `TURNKEY_*` creds (Task 4); the user's commit is signed in-browser by the user's Turnkey session key (Task 6). Restated in Global Constraints + the funding handler comment.
+- **Fallback preserved:** with env absent, the engine constructor keeps `network:'regtest'` + `OrdMockProvider` and `inscribe()` takes the unchanged bare-feeRate path; `/api/btc/*` are simply not mounted (Task 4 Step 5, Task 7 Step 3).
+- **Placeholder scan:** every implementation step contains complete code. The ONE intentional throw-until-wired (`getSpendableUtxos` in `serve.ts`, Task 4 Step 5) is an honest operational "not configured" state, is called out as such, is bypassed by injected fakes in tests, and fails loudly (`faucet_unavailable`) rather than fabricating data — it is not a shipping-logic placeholder. All test commands are exact (`cd apps/landing && bun test <path>` / `cd packages/sdk && bun test <path>`) with expected PASS/FAIL.
+- **Type/name consistency:** `TurnkeyBitcoinClient` (`signTransaction`/`createWalletAccounts`/`getWallets`) is defined once (Task 3) and consumed identically by `TurnkeySatSigner` (Task 6), the engine (Task 7), and `useAuth` (Task 3). `finalizeSignedPsbt` (Task 2) is reused by `TurnkeySatSigner` (Task 6) and mirrored by the server's `maybeFinalize` (Task 4). `BitcoinRoutes` type flows `bitcoin.ts` → `index.ts` → `serve.ts`. `HttpOrdinalsProvider`/`HttpHostingStorageAdapter` share the `{ baseUrl?; fetchImpl? }` constructor convention. `btcTestnetEnabled`/`btcoExplorerUrl` are exported from `engine.ts` and consumed by `Demo.tsx`. The engine `inscribe({ funding })` option shape matches what `Demo.tsx` passes and what the SDK's `InscribeOnBitcoinOptions` requires (`fundingUtxo`/`satSigner`/`changeAddress`/`feeRate`). `verificationToken`/`publicKey` flow verify-otp (server) → `completeOtp` (api.ts) → `useAuth` → `otpLoginToSession`.
+- **Risks flagged for the live smoke (Task 8 Step 11):** (1) Turnkey `signTransaction` result envelope (raw hex vs. partially-signed PSBT) — tolerated by `maybeFinalize`/`TurnkeySatSigner`, confirm live; (2) `otpLogin` `clientSignature` scheme + `@noble/curves` P-256 DER method (`toDERRawBytes`) — confirm live; (3) commit spending the unconfirmed faucet UTXO without a confirmation wait; (4) QuickNode Ordinals add-on `ord_*` availability on testnet4 + a `getSpendableUtxos` address-index source. All four are isolated so a mismatch is a localized fix, not a redesign.
+```

--- a/docs/superpowers/specs/2026-07-16-landing-real-onchain-demo-design.md
+++ b/docs/superpowers/specs/2026-07-16-landing-real-onchain-demo-design.md
@@ -1,0 +1,270 @@
+# Landing demo: real on-chain did:webvh hosting + testnet4 inscription
+
+**Issue:** #417 — "Landing demo: make it do real on-chain things (and fix did:peer / mock mislabeling)"
+**Date:** 2026-07-16
+**Status:** Approved design → implementation planning
+
+## Problem
+
+`apps/landing`'s "live demo" (`src/sdk/engine.ts`) runs the real `@originals/sdk`
+in the browser, but only the crypto/protocol layer is genuinely real. Two steps
+are mocked and the UI oversells them:
+
+- `ordinalsProvider: new OrdMockProvider()` — "inscribed on Bitcoin" is a mock:
+  no sat, no transaction, no chain.
+- `storageAdapter: new MemoryStorageAdapter()` — "published to hosted storage" is
+  in-memory: no real HTTPS host, nothing resolves.
+- Mislabeling: `engine.ts:118` says "a private **did:peer** identity" (stale — it's
+  did:cel now); `engine.ts:123` "published to hosted storage" implies real hosting.
+
+## Goal
+
+Make the demo do **real** on-chain work while staying public-safe:
+
+1. **Track A — real did:webvh hosting:** `publishToWeb` uploads the signed DID log
+   (+ CEL log + resources) to the demo's own origin over real HTTPS; the SDK's real
+   resolver fetches it back and the UI proves it resolved. No funds.
+2. **Track B — real testnet4 inscription (login-gated):** the logged-in user's own
+   **Turnkey** key signs a real commit/reveal built in-browser, broadcast to Bitcoin
+   **testnet4** via QuickNode. Funding comes from a **Turnkey-org faucet** (the server
+   signs the faucet's own funding tx via its Turnkey creds — no raw key on the
+   server). Real txid + inscription, worthless tBTC.
+3. **Honesty:** fix the did:peer→did:cel labels and make every step's UI badge state
+   exactly what is real vs. simulated.
+
+## Decisions (locked)
+
+| Question | Decision | Why |
+|---|---|---|
+| Inscription network | **testnet4 via QuickNode** | QuickNode supports only mainnet + testnet4 (no signet). Mainnet is unsafe for a public demo. testnet4 is a real chain with worthless tBTC. |
+| Signing model | **User's Turnkey key signs the inscription** | Reuses the existing `@originals/auth` Turnkey OTP login + secp256k1 signer; the user's own key signs their own inscription (best self-custody narrative). Inscription becomes login-gated. |
+| Funding model | **Turnkey-org faucet (zero raw keys)** | The faucet wallet is itself a Turnkey org key; the server signs only the faucet's *own* funding tx via its Turnkey creds. Both funding and user signing go through Turnkey → **no raw private key anywhere on the server**. |
+| Fallback | **Raw-key faucet** (de-risk only) | If the Turnkey Bitcoin integration proves fiddly mid-build, drop the funding half to a raw testnet4 key without disturbing the user-signing story. |
+| Unified server | **In scope (foundation)** | Real webvh hosting requires the DID log served from the demo's own origin. Matches this branch's purpose (`fix/landing-serve-unified-api`). |
+| `content.ts` label reconciliation | **Out of scope** | Separately-tracked content issue. This work touches only demo-adjacent strings. |
+
+## Constraints discovered
+
+- **QuickNode:** mainnet + testnet4 only; no signet. Provides real
+  `getFirstSatOfOutput` / `estimateFee` / `broadcastTransaction`; its
+  `createInscription`/`transferInscription` fail by design (tx built locally).
+- **`publishToWeb` needs no SDK change:** it routes all hosting (DID log, CEL log,
+  resources) through `config.storageAdapter` (`put`/`putObject`). Injecting a real
+  HTTP-backed adapter is sufficient.
+- **`inscribeOnBitcoin` (merged PR #414)** signature:
+  `inscribeOnBitcoin(asset, { fundingUtxo, satSigner, changeAddress, feeRate })`.
+  - `fundingUtxo: Utxo` — its first sat becomes the did:btco identity (derived from
+    the provider, never caller-asserted).
+  - `satSigner: BitcoinSigner` — one method
+    `signAndFinalizeCommitPsbt(psbtBase64) → broadcast-ready raw tx hex` (NOT a PSBT).
+  - `changeAddress: string`.
+  - Providing `fundingUtxo` without both `satSigner` and `changeAddress` throws
+    `INVALID_INPUT`. Missing fee with no oracle throws `FEE_RATE_REQUIRED`.
+  - Flow (`bitcoin/inscribe-on-sat.ts`): provider sat-lookup → build commit locally →
+    `satSigner` signs → commit txid computed locally + invariant-checked → reveal
+    built + self-signed locally with ephemeral key → broadcast commit, then reveal.
+    `REVEAL_BROADCAST_FAILED` returns recovery data.
+- **Browser feasibility:** the commit/reveal stack is `@scure/btc-signer` +
+  `@noble/*` (browser-safe). Uses Node `Buffer` — must be polyfilled in Vite (the
+  engine already imports `../shims/buffer-global`; confirm it covers this path).
+- **Deployment now:** SPA (`serve.ts`, static) and API (`server/index.ts`, :8787) are
+  separate; dev proxies `/api`. Prod Railway runs only the static server.
+- **Turnkey signing already wired:** `@originals/auth` has `server/turnkey-signer.ts`
+  and `client/turnkey-did-signer.ts`, both signing via Turnkey `signRawPayload`
+  (secp256k1). OTP login provisions a per-user Turnkey sub-org + secp256k1 wallet
+  (`server/turnkey-client.ts`), so a user Bitcoin signer needs no new primitive.
+- **Turnkey has native Bitcoin signing:** `SIGN_TRANSACTION` covers P2PKH/P2SH/
+  P2WPKH/P2WSH/P2TR with SIGHASH_ALL; `signRawPayload` handles pre-generated
+  sighashes for anything exotic. Keeping funding addresses **P2WPKH** (ECDSA,
+  SIGHASH_ALL) stays on the simplest native path — no schnorr for Turnkey-signed
+  inputs. (Commit output + reveal are taproot but self-signed locally by the SDK's
+  ephemeral reveal key, never by Turnkey.)
+- **Current Turnkey user wallet has no Bitcoin account:** default accounts are
+  ETHEREUM (secp256k1) + Solana (ed25519) (`turnkey-client.ts:59`). A testnet4
+  P2WPKH account must be added to the user wallet provisioning (or derived from the
+  existing secp256k1 pubkey).
+
+## Architecture
+
+One Bun server (prod entry) serving a single origin:
+
+```
+        ┌──────────────────────────── apps/landing (browser SPA) ────────────────────────────┐
+        │  DemoEngine (src/sdk/engine.ts)                                                      │
+        │    ├── HttpHostingStorageAdapter ──PUT/GET /api/host/*, GET /.well-known,/<path>─┐   │
+        │    ├── HttpOrdinalsProvider ───────POST /api/btc/{sat,fee,broadcast}─────────┐   │   │
+        │    └── TurnkeySatSigner ───signs commit sighash via USER's Turnkey session┐  │   │   │
+        │           (existing client turnkey-did-signer / signRawPayload)           │  │   │   │
+        └───────────────────────────────────────────────────────────────────────── │──│───│───┘
+                                                          user Turnkey session ──────┘  │   │
+   ┌──────────────────────────── apps/landing/server (Bun, one origin) ───────────────────▼───▼───┐
+   │  static SPA + SPA fallback   │  /api/auth/* (unchanged)                                       │
+   │  webvh-host.ts:  PUT /api/host/*  ·  GET /.well-known/…  ·  GET /<path>/did.jsonl (Map+TTL)   │
+   │  bitcoin.ts:                                                                                  │
+   │    POST /api/btc/funding  → build+sign faucet funding tx via TURNKEY-ORG creds, broadcast    │
+   │                             (tops up the logged-in user's P2WPKH testnet4 address)           │
+   │    POST /api/btc/{sat,fee,broadcast} → thin QuickNode proxy                                   │
+   │  rate-limit.ts / cookies.ts / router.ts  (reused)                                            │
+   └───────────────────────────────┬──────────────────────────────────┬───────────────────────────┘
+              QUICKNODE_ENDPOINT ───┘ (testnet4)   Turnkey faucet org ──┘  (API creds, NOT a raw key)
+```
+
+**No raw private key anywhere on the server:** the faucet is a Turnkey org wallet;
+the server authorizes its funding tx with the same Turnkey API credentials it already
+uses for auth. The user's inscription is signed by the user's own Turnkey key.
+
+### Units (each: purpose / interface / deps)
+
+1. **Unified prod server** — `apps/landing/server/index.ts` (extended) + Railway
+   `startCommand`. *Purpose:* one origin serving SPA + all API. *Interface:* Bun
+   `fetch` → router; static + SPA fallback (moved from `serve.ts`). *Deps:* existing
+   router/rate-limit/cookies; new `webvh-host.ts`, `bitcoin.ts`. `serve.ts` retired
+   or reduced to a thin re-export.
+
+2. **`HttpHostingStorageAdapter`** — `src/sdk/http-hosting-adapter.ts` (browser).
+   *Purpose:* SDK `StorageAdapter` backed by HTTPS. *Interface:* `put(key, bytes,
+   opts)` / `putObject(domain, path, bytes)` / `get(...)` → `PUT`/`GET /api/host/*`.
+   *Deps:* fetch, same origin.
+
+3. **`webvh-host.ts`** — server. *Purpose:* receive + serve DID/CEL/resource bytes at
+   the exact URLs the resolver GETs. *Interface:* `PUT /api/host/*` (store),
+   `GET /.well-known/…` + `GET /<path>/did.jsonl` (serve). *Deps:* in-memory Map,
+   TTL, size cap, slug namespace; rate-limit.
+
+4. **`HttpOrdinalsProvider`** — `src/sdk/http-ordinals-provider.ts` (browser).
+   *Purpose:* SDK `OrdinalsProvider` via proxy. *Interface:* `getFirstSatOfOutput`,
+   `estimateFee`, `broadcastTransaction` → `POST /api/btc/*`;
+   `createInscription`/`transferInscription` throw. *Deps:* fetch.
+
+5. **`TurnkeySatSigner`** — `src/sdk/turnkey-sat-signer.ts` (browser). *Purpose:* SDK
+   `BitcoinSigner` backed by the **user's** Turnkey key. *Interface:*
+   `signAndFinalizeCommitPsbt(psbt) → broadcast-ready hex` — computes the commit
+   input's sighash, signs via the user's Turnkey session (reusing the
+   `client/turnkey-did-signer` `signRawPayload` pattern, or Turnkey `SIGN_TRANSACTION`
+   for the P2WPKH input), assembles the witness, returns finalized hex. *Deps:*
+   Turnkey client + user session, `@scure/btc-signer`. Requires login.
+
+6. **`bitcoin.ts`** — server. *Purpose:* Turnkey-org faucet + QuickNode proxy.
+   *Interface:*
+   - `POST /api/btc/funding` — authenticated (logged-in user). Builds a funding tx
+     from the faucet's P2WPKH UTXOs to the user's testnet4 P2WPKH address, signs it
+     with the **faucet Turnkey org** creds, broadcasts via QuickNode, returns the
+     resulting `{ fundingUtxo, changeAddress }` (the user's own address) for the SDK
+     call. Spendable immediately (commit may chain on the unconfirmed funding tx).
+   - `POST /api/btc/{sat,fee,broadcast}` — thin proxies to `QuickNodeProvider`.
+   *Deps:* `QUICKNODE_ENDPOINT`, faucet Turnkey org (via existing Turnkey client),
+   `@scure/btc-signer`, rate-limit + auth middleware. Degrades to "unconfigured"
+   (503) / `OrdMockProvider` when env absent.
+
+7. **User Bitcoin account provisioning** — `@originals/auth` /
+   `apps/landing/server`. *Purpose:* give each logged-in user a testnet4 P2WPKH
+   address. *Interface:* add a `CURVE_SECP256K1` / testnet4-P2WPKH account to the
+   user wallet (or derive from the existing secp256k1 pubkey) + expose the address to
+   the browser. *Deps:* Turnkey `createWallet`/account APIs already used in
+   `turnkey-client.ts`.
+
+8. **`DemoEngine` changes** — `src/sdk/engine.ts`. Inject `HttpHostingStorageAdapter`
+   + `HttpOrdinalsProvider` + (when logged in) `TurnkeySatSigner`; `network:
+   'testnet'`; explicit webvh `domain` = the demo origin; post-publish `resolveDID`
+   confirmation; fix labels; gate `inscribe()` on login + request funding first;
+   surface the inscription txid/inscription for an explorer link.
+
+9. **UI/UX** — `src/components/Demo.tsx` + demo-adjacent strings in `content.ts`.
+   Honest per-step badges; resolvable did:webvh link + "resolved ✓"; a
+   **sign-in-to-inscribe** gate + "your Turnkey key signs this" moment; testnet4
+   explorer link; timing + error states (faucet empty / rate-limited /
+   reveal-broadcast recovery).
+
+## Data flow
+
+**Publish (Track A):** `publishToWeb` → `HttpHostingStorageAdapter.put*` → `PUT
+/api/host/*` (server stores) → demo calls `resolveDID(webvhDid)` → real resolver
+`GET`s the live log over HTTPS → UI shows link + "resolved ✓".
+
+**Inscribe (Track B, login-gated):** user is logged in → has a Turnkey testnet4
+P2WPKH address → demo `POST /api/btc/funding` (server signs the faucet funding tx via
+its Turnkey org creds, broadcasts, returns the user's now-funded `{ fundingUtxo,
+changeAddress }`) → `inscribeOnBitcoin(asset, { fundingUtxo, satSigner:
+TurnkeySatSigner, changeAddress, feeRate })` → SDK builds commit → `TurnkeySatSigner`
+signs the commit input with the **user's** Turnkey key → SDK computes commit txid +
+checks invariants → builds+signs reveal (ephemeral local key) →
+`HttpOrdinalsProvider.broadcastTransaction` → `POST /api/btc/broadcast` (QuickNode) →
+UI shows testnet4 explorer link. The commit may spend the still-unconfirmed funding
+UTXO (unconfirmed chain), so there is no block-confirmation wait mid-demo.
+
+## Security
+
+- **No raw private keys on the server.** QuickNode key + the Turnkey API creds are
+  server-side only. The faucet is a Turnkey org wallet; the user's inscription is
+  signed by the user's own Turnkey key. The browser never sees any key.
+- Faucet funding is **login-gated + rate-limited per user + per IP** (reuse
+  `rate-limit.ts` + auth middleware); the server only ever signs the faucet's *own*
+  funding tx to a *logged-in user's* address — it is not a general signing oracle.
+- Faucet: small fixed funding amount, per-user inscription cap, "faucet empty"
+  graceful state. Financial risk ≈ 0 (tBTC worthless); griefing risk (faucet drain)
+  bounded by rate limits + small amounts.
+- `/api/host/*` rate-limited; WebVH host store: size cap + TTL + slug namespacing to
+  prevent storage abuse and cross-DID collisions.
+
+## Phasing
+
+- **Phase 0 — foundation:** unify SPA + API into one Bun server; Railway
+  `startCommand`; keep dev proxy working. Fix did:peer→did:cel labels.
+- **Phase 1 — Track A (real webvh):** `HttpHostingStorageAdapter` + `webvh-host.ts` +
+  engine wiring + `resolveDID` confirmation + UI. Self-contained, no secrets.
+- **Phase 2 — Track B (real testnet4 inscription):** user Bitcoin-account
+  provisioning + `TurnkeySatSigner` + `bitcoin.ts` (Turnkey-org faucet + QuickNode
+  proxy) + `HttpOrdinalsProvider` + engine wiring + login-gated UI. Gated on env;
+  falls back to `OrdMockProvider` when `QUICKNODE_ENDPOINT`/faucet unset. If the
+  Turnkey Bitcoin path proves fiddly, fall back to a raw-key faucet (funding half
+  only) without changing user-signing.
+
+## Operational prerequisites (user-provided)
+
+- QuickNode **testnet4** endpoint with the Ordinals & Runes add-on → `QUICKNODE_ENDPOINT`.
+- A **testnet4 faucet as a Turnkey org wallet** (P2WPKH), funded with a pool of small
+  confirmed UTXOs; the server reaches it with the existing Turnkey API credentials —
+  no raw key secret.
+- The user wallet provisioning must include a **testnet4 P2WPKH secp256k1 account**.
+- Turnkey environment reachable from the deployed server (already true for auth).
+
+## Risks to verify during implementation
+
+- SDK support for `network: 'testnet'` (testnet4) end-to-end, incl. the `did:btco`
+  network prefix; may need a small tier addition. QuickNodeProvider accepts
+  `BITCOIN_NETWORK=testnet`.
+- **Turnkey commit-input signing shape:** whether Turnkey `SIGN_TRANSACTION`
+  (P2WPKH, SIGHASH_ALL) or `signRawPayload`-of-sighash + local witness assembly is the
+  cleaner path; low-S / DER encoding correctness. Prototype early — it is the
+  load-bearing unknown for Phase 2.
+- **User session signing UX:** whether the OTP-bound P-256 session can authorize the
+  inscription signature without an extra Turnkey credential/passkey step.
+- Deriving/adding a testnet4 P2WPKH account on the existing user Turnkey wallet.
+- **Unconfirmed funding-input spend:** QuickNode/ord accepting a commit that spends
+  the still-unconfirmed faucet funding UTXO; else a short confirmation wait.
+- Exact URL layout didwebvh-ts's resolver GETs, so the host store serves identical
+  paths (`.well-known` vs. `/<path>/did.jsonl`).
+- `Buffer` coverage for the browser commit/reveal path (existing
+  `shims/buffer-global`).
+- QuickNode Ordinals add-on availability on testnet4 specifically (docs list
+  mainnet + testnet4 for base RPC; confirm `ord_*` methods on testnet4).
+
+## Testing
+
+- **Server units** (`server/tests/`): `webvh-host` store/serve + caps/TTL; `bitcoin`
+  faucet funding-tx build/sign (Turnkey mock), auth-gating (rejects anonymous),
+  proxy error mapping; rate-limit enforcement. Bun tests, no live network.
+- **Browser adapters:** `HttpHostingStorageAdapter` / `HttpOrdinalsProvider` against a
+  mock fetch; `TurnkeySatSigner` against a mock Turnkey client — assert it returns
+  finalized, low-S, broadcast-ready hex for a P2WPKH commit input.
+- **Engine integration:** publish → resolve round-trip against an in-process host;
+  inscribe against a stubbed `/api/btc/*` + mock Turnkey signer, mirroring the
+  existing `inscribeOnBitcoin.satSelect.test.ts` convention.
+- **Manual smoke:** real testnet4 inscription end-to-end (login → fund → inscribe)
+  once env is provisioned.
+
+## Out of scope
+
+- Broad `content.ts` did:peer→did:cel reconciliation (separate issue).
+- Mainnet inscription; signet (unsupported by QuickNode).
+- Persistent hosting of demo DIDs beyond the TTL window.

--- a/packages/sdk/src/bitcoin/BitcoinManager.ts
+++ b/packages/sdk/src/bitcoin/BitcoinManager.ts
@@ -422,7 +422,8 @@ export class BitcoinManager {
     const expectedPrefix =
       this.config.network === 'regtest' ? 'reg'
         : this.config.network === 'signet' ? 'sig'
-          : null; // mainnet DIDs have no network prefix (did:btco:<sat>)
+          : this.config.network === 'testnet' ? 'test'
+            : null; // mainnet DIDs have no network prefix (did:btco:<sat>)
     const actualPrefix = prefix === 'reg' || prefix === 'sig' || prefix === 'test' ? prefix : null;
     if (actualPrefix !== expectedPrefix) return false;
     

--- a/packages/sdk/src/cel/btcoDid.ts
+++ b/packages/sdk/src/cel/btcoDid.ts
@@ -12,6 +12,8 @@ export function btcoDidPrefix(network: string | undefined): string {
       return 'did:btco:sig';
     case 'regtest':
       return 'did:btco:reg';
+    case 'testnet':
+      return 'did:btco:test';
     case 'mainnet':
     case undefined:
       // undefined = legacy log with no recorded network; mainnet is the only

--- a/packages/sdk/src/cel/layers/BtcoCelManager.ts
+++ b/packages/sdk/src/cel/layers/BtcoCelManager.ts
@@ -36,7 +36,7 @@ export interface BtcoCelConfig {
    * BitcoinManager is configured (read-only replay). New logs record the
    * network in the signed data, so this is never consulted for them.
    */
-  network?: 'mainnet' | 'regtest' | 'signet';
+  network?: 'mainnet' | 'testnet' | 'regtest' | 'signet';
 }
 
 /**
@@ -71,7 +71,7 @@ export interface BtcoMigrationData {
    * than from the replaying SDK's runtime config. Absent on logs created before
    * this field existed.
    */
-  network?: 'mainnet' | 'regtest' | 'signet';
+  network?: 'mainnet' | 'testnet' | 'regtest' | 'signet';
   /** The Bitcoin transaction ID anchoring the migration */
   txid?: string;
   /** The inscription ID on Bitcoin */

--- a/packages/sdk/src/did/DIDManager.ts
+++ b/packages/sdk/src/did/DIDManager.ts
@@ -242,7 +242,7 @@ export class DIDManager {
    * (migrateToDIDBTCO) and the cross-network resolution guard (issue #267), so
    * the two can never disagree about which network the SDK is on.
    */
-  private getConfiguredBitcoinNetwork(): 'mainnet' | 'regtest' | 'signet' | undefined {
+  private getConfiguredBitcoinNetwork(): 'mainnet' | 'testnet' | 'regtest' | 'signet' | undefined {
     if (this.config.network) return this.config.network;
     if (this.config.webvhNetwork) return getBitcoinNetworkForWebVH(this.config.webvhNetwork);
     return undefined;
@@ -272,7 +272,7 @@ export class DIDManager {
     // inscriptions (issue #247). The WebVH mapping (magby→regtest,
     // cleffa→signet, pichu→mainnet) applies only when no explicit Bitcoin
     // network was configured.
-    const network: 'mainnet' | 'regtest' | 'signet' = this.getConfiguredBitcoinNetwork() ?? 'mainnet';
+    const network: 'mainnet' | 'testnet' | 'regtest' | 'signet' = this.getConfiguredBitcoinNetwork() ?? 'mainnet';
 
     // Carry over the first verification method's key into the did:btco
     // document. If the source document declares a verification method but its
@@ -311,7 +311,11 @@ export class DIDManager {
     if (publicKey && keyType) {
       btcoDoc = createBtcoDidDocument(satoshi, network, { publicKey, keyType });
     } else {
-      const prefix = network === 'mainnet' ? 'did:btco:' : network === 'regtest' ? 'did:btco:reg:' : 'did:btco:sig:';
+      const prefix =
+        network === 'mainnet' ? 'did:btco:'
+        : network === 'regtest' ? 'did:btco:reg:'
+        : network === 'testnet' ? 'did:btco:test:'
+        : 'did:btco:sig:';
       btcoDoc = {
         '@context': ['https://www.w3.org/ns/did/v1'],
         id: prefix + canonicalizeSatoshi(satoshi)
@@ -459,16 +463,19 @@ export class DIDManager {
             // SDK-wide config — a signet DID handed to a mainnet-configured SDK
             // must still be treated as a signet identifier.
             const btcoPrefix = did.match(/^did:btco:(reg|sig|test):/)?.[1];
-            const network: 'mainnet' | 'regtest' | 'signet' =
+            const network: 'mainnet' | 'testnet' | 'regtest' | 'signet' =
               btcoPrefix === 'reg' ? 'regtest'
               : btcoPrefix === 'sig' ? 'signet'
-              : btcoPrefix === 'test'
-                // OrdinalsClient has no testnet variant; fall back to the
-                // configured network (BtcoDidResolver still validates the DID
-                // against its own testnet prefix).
-                ? (this.config.network || 'mainnet')
-                : 'mainnet';
-            const client = new OrdinalsClient(rpcUrl, network);
+              // The DID's own prefix determines the network, independent of SDK
+              // config — consistent with reg/sig. OrdinalsClient has no testnet
+              // variant, so the call below coerces testnet→signet (shared tb1
+              // params); BtcoDidResolver still validates the testnet prefix.
+              : btcoPrefix === 'test' ? 'testnet'
+              : 'mainnet';
+            // OrdinalsClient has no testnet variant; testnet4 shares signet's
+            // address params, so use signet for this RPC path (QuickNode is the
+            // real testnet provider — see QuickNodeProvider).
+            const client = new OrdinalsClient(rpcUrl, network === 'testnet' ? 'signet' : network);
             const adapter = new OrdinalsClientProviderAdapter(client, rpcUrl);
             // fetchContent pins content retrieval to the rpcUrl origin and
             // refuses redirects. Without it the resolver would fetch whatever

--- a/packages/sdk/src/did/createBtcoDidDocument.ts
+++ b/packages/sdk/src/did/createBtcoDidDocument.ts
@@ -2,7 +2,7 @@ import { DIDDocument, VerificationMethod } from '../types/did.js';
 import { multikey, MultikeyType } from '../crypto/Multikey.js';
 import { canonicalizeSatoshi } from '../utils/satoshi-validation.js';
 
-export type BitcoinNetwork = 'mainnet' | 'regtest' | 'signet';
+export type BitcoinNetwork = 'mainnet' | 'testnet' | 'regtest' | 'signet';
 
 interface CreateBtcoDidDocumentParams {
 	publicKey: Uint8Array;
@@ -14,6 +14,7 @@ function getDidPrefix(network: BitcoinNetwork): string {
 	if (network === 'mainnet') return 'did:btco';
 	if (network === 'signet') return 'did:btco:sig';
 	if (network === 'regtest') return 'did:btco:reg';
+	if (network === 'testnet') return 'did:btco:test';
 	const _exhaustiveCheck: never = network;
 	throw new Error(`Unsupported Bitcoin network: ${String(_exhaustiveCheck)}`);
 }

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -3605,7 +3605,7 @@ export class LifecycleManager {
    * tier mapping, #247). Both the btco binding fallback and rotateBtcoKeys use
    * this so a tier-only config can never drift into a NETWORK_MISMATCH.
    */
-  private getConfiguredBitcoinNetwork(): 'mainnet' | 'regtest' | 'signet' {
+  private getConfiguredBitcoinNetwork(): 'mainnet' | 'testnet' | 'regtest' | 'signet' {
     return this.config.network
       ?? (this.config.webvhNetwork ? getBitcoinNetworkForWebVH(this.config.webvhNetwork) : undefined)
       ?? 'mainnet';

--- a/packages/sdk/src/types/common.ts
+++ b/packages/sdk/src/types/common.ts
@@ -51,7 +51,7 @@ export type InscribeConfirm =
   | ((estimate: AppendCostEstimate) => boolean | Promise<boolean>);
 
 export interface OriginalsConfig {
-  network: 'mainnet' | 'regtest' | 'signet';
+  network: 'mainnet' | 'testnet' | 'regtest' | 'signet';
   bitcoinRpcUrl?: string;
   defaultKeyType: 'ES256K' | 'Ed25519' | 'ES256';
   keyStore?: KeyStore;

--- a/packages/sdk/src/types/network.ts
+++ b/packages/sdk/src/types/network.ts
@@ -9,7 +9,7 @@
 
 export type WebVHNetworkName = 'magby' | 'cleffa' | 'pichu';
 
-export type BitcoinNetworkName = 'mainnet' | 'regtest' | 'signet';
+export type BitcoinNetworkName = 'mainnet' | 'testnet' | 'regtest' | 'signet';
 
 export type VersionStability = 'patch' | 'minor' | 'major';
 

--- a/packages/sdk/src/utils/bitcoin-address.ts
+++ b/packages/sdk/src/utils/bitcoin-address.ts
@@ -3,7 +3,7 @@ import * as bitcoin from 'bitcoinjs-lib';
 /**
  * Bitcoin network types supported by the validation
  */
-export type BitcoinNetwork = 'mainnet' | 'regtest' | 'signet';
+export type BitcoinNetwork = 'mainnet' | 'testnet' | 'regtest' | 'signet';
 
 /**
  * Maps our network names to bitcoinjs-lib network configurations
@@ -12,6 +12,9 @@ const getNetwork = (network: BitcoinNetwork): bitcoin.Network => {
   switch (network) {
     case 'mainnet':
       return bitcoin.networks.bitcoin;
+    case 'testnet':
+      // testnet4 shares testnet3's bech32 params (tb1) — same as signet below.
+      return bitcoin.networks.testnet;
     case 'regtest':
       // Regtest uses testnet parameters but with bcrt prefix
       // However, since many regtest addresses in tests use testnet format,

--- a/packages/sdk/tests/unit/cel/btcoDid.test.ts
+++ b/packages/sdk/tests/unit/cel/btcoDid.test.ts
@@ -13,7 +13,8 @@ describe('btcoDid helpers', () => {
   });
 
   test('throws on unrecognized networks instead of silently minting a mainnet DID', () => {
-    expect(() => btcoDidPrefix('testnet')).toThrow('Unsupported Bitcoin network');
+    // 'testnet' is now a supported network; assert on genuinely-invalid ones.
+    expect(() => btcoDidPrefix('mars')).toThrow('Unsupported Bitcoin network');
     expect(() => btcoDidFromSatoshi('123', 'mainet')).toThrow('Unsupported Bitcoin network');
   });
 });

--- a/packages/sdk/tests/unit/did/createBtcoDidDocument.test.ts
+++ b/packages/sdk/tests/unit/did/createBtcoDidDocument.test.ts
@@ -59,9 +59,9 @@ describe('createBtcoDidDocument', () => {
 	it('throws on unsupported network', () => {
 		const pub = rangeBytes(32, 9);
 		expect(() =>
-			// @ts-expect-error testing invalid network
-			createBtcoDidDocument('1', 'testnet', { publicKey: pub, keyType: 'Ed25519' })
-		).toThrow('Unsupported Bitcoin network: testnet');
+			// @ts-expect-error testing invalid network ('testnet' is now supported)
+			createBtcoDidDocument('1', 'mars', { publicKey: pub, keyType: 'Ed25519' })
+		).toThrow('Unsupported Bitcoin network: mars');
 	});
 
 	it('canonicalizes a satoshi string with surrounding whitespace into a resolvable id', () => {

--- a/packages/sdk/tests/unit/testnet-support.test.ts
+++ b/packages/sdk/tests/unit/testnet-support.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect } from 'bun:test';
+import { btcoDidPrefix, btcoDidFromSatoshi } from '../../src/cel/btcoDid.js';
+import { createBtcoDidDocument } from '../../src/did/createBtcoDidDocument.js';
+import { validateBitcoinAddress, isValidBitcoinAddress } from '../../src/utils/bitcoin-address.js';
+
+describe('SDK testnet (testnet4) support', () => {
+  test('btcoDidPrefix maps testnet to did:btco:test', () => {
+    expect(btcoDidPrefix('testnet')).toBe('did:btco:test');
+    expect(btcoDidFromSatoshi('123456', 'testnet')).toBe('did:btco:test:123456');
+  });
+
+  test('createBtcoDidDocument mints a did:btco:test id on testnet', () => {
+    const doc = createBtcoDidDocument('123456', 'testnet', {
+      publicKey: '02'.padEnd(66, '0'),
+      keyType: 'ES256K',
+    });
+    expect(doc.id).toBe('did:btco:test:123456');
+  });
+
+  test('validateBitcoinAddress accepts a testnet4 tb1 P2WPKH address under "testnet"', () => {
+    // Canonical BIP-173 testnet P2WPKH vector (tb1 prefix; testnet4 shares it).
+    const tb1 = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx';
+    expect(isValidBitcoinAddress(tb1, 'testnet')).toBe(true);
+    // A mainnet bc1 address must NOT validate as testnet.
+    expect(isValidBitcoinAddress('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4', 'testnet')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Both tracks of issue #417, **re-applied cleanly onto `main`** as a single focused PR (52 files, +6k/-89):

- **Track A — real did:webvh hosting:** the signed DID log (+ CEL log + resources) is uploaded to this origin at `PUT /api/host/*`, served back at the exact URLs `didwebvh-ts`'s resolver GETs, and the SDK's **real resolver** fetches it → the demo shows the resolvable log link + "resolved ✓". Grafted onto main's `serve.ts` (#421) via a small `buildFetch` refactor; adds a `webvh-host` store (TTL / size / entry caps, socket-IP rate limiting, anti-stored-XSS headers).
- **Track B — real testnet4 inscription (login- and env-gated):** the logged-in user's **own Turnkey key** signs a real commit in-browser; a **Turnkey-org faucet** funds it via `/api/btc/*` (**no raw private key on the server**); the UI shows the real txid + a mempool.space/testnet4 link. Absent `QUICKNODE_ENDPOINT` + `BTC_FAUCET_*`, the inscribe step stays exactly the current `OrdMockProvider` mock.
- **SDK:** first-class `network:'testnet'` (testnet4) — `did:btco:test` prefix + `tb1` validation.

## Why this shape

The original stacked PRs (#422 Track A, #423 Track B) were built on the `claude/turnkey-auth-hardening-n83ch0` branch, which was **superseded** — `main` landed the same landing/auth foundation independently via #418–#421. Rather than force a 10-file-conflict merge of 51 stale commits, this re-applies just the **net-new** work onto current `main`, reconciling `serve.ts` / `auth-routes` / `api` / `useAuth` / `engine` / `content` against what #421/#418 landed (kept main's `did:cel` layer rename; grafted onto main's unified `serve.ts`). #422/#423 can be closed in favor of this.

## Verification

- **Landing: 70 tests pass**; **SDK testnet regression green**; client + server typecheck clean (bar a pre-existing `IdentityPanel.tsx` `useRef` error that's already on `main`); `vite build` succeeds (engine chunk stays lazy-loaded).
- Boot smoke: auth enabled + testnet disabled → `/api/health` 200, `PUT`/`GET /api/host/*` roundtrip at the resolver URL works, `/api/btc/*` unmounted (404), SPA fallback intact.
- All automated tests run **offline** against mocked Turnkey + QuickNode.

## Follow-up (yours)

The real testnet4 path is a **manual smoke gated on provisioned env**: a QuickNode testnet4 endpoint (Ordinals add-on), a funded Turnkey-org faucet wallet (`BTC_FAUCET_*`), `VITE_BTC_TESTNET=1`, and wiring `getSpendableUtxos` in `serve.ts` (an explicit throw-until-wired gap — fails loudly, never fabricates). It confirms 3 flagged unknowns: Turnkey `signTransaction` envelope, `otpLogin` clientSignature shape, and unconfirmed-faucet-UTXO spend.

Design: `docs/superpowers/specs/2026-07-16-landing-real-onchain-demo-design.md`
Plans: `docs/superpowers/plans/2026-07-16-landing-real-webvh-hosting.md`, `…-testnet4-inscription.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add real did:webvh hosting and testnet4 Bitcoin inscription to the landing demo
> - Replaces the in-memory mock storage with `HttpHostingStorageAdapter`, which PUTs/GETs did:webvh logs via `/api/host/*`, and adds a server-side `createWebvhHostStore` with TTL, rate limiting, and anti-XSS response headers.
> - Adds a real testnet4 inscription path in `DemoEngine.inscribe()`: when the user is authenticated and `VITE_BTC_TESTNET=1`, the server funds the user's Turnkey-held P2WPKH address via `/api/btc/funding`, then signs the commit PSBT via `TurnkeySatSigner` before broadcasting.
> - After `publish()`, the engine attempts live HTTPS resolution of the hosted did:webvh log and emits a `did:webvh:resolved` event; the demo UI surfaces resolution status, a link to the log, and a mempool.space explorer link for the inscription.
> - Extends the SDK's `BitcoinNetwork` type and related utilities (`btcoDidPrefix`, `BitcoinManager`, `LifecycleManager`) to support `'testnet'`, yielding `did:btco:test:` identifiers and accepting `tb1` addresses.
> - Unifies all server request handling (API routes, `/api/host/*`, resolver GETs, and static SPA serving) behind a single `buildFetch` handler in [app.ts](https://github.com/onionoriginals/sdk/pull/428/files#diff-ef121ba8d934c8a73e073096cd62f8ee039823be939191d9721c1c00cc810ba6).
> - Risk: `getSpendableUtxos` on the faucet provider is a stub that throws until wired to QuickNode Ordinals or `bitcoind scantxoutset`; faucet funding returns 502 in production until implemented.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5d4f1d3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->