### PR TITLE
fix(sdk): accept network 'testnet' in the constructor guard

### DIFF
--- a/.changeset/sdk-accept-testnet-network.md
+++ b/.changeset/sdk-accept-testnet-network.md
@@ -1,0 +1,12 @@
+---
+"@originals/sdk": patch
+---
+
+fix: accept `network: 'testnet'` in the `OriginalsSDK` constructor
+
+`OriginalsConfig.network` has always included `'testnet'` and the entire
+Bitcoin layer handles it (BitcoinManager→`did:btco:test`, transfer→signet
+validation, address validation), but the constructor's validation array
+omitted it — so `OriginalsSDK.create({ network: 'testnet' })` threw
+`Invalid network`. This bricked the landing demo (and any testnet4 consumer)
+whenever a testnet network was configured. The guard now accepts `testnet`.

--- a/packages/sdk/src/core/OriginalsSDK.ts
+++ b/packages/sdk/src/core/OriginalsSDK.ts
@@ -159,8 +159,8 @@ export class OriginalsSDK {
     if (!config || typeof config !== 'object') {
       throw new Error('Configuration object is required');
     }
-    if (!config.network || !['mainnet', 'regtest', 'signet'].includes(config.network)) {
-      throw new Error('Invalid network: must be mainnet, regtest, or signet');
+    if (!config.network || !['mainnet', 'testnet', 'regtest', 'signet'].includes(config.network)) {
+      throw new Error('Invalid network: must be mainnet, testnet, regtest, or signet');
     }
     if (!config.defaultKeyType || !['ES256K', 'Ed25519', 'ES256'].includes(config.defaultKeyType)) {
       throw new Error('Invalid defaultKeyType: must be ES256K, Ed25519, or ES256');

--- a/packages/sdk/tests/unit/core/OriginalsSDK.test.ts
+++ b/packages/sdk/tests/unit/core/OriginalsSDK.test.ts
@@ -89,6 +89,17 @@ describe('OriginalsSDK', () => {
     expect((explicitTier as any).config.webvhNetwork).toBe('pichu');
   });
 
+  test("accepts network 'testnet' (testnet4) — the type and Bitcoin layer support it", () => {
+    // Regression: OriginalsConfig.network includes 'testnet' and the whole
+    // bitcoin layer handles it (BitcoinManager→'test', transfer→signet, address
+    // validation), but the constructor guard omitted it, so a config with
+    // network:'testnet' threw 'Invalid network' — bricking e.g. the landing
+    // demo whenever VITE_BTC_TESTNET was set.
+    expect(() => new OriginalsSDK({ network: 'testnet', defaultKeyType: 'Ed25519' })).not.toThrow();
+    const sdk = OriginalsSDK.create({ network: 'testnet', webvhNetwork: 'magby' });
+    expect((sdk as any).config.network).toBe('testnet');
+  });
+
   test('constructor honors config.keyStore (issue #277)', () => {
     // Regression: OriginalsConfig declares keyStore, but the constructor only
     // forwarded its second parameter — config.keyStore was silently ignored
@@ -127,12 +138,12 @@ describe('OriginalsSDK', () => {
 
   test('constructor throws error when network is invalid', () => {
     expect(() => new OriginalsSDK({ network: 'invalid' as any, defaultKeyType: 'ES256K' }))
-      .toThrow('Invalid network: must be mainnet, regtest, or signet');
+      .toThrow('Invalid network: must be mainnet, testnet, regtest, or signet');
   });
 
   test('constructor throws error when network is missing', () => {
     expect(() => new OriginalsSDK({ defaultKeyType: 'ES256K' } as any))
-      .toThrow('Invalid network: must be mainnet, regtest, or signet');
+      .toThrow('Invalid network: must be mainnet, testnet, regtest, or signet');
   });
 
   test('constructor throws error when defaultKeyType is invalid', () => {


### PR DESCRIPTION
## What

`OriginalsSDK.create({ network: 'testnet' })` (and the `new OriginalsSDK(...)` constructor) threw **`Invalid network: must be mainnet, regtest, or signet`** — even though `OriginalsConfig.network` has always been typed `'mainnet' | 'testnet' | 'regtest' | 'signet'` and the **entire Bitcoin layer already handles `testnet`**:

- `BitcoinManager` → `did:btco:test:` prefix
- `transfer.ts` → maps `testnet` → signet for address validation
- `bitcoin-address.ts` / `PSBTBuilder` / `inscribe-on-sat.ts` → all accept `testnet`

Only the constructor's validation array omitted it — a stale guard contradicting the type and the rest of the SDK.

## Impact

This bricked the landing demo whenever a testnet network was configured (`VITE_BTC_TESTNET=1`): the engine constructs `OriginalsSDK` lazily, so the throw surfaced on the user's **first action — creating a did:cel** — with a confusing "Invalid network" error unrelated to what they were doing.

## Fix

Add `'testnet'` to the allowed set (and the error message), update the two message assertions, and add a regression test asserting both `new OriginalsSDK({ network: 'testnet' })` and `OriginalsSDK.create({ network: 'testnet', webvhNetwork: 'magby' })` succeed.

## Tests

All 27 `OriginalsSDK` constructor tests pass; SDK `dist/` rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `OriginalsSDK` constructor to accept `'testnet'` as a valid network
> The constructor in [OriginalsSDK.ts](https://github.com/onionoriginals/sdk/pull/432/files#diff-f47b3916152eac3d307d28a18d92938fefd3bf5afecf7a755bad9040d371134f) previously rejected `'testnet'` as an invalid network, throwing an error that only listed `mainnet`, `regtest`, and `signet`. The allowed list now includes `'testnet'` and the error message is updated to match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b10b39.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->