### PR TITLE
fix(landing): header section links dead on /me route

### DIFF
--- a/.changeset/nav-section-links.md
+++ b/.changeset/nav-section-links.md
@@ -1,0 +1,5 @@
+---
+"@originals/landing": patch
+---
+
+Fix header nav links being dead on the `/me` (Your Originals) route. The nav renders on every route, but its in-page section anchors (`#why`, `#demo`, `#protocol`, `#developers`, and the wordmark's `#top`) had no target when those sections weren't mounted — so on `/me` only the JS-driven buttons (Sign out, Your Originals) responded. A shared `goToSection()` now routes home first when off `/`, then smooth-scrolls to the section once it mounts (and smooth-scrolls in place when already on `/`).

--- a/apps/landing/src/components/Nav.tsx
+++ b/apps/landing/src/components/Nav.tsx
@@ -1,13 +1,27 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type MouseEvent } from 'react';
 import { nav, site, yourOriginals } from '../content';
 import { useAuth } from '../auth/useAuth';
-import { navigate } from '../router';
+import { navigate, goToSection } from '../router';
 import { LoginModal } from './LoginModal';
 import './nav.css';
 
+// In-page section links (#why, #demo, …, #top) must work from any route — on
+// /me the target sections aren't mounted, so a bare hash anchor is dead. Route
+// home first, then scroll.
+function onSectionClick(e: MouseEvent<HTMLAnchorElement>, href: string) {
+  if (!href.startsWith('#')) return; // external/absolute links: default behavior
+  e.preventDefault();
+  goToSection(href);
+}
+
 function Wordmark() {
   return (
-    <a className="nav-wordmark" href="#top" aria-label={`${site.wordmark} — home`}>
+    <a
+      className="nav-wordmark"
+      href="#top"
+      aria-label={`${site.wordmark} — home`}
+      onClick={(e) => onSectionClick(e, '#top')}
+    >
       <svg viewBox="0 0 20 20" aria-hidden="true">
         <circle cx="10" cy="10" r="7.25" fill="none" stroke="var(--accent)" strokeWidth="2.5" />
         <circle cx="10" cy="10" r="2" fill="currentColor" />
@@ -36,7 +50,7 @@ export function Nav() {
         <Wordmark />
         <nav className="nav-links" aria-label="Primary">
           {nav.links.map((link) => (
-            <a key={link.href} href={link.href}>
+            <a key={link.href} href={link.href} onClick={(e) => onSectionClick(e, link.href)}>
               {link.label}
             </a>
           ))}
@@ -96,7 +110,14 @@ export function Nav() {
       {open && (
         <nav className="nav-mobile" aria-label="Mobile">
           {nav.links.map((link) => (
-            <a key={link.href} href={link.href} onClick={() => setOpen(false)}>
+            <a
+              key={link.href}
+              href={link.href}
+              onClick={(e) => {
+                setOpen(false);
+                onSectionClick(e, link.href);
+              }}
+            >
               {link.label}
             </a>
           ))}

--- a/apps/landing/src/router.tsx
+++ b/apps/landing/src/router.tsx
@@ -19,6 +19,31 @@ export function navigate(path: string): void {
   window.dispatchEvent(new Event(NAV_EVENT));
 }
 
+/**
+ * Navigate to a landing-page section by hash (e.g. '#why'). The nav is shown on
+ * every route, but its section anchors are dead off '/' (on '/me' those sections
+ * aren't mounted, so a plain `<a href="#why">` has no target). This routes home
+ * first when needed, then smooth-scrolls once the section mounts.
+ */
+export function goToSection(hash: string): void {
+  if (typeof window === 'undefined') return;
+  const scrollWhenReady = (tries = 30): void => {
+    const el = hash ? document.querySelector(hash) : null;
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth' });
+      return;
+    }
+    if (tries > 0) requestAnimationFrame(() => scrollWhenReady(tries - 1));
+  };
+  if (window.location.pathname !== '/') {
+    navigate('/'); // remount the landing, then scroll
+    scrollWhenReady();
+  } else {
+    if (hash) window.history.replaceState({}, '', hash);
+    scrollWhenReady();
+  }
+}
+
 export function useLocationPath(): string {
   const [path, setPath] = useState(() =>
     typeof window !== 'undefined' ? window.location.pathname : '/'

--- a/apps/landing/src/router.tsx
+++ b/apps/landing/src/router.tsx
@@ -37,6 +37,7 @@ export function goToSection(hash: string): void {
   };
   if (window.location.pathname !== '/') {
     navigate('/'); // remount the landing, then scroll
+    if (hash) window.history.replaceState({}, '', hash);
     scrollWhenReady();
   } else {
     if (hash) window.history.replaceState({}, '', hash);


### PR DESCRIPTION
## Bug

On the deployed landing page, **none of the header nav buttons worked except Sign out and Your Originals** — reported while signed in.

## Cause

The nav (`Nav.tsx`) renders on **every** route, but the section links are plain hash anchors (`#why`, `#demo`, `#protocol`, `#developers`, wordmark `#top`). On the `/me` (Your Originals) route those sections aren't mounted, so the anchors have **no scroll target** and do nothing. Only the JS-driven controls (Sign out, Your Originals — `onClick`/`navigate`) responded — exactly the reported symptom.

## Fix

A shared `goToSection(hash)` in `router.tsx`:
- **off `/`** (e.g. `/me`): `navigate('/')` to remount the landing, then poll via `requestAnimationFrame` until the section exists and `scrollIntoView`.
- **on `/`**: smooth-scroll in place and update the URL hash.

Wired into the wordmark, desktop nav links, and mobile nav links. External links (GitHub) and JS buttons keep their behavior.

## Verify

Client typecheck clean, `vite build` succeeds. Manual: from `/me`, each header link now returns to the landing page and scrolls to its section; from `/`, links smooth-scroll as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix dead header section links on the `/me` route in the landing nav
> - Adds `goToSection(hash)` in [router.tsx](https://github.com/onionoriginals/sdk/pull/438/files#diff-a856abde5a93acada42b606aead64318f004bf9dd8b0950fb275e3b673b422c9) that navigates to `/` if not already there, then polls via `requestAnimationFrame` until the target element mounts before smooth-scrolling to it.
> - Updates [Nav.tsx](https://github.com/onionoriginals/sdk/pull/438/files#diff-595b6cb6408a6998a454fbd4bf682cd8238c676a18355aa09fcf34cd86a43d58) to intercept clicks on hash links via `onSectionClick`, delegating to `goToSection` instead of relying on default anchor behavior.
> - Mobile nav now closes the menu before triggering section navigation; external links (e.g. GitHub) are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2bbfec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->