### PR TITLE
fix(sdk): controller-authenticated did:cel uniqueness — close deny-only front-run (#402)

### DIFF
--- a/.changeset/cel-uniqueness-controller-auth.md
+++ b/.changeset/cel-uniqueness-controller-auth.md
@@ -1,0 +1,5 @@
+---
+"@originals/sdk": patch
+---
+
+Fix a deny-only front-running weakness in did:cel first-anchor-wins uniqueness (#402). `verifyUniqueness` counted **any** inscription that back-linked the did:cel via `alsoKnownAs`, so a non-controller could inscribe `{alsoKnownAs:["did:cel:Z"]}` on their own earlier sat and permanently trip `NON_CANONICAL_ANCHOR`/`AMBIGUOUS_CANONICAL` on an honest mint (deny-only — no theft). Now a competing anchoring on a different sat counts only if its inscribed did:btco document is signed by a key in the log's authorized-key history (genesis controller + rotations); the log's own anchored sat always counts. A bare or unauthorized-key back-link is ignored, so it can no longer deny a mint. Legit controller-signed dupe detection and all fail-closed behavior are preserved.

--- a/packages/sdk/src/adapters/providers/OrdMockProvider.ts
+++ b/packages/sdk/src/adapters/providers/OrdMockProvider.ts
@@ -155,8 +155,9 @@ export class OrdMockProvider implements OrdinalsProvider {
     satoshi: string;
     inscriptionId: string;
     blockHeight?: number;
+    didDocument?: Record<string, unknown>;
   }>> {
-    const out: Array<{ satoshi: string; inscriptionId: string; blockHeight?: number }> = [];
+    const out: Array<{ satoshi: string; inscriptionId: string; blockHeight?: number; didDocument?: Record<string, unknown> }> = [];
     for (const rec of this.state.inscriptionsById.values()) {
       if (rec.satoshi === undefined) continue;
       // #407 phase 2: the DID document rides in inscription METADATA (content is
@@ -172,7 +173,13 @@ export class OrdMockProvider implements OrdinalsProvider {
       }
       const aka = (doc as { alsoKnownAs?: unknown } | null)?.alsoKnownAs;
       if (Array.isArray(aka) && aka.includes(didCel)) {
-        out.push({ satoshi: rec.satoshi, inscriptionId: rec.inscriptionId, blockHeight: rec.blockHeight });
+        // Surface the inscribed doc so uniqueness can authenticate a competing
+        // anchoring via its DataIntegrityProof (#402). Clone so a reader mutating
+        // the result cannot corrupt stored state.
+        const didDocument = doc && typeof doc === 'object'
+          ? (structuredClone(doc) as Record<string, unknown>)
+          : undefined;
+        out.push({ satoshi: rec.satoshi, inscriptionId: rec.inscriptionId, blockHeight: rec.blockHeight, didDocument });
       }
     }
     return out;

--- a/packages/sdk/src/adapters/types.ts
+++ b/packages/sdk/src/adapters/types.ts
@@ -106,11 +106,19 @@ export interface OrdinalsProvider {
    * providers implement this via a content/metadata index (an `ord` instance
    * or a service such as the QuickNode Ordinals add-on). `blockHeight` is the
    * canonical ordering signal; a missing height fails uniqueness closed.
+   *
+   * `didDocument` (#402) is the inscribed did:btco document with its
+   * DataIntegrityProof, used to authenticate a competing anchoring on a
+   * DIFFERENT sat (a competitor counts only if signed by a key in the verified
+   * log's authorized-key history). Optional/backward-compatible: an omitted
+   * `didDocument` means the competitor cannot be authenticated and does not
+   * count toward canonicality.
    */
   getAnchoringsForDidCel?(didCel: string): Promise<Array<{
     satoshi: string;
     inscriptionId: string;
     blockHeight?: number;
+    didDocument?: Record<string, unknown>;
   }>>;
   transferInscription(
     inscriptionId: string,

--- a/packages/sdk/src/cel/algorithms/verifyEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/verifyEventLog.ts
@@ -609,10 +609,13 @@ async function verifyHeadFreshness(
  * and permanently DENY an honest mint (deny-only front-run). A bare back-link, or
  * a proof by an unauthorized key, therefore does NOT count.
  *
- * The signed payload is the DID document with its `proof` removed (standard Data
- * Integrity: proofs are stripped before canonicalization), verified with the SAME
- * `eddsa-jcs-2022` primitive the CEL uses (`dispatchVerify` over
- * `canonicalizeEvent(docWithoutProof)`). Authorization compares the resolved
+ * The signed payload is the DID document with its `proof` removed, verified with
+ * the SAME `eddsa-jcs-2022` primitive the CEL uses (`dispatchVerify` over
+ * `canonicalizeEvent(docWithoutProof)`). NOTE: this is THIS codebase's signing
+ * convention — JCS over the proofless document — NOT W3C Data Integrity, which
+ * signs over document + proof-options (the proof sans `proofValue`); don't treat
+ * them as interchangeable if a real VCDM proof path is ever added. Authorization
+ * compares the resolved
  * PUBLIC KEY against the history set — not the VM URI string — matching the
  * controller-binding elsewhere in this file. Fail-closed throughout: a missing
  * doc, a malformed/structurally-invalid proof, an unresolvable or unauthorized
@@ -701,6 +704,11 @@ async function verifyUniqueness(
   // can never trip NON_CANONICAL_ANCHOR / AMBIGUOUS_CANONICAL. Fail-closed by
   // construction: a competitor the provider cannot surface a doc for, or whose
   // doc is not authorized-signed, simply does not count.
+  // ACCEPTED TRADE-OFF: an OrdinalsProvider that doesn't populate `didDocument`
+  // (backward-compat) makes ALL competitors uncountable — closing the DoS but
+  // also silently suppressing legit-dupe detection (a genuine earlier
+  // controller-signed mint on another sat would be ignored). Providers must
+  // surface the doc (see OrdinalsLookup/OrdinalsProvider docs) to restore it.
   const anchorings: Array<{ satoshi: string; inscriptionId: string; blockHeight?: number }> = [];
   for (const a of rawAnchorings) {
     if (a.satoshi === anchoredSat.satoshi) {

--- a/packages/sdk/src/cel/algorithms/verifyEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/verifyEventLog.ts
@@ -601,6 +601,52 @@ async function verifyHeadFreshness(
 }
 
 /**
+ * Authenticates a COMPETING anchoring (#402): true iff its inscribed did:btco
+ * document carries a DataIntegrityProof (eddsa-jcs-2022) signed by a key in the
+ * verified log's authorized-key history. Without this gate, `getAnchoringsForDidCel`
+ * counts ANY inscription that back-links the did:cel via `alsoKnownAs` — so a
+ * non-controller could inscribe `{alsoKnownAs:[didCel]}` on their own earlier sat
+ * and permanently DENY an honest mint (deny-only front-run). A bare back-link, or
+ * a proof by an unauthorized key, therefore does NOT count.
+ *
+ * The signed payload is the DID document with its `proof` removed (standard Data
+ * Integrity: proofs are stripped before canonicalization), verified with the SAME
+ * `eddsa-jcs-2022` primitive the CEL uses (`dispatchVerify` over
+ * `canonicalizeEvent(docWithoutProof)`). Authorization compares the resolved
+ * PUBLIC KEY against the history set — not the VM URI string — matching the
+ * controller-binding elsewhere in this file. Fail-closed throughout: a missing
+ * doc, a malformed/structurally-invalid proof, an unresolvable or unauthorized
+ * key, or a bad signature all yield false (the competitor simply does not count).
+ */
+async function anchoringDocAuthenticated(
+  didDocument: Record<string, unknown> | undefined,
+  authorizedKeyHexes: Set<string>,
+  resolveKey?: (verificationMethod: string) => Promise<Uint8Array | null>
+): Promise<boolean> {
+  if (!didDocument || typeof didDocument !== 'object') return false;
+  const rawProof = (didDocument as { proof?: unknown }).proof;
+  const proofs = Array.isArray(rawProof) ? rawProof : rawProof ? [rawProof] : [];
+  if (proofs.length === 0) return false;
+
+  // Canonicalize over the document WITHOUT any proof (all proofs stripped).
+  const docWithoutProof: Record<string, unknown> = { ...didDocument };
+  delete docWithoutProof.proof;
+
+  for (const candidate of proofs) {
+    if (!candidate || typeof candidate !== 'object') continue;
+    const proof = candidate as DataIntegrityProof;
+    if (!structuralCheck(proof)) continue;
+    // KEY must be in the log's authorized-key history.
+    const keyHex = await resolveControllerKeyHex(proof.verificationMethod, resolveKey);
+    if (keyHex === null || !authorizedKeyHexes.has(keyHex)) continue;
+    // SIGNATURE must verify over the proofless document.
+    const { verified } = await dispatchVerify(proof, docWithoutProof, resolveKey);
+    if (verified) return true;
+  }
+  return false;
+}
+
+/**
  * did:cel uniqueness — first-anchor-wins (follow-up to the signed-anchored-sat
  * spec). The canonical sat for a did:cel is the sat of its EARLIEST on-chain
  * anchoring: the lowest confirmed block height, GROUPED BY SAT. Multiple
@@ -608,10 +654,20 @@ async function verifyHeadFreshness(
  * compete — only a different, earlier sat wins. A btco-anchored log whose
  * anchored sat is not that canonical sat is a non-canonical dupe.
  *
+ * COMPETITOR AUTHENTICATION (#402): only CONTROLLER-authenticated anchorings
+ * count. The log's OWN anchored sat always counts (it is the artifact under
+ * verification). A competitor on a DIFFERENT sat counts only if its inscribed
+ * did:btco document is signed by a key in THIS log's authorized-key history
+ * (`anchoringDocAuthenticated`). An unauthenticated back-link — a bare
+ * `alsoKnownAs`, or a proof by an unauthorized key — is IGNORED, so a
+ * non-controller cannot front-run and deny an honest mint. A genuinely
+ * controller-signed earlier anchoring on a different sat still competes (legit
+ * dupe detection preserved).
+ *
  * Fail-closed and NOT opt-in: a btco-anchored did:cel log already requires a
  * provider, so a provider that cannot enumerate, an empty enumeration, or any
- * anchoring missing a confirmed block height → `UNIQUENESS_UNVERIFIABLE`. A
- * same-block tie between two DIFFERENT sats → `AMBIGUOUS_CANONICAL` (no finer
+ * COUNTABLE anchoring missing a confirmed block height → `UNIQUENESS_UNVERIFIABLE`.
+ * A same-block tie between two DIFFERENT sats → `AMBIGUOUS_CANONICAL` (no finer
  * on-chain order is exposed by the provider contract today).
  *
  * Returns a coded error string on failure, or null when the anchored sat is
@@ -620,25 +676,50 @@ async function verifyHeadFreshness(
 async function verifyUniqueness(
   didCel: string,
   anchoredSat: AnchoredSat,
-  ordinalsProvider: OrdinalsLookup | undefined
+  authorizedKeyHexes: Set<string>,
+  ordinalsProvider: OrdinalsLookup | undefined,
+  resolveKey?: (verificationMethod: string) => Promise<Uint8Array | null>
 ): Promise<string | null> {
   if (!ordinalsProvider || typeof ordinalsProvider.getAnchoringsForDidCel !== 'function') {
     return `UNIQUENESS_UNVERIFIABLE: the ordinals provider cannot enumerate anchorings for ${didCel}; a btco-anchored did:cel log requires this to confirm first-anchor-wins canonicality`;
   }
 
-  let anchorings: Array<{ satoshi: string; inscriptionId: string; blockHeight?: number }>;
+  let rawAnchorings: Array<{ satoshi: string; inscriptionId: string; blockHeight?: number; didDocument?: Record<string, unknown> }>;
   try {
-    anchorings = await ordinalsProvider.getAnchoringsForDidCel(didCel);
+    rawAnchorings = await ordinalsProvider.getAnchoringsForDidCel(didCel);
   } catch (e) {
     return `UNIQUENESS_UNVERIFIABLE: failed to enumerate anchorings for ${didCel}: ${e instanceof Error ? e.message : String(e)}`;
   }
 
-  if (!Array.isArray(anchorings) || anchorings.length === 0) {
+  if (!Array.isArray(rawAnchorings) || rawAnchorings.length === 0) {
     return `UNIQUENESS_UNVERIFIABLE: no on-chain anchorings found for ${didCel}; cannot confirm the anchored sat ${anchoredSat.satoshi} is canonical`;
   }
 
-  // Every anchoring must carry a confirmed (non-negative integer) block height:
-  // the ordering signal must be provable, or canonicality is undecidable.
+  // #402 filter: keep only COUNTABLE anchorings — the log's own anchored sat
+  // (always) plus controller-authenticated competitors on other sats. Everything
+  // else (unauthenticated back-links) is dropped BEFORE any ordering logic, so it
+  // can never trip NON_CANONICAL_ANCHOR / AMBIGUOUS_CANONICAL. Fail-closed by
+  // construction: a competitor the provider cannot surface a doc for, or whose
+  // doc is not authorized-signed, simply does not count.
+  const anchorings: Array<{ satoshi: string; inscriptionId: string; blockHeight?: number }> = [];
+  for (const a of rawAnchorings) {
+    if (a.satoshi === anchoredSat.satoshi) {
+      anchorings.push(a);
+    } else if (await anchoringDocAuthenticated(a.didDocument, authorizedKeyHexes, resolveKey)) {
+      anchorings.push(a);
+    }
+  }
+
+  if (anchorings.length === 0) {
+    // No countable anchoring at all: the log's OWN anchored sat is absent from
+    // the enumeration (its inscribed did:btco doc is missing the did:cel
+    // back-link) and every competitor was unauthenticated. Cannot confirm
+    // canonicality — fail closed.
+    return `UNIQUENESS_UNVERIFIABLE: the log's own anchoring sat ${anchoredSat.satoshi} for ${didCel} is absent from the on-chain enumeration and no controller-authenticated competitor was found; cannot confirm canonicality`;
+  }
+
+  // Every COUNTABLE anchoring must carry a confirmed (non-negative integer) block
+  // height: the ordering signal must be provable, or canonicality is undecidable.
   for (const a of anchorings) {
     if (typeof a.blockHeight !== 'number' || !Number.isInteger(a.blockHeight) || a.blockHeight < 0) {
       return `UNIQUENESS_UNVERIFIABLE: anchoring ${a.inscriptionId} on satoshi ${a.satoshi} has no confirmed block height; first-anchor-wins ordering is unprovable`;
@@ -1461,6 +1542,14 @@ export async function verifyEventLog(
   const currentResourceHash = new Map<string, string>();
 
   let authorizedKeyIds = new Set<string>();
+  // The UNION of every key the log's key history ever authorized (genesis
+  // controller + each accepted rotation's newController). Unlike authorizedKeyIds
+  // — which a rotation REPLACES (hand-off semantics) — this only grows, because a
+  // legitimate earlier btco anchoring may have been signed by an EARLIER
+  // controller key. Used solely to authenticate competing anchorings in #402
+  // uniqueness (it never relaxes per-event authorization, which stays scoped to
+  // authorizedKeyIds as it stood when each event was appended).
+  const allAuthorizedKeyHexes = new Set<string>();
   let authorityError: string | undefined;
   if (!options?.verifier) {
     // A non-array proof (missing, object, string, …) yields zero controller
@@ -1556,6 +1645,8 @@ export async function verifyEventLog(
   // confirmed by a matching bitcoin witness proof, the log's authority is
   // anchored to that sat. Default-path only; a custom verifier owns semantics.
   let anchoredSat: AnchoredSat | undefined;
+  // Seed the history union with the genesis-authorized key(s) established above.
+  for (const k of authorizedKeyIds) allAuthorizedKeyHexes.add(k);
   for (let i = 0; i < log.events.length; i++) {
     const event = log.events[i];
     const previousEvent = i > 0 ? log.events[i - 1] : undefined;
@@ -1607,6 +1698,10 @@ export async function verifyEventLog(
         // REPLACE, not union — hand-off semantics (design spec §2/§5); keeping
         // the old keys would reopen the stale-key window rotation closes.
         authorizedKeyIds = newKeys;
+        // The uniqueness history union (#402) DOES accumulate: an earlier
+        // anchoring signed by this now-superseded controller must still be
+        // recognizable as a legit competitor.
+        for (const k of newKeys) allAuthorizedKeyHexes.add(k);
       }
     }
 
@@ -1699,7 +1794,7 @@ export async function verifyEventLog(
   // path (which owns proof semantics and never establishes `anchoredSat`).
   let uniquenessError: string | undefined;
   if (!options?.verifier && anchoredSat && typeof assetDid === 'string' && assetDid.startsWith('did:cel:')) {
-    uniquenessError = (await verifyUniqueness(assetDid, anchoredSat, options?.ordinalsProvider)) ?? undefined;
+    uniquenessError = (await verifyUniqueness(assetDid, anchoredSat, allAuthorizedKeyHexes, options?.ordinalsProvider, options?.resolveKey)) ?? undefined;
   }
 
   // Content-as-ordinal integrity (#407 phase 2): a phase-2 anchor inscription's

--- a/packages/sdk/src/cel/types.ts
+++ b/packages/sdk/src/cel/types.ts
@@ -192,11 +192,20 @@ export interface OrdinalsLookup {
    * fails uniqueness CLOSED (`UNIQUENESS_UNVERIFIABLE`). Multiple inscriptions
    * on the SAME sat (migrate + rotation reinscriptions) are expected and do
    * not compete — only a different, earlier sat wins.
+   *
+   * `didDocument` (#402) is the inscribed did:btco document carrying its
+   * DataIntegrityProof. Uniqueness uses it to AUTHENTICATE a competing anchoring
+   * on a DIFFERENT sat: a competitor counts only if its doc is signed by a key
+   * in the verified log's authorized-key history — otherwise a non-controller
+   * could inscribe a bare `alsoKnownAs` back-link on an earlier sat and deny an
+   * honest mint. Optional/backward-compatible: an omitted `didDocument` simply
+   * means that competitor cannot be authenticated and does not count.
    */
   getAnchoringsForDidCel?(didCel: string): Promise<Array<{
     satoshi: string;
     inscriptionId: string;
     blockHeight?: number;
+    didDocument?: Record<string, unknown>;
   }>>;
 }
 

--- a/packages/sdk/tests/unit/cel/did-cel-uniqueness.test.ts
+++ b/packages/sdk/tests/unit/cel/did-cel-uniqueness.test.ts
@@ -57,6 +57,18 @@ function btcoDoc(satoshi: string, headDigestMultibase: string, didCel: string, p
   };
 }
 
+// Controller-sign a btco doc so it counts as an authenticated competitor (#402):
+// the proof is over the JCS of the doc WITHOUT its proof — exactly what
+// verifyUniqueness re-checks. `signer` must be a key in the log's authorized-key
+// history (genesis controller or a rotated-in controller).
+async function signBtcoDoc(
+  doc: Record<string, unknown>,
+  signer: (data: unknown) => Promise<Record<string, unknown>>
+): Promise<Record<string, unknown>> {
+  const proof = await signer(doc);
+  return { ...doc, proof };
+}
+
 function attachWitness(log: EventLog, insc: { inscriptionId: string; txid: string }, satoshi: string): EventLog {
   const last = log.events[log.events.length - 1];
   const witnessedAt = '2026-07-13T00:00:01Z';
@@ -75,9 +87,20 @@ function attachWitness(log: EventLog, insc: { inscriptionId: string; txid: strin
   return { events: [...log.events.slice(0, -1), { ...last, proof: [...last.proof, witnessProof] }] };
 }
 
-async function inscribeDoc(p: OrdMockProvider, satoshi: string, headDigest: string, didCel: string, publicKeyMultibase?: string) {
+// Inscribe a btco doc on `satoshi`. When `signer` is provided the doc is
+// controller-signed (authenticated competitor, #402); when omitted the doc is
+// a BARE back-link (the front-run attacker shape — must be ignored by uniqueness).
+async function inscribeDoc(
+  p: OrdMockProvider,
+  satoshi: string,
+  headDigest: string,
+  didCel: string,
+  opts?: { publicKeyMultibase?: string; signer?: (data: unknown) => Promise<Record<string, unknown>> }
+) {
+  let doc: Record<string, unknown> = btcoDoc(satoshi, headDigest, didCel, opts?.publicKeyMultibase);
+  if (opts?.signer) doc = await signBtcoDoc(doc, opts.signer);
   const res = await p.createInscription({
-    data: Buffer.from(JSON.stringify(btcoDoc(satoshi, headDigest, didCel, publicKeyMultibase))),
+    data: Buffer.from(JSON.stringify(doc)),
     contentType: 'application/did+json',
     targetSatoshi: satoshi,
   });
@@ -101,7 +124,9 @@ async function branch(base: EventLog, a: Key, p: OrdMockProvider, sat: string, d
     { sourceDid: didCel, layer: 'btco', network: 'regtest', to: `did:btco:reg:${sat}`, migratedAt: '2026-07-13T00:00:00Z' },
     { signer: a.signer, verificationMethod: a.vm }
   );
-  const insc = await inscribeDoc(p, sat, chainDigest(log.events[log.events.length - 1]), didCel);
+  // Controller-signed (by `a`, the genesis controller) so this anchoring counts
+  // as an authenticated competitor when a DIFFERENT branch's log is verified.
+  const insc = await inscribeDoc(p, sat, chainDigest(log.events[log.events.length - 1]), didCel, { signer: a.signer });
   log = attachWitness(log, insc, sat);
   return { log, inscriptionId: insc.inscriptionId };
 }
@@ -172,7 +197,7 @@ describe('did:cel uniqueness — first-anchor-wins', () => {
       { newController: b.didKey, rotatedAt: '2026-07-13T00:00:02Z' },
       { signer: b.signer, verificationMethod: b.vm }
     );
-    const rotInsc = await inscribeDoc(p, X, chainDigest(rotated.events[rotated.events.length - 1]), didCel, b.pubMb);
+    const rotInsc = await inscribeDoc(p, X, chainDigest(rotated.events[rotated.events.length - 1]), didCel, { publicKeyMultibase: b.pubMb, signer: b.signer });
     const full = attachWitness(rotated, rotInsc, X);
 
     // Migrate at block 100, rotation reinscription at block 200 — both on X.
@@ -254,6 +279,67 @@ describe('did:cel uniqueness — first-anchor-wins', () => {
     const result = await verifyEventLog(bx.log, { ordinalsProvider: provider });
     expect(result.verified).toBe(false);
     expect(hasCode(result, 'UNIQUENESS_UNVERIFIABLE')).toBe(true);
+  });
+
+  // #402: only CONTROLLER-authenticated competitors count. A non-controller who
+  // inscribes a bare {alsoKnownAs:[didCel]} back-link on an earlier sat must NOT
+  // be able to deny an honest mint (deny-only front-run). These are the
+  // regression tests — they FAIL on origin/main (the honest mint trips
+  // NON_CANONICAL_ANCHOR because the unauthenticated rival is counted).
+  test('FRONT-RUN (bare back-link): an UNSIGNED earlier anchoring on a rival sat is IGNORED; the honest mint verifies', async () => {
+    const p = new OrdMockProvider();
+    const a = await makeKey();
+    const { base, didCel } = await genesis(a, 'uniq-frontrun-bare');
+    const S = '900000009'; // honest own sat
+    const Z = '100000001'; // attacker's earlier sat
+
+    // Honest controller mints on its own sat S (controller-signed via branch()).
+    const honest = await branch(base, a, p, S, didCel);
+    // Attacker front-runs: a BARE back-link doc on an EARLIER sat Z, NO controller
+    // proof. It back-links the did:cel (so it IS enumerated) but authenticates to
+    // nobody, so uniqueness must ignore it.
+    const attackInsc = await inscribeDoc(p, Z, 'uATTACKERHEAD', didCel);
+
+    // Attacker's Z anchored FIRST (block 100); honest S later (block 200).
+    const provider = withHeights(p, { [honest.inscriptionId]: 200, [attackInsc.inscriptionId]: 100 });
+    const result = await verifyEventLog(honest.log, { ordinalsProvider: provider });
+    expect(result.errors).toEqual([]);
+    expect(result.verified).toBe(true);
+  });
+
+  test('FRONT-RUN (unauthorized signature): an earlier anchoring signed by a NON-controller key is IGNORED; the honest mint verifies', async () => {
+    const p = new OrdMockProvider();
+    const a = await makeKey();
+    const attacker = await makeKey();
+    const { base, didCel } = await genesis(a, 'uniq-frontrun-badkey');
+    const S = '900000009';
+    const Z = '100000001';
+
+    const honest = await branch(base, a, p, S, didCel);
+    // The rival doc is signed — but by the ATTACKER's own key, which is not in
+    // the log's authorized-key history, so it must not count.
+    const attackInsc = await inscribeDoc(p, Z, 'uATTACKERHEAD', didCel, { signer: attacker.signer });
+
+    const provider = withHeights(p, { [honest.inscriptionId]: 200, [attackInsc.inscriptionId]: 100 });
+    const result = await verifyEventLog(honest.log, { ordinalsProvider: provider });
+    expect(result.errors).toEqual([]);
+    expect(result.verified).toBe(true);
+  });
+
+  test('LEGIT DUPE PRESERVED: a CONTROLLER-signed earlier anchoring on a different sat STILL trips NON_CANONICAL_ANCHOR', async () => {
+    const p = new OrdMockProvider();
+    const a = await makeKey();
+    const { base, didCel } = await genesis(a, 'uniq-legit-dupe');
+    const X = '100000001'; // controller's earlier legit anchoring
+    const S = '900000009'; // the branch under verification, later
+
+    const legit = await branch(base, a, p, X, didCel); // controller-signed, earlier
+    const mine = await branch(base, a, p, S, didCel); // controller-signed, later
+    const provider = withHeights(p, { [legit.inscriptionId]: 100, [mine.inscriptionId]: 200 });
+
+    const result = await verifyEventLog(mine.log, { ordinalsProvider: provider });
+    expect(result.verified).toBe(false);
+    expect(hasCode(result, 'NON_CANONICAL_ANCHOR')).toBe(true);
   });
 
   test('THROWING PROVIDER: getAnchoringsForDidCel throws → UNIQUENESS_UNVERIFIABLE', async () => {


### PR DESCRIPTION
Fixes #402.

## The weakness
did:cel uniqueness is first-anchor-wins: `verifyUniqueness` treats the sat of the *earliest* on-chain anchoring as canonical, and a btco-anchored log on a non-canonical sat fails `NON_CANONICAL_ANCHOR`/`AMBIGUOUS_CANONICAL`. But `getAnchoringsForDidCel` counted **any** inscription that back-linked the did:cel via `alsoKnownAs` — with **no authentication**. So a non-controller could inscribe `{alsoKnownAs:["did:cel:Z"]}` on their own earlier/same-block sat and **permanently deny an honest mint**. Deny-only (ownership is sat control — no theft), but real, and it hits assets already published to did:webvh (public log).

## The fix — controller-authenticated competitors only
A competing anchoring on a **different** sat counts toward canonicality only if its inscribed did:btco document carries a `DataIntegrityProof` (`eddsa-jcs-2022`) whose key is in **this log's authorized-key history**. The log's **own** anchored sat always counts (it's the artifact under verification; the honest inscribe path doesn't sign the doc). A bare `alsoKnownAs` back-link, or a proof by an unauthorized key, is **dropped before any ordering logic** — so it can't trip the check.

- **Authorized-key history:** a new grow-only union (`allAuthorizedKeyHexes`) seeded from the genesis controller and extended by each accepted rotation's `newKeys` — because a legitimate *earlier* anchoring may have been signed by a now-superseded controller. It's used **only** to authenticate competitors; per-event authorization stays scoped to `authorizedKeyIds` (unchanged), so nothing is relaxed.
- Reuses the existing `structuralCheck` / `resolveControllerKeyHex` / `dispatchVerify` primitives — no new crypto.
- **Fail-closed preserved:** if the only enumerated anchoring is the log's own sat missing its back-link *and* no authenticated competitor exists → `UNIQUENESS_UNVERIFIABLE`; block-height and AMBIGUOUS checks now run on the *countable* set.

## Tests
- **Front-run (bare back-link)** and **front-run (unauthorized-key signature)**: earlier rival anchoring **ignored** → honest mint verifies. Both **fail on `main`** (honest mint tripped `NON_CANONICAL_ANCHOR`), pass here.
- **Legit dupe preserved:** a genuinely controller-signed earlier anchoring on a different sat still trips `NON_CANONICAL_ANCHOR`.
- Existing AMBIGUOUS + block-height fail-closed tests still pass.

Full SDK suite **3845 pass / 0 fail**; build + lint clean. Reviewed the agent's diff line-by-line (own-sat invariant, hex-key representation consistency, grow-only union, fail-closed edges) before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix did:cel first-anchor-wins uniqueness to ignore unauthenticated competing anchorings
> - Previously, any inscription with a bare `alsoKnownAs` back-link to a `did:cel` could count as a competing anchoring, enabling a deny-only front-run attack that blocks legitimate mints.
> - Introduces `anchoringDocAuthenticated` in [`verifyEventLog.ts`](https://github.com/onionoriginals/sdk/pull/440/files#diff-aba8e823ef267585b4b8a9603e5b6afe67fce86d0fee4f9ce67bd95b013efedf) to verify that competing anchorings carry a valid `eddsa-jcs-2022` DataIntegrityProof signed by a key in the DID's authorized-key history before counting them.
> - `verifyUniqueness` now only counts the log's own anchored sat unconditionally; rival anchorings on different sats must pass authentication to be considered.
> - [`OrdMockProvider.getAnchoringsForDidCel`](https://github.com/onionoriginals/sdk/pull/440/files#diff-615e0a7d4384208563eb1db1b8db81ff5e8242b43022bafea050a6e2940c093c) is updated to return the inscribed `didDocument` alongside each anchoring so the authentication check has data to verify.
> - Behavioral Change: unauthenticated or non-controller-signed rival anchorings are now silently ignored rather than counted toward first-anchor-wins ordering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bc5597a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->