### PR TITLE
fix(sdk): unify per-asset CEL-log lock to close addResourceVersion↔lifecycle append race (#400)

### DIFF
--- a/.changeset/cel-append-race-400.md
+++ b/.changeset/cel-append-race-400.md
@@ -1,0 +1,19 @@
+---
+"@originals/sdk": patch
+---
+
+fix: unify the per-asset CEL-log lock so `addResourceVersion` and lifecycle
+appends can't clobber each other (#400)
+
+Per-asset CEL appends were serialized by two mutually-invisible locks:
+`OriginalsAsset.#appendChain` (for `addResourceVersion`) and
+`LifecycleManager.inFlightAssets` (for publish/inscribe/rotate/authorize). A
+concurrent `addResourceVersion` and a lifecycle op could interleave across
+await points and clobber each other's signed append (an event silently
+dropped, or a stale-chained event that fails verification).
+
+Fix: `OriginalsAsset` exposes a `runExclusive()` backed by the existing
+`#appendChain` mutex — now the SOLE per-asset CEL lock — and every lifecycle
+log-mutating op runs its append span (including rollback) through it, taken
+after the non-blocking `inFlightAssets` guard (no lock cycle; guard still
+throws OPERATION_IN_PROGRESS for concurrent same-asset lifecycle ops).

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -1476,6 +1476,11 @@ export class LifecycleManager {
       }
       this.inFlightAssets.add(asset.id);
       try {
+      // Serialize the CEL-log mutations below (migrate append + any rollback)
+      // against a concurrent addResourceVersion on the same asset (#400). Taken
+      // AFTER the non-blocking inFlightAssets guard so concurrent publishes still
+      // throw OPERATION_IN_PROGRESS rather than queue.
+      return await asset.runExclusive(async () => {
       const { publisherDid, signer } = this.extractPublisherInfo(publisherDidOrSigner);
       // Publisher DID contributes only the domain; the hosting path comes
       // from the minted DID below.
@@ -1613,6 +1618,7 @@ export class LifecycleManager {
       this.metrics.recordMigration(priorLayer, 'did:webvh');
 
       return asset;
+      });
       } finally {
         this.inFlightAssets.delete(asset.id);
       }
@@ -2576,6 +2582,15 @@ export class LifecycleManager {
     }
     this.inFlightAssets.add(asset.id);
     try {
+    // #400: serialize the migrate append, its witness-proof attach, the
+    // witness-ack, AND the append-rollback (moved into this span, see the inner
+    // catch below) against a concurrent addResourceVersion on the same asset.
+    // The rollback MUST hold this lock too — otherwise a concurrent update could
+    // interleave between a post-append failure and the restore and be clobbered.
+    // Taken after the non-blocking inFlightAssets guard (concurrent inscribes
+    // still throw OPERATION_IN_PROGRESS).
+    return await asset.runExclusive(async () => {
+    try {
     const bitcoinManager = this.deps?.bitcoinManager ?? new BitcoinManager(this.config);
     // The manifest permanently records each resource's declared hash on
     // Bitcoin; verify inline content against it first so a mismatched hash
@@ -2925,22 +2940,28 @@ export class LifecycleManager {
     this.metrics.recordMigration(fromLayer, 'did:btco');
 
     return asset;
-    } finally {
-      this.inFlightAssets.delete(asset.id);
-    }
     } catch (error) {
       // Anything thrown after the append leaves the log ahead of reality —
-      // restore the pre-append snapshot (pure in-memory). EXCEPTION (#Greptile):
-      // a recoverable REVEAL_BROADCAST_FAILED is INTENTIONALLY not rolled back —
-      // its commit is on-chain and the reveal can be rebroadcast, so the migrate
-      // event (now witnessed) plus the advanced btco state correctly reflect
-      // "migrated, inscription pending". Rolling back would desync the log from
-      // an inscription that can still land.
+      // restore the pre-append snapshot (pure in-memory). Kept INSIDE runExclusive
+      // (#400) so a concurrent addResourceVersion cannot interleave between the
+      // failure and this restore. EXCEPTION (#Greptile): a recoverable
+      // REVEAL_BROADCAST_FAILED is INTENTIONALLY not rolled back — its commit is
+      // on-chain and the reveal can be rebroadcast, so the migrate event (now
+      // witnessed) plus the advanced btco state correctly reflect "migrated,
+      // inscription pending". Rolling back would desync the log from an
+      // inscription that can still land.
       const recoverableReveal =
         error instanceof StructuredError && error.code === 'REVEAL_BROADCAST_FAILED';
       if (!recoverableReveal && celHeadDigest !== null && celLogBefore && asset.celLog !== celLogBefore) {
         asset._replaceCelLog(celLogBefore);
       }
+      throw error;
+    }
+    });
+    } finally {
+      this.inFlightAssets.delete(asset.id);
+    }
+    } catch (error) {
       stopTimer();
       this.logger.error('Bitcoin inscription failed', error as Error, { assetId: asset.id, feeRate });
       this.metrics.recordOperation('lifecycle.inscribeOnBitcoin', performance.now() - metricsStart, false);
@@ -3325,6 +3346,10 @@ export class LifecycleManager {
     }
     this.inFlightAssets.add(asset.id);
     try {
+    // Serialize the CEL rotateKey append + witness-ack + reinscribe-failure
+    // rollback against a concurrent addResourceVersion (#400). After the
+    // non-blocking inFlightAssets guard (concurrent rotations still throw).
+    return await asset.runExclusive(async () => {
     // pop() yields the sat for every prefix form (did:btco:N, :reg:N, :sig:N).
     const satoshi = btcoDid.split(':').pop()!;
     // Shared rotated-doc build (backLinks + manifest + NETWORK_MISMATCH guard).
@@ -3437,6 +3462,7 @@ export class LifecycleManager {
     });
 
     return { inscriptionId: inscription.inscriptionId, did: btcoDid };
+    });
     } finally {
       this.inFlightAssets.delete(asset.id);
     }
@@ -3495,6 +3521,10 @@ export class LifecycleManager {
     }
     this.inFlightAssets.add(asset.id);
     try {
+    // Serialize the self-signed rotateKey append + witness-proof attach +
+    // reinscribe-failure rollback against a concurrent addResourceVersion (#400).
+    // After the non-blocking inFlightAssets guard (concurrent calls still throw).
+    return await asset.runExclusive(async () => {
     const satoshi = btcoDid.split(':').pop()!;
     const pkm = newVerificationMethod.publicKeyMultibase;
     // Derive-check the new signer's keypair (privateKey REQUIRED); register it
@@ -3594,6 +3624,7 @@ export class LifecycleManager {
     });
 
     return { inscriptionId: inscription.inscriptionId, did: btcoDid };
+    });
     } finally {
       this.inFlightAssets.delete(asset.id);
     }

--- a/packages/sdk/src/lifecycle/OriginalsAsset.ts
+++ b/packages/sdk/src/lifecycle/OriginalsAsset.ts
@@ -78,13 +78,39 @@ export class OriginalsAsset {
     data: unknown,
     opts?: { inscribeConfirm?: InscribeConfirm }
   ) => Promise<string | null>;
-  // Per-asset serialization for addResourceVersion: the sync→async cutover made
-  // the shared #celLog read-modify-write span await points, so concurrent calls
-  // raced (a later _replaceCelLog clobbered an earlier signed append, or landed
-  // a stale-chained unverifiable event). A promise-chain mutex forces each call
-  // to run its critical section — re-read head, base-check, append — to
-  // completion before the next begins.
+  // The SOLE per-asset lock for CEL #celLog read-modify-write (#400). The
+  // sync→async cutover made every head→sign→_replaceCelLog span cross await
+  // points, so concurrent mutators raced (a later _replaceCelLog clobbered an
+  // earlier signed append, or landed a stale-chained unverifiable event). A
+  // promise-chain mutex forces each critical section — re-read head, base-check,
+  // append/replace — to run to completion before the next begins.
+  //
+  // Routed through it: addResourceVersion (internally) AND every LifecycleManager
+  // log-mutating op (publish/inscribe/rotate/authorize), which wrap their append
+  // span in `runExclusive`. Originally it only serialized addResourceVersion vs
+  // itself; the lifecycle ops were serialized only by LifecycleManager's
+  // (mutually invisible) inFlightAssets guard, so a migrate could interleave with
+  // and clobber an addResourceVersion append (#400).
+  //
+  // LOCK ORDERING (no cycle): lifecycle ops take inFlightAssets (a synchronous,
+  // non-blocking throw-guard — never waits) BEFORE this lock; addResourceVersion
+  // takes ONLY this lock and NEVER inFlightAssets. NOT reentrant — a holder must
+  // not re-acquire it (LifecycleManager's append helpers deliberately do NOT
+  // self-acquire; only their outermost op span does).
   #appendChain: Promise<unknown> = Promise.resolve();
+
+  /**
+   * Run `fn` as an exclusive critical section against every other per-asset CEL
+   * mutation (#400). All #celLog read-modify-write must pass through here (or via
+   * addResourceVersion, which does). NON-reentrant: never call from inside a fn
+   * already holding the lock, or it deadlocks. See #appendChain for ordering.
+   */
+  async runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.#appendChain.then(() => fn());
+    // Keep the chain alive across a rejected turn without swallowing it for the caller.
+    this.#appendChain = run.then(() => {}, () => {});
+    return run;
+  }
   // #407 phase 3: the new version's inline bytes, exposed transiently WHILE the
   // bound appender runs (addResourceVersion appends+inscribes BEFORE pushing the
   // new resource, so the per-event inscription can carry the new media as
@@ -628,16 +654,15 @@ export class OriginalsAsset {
         'or host the bytes externally and reference them by hash.'
       );
     }
-    // Serialize the whole read-modify-write of #celLog per asset: acquire this
-    // asset's append turn, run the critical section to completion, release. A
-    // second queued call re-reads the head INSIDE its turn, so it chains from
-    // the first call's committed result rather than a stale snapshot (Finding 2).
-    const run = this.#appendChain.then(() =>
+    // Serialize the whole read-modify-write of #celLog per asset via the shared
+    // lock: acquire this asset's append turn, run the critical section to
+    // completion, release. A second queued call (another addResourceVersion OR a
+    // lifecycle migrate/rotate) re-reads the head INSIDE its turn, so it chains
+    // from the first call's committed result rather than a stale snapshot
+    // (Finding 2 / #400).
+    return this.runExclusive(() =>
       this.#addResourceVersionCritical(resourceId, newContent, contentType, changes, opts)
     );
-    // Keep the chain alive across a rejected turn without swallowing it for the caller.
-    this.#appendChain = run.catch(() => {});
-    return run;
   }
 
   /**

--- a/packages/sdk/tests/unit/lifecycle/LifecycleManager.appendRace.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/LifecycleManager.appendRace.test.ts
@@ -107,4 +107,51 @@ describe('#400: addResourceVersion vs lifecycle append race', () => {
     // would break continuity).
     expect(await asset.verify()).toBe(true);
   });
+
+  // The end-to-end publish variant proves one op's wiring against a real clobber.
+  // The other three wrapped ops (inscribe/rotate/authorize) can't be guarded the
+  // same way: they migrate to did:btco, after which addResourceVersion takes a
+  // different per-event-inscription path (event count varies with lock order)
+  // and btco verify() needs an ordinalsProvider — so a full end-to-end race
+  // asserts nothing deterministic. Instead, lock down the shared primitive every
+  // op wraps: if runExclusive stops serializing, ALL four ops regress.
+  test('runExclusive serializes concurrent critical sections (mutual exclusion + FIFO)', async () => {
+    const sdk = OriginalsSDK.create({
+      network: 'regtest',
+      defaultKeyType: 'Ed25519',
+      ordinalsProvider: new OrdMockProvider(),
+      keyStore: new MockKeyStore(),
+      storageAdapter: new MemoryStorageAdapter()
+    } as any);
+    const asset = await sdk.lifecycle.createAsset(RES);
+
+    const order: string[] = [];
+    let active = 0;
+    let maxActive = 0;
+    const critical = (label: string, delayMs: number) => async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      order.push(`${label}:start`);
+      await new Promise((r) => setTimeout(r, delayMs));
+      order.push(`${label}:end`);
+      active--;
+      return label;
+    };
+
+    // A runs longest but is enqueued first — FIFO must still run A→B→C to
+    // completion each, never overlapping (a broken lock would interleave).
+    const results = await Promise.all([
+      asset.runExclusive(critical('A', 30)),
+      asset.runExclusive(critical('B', 5)),
+      asset.runExclusive(critical('C', 5))
+    ]);
+
+    expect(maxActive).toBe(1); // never two critical sections in flight at once
+    expect(order).toEqual(['A:start', 'A:end', 'B:start', 'B:end', 'C:start', 'C:end']);
+    expect(results).toEqual(['A', 'B', 'C']);
+
+    // A rejected turn must not wedge the chain: the next acquirer still runs.
+    await expect(asset.runExclusive(async () => { throw new Error('boom'); })).rejects.toThrow('boom');
+    expect(await asset.runExclusive(async () => 'after')).toBe('after');
+  });
 });

--- a/packages/sdk/tests/unit/lifecycle/LifecycleManager.appendRace.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/LifecycleManager.appendRace.test.ts
@@ -1,0 +1,110 @@
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { OriginalsSDK } from '../../../src';
+import { MemoryStorageAdapter } from '../../../src/storage/MemoryStorageAdapter';
+import { OrdMockProvider } from '../../../src/adapters/providers/OrdMockProvider';
+import { MockKeyStore } from '../../mocks/MockKeyStore';
+import { hashResource } from '../../../src/utils/validation';
+
+/**
+ * Regression for #400: a per-asset CEL-log append from addResourceVersion
+ * (serialized by OriginalsAsset.#appendChain) and a lifecycle migrate/rotate
+ * append (serialized only by LifecycleManager.inFlightAssets) were guarded by
+ * TWO independent locks that could not see each other. Both do a
+ * read(head)→sign→_replaceCelLog cycle; when their windows overlap the second
+ * writer clobbers the first signed append (an event is silently dropped).
+ *
+ * This test FORCES the overlapping-window interleaving deterministically via a
+ * keyStore gate: it blocks the two CEL-signing getPrivateKey calls (each runs
+ * one line AFTER its op has already captured the current log head) until BOTH
+ * have arrived, then releases them together — guaranteeing both signed from the
+ * SAME genesis head. Pre-fix that drops one event; post-fix the shared lock
+ * serializes them so both land. A timeout fallback releases a lone waiter so
+ * the (correctly serialized) post-fix run never deadlocks.
+ */
+class TwoArrivalGate extends MockKeyStore {
+  private targetVm: string | null = null;
+  private waiters: Array<() => void> = [];
+  private armed = false;
+
+  /** Gate getPrivateKey calls for `vm` until 2 have arrived (or the fallback). */
+  arm(vm: string): void {
+    this.targetVm = vm;
+    this.armed = true;
+  }
+
+  override async getPrivateKey(verificationMethodId: string): Promise<string | null> {
+    const key = await super.getPrivateKey(verificationMethodId);
+    if (this.armed && verificationMethodId === this.targetVm) {
+      await this.#waitTurn();
+    }
+    return key;
+  }
+
+  #waitTurn(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.waiters.push(resolve);
+      if (this.waiters.length >= 2) {
+        // Both ops have captured the head and are parked here — release together.
+        this.#releaseAll();
+      } else {
+        // Fallback: a correctly serialized (post-fix) run only ever parks one
+        // waiter; release it so the test cannot deadlock.
+        setTimeout(() => this.#releaseAll(), 200);
+      }
+    });
+  }
+
+  #releaseAll(): void {
+    const w = this.waiters;
+    this.waiters = [];
+    for (const resolve of w) resolve();
+  }
+}
+
+const RES = [
+  { id: 'res-1', type: 'data', contentType: 'text/plain', hash: hashResource(Buffer.from('v1', 'utf-8')) }
+];
+
+describe('#400: addResourceVersion vs lifecycle append race', () => {
+  beforeEach(() => {
+    MemoryStorageAdapter.clear();
+  });
+
+  test('concurrent addResourceVersion + publishToWeb both land in the CEL log', async () => {
+    const keyStore = new TwoArrivalGate();
+    const sdk = OriginalsSDK.create({
+      network: 'regtest',
+      defaultKeyType: 'Ed25519',
+      ordinalsProvider: new OrdMockProvider(),
+      keyStore,
+      storageAdapter: new MemoryStorageAdapter()
+    } as any);
+
+    const asset = await sdk.lifecycle.createAsset(RES);
+    expect(asset.celLog!.events.map((e) => e.type)).toEqual(['create']);
+
+    // Both CEL appends sign with the genesis controller (folded from the log
+    // head 'create'). Arm the gate on that VM so both park after reading the
+    // head but before writing it back.
+    const genesisVm = keyStore.getAllVerificationMethodIds().find((id) => id.startsWith('did:key:'))!;
+    keyStore.arm(genesisVm);
+
+    // Fire both per-asset CEL mutations concurrently.
+    const [version] = await Promise.all([
+      asset.addResourceVersion('res-1', 'v2', 'text/plain'),
+      sdk.lifecycle.publishToWeb(asset, 'example.com')
+    ]);
+
+    expect(version.version).toBe(2);
+
+    // Both signed appends must survive: create + update + migrate.
+    const types = asset.celLog!.events.map((e) => e.type);
+    expect(asset.celLog!.events.length).toBe(3);
+    expect(types).toContain('update');
+    expect(types).toContain('migrate');
+
+    // The chain must still verify end-to-end (a clobbered/stale-chained append
+    // would break continuity).
+    expect(await asset.verify()).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #400.

## The race

Per-asset CEL-log appends were serialized by **two mutually-invisible locks**:
- `OriginalsAsset.#appendChain` — a promise-chain mutex for `addResourceVersion`
- `LifecycleManager.inFlightAssets` — a check-then-throw Set for publish/inscribe/rotate/authorize

Both do a `read(head) → sign → _replaceCelLog` cycle across await points. When an `addResourceVersion` and a lifecycle migrate/rotate overlap, the second writer clobbers the first's signed append — an event is silently dropped, or a stale-chained event lands that later fails `verifyEventLog`. The existing in-code "Finding 1/2" comments only covered `addResourceVersion`-vs-itself, not this cross-op race.

## The fix

`OriginalsAsset` exposes `runExclusive<T>(fn)` backed by the **existing** `#appendChain` mutex — now the **sole** per-asset CEL lock:
- `addResourceVersion` routes through it (behavior unchanged).
- Every `LifecycleManager` log-mutating op (`publishToWeb`, `inscribeOnBitcoin`, `rotateBtcoKeys`, `authorizeSigner`) wraps its append span in `asset.runExclusive(...)`, taken **after** the non-blocking `inFlightAssets` guard.
- `inscribeOnBitcoin`'s CEL rollback was moved **inside** the locked span (otherwise a concurrent `addResourceVersion` could interleave between a post-append failure and the restore).

**No lock cycle:** lifecycle ops take `inFlightAssets` (a synchronous throw-guard that never waits) before the append lock; `addResourceVersion` takes only the append lock and never `inFlightAssets`. Concurrent same-asset lifecycle ops still throw `OPERATION_IN_PROGRESS`. The mutex is non-reentrant and no op self-acquires (verified).

## Test

New deterministic regression `tests/unit/lifecycle/LifecycleManager.appendRace.test.ts` forces the overlapping-window interleave via a two-arrival keyStore gate (both ops park after reading the head, released together):
- **Pre-fix:** one signed append is clobbered → 2 events.
- **Post-fix:** create + update + migrate all land → 3 events, `verify()` true.

## Verification

Full SDK suite **3840 pass / 0 fail** (lifecycle + integration subset 576/0); `bun run build` + `bun run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix append race between `addResourceVersion` and lifecycle CEL-log mutations in `OriginalsAsset`
> - Adds `runExclusive<T>` to [`OriginalsAsset`](https://github.com/onionoriginals/sdk/pull/435/files#diff-608e746fc4c7d32a537d26642c0203cf553e14039d42b35b41bfe686b6784ece), a per-asset FIFO mutex backed by a private promise chain (`#appendChain`) that serializes all CEL-log mutations.
> - Wraps the critical sections of `publishToWeb`, `inscribeOnBitcoin`, `transferOwnership`, and `authorizeSigner` in [`LifecycleManager`](https://github.com/onionoriginals/sdk/pull/435/files#diff-f7ee48c88de9ace2f72662a51534f0bbb19607128b3c2178416d1b28c87fc9e8) inside `asset.runExclusive(...)`, preventing interleaving with concurrent `addResourceVersion` calls.
> - Reworks `addResourceVersion` to delegate to `runExclusive` instead of managing `#appendChain` manually.
> - Adds regression tests in [`LifecycleManager.appendRace.test.ts`](https://github.com/onionoriginals/sdk/pull/435/files#diff-449c02cc44cecd88394ddb5611df2bb29fdbb0f42545358a2b0f94f6af865379) using a `TwoArrivalGate` to force overlapping windows and verify both FIFO ordering and rollback correctness.
> - Behavioral Change: lifecycle methods now hold the per-asset lock for the full duration of their CEL mutate span, including rollback; this increases lock contention but eliminates event clobbering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c70d4d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->