### PR TITLE
fix(sdk): QuickNodeProvider recognizes chain 'testnet4' (dropped from #429 squash)

### DIFF
--- a/.changeset/quicknode-testnet4-chain.md
+++ b/.changeset/quicknode-testnet4-chain.md
@@ -1,0 +1,5 @@
+---
+"@originals/sdk": patch
+---
+
+QuickNodeProvider: recognize `testnet4` (and `testnet3`) as the `testnet` network in its `getblockchaininfo.chain` guard. Modern bitcoind reports `chain: "testnet4"`, which previously failed the network check with a false "endpoint serves a different chain" error.

--- a/apps/landing/scripts/check-quicknode-ordinals.ts
+++ b/apps/landing/scripts/check-quicknode-ordinals.ts
@@ -37,8 +37,14 @@ try {
   console.log(`   first sat of ${u.txid}:${u.vout} = ${sat}`);
   console.log(`   → real testnet4 inscription is viable on this endpoint.`);
 } catch (e) {
-  console.error(`❌ getFirstSatOfOutput failed — the QuickNode Ordinals add-on likely does NOT cover testnet4.`);
-  console.error(`   ${(e as Error).message}`);
-  console.error(`   → use a self-hosted ord + bitcoind on testnet4 instead.`);
+  const msg = (e as Error).message;
+  if (/serves chain|configured for/.test(msg)) {
+    console.error(`❌ Network-guard mismatch (NOT an add-on problem): ${msg}`);
+    console.error(`   → update @originals/sdk (CHAIN_TO_NETWORK must map your endpoint's chain to 'testnet') and rebuild.`);
+  } else {
+    console.error(`❌ getFirstSatOfOutput failed — the QuickNode Ordinals add-on likely does NOT cover testnet4.`);
+    console.error(`   ${msg}`);
+    console.error(`   → use a self-hosted ord + bitcoind on testnet4 instead.`);
+  }
   process.exit(1);
 }

--- a/packages/sdk/src/adapters/providers/QuickNodeProvider.ts
+++ b/packages/sdk/src/adapters/providers/QuickNodeProvider.ts
@@ -43,7 +43,9 @@ export interface QuickNodeProviderOptions {
 /** getblockchaininfo.chain values mapped to SDK network names. */
 const CHAIN_TO_NETWORK: Record<string, 'mainnet' | 'testnet' | 'signet' | 'regtest'> = {
   main: 'mainnet',
-  test: 'testnet',
+  test: 'testnet', // testnet3 (older bitcoind)
+  testnet3: 'testnet',
+  testnet4: 'testnet', // modern bitcoind reports 'testnet4' for testnet4
   signet: 'signet',
   regtest: 'regtest',
 };

--- a/packages/sdk/tests/unit/adapters/QuickNodeProvider.test.ts
+++ b/packages/sdk/tests/unit/adapters/QuickNodeProvider.test.ts
@@ -468,6 +468,15 @@ describe('QuickNodeProvider hardening (issue #350)', () => {
       expect(requests.filter((r) => r.method === 'getblockchaininfo').length).toBe(1);
     });
 
+    test("accepts chain 'testnet4' for expectedNetwork 'testnet'", async () => {
+      // Modern bitcoind reports chain 'testnet4' (not 'test') on testnet4.
+      mockRpc('getblockchaininfo', { chain: 'testnet4' });
+      mockRpc('ord_getSat', { inscriptions: [] });
+      const provider = new QuickNodeProvider({ endpoint: ENDPOINT, expectedNetwork: 'testnet' });
+      await provider.getInscriptionsBySatoshi('123'); // must NOT throw a network mismatch
+      expect(requests.filter((r) => r.method === 'ord_getSat').length).toBe(1);
+    });
+
     test('performs no chain check when expectedNetwork is not set', async () => {
       mockRpc('ord_getSat', { inscriptions: [] });
       await new QuickNodeProvider({ endpoint: ENDPOINT }).getInscriptionsBySatoshi('123');


### PR DESCRIPTION
The `testnet4`/`testnet3` → `testnet` chain mapping in `QuickNodeProvider` was on the #429 branch but **got dropped from its squash-merge**, so `main` still rejects a real testnet4 QuickNode endpoint with a false *"endpoint serves a different chain"* error (modern bitcoind reports `getblockchaininfo.chain = "testnet4"`, which the guard didn't map).

Re-lands just that fix (+ its test + the sharpened check:ordinals error message + changeset). Without it, `bun run check:ordinals` / the faucet can't get past the network guard on testnet4.

Verified: `QuickNodeProvider.test.ts` green (incl. the new `chain: 'testnet4'` case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `QuickNodeProvider` to recognize 'testnet3' and 'testnet4' as 'testnet'
> Extends the `CHAIN_TO_NETWORK` mapping in [QuickNodeProvider.ts](https://github.com/onionoriginals/sdk/pull/430/files#diff-3ec4f2e71a77a110f95aa2d913ced4c9736676e1414fd638a66362d7cd8825e4) to treat both `testnet3` and `testnet4` chain values as `testnet`, preventing false 'endpoint serves a different chain' errors for modern bitcoind nodes.
>
> Also updates the [check-quicknode-ordinals.ts](https://github.com/onionoriginals/sdk/pull/430/files#diff-302aeccb5c864cc8bfc8f1b76effd87cffae67751abb210d21d0f2529de7a06e) diagnostic script to distinguish network-guard mismatches from actual add-on failures, emitting targeted guidance when the error matches a network/chain message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e00f8a1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->