### PR TITLE
Add Original detail page with provenance timeline and verification

### DIFF
--- a/apps/landing/src/App.tsx
+++ b/apps/landing/src/App.tsx
@@ -7,8 +7,9 @@ import { RealExample } from './components/RealExample';
 import { Protocol } from './components/Protocol';
 import { Developers } from './components/Developers';
 import { Footer } from './components/Footer';
-import { useLocationPath, routeForPath } from './router';
+import { useLocationPath, routeForPath, didFromPath } from './router';
 import { YourOriginals } from './pages/YourOriginals';
+import { OriginalDetail } from './pages/OriginalDetail';
 
 export function App() {
   if (new URLSearchParams(location.search).has('smoke')) {
@@ -19,10 +20,13 @@ export function App() {
 
 function RoutedApp() {
   const path = useLocationPath();
+  const route = routeForPath(path);
   return (
     <>
       <Nav />
-      {routeForPath(path) === 'your-originals' ? (
+      {route === 'original-detail' ? (
+        <OriginalDetail did={didFromPath(path)!} />
+      ) : route === 'your-originals' ? (
         <YourOriginals />
       ) : (
         <main>

--- a/apps/landing/src/components/IdentityPanel.tsx
+++ b/apps/landing/src/components/IdentityPanel.tsx
@@ -12,7 +12,7 @@ export function IdentityPanel() {
   const [did, setDid] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
-  const copyTimer = useRef<ReturnType<typeof setTimeout>>();
+  const copyTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   if (!isAuthenticated) return null;
 

--- a/apps/landing/src/content.ts
+++ b/apps/landing/src/content.ts
@@ -190,6 +190,82 @@ export const yourOriginals = {
   pendingBadge: 'resolves in production',
   openLog: 'Open the signed DID log',
   createdLabel: 'Created',
+  viewLabel: 'View provenance',
+};
+
+export const originalDetail = {
+  backLabel: 'Your Originals',
+  signedOut: 'Sign in to see this Original.',
+  loading: 'Fetching the signed artifacts…',
+  notFoundTitle: 'Not one of your Originals.',
+  notFoundBody:
+    'This page shows Originals saved to your account — this DID isn’t among them. It may belong to another account, or the link is stale.',
+  notFoundCta: 'Back to Your Originals',
+  createdLabel: 'Created',
+  verifyingBadge: 'Verifying in your browser…',
+  verifiedBadge: 'Verified in this tab',
+  failedBadge: 'Verification incomplete',
+  verifyNote:
+    'These checks run locally, against the artifacts this Original hosts at this origin — not a database row.',
+  checkLabels: {
+    hash: 'Resource bytes match their declared sha-256',
+    log: 'did:webvh log — SCID and Ed25519 proof chain verify',
+    cel: 'CEL event chain verifies back to the did:cel genesis'
+  },
+  artifactsMissing:
+    'The signed artifacts could not be fetched in this environment — they resolve at the production origin.',
+  timeline: {
+    eyebrow: 'Provenance',
+    heading: 'How this Original came to be',
+    subhead:
+      'Every step is a signed event in the asset’s own cryptographic event log. The log — not this page — is the source of truth: anyone can fetch it and re-verify the chain.',
+    steps: {
+      create: {
+        title: 'Created',
+        blurb:
+          'Born as a did:cel genesis — a signed event log minted in the browser, no server involved. The resource bytes were hashed and sealed into the very first event.'
+      },
+      publish: {
+        title: 'Published',
+        blurb:
+          'Migrated to did:webvh: a signed version history went live at this origin, resolvable by anyone with the SDK — or curl.'
+      },
+      inscribe: {
+        title: 'Inscribed',
+        blurb:
+          'The next step in the lifecycle: inscribing on a satoshi makes ownership transferable on Bitcoin — permanent, final, and platform-free.'
+      }
+    },
+    upcomingLabel: 'Up next',
+    proofLabel: 'Signed',
+  },
+  resources: {
+    heading: 'Sealed resources',
+    subhead:
+      'The files hashed into the genesis event. Change a single byte anywhere and every verification on this page fails.',
+    digestLabel: 'Digest',
+    typeLabel: 'Type',
+    openRaw: 'Open raw bytes'
+  },
+  identity: {
+    heading: 'Identity on the open web',
+    subhead:
+      'The current DID document, derived from the signed version-history log — the same document the SDK’s resolver returns for this DID.',
+    did: 'DID',
+    scid: 'SCID',
+    versions: 'Log entries',
+    updated: 'Last updated',
+    updateKey: 'Update key',
+    signingKey: 'Signing key',
+    documentToggle: 'View the resolved DID document'
+  },
+  artifacts: {
+    heading: 'Raw artifacts',
+    subhead:
+      'Nothing hidden: these are the exact files the resolver fetches. Take them anywhere — the signatures travel with the bytes.',
+    logLabel: 'did.jsonl — signed version history',
+    celLabel: 'cel.json — cryptographic event log'
+  }
 };
 
 export const realExample = {

--- a/apps/landing/src/pages/OriginalDetail.tsx
+++ b/apps/landing/src/pages/OriginalDetail.tsx
@@ -1,0 +1,580 @@
+/**
+ * The '/me/<did>' page — one Original, fully expanded. Auth-gated like /me.
+ *
+ * Everything shown is pulled from the Original's real artifacts hosted at this
+ * origin: the CEL event log (cel.json) drives the provenance timeline, the
+ * signed did:webvh log (did.jsonl) drives the identity section, and the sealed
+ * resources render from their hosted bytes. A lazy verification pass re-checks
+ * hashes and both proof chains in the visitor's browser (verify-original.ts).
+ */
+import { useEffect, useRef, useState } from 'react';
+import { originalDetail } from '../content';
+import { useAuth } from '../auth/useAuth';
+import { navigate } from '../router';
+import { short } from '../sdk/format';
+import type { OriginalCheck } from '../sdk/verify-original';
+import { fetchOriginals, type OriginalRow } from './YourOriginals';
+import {
+  webvhArtifacts,
+  celTimeline,
+  celResources,
+  parseDidLog,
+  didLogSummary,
+  digestMultibaseSha256Hex,
+  sha256HexToResourceMultibase,
+  sameOriginUrl,
+  detailMode,
+  type CelLog,
+  type CelResourceRef,
+  type DidLogSummary,
+  type TimelineStep
+} from './original-detail-data';
+import './original-detail.css';
+
+interface DetailData {
+  row: OriginalRow | null;
+  cel: CelLog | null;
+  logEntries: ReturnType<typeof parseDidLog> | null;
+  logSummary: DidLogSummary | null;
+  resources: CelResourceRef[];
+  /** Hosted URL + fetched text per resource id (text only for JSON/text types). */
+  resourceUrls: Record<string, string>;
+  resourceTexts: Record<string, string>;
+}
+
+async function fetchText(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url);
+    return res.ok ? await res.text() : null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchBytes(url: string): Promise<Uint8Array | null> {
+  try {
+    const res = await fetch(url);
+    return res.ok ? new Uint8Array(await res.arrayBuffer()) : null;
+  } catch {
+    return null;
+  }
+}
+
+const isImage = (r: CelResourceRef) => (r.mediaType ?? '').startsWith('image/');
+const isText = (r: CelResourceRef) =>
+  /^(application\/json|text\/)/.test(r.mediaType ?? '');
+
+export function OriginalDetail({ did }: { did: string }) {
+  const { isAuthenticated } = useAuth();
+  const [loaded, setLoaded] = useState(false);
+  const [data, setData] = useState<DetailData | null>(null);
+  const [checks, setChecks] = useState<OriginalCheck[] | null>(null);
+  const [copied, setCopied] = useState(false);
+  const copyTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    let live = true;
+    setLoaded(false);
+    setData(null);
+    setChecks(null);
+
+    (async () => {
+      const arts = webvhArtifacts(did, window.location.host);
+      const [rows, logRaw, celRaw] = await Promise.all([
+        fetchOriginals(),
+        arts ? fetchText(arts.logUrl) : null,
+        arts ? fetchText(arts.celUrl) : null
+      ]);
+      const row = rows.find((r) => r.did === did) ?? null;
+
+      let logEntries: ReturnType<typeof parseDidLog> | null = null;
+      try {
+        logEntries = logRaw ? parseDidLog(logRaw) : null;
+      } catch {
+        logEntries = null;
+      }
+      let cel: CelLog | null = null;
+      try {
+        cel = celRaw ? (JSON.parse(celRaw) as CelLog) : null;
+      } catch {
+        cel = null;
+      }
+
+      const resources = celResources(cel);
+      const resourceUrls: Record<string, string> = {};
+      const resourceTexts: Record<string, string> = {};
+      for (const r of resources) {
+        // Resources are hosted under the raw-hash multibase, not the CEL's
+        // multihash digest — convert declared digest → hosted key segment.
+        const hex = r.digestMultibase ? digestMultibaseSha256Hex(r.digestMultibase) : null;
+        const hosted = hex ? sha256HexToResourceMultibase(hex) : null;
+        if (arts && hosted) resourceUrls[r.id] = arts.resourceUrl(hosted);
+      }
+      await Promise.all(
+        resources.filter(isText).map(async (r) => {
+          const url = resourceUrls[r.id];
+          if (!url) return;
+          const text = await fetchText(url);
+          if (text) resourceTexts[r.id] = text;
+        })
+      );
+
+      if (!live) return;
+      setData({
+        row,
+        cel,
+        logEntries,
+        logSummary: logEntries ? didLogSummary(logEntries) : null,
+        resources,
+        resourceUrls,
+        resourceTexts
+      });
+      setLoaded(true);
+
+      // Verification pass — real cryptography, lazy chunk. The primary resource
+      // (the artwork) is re-fetched as bytes and re-hashed; both signed chains
+      // re-verify locally.
+      const primary = resources.find(isImage) ?? resources[0];
+      const primaryUrl = primary
+        ? resourceUrls[primary.id]
+        : row?.resourceUrl && sameOriginUrl(row.resourceUrl, window.location.host);
+      const bytes = primaryUrl ? await fetchBytes(primaryUrl) : null;
+      const declaredHash =
+        (primary?.digestMultibase ? digestMultibaseSha256Hex(primary.digestMultibase) : null) ??
+        row?.resourceHash ??
+        null;
+      try {
+        const { verifyOriginal } = await import('../sdk/verify-original');
+        const result = await verifyOriginal({
+          did,
+          logEntries,
+          celLog: cel,
+          resourceBytes: bytes,
+          declaredHash
+        });
+        if (live) setChecks(result);
+      } catch (err) {
+        console.error('[originals-sdk] original verification failed', err);
+        if (live) setChecks([]);
+      }
+    })();
+
+    return () => {
+      live = false;
+    };
+  }, [isAuthenticated, did]);
+
+  const mode = detailMode({ authenticated: isAuthenticated, loaded, row: data?.row ?? null });
+
+  const copyDid = async () => {
+    try {
+      await navigator.clipboard.writeText(did);
+    } catch {
+      // clipboard can be unavailable — the DID text stays selectable
+    }
+    setCopied(true);
+    clearTimeout(copyTimer.current);
+    copyTimer.current = setTimeout(() => setCopied(false), 1800);
+  };
+
+  const allOk = !!checks && checks.length > 0 && checks.every((c) => c.ok);
+  const anyFail = !!checks && (checks.length === 0 || checks.some((c) => !c.ok));
+
+  return (
+    <main className="section od">
+      <div className="container">
+        <a
+          className="od-back"
+          href="/me"
+          onClick={(e) => {
+            e.preventDefault();
+            navigate('/me');
+          }}
+        >
+          <svg viewBox="0 0 16 16" aria-hidden="true" width="12" height="12">
+            <path d="M10 3 5 8l5 5" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          {originalDetail.backLabel}
+        </a>
+
+        {mode === 'signed-out' && <p className="od-note">{originalDetail.signedOut}</p>}
+        {mode === 'loading' && (
+          <p className="od-note" role="status">
+            <span className="od-pulse" aria-hidden="true" />
+            {originalDetail.loading}
+          </p>
+        )}
+
+        {mode === 'not-found' && (
+          <div className="od-empty">
+            <p className="od-empty-title">{originalDetail.notFoundTitle}</p>
+            <p>{originalDetail.notFoundBody}</p>
+            <button type="button" className="btn btn-ghost" onClick={() => navigate('/me')}>
+              {originalDetail.notFoundCta}
+            </button>
+          </div>
+        )}
+
+        {mode === 'ready' && data?.row && (
+          <>
+            <Hero did={did} data={data} checks={checks} allOk={allOk} anyFail={anyFail} copied={copied} onCopy={copyDid} />
+            {data.cel ? (
+              <Timeline steps={celTimeline(data.cel)} />
+            ) : (
+              <p className="od-note">{originalDetail.artifactsMissing}</p>
+            )}
+            {data.resources.length > 0 && <Resources data={data} />}
+            {data.logSummary && <Identity summary={data.logSummary} />}
+            <Artifacts did={did} />
+          </>
+        )}
+      </div>
+    </main>
+  );
+}
+
+/* ——— sections ——— */
+
+function Hero(props: {
+  did: string;
+  data: DetailData;
+  checks: OriginalCheck[] | null;
+  allOk: boolean;
+  anyFail: boolean;
+  copied: boolean;
+  onCopy: () => void;
+}) {
+  const { did, data, checks, allOk, anyFail, copied, onCopy } = props;
+  const row = data.row!;
+  const artResource = data.resources.find(isImage);
+  const artUrl =
+    (artResource && data.resourceUrls[artResource.id]) ??
+    (row.resourceUrl ? sameOriginUrl(row.resourceUrl, window.location.host) : undefined);
+  const medium = mediumFromMetadata(data);
+
+  return (
+    <header className="card od-hero">
+      <div className="od-art">
+        {artUrl ? (
+          <img src={artUrl} alt={`Artwork for “${row.title}”`} />
+        ) : (
+          <div className="od-art-placeholder" aria-hidden="true" />
+        )}
+      </div>
+      <div className="od-hero-body">
+        <div className="od-hero-pills">
+          <span className="layer-pill" data-layer="did:webvh">
+            <span className="dot" />
+            did:webvh
+          </span>
+          {!checks && (
+            <span className="od-badge" data-state="pending">
+              <span className="od-pulse" aria-hidden="true" />
+              {originalDetail.verifyingBadge}
+            </span>
+          )}
+          {checks && (
+            <span className="od-badge" data-state={allOk ? 'ok' : 'warn'}>
+              {allOk ? originalDetail.verifiedBadge : originalDetail.failedBadge}
+            </span>
+          )}
+        </div>
+        <h1>{row.title}</h1>
+        <p className="od-hero-meta">
+          {medium && <span>{medium} · </span>}
+          {originalDetail.createdLabel} {row.createdAt.slice(0, 10)}
+        </p>
+        <div className="od-did">
+          <code title={did}>{did}</code>
+          <button
+            type="button"
+            className="od-copy"
+            data-copied={copied || undefined}
+            onClick={onCopy}
+            aria-label={copied ? 'DID copied' : 'Copy DID'}
+          >
+            {copied ? (
+              <svg viewBox="0 0 16 16" aria-hidden="true">
+                <path d="m3.5 8.5 3 3 6-7" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            ) : (
+              <svg viewBox="0 0 16 16" aria-hidden="true">
+                <rect x="5.5" y="5.5" width="7" height="7" rx="1.5" fill="none" stroke="currentColor" strokeWidth="1.3" />
+                <path d="M10.5 5.5v-1a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v4a2 2 0 0 0 2 2h1" fill="none" stroke="currentColor" strokeWidth="1.3" />
+              </svg>
+            )}
+            <span>{copied ? 'Copied' : 'Copy'}</span>
+          </button>
+        </div>
+
+        <ul className="od-checks">
+          {(['hash', 'log', 'cel'] as const).map((id) => {
+            const check = checks?.find((c) => c.id === id);
+            const status = !checks ? 'pending' : check?.ok ? 'ok' : 'fail';
+            return (
+              <li key={id} data-state={status}>
+                <span className="od-check-mark" aria-hidden="true">
+                  {status === 'ok' ? (
+                    <svg viewBox="0 0 16 16">
+                      <path d="m3.5 8.5 3 3 6-7" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  ) : status === 'fail' ? (
+                    <svg viewBox="0 0 16 16">
+                      <path d="m4 4 8 8m0-8-8 8" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+                    </svg>
+                  ) : (
+                    <span className="od-check-dot" />
+                  )}
+                </span>
+                <div>
+                  <p className="od-check-label">{originalDetail.checkLabels[id]}</p>
+                  {check && <p className="od-check-detail">{check.detail}</p>}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+        <p className="od-verify-note">{originalDetail.verifyNote}</p>
+      </div>
+    </header>
+  );
+}
+
+function mediumFromMetadata(data: DetailData): string | null {
+  const meta = data.resources.find((r) => r.mediaType === 'application/json');
+  const text = meta ? data.resourceTexts[meta.id] : undefined;
+  if (!text) return null;
+  try {
+    const parsed = JSON.parse(text) as { medium?: unknown };
+    return typeof parsed.medium === 'string' ? parsed.medium : null;
+  } catch {
+    return null;
+  }
+}
+
+function Timeline({ steps }: { steps: TimelineStep[] }) {
+  return (
+    <section className="od-section">
+      <div className="section-head">
+        <p className="eyebrow">{originalDetail.timeline.eyebrow}</p>
+        <h2>{originalDetail.timeline.heading}</h2>
+        <p>{originalDetail.timeline.subhead}</p>
+      </div>
+      <ol className="od-timeline">
+        {steps.map((step) => {
+          const copy = originalDetail.timeline.steps[step.id];
+          return (
+            <li key={step.id} className="od-step" data-state={step.state} data-layer={step.layer}>
+              <span className="od-step-node" aria-hidden="true" />
+              <div className="card od-step-card">
+                <div className="od-step-head">
+                  <span className="layer-pill" data-layer={step.layer}>
+                    <span className="dot" />
+                    {step.layer}
+                  </span>
+                  <h3>{copy.title}</h3>
+                  {step.state === 'done' && step.at ? (
+                    <time className="od-step-time" dateTime={step.at}>
+                      {step.at.slice(0, 10)} · {step.at.slice(11, 19)} UTC
+                    </time>
+                  ) : (
+                    <span className="od-step-time">{originalDetail.timeline.upcomingLabel}</span>
+                  )}
+                </div>
+                <p className="od-step-blurb">{copy.blurb}</p>
+                {step.facts.length > 0 && (
+                  <dl className="od-step-facts">
+                    {step.facts.map((f) => (
+                      <div key={f.label}>
+                        <dt>{f.label}</dt>
+                        <dd>
+                          {f.mono ? <code title={f.value}>{short(f.value, 34, 8)}</code> : f.value}
+                        </dd>
+                      </div>
+                    ))}
+                  </dl>
+                )}
+                {step.proof?.proofValue && (
+                  <p className="od-step-proof">
+                    <span className="od-step-proof-label">{originalDetail.timeline.proofLabel}</span>
+                    <code title={step.proof.proofValue}>
+                      {step.proof.cryptosuite ?? 'proof'} · {short(step.proof.proofValue, 18, 6)}
+                    </code>
+                  </p>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}
+
+function Resources({ data }: { data: DetailData }) {
+  return (
+    <section className="od-section">
+      <div className="section-head">
+        <h2>{originalDetail.resources.heading}</h2>
+        <p>{originalDetail.resources.subhead}</p>
+      </div>
+      <div className="od-resources">
+        {data.resources.map((r) => {
+          const url = data.resourceUrls[r.id];
+          const text = data.resourceTexts[r.id];
+          return (
+            <article key={r.id} className="card od-resource">
+              <div className="od-resource-preview">
+                {isImage(r) && url ? (
+                  <img src={url} alt={`Resource ${r.id}`} />
+                ) : text ? (
+                  <pre>{prettyJson(text)}</pre>
+                ) : (
+                  <div className="od-art-placeholder" aria-hidden="true" />
+                )}
+              </div>
+              <div className="od-resource-body">
+                <h3>
+                  <code>{r.id}</code>
+                </h3>
+                <dl className="od-resource-facts">
+                  {r.mediaType && (
+                    <div>
+                      <dt>{originalDetail.resources.typeLabel}</dt>
+                      <dd>
+                        <code>{r.mediaType}</code>
+                      </dd>
+                    </div>
+                  )}
+                  {r.digestMultibase && (
+                    <div>
+                      <dt>{originalDetail.resources.digestLabel}</dt>
+                      <dd>
+                        <code title={r.digestMultibase}>{short(r.digestMultibase, 20, 6)}</code>
+                      </dd>
+                    </div>
+                  )}
+                </dl>
+                {url && (
+                  <a className="od-raw-link" href={url} target="_blank" rel="noreferrer">
+                    {originalDetail.resources.openRaw}
+                    <ExternalIcon />
+                  </a>
+                )}
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function prettyJson(text: string): string {
+  try {
+    return JSON.stringify(JSON.parse(text), null, 2);
+  } catch {
+    return text;
+  }
+}
+
+function Identity({ summary }: { summary: DidLogSummary }) {
+  const vm = summary.verificationMethods[0];
+  return (
+    <section className="od-section">
+      <div className="section-head">
+        <h2>{originalDetail.identity.heading}</h2>
+        <p>{originalDetail.identity.subhead}</p>
+      </div>
+      <div className="card od-identity">
+        <dl className="od-identity-kv">
+          {summary.did && (
+            <div>
+              <dt>{originalDetail.identity.did}</dt>
+              <dd>
+                <code title={summary.did}>{summary.did}</code>
+              </dd>
+            </div>
+          )}
+          {summary.scid && (
+            <div>
+              <dt>{originalDetail.identity.scid}</dt>
+              <dd>
+                <code title={summary.scid}>{short(summary.scid, 24, 6)}</code>
+              </dd>
+            </div>
+          )}
+          <div>
+            <dt>{originalDetail.identity.versions}</dt>
+            <dd>{summary.versions}</dd>
+          </div>
+          {summary.updatedAt && (
+            <div>
+              <dt>{originalDetail.identity.updated}</dt>
+              <dd>{summary.updatedAt.slice(0, 10)}</dd>
+            </div>
+          )}
+          {summary.updateKeys[0] && (
+            <div>
+              <dt>{originalDetail.identity.updateKey}</dt>
+              <dd>
+                <code title={summary.updateKeys[0]}>{short(summary.updateKeys[0], 24, 6)}</code>
+              </dd>
+            </div>
+          )}
+          {vm?.publicKeyMultibase && (
+            <div>
+              <dt>{originalDetail.identity.signingKey}</dt>
+              <dd>
+                <code title={vm.publicKeyMultibase}>{short(vm.publicKeyMultibase, 24, 6)}</code>
+              </dd>
+            </div>
+          )}
+        </dl>
+        {summary.document && (
+          <details className="od-doc">
+            <summary>{originalDetail.identity.documentToggle}</summary>
+            <pre>{JSON.stringify(summary.document, null, 2)}</pre>
+          </details>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function Artifacts({ did }: { did: string }) {
+  const arts = webvhArtifacts(did, typeof window !== 'undefined' ? window.location.host : undefined);
+  if (!arts) return null;
+  const links = [
+    { href: arts.logUrl, label: originalDetail.artifacts.logLabel },
+    { href: arts.celUrl, label: originalDetail.artifacts.celLabel }
+  ];
+  return (
+    <section className="od-section">
+      <div className="section-head">
+        <h2>{originalDetail.artifacts.heading}</h2>
+        <p>{originalDetail.artifacts.subhead}</p>
+      </div>
+      <ul className="od-artifacts">
+        {links.map((l) => (
+          <li key={l.href}>
+            <a className="od-raw-link" href={l.href} target="_blank" rel="noreferrer">
+              <code>{l.href.replace(/^https?:\/\//, '')}</code>
+              <span>{l.label}</span>
+              <ExternalIcon />
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function ExternalIcon() {
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true" width="12" height="12">
+      <path d="M6 3h7v7M13 3 7 9" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}

--- a/apps/landing/src/pages/YourOriginals.tsx
+++ b/apps/landing/src/pages/YourOriginals.tsx
@@ -1,13 +1,16 @@
 /**
  * The /me "Your Originals" page. Auth-gated: signed-out users get a prompt;
- * signed-in users see their durable did:webvh Originals (artwork thumbnail,
- * title, did with a live "resolved ✓", open-log link, created date). Empty
- * state links back to the demo.
+ * signed-in users see their durable did:webvh Originals as a gallery of cards
+ * (artwork cover, title, did with a live "resolved ✓", created date). Each
+ * card opens the Original's own detail page ('/me/<did>') where the full
+ * provenance — CEL timeline, signed DID log, sealed resources — is laid out
+ * and re-verified in the browser. Empty state links back to the demo.
  */
 import { useEffect, useState } from 'react';
 import { yourOriginals } from '../content';
 import { useAuth } from '../auth/useAuth';
-import { navigate } from '../router';
+import { navigate, originalPath } from '../router';
+import { sameOriginUrl } from './original-detail-data';
 import './your-originals.css';
 
 export interface OriginalRow {
@@ -28,15 +31,20 @@ export function originalsView(input: { authenticated: boolean; originals: Origin
   return { mode: 'list', rows: input.originals };
 }
 
-async function fetchOriginals(): Promise<OriginalRow[]> {
-  const res = await fetch('/api/originals', { credentials: 'same-origin' });
-  if (!res.ok) return [];
-  const body = (await res.json()) as { originals?: OriginalRow[] };
-  return body.originals ?? [];
+/** The signed-in user's Originals, newest first ([] when signed out / on error). */
+export async function fetchOriginals(): Promise<OriginalRow[]> {
+  try {
+    const res = await fetch('/api/originals', { credentials: 'same-origin' });
+    if (!res.ok) return [];
+    const body = (await res.json()) as { originals?: OriginalRow[] };
+    return body.originals ?? [];
+  } catch {
+    return [];
+  }
 }
 
 // Best-effort live resolution proof (production only — the resolver forces
-// https, so a dev http origin returns false; the row still renders).
+// https, so a dev http origin returns false; the card still renders).
 async function resolveLive(did: string): Promise<boolean> {
   try {
     const { OriginalsSDK, OrdMockProvider } = await import('@originals/sdk');
@@ -53,13 +61,6 @@ async function resolveLive(did: string): Promise<boolean> {
   } catch {
     return false;
   }
-}
-
-function didLogUrl(did: string): string {
-  const parts = did.split(':'); // did:webvh:<SCID>:<host>[:<seg>…]
-  const host = decodeURIComponent(parts[3] ?? '');
-  const segs = parts.slice(4).map((s) => decodeURIComponent(s));
-  return segs.length ? `https://${host}/${segs.join('/')}/did.jsonl` : `https://${host}/.well-known/did.jsonl`;
 }
 
 export function YourOriginals() {
@@ -100,32 +101,51 @@ export function YourOriginals() {
         )}
 
         {view.mode === 'list' && (
-          <ul className="your-originals-list">
+          <ul className="your-originals-grid">
             {view.rows.map((row) => {
-              const logUrl = didLogUrl(row.did);
+              const href = originalPath(row.did);
               const ok = resolved[row.did];
               return (
-                <li key={row.did} className="your-original">
-                  {row.resourceUrl ? (
-                    <img className="your-original-thumb" src={row.resourceUrl} alt={`Artwork for “${row.title}”`} />
-                  ) : (
-                    <span className="your-original-thumb your-original-thumb-empty" aria-hidden="true" />
-                  )}
-                  <div className="your-original-body">
-                    <h2>{row.title}</h2>
-                    <div className="your-original-did">
-                      <code title={row.did}>{row.did}</code>
+                <li key={row.did}>
+                  <a
+                    className="card your-original-card"
+                    href={href}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      navigate(href);
+                    }}
+                    aria-label={`“${row.title}” — ${yourOriginals.viewLabel}`}
+                  >
+                    <span className="your-original-cover">
+                      {row.resourceUrl ? (
+                        <img src={sameOriginUrl(row.resourceUrl, window.location.host)} alt="" />
+                      ) : (
+                        <span className="your-original-cover-empty" aria-hidden="true" />
+                      )}
                       <span className="your-original-badge" data-ok={ok || undefined}>
                         {ok ? yourOriginals.resolvedBadge : yourOriginals.pendingBadge}
                       </span>
-                    </div>
-                    <a href={logUrl} target="_blank" rel="noreferrer" className="your-original-log">
-                      {yourOriginals.openLog}
-                    </a>
-                    <p className="your-original-created">
-                      {yourOriginals.createdLabel} {row.createdAt.slice(0, 10)}
-                    </p>
-                  </div>
+                    </span>
+                    <span className="your-original-card-body">
+                      <span className="layer-pill" data-layer="did:webvh">
+                        <span className="dot" />
+                        did:webvh
+                      </span>
+                      <h2>{row.title}</h2>
+                      <code className="your-original-did" title={row.did}>{row.did}</code>
+                      <span className="your-original-foot">
+                        <span className="your-original-created">
+                          {yourOriginals.createdLabel} {row.createdAt.slice(0, 10)}
+                        </span>
+                        <span className="your-original-view">
+                          {yourOriginals.viewLabel}
+                          <svg viewBox="0 0 16 16" aria-hidden="true" width="12" height="12">
+                            <path d="M6 3l5 5-5 5" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+                          </svg>
+                        </span>
+                      </span>
+                    </span>
+                  </a>
                 </li>
               );
             })}

--- a/apps/landing/src/pages/original-detail-artifacts.integration.test.ts
+++ b/apps/landing/src/pages/original-detail-artifacts.integration.test.ts
@@ -1,0 +1,117 @@
+/**
+ * End-to-end guarantee for the detail page's data pipeline: after a real authed
+ * publish (DemoEngine → DurableHostingStorageAdapter → originals store), every
+ * artifact URL webvhArtifacts() derives from the DID — did.jsonl, cel.json, and
+ * each sealed resource — serves from the durable store, and the parsed
+ * artifacts fold into the timeline/summary/digests the page renders.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { signToken, getAuthCookieConfig } from '@originals/auth/server';
+import { DemoEngine } from '../sdk/engine';
+import { createOriginalsStore } from '../../server/originals-store';
+import { createOriginalsRoutes } from '../../server/originals-routes';
+import { createWebvhHostStore } from '../../server/webvh-host';
+import { buildFetch } from '../../server/app';
+import {
+  webvhArtifacts,
+  celTimeline,
+  celResources,
+  parseDidLog,
+  didLogSummary,
+  digestMultibaseSha256Hex,
+  sha256HexToResourceMultibase,
+  type CelLog
+} from './original-detail-data';
+
+const JWT = 'test-secret-at-least-32-chars-long!!';
+const HOST = 'demo.test';
+
+const toHex = (bytes: Uint8Array) =>
+  Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+
+// Route the browser's durable PUTs, the summary POST, AND the resolver's https
+// GETs through one in-process server (buildFetch) with a real durable store.
+function installServerFetch(store: ReturnType<typeof createOriginalsStore>) {
+  const originals = createOriginalsRoutes({ jwtSecret: JWT, store });
+  const apiRoutes = { 'POST /api/originals': originals.record, 'GET /api/originals': originals.list } as Record<
+    string,
+    (req: Request, url: URL) => Response | Promise<Response>
+  >;
+  const fetchFn = buildFetch({ apiRoutes, hostStore: createWebvhHostStore(), distDir: '/nonexistent/', originals });
+  const cookie = getAuthCookieConfig(signToken('sub-1', 's@b.com', undefined, { secret: JWT }));
+  const cookieHeader = `${cookie.name}=${cookie.value}`;
+  const real = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const raw = typeof input === 'string' ? input : input.toString();
+    const url = new URL(raw, `http://${HOST}`);
+    const headers = new Headers(init?.headers as HeadersInit);
+    headers.set('cookie', cookieHeader); // the browser would attach the auth cookie
+    return fetchFn(new Request(url, { ...init, headers }));
+  }) as unknown as typeof fetch;
+  return () => { globalThis.fetch = real; };
+}
+
+describe('detail page artifacts after a real durable publish', () => {
+  let restore: () => void;
+  let store: ReturnType<typeof createOriginalsStore>;
+
+  beforeEach(() => {
+    (import.meta as unknown as { env: Record<string, string> }).env ??= {};
+    (import.meta as unknown as { env: Record<string, string> }).env.VITE_WEBVH_HOST = HOST;
+    store = createOriginalsStore({ dataDir: mkdtempSync(join(tmpdir(), 'od-artifacts-')) });
+    restore = installServerFetch(store);
+  });
+  afterEach(() => restore());
+
+  test('every derived artifact URL serves, and the artifacts fold into the page models', async () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="8" height="8"/></svg>';
+    const engine = new DemoEngine({ authed: true, subOrgId: 'sub-1' });
+    await engine.create('Detail Piece', 'Artwork', svg);
+    const state = await engine.publish();
+    const did = state.webvhDid!;
+
+    const arts = webvhArtifacts(did);
+    expect(arts).not.toBeNull();
+
+    // did.jsonl serves at the derived URL and summarizes to THIS did.
+    const logRes = store.serve(new URL(arts!.logUrl));
+    expect(logRes).not.toBeNull();
+    const entries = parseDidLog(await logRes!.text());
+    const summary = didLogSummary(entries);
+    expect(summary?.did).toBe(did);
+    expect(summary?.scid).toBeDefined();
+    expect(summary?.verificationMethods.length).toBeGreaterThan(0);
+
+    // cel.json serves beside it and folds into the timeline the page renders.
+    const celRes = store.serve(new URL(arts!.celUrl));
+    expect(celRes).not.toBeNull();
+    const cel = JSON.parse(await celRes!.text()) as CelLog;
+    const steps = celTimeline(cel);
+    expect(steps[0].state).toBe('done'); // create (did:cel genesis)
+    expect(steps[1].state).toBe('done'); // publish (did:webvh)
+    expect(steps[1].facts.find((f) => f.label === 'Published as')?.value).toBe(did);
+    expect(steps[2].state).toBe('upcoming'); // inscribe (did:btco)
+    expect(steps[0].proof?.proofValue).toBeDefined();
+
+    // Every sealed resource serves at its derived URL (declared multihash
+    // digest → hosted raw-hash multibase, the exact key publishResources
+    // writes), and the artwork's declared digest matches the sha-256 of the
+    // bytes actually served.
+    const resources = celResources(cel);
+    expect(resources.length).toBe(2); // artwork.svg + metadata.json
+    const hostedSeg = (digest: string) => sha256HexToResourceMultibase(digestMultibaseSha256Hex(digest)!)!;
+    for (const r of resources) {
+      expect(r.digestMultibase).toBeDefined();
+      const served = store.serve(new URL(arts!.resourceUrl(hostedSeg(r.digestMultibase!))));
+      expect(served).not.toBeNull();
+    }
+    const artwork = resources.find((r) => r.mediaType === 'image/svg+xml')!;
+    const artRes = store.serve(new URL(arts!.resourceUrl(hostedSeg(artwork.digestMultibase!))));
+    const bytes = new Uint8Array(await artRes!.arrayBuffer());
+    expect(toHex(sha256(bytes))).toBe(digestMultibaseSha256Hex(artwork.digestMultibase!));
+  });
+});

--- a/apps/landing/src/pages/original-detail-data.test.ts
+++ b/apps/landing/src/pages/original-detail-data.test.ts
@@ -1,0 +1,209 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  webvhArtifacts,
+  celTimeline,
+  celResources,
+  parseDidLog,
+  didLogSummary,
+  digestMultibaseSha256Hex,
+  sha256HexToResourceMultibase,
+  sameOriginUrl,
+  detailMode,
+  type CelLog
+} from './original-detail-data';
+
+const DID = 'did:webvh:QmScid:demo.example.com:user-abc:asset-1';
+
+// Shaped like a real published Original's cel.json (see public/example/cel-log.json).
+const cel: CelLog = {
+  events: [
+    {
+      type: 'create',
+      data: {
+        controller: 'did:key:z6MkhhHvRLSgmvgneytgm64PBFzgrr1maxVjEgCr4gWGZ85p',
+        createdAt: '2026-07-16T05:56:22.011Z',
+        name: 'artwork.svg',
+        resources: [
+          { id: 'artwork.svg', mediaType: 'image/svg+xml', digestMultibase: 'uEiDdigest1' },
+          { id: 'metadata.json', mediaType: 'application/json', digestMultibase: 'uEiDdigest2' }
+        ]
+      },
+      proof: [
+        {
+          created: '2026-07-16T05:56:22.038Z',
+          cryptosuite: 'eddsa-jcs-2022',
+          proofValue: 'z2nTv6dFXWK9…',
+          type: 'DataIntegrityProof',
+          verificationMethod: 'did:key:z6Mkhh…#z6Mkhh…'
+        }
+      ]
+    },
+    {
+      type: 'migrate',
+      data: {
+        domain: 'demo.example.com',
+        layer: 'webvh',
+        migratedAt: '2026-07-16T05:56:22.053Z',
+        sourceDid: 'did:cel:uEiD6909LPnH10_myIoEODhInq6jVmhbAl0hR_i0bpUpDKQ',
+        targetDid: DID
+      },
+      proof: [{ cryptosuite: 'eddsa-jcs-2022', proofValue: 'z47VVZi…' }],
+      previousEvent: 'uEiD6909…'
+    }
+  ]
+};
+
+describe('webvhArtifacts', () => {
+  test('derives artifact URLs from a pathed DID', () => {
+    const arts = webvhArtifacts(DID);
+    expect(arts).not.toBeNull();
+    expect(arts!.host).toBe('demo.example.com');
+    expect(arts!.logUrl).toBe('https://demo.example.com/user-abc/asset-1/did.jsonl');
+    expect(arts!.celUrl).toBe('https://demo.example.com/user-abc/asset-1/cel.json');
+    expect(arts!.resourceUrl('uEiDx')).toBe('https://demo.example.com/user-abc/asset-1/resources/uEiDx');
+  });
+  test('same-host URLs are origin-relative (works over dev http)', () => {
+    const arts = webvhArtifacts(DID, 'demo.example.com');
+    expect(arts!.logUrl).toBe('/user-abc/asset-1/did.jsonl');
+    expect(arts!.resourceUrl('uEiDx')).toBe('/user-abc/asset-1/resources/uEiDx');
+  });
+  test('decodes percent-encoded hosts (dev origins include a port)', () => {
+    const arts = webvhArtifacts('did:webvh:QmS:localhost%3A3000:studio:you', 'localhost:3000');
+    expect(arts!.host).toBe('localhost:3000');
+    expect(arts!.logUrl).toBe('/studio/you/did.jsonl');
+  });
+  test('domain-root DIDs resolve under .well-known', () => {
+    const arts = webvhArtifacts('did:webvh:QmS:demo.example.com');
+    expect(arts!.logUrl).toBe('https://demo.example.com/.well-known/did.jsonl');
+  });
+  test('null for non-webvh DIDs', () => {
+    expect(webvhArtifacts('did:cel:uEiDabc')).toBeNull();
+    expect(webvhArtifacts('not-a-did')).toBeNull();
+  });
+});
+
+describe('celTimeline', () => {
+  test('folds create + webvh migrate into done steps, btco stays upcoming', () => {
+    const steps = celTimeline(cel);
+    expect(steps.map((s) => s.id)).toEqual(['create', 'publish', 'inscribe']);
+    expect(steps[0].state).toBe('done');
+    expect(steps[0].at).toBe('2026-07-16T05:56:22.011Z');
+    expect(steps[0].proof?.cryptosuite).toBe('eddsa-jcs-2022');
+    expect(steps[0].facts.some((f) => f.label === 'Signed by')).toBe(true);
+    expect(steps[1].state).toBe('done');
+    expect(steps[1].facts.find((f) => f.label === 'Published as')?.value).toBe(DID);
+    expect(steps[2].state).toBe('upcoming');
+    expect(steps[2].at).toBeUndefined();
+  });
+  test('every step upcoming when there is no log', () => {
+    const steps = celTimeline(null);
+    expect(steps.every((s) => s.state === 'upcoming')).toBe(true);
+  });
+});
+
+describe('celResources', () => {
+  test('returns the resources sealed at genesis', () => {
+    const res = celResources(cel);
+    expect(res.map((r) => r.id)).toEqual(['artwork.svg', 'metadata.json']);
+  });
+  test('empty without a create event', () => {
+    expect(celResources(null)).toEqual([]);
+    expect(celResources({ events: [] })).toEqual([]);
+  });
+});
+
+describe('parseDidLog / didLogSummary', () => {
+  const line1 = JSON.stringify({
+    versionId: '1-QmV1',
+    versionTime: '2026-07-16T05:56:22Z',
+    parameters: { scid: 'QmScid', updateKeys: ['z6MkKeyA'] },
+    state: {
+      id: DID,
+      verificationMethod: [{ id: '#key-0', type: 'Multikey', publicKeyMultibase: 'z6MkKeyA' }]
+    }
+  });
+  const line2 = JSON.stringify({
+    versionId: '2-QmV2',
+    versionTime: '2026-07-17T00:00:00Z',
+    parameters: {},
+    state: {
+      id: DID,
+      verificationMethod: [{ id: '#key-1', type: 'Multikey', publicKeyMultibase: 'z6MkKeyB' }]
+    }
+  });
+
+  test('parses one JSON entry per non-empty line', () => {
+    expect(parseDidLog(`${line1}\n${line2}\n`)).toHaveLength(2);
+  });
+
+  test('summary carries parameters forward and takes the last state', () => {
+    const summary = didLogSummary(parseDidLog(`${line1}\n${line2}`));
+    expect(summary).not.toBeNull();
+    expect(summary!.versions).toBe(2);
+    expect(summary!.scid).toBe('QmScid');
+    expect(summary!.updateKeys).toEqual(['z6MkKeyA']);
+    expect(summary!.did).toBe(DID);
+    expect(summary!.createdAt).toBe('2026-07-16T05:56:22Z');
+    expect(summary!.updatedAt).toBe('2026-07-17T00:00:00Z');
+    expect(summary!.verificationMethods[0]?.publicKeyMultibase).toBe('z6MkKeyB');
+  });
+
+  test('null summary for an empty log', () => {
+    expect(didLogSummary([])).toBeNull();
+  });
+});
+
+describe('digestMultibaseSha256Hex', () => {
+  // Real pair from the shipped example: cel-log.json's digestMultibase for
+  // artwork.svg vs manifest.json's declared sha-256 hex.
+  test('decodes a real sha2-256 multihash digest', () => {
+    expect(digestMultibaseSha256Hex('uEiDq42LG0UdTeZMLYrsckqR3sn7DCIZuAV6nnKrn11NgWg')).toBe(
+      'eae362c6d1475379930b62bb1c92a477b27ec308866e015ea79caae7d753605a'
+    );
+  });
+  test('null for a non-u multibase or a non-sha2-256 multihash', () => {
+    expect(digestMultibaseSha256Hex('zQmNotBase64url')).toBeNull();
+    expect(digestMultibaseSha256Hex('uAAA')).toBeNull();
+  });
+});
+
+describe('sha256HexToResourceMultibase', () => {
+  // Real pair from a live publish: resource.hash hex vs the multibase segment
+  // LifecycleManager.publishResources hosts the bytes under.
+  test('encodes a raw sha-256 as the hosted base64url multibase', () => {
+    expect(
+      sha256HexToResourceMultibase('5d53804fc73b572e35ddbe52354379ef11b2ac295b92d84c1589bd473700d3e0')
+    ).toBe('uXVOAT8c7Vy413b5SNUN57xGyrClbkthMFYm9RzcA0-A');
+  });
+  test('null for a non-sha-256 hex', () => {
+    expect(sha256HexToResourceMultibase('abc')).toBeNull();
+    expect(sha256HexToResourceMultibase('not-hex')).toBeNull();
+  });
+});
+
+describe('sameOriginUrl', () => {
+  test('relativizes a same-host https URL (works over dev http)', () => {
+    expect(sameOriginUrl('https://demo.test/a/resources/uX', 'demo.test')).toBe('/a/resources/uX');
+  });
+  test('passes foreign hosts and non-URLs through unchanged', () => {
+    expect(sameOriginUrl('https://other.test/a', 'demo.test')).toBe('https://other.test/a');
+    expect(sameOriginUrl('not-a-url', 'demo.test')).toBe('not-a-url');
+    expect(sameOriginUrl('https://demo.test/a')).toBe('https://demo.test/a');
+  });
+});
+
+describe('detailMode', () => {
+  const row = { did: DID, title: 'T', resourceHash: 'h', createdAt: '2026-07-21T00:00:00Z' };
+  test('signed-out wins over everything', () => {
+    expect(detailMode({ authenticated: false, loaded: true, row })).toBe('signed-out');
+  });
+  test('loading until the fetch settles', () => {
+    expect(detailMode({ authenticated: true, loaded: false, row: null })).toBe('loading');
+  });
+  test('not-found when the DID is not among the user’s Originals', () => {
+    expect(detailMode({ authenticated: true, loaded: true, row: null })).toBe('not-found');
+  });
+  test('ready with a row', () => {
+    expect(detailMode({ authenticated: true, loaded: true, row })).toBe('ready');
+  });
+});

--- a/apps/landing/src/pages/original-detail-data.ts
+++ b/apps/landing/src/pages/original-detail-data.ts
@@ -1,0 +1,309 @@
+/**
+ * Pure data shaping for the Original detail page ('/me/<did>') — no DOM, no
+ * fetch, fully unit-testable. Turns the artifacts a published Original hosts at
+ * this origin (did.jsonl, cel.json, resources/*) into view models: artifact
+ * URLs derived from the DID, a lifecycle timeline folded from the CEL events,
+ * and a summary of the signed did:webvh version-history log.
+ */
+import type { OriginalRow } from './YourOriginals';
+
+/* ——— CEL log shapes (what LifecycleManager publishes as cel.json) ——— */
+
+export interface CelProof {
+  type?: string;
+  created?: string;
+  cryptosuite?: string;
+  proofPurpose?: string;
+  proofValue?: string;
+  verificationMethod?: string;
+}
+
+export interface CelResourceRef {
+  id: string;
+  mediaType?: string;
+  digestMultibase?: string;
+}
+
+export interface CelEvent {
+  type: string;
+  data?: {
+    controller?: string;
+    createdAt?: string;
+    name?: string;
+    resources?: CelResourceRef[];
+    domain?: string;
+    layer?: string;
+    migratedAt?: string;
+    sourceDid?: string;
+    targetDid?: string;
+  } & Record<string, unknown>;
+  proof?: CelProof[];
+  previousEvent?: string;
+}
+
+export interface CelLog {
+  events: CelEvent[];
+}
+
+/* ——— Artifact locations ——— */
+
+export interface WebvhArtifacts {
+  /** The DID's host (may include a port in dev). */
+  host: string;
+  /** Path under the host: '/<seg>/…' for pathed DIDs, '/.well-known' for domain-root. */
+  path: string;
+  /** URL of the signed did:webvh version-history log. */
+  logUrl: string;
+  /** URL of the CEL event log hosted beside it. */
+  celUrl: string;
+  /** URL of a hosted resource by its digest multibase. */
+  resourceUrl(digestMultibase: string): string;
+}
+
+/**
+ * Where a did:webvh Original's artifacts live, derived purely from the DID
+ * (did:webvh:<SCID>:<host>[:<seg>…]). When `currentHost` matches the DID's
+ * host, URLs are origin-relative — this keeps fetches same-origin in dev
+ * (http) and prod alike; otherwise they are absolute https, the exact URLs
+ * the SDK's resolver GETs.
+ */
+export function webvhArtifacts(did: string, currentHost?: string): WebvhArtifacts | null {
+  const parts = did.split(':');
+  if (parts.length < 4 || parts[0] !== 'did' || parts[1] !== 'webvh') return null;
+  let host: string;
+  let segs: string[];
+  try {
+    host = decodeURIComponent(parts[3] ?? '');
+    segs = parts.slice(4).map((s) => decodeURIComponent(s));
+  } catch {
+    return null;
+  }
+  if (!host) return null;
+  const path = segs.length ? `/${segs.join('/')}` : '/.well-known';
+  const base = currentHost === host ? '' : `https://${host}`;
+  return {
+    host,
+    path,
+    logUrl: `${base}${path}/did.jsonl`,
+    celUrl: `${base}${path}/cel.json`,
+    resourceUrl: (digestMultibase: string) => `${base}${path}/resources/${digestMultibase}`
+  };
+}
+
+/* ——— Lifecycle timeline (folded from the CEL) ——— */
+
+export interface TimelineFact {
+  label: string;
+  value: string;
+  /** Render in the mono font and shorten for display (full value in the title). */
+  mono?: boolean;
+}
+
+export interface TimelineStep {
+  id: 'create' | 'publish' | 'inscribe';
+  layer: 'did:cel' | 'did:webvh' | 'did:btco';
+  state: 'done' | 'upcoming';
+  at?: string;
+  facts: TimelineFact[];
+  proof?: CelProof;
+}
+
+/**
+ * Fold the CEL event log into the three-layer lifecycle. Every completed step
+ * carries the signed proof of the event that performed it; steps the asset
+ * hasn't reached yet render as 'upcoming'.
+ */
+export function celTimeline(cel: CelLog | null): TimelineStep[] {
+  const events = cel?.events ?? [];
+  const create = events.find((e) => e.type === 'create');
+  const publish = events.find((e) => e.type === 'migrate' && e.data?.layer === 'webvh');
+  const inscribe = events.find((e) => e.type === 'migrate' && e.data?.layer === 'btco');
+
+  const createFacts: TimelineFact[] = [];
+  if (create?.data?.controller) {
+    createFacts.push({ label: 'Signed by', value: create.data.controller, mono: true });
+  }
+  const resourceCount = create?.data?.resources?.length ?? 0;
+  if (resourceCount > 0) {
+    createFacts.push({
+      label: 'Resources sealed',
+      value: `${resourceCount} ${resourceCount === 1 ? 'file' : 'files'}, hashed byte-for-byte`
+    });
+  }
+
+  const publishFacts: TimelineFact[] = [];
+  if (publish?.data?.sourceDid) {
+    publishFacts.push({ label: 'Genesis', value: publish.data.sourceDid, mono: true });
+  }
+  if (publish?.data?.targetDid) {
+    publishFacts.push({ label: 'Published as', value: publish.data.targetDid, mono: true });
+  }
+  if (publish?.data?.domain) {
+    publishFacts.push({ label: 'Host', value: publish.data.domain, mono: true });
+  }
+
+  const inscribeFacts: TimelineFact[] = [];
+  if (inscribe?.data?.targetDid) {
+    inscribeFacts.push({ label: 'Inscribed as', value: inscribe.data.targetDid, mono: true });
+  }
+
+  return [
+    {
+      id: 'create',
+      layer: 'did:cel',
+      state: create ? 'done' : 'upcoming',
+      at: create?.data?.createdAt,
+      facts: createFacts,
+      proof: create?.proof?.[0]
+    },
+    {
+      id: 'publish',
+      layer: 'did:webvh',
+      state: publish ? 'done' : 'upcoming',
+      at: publish?.data?.migratedAt,
+      facts: publishFacts,
+      proof: publish?.proof?.[0]
+    },
+    {
+      id: 'inscribe',
+      layer: 'did:btco',
+      state: inscribe ? 'done' : 'upcoming',
+      at: inscribe?.data?.migratedAt,
+      facts: inscribeFacts,
+      proof: inscribe?.proof?.[0]
+    }
+  ];
+}
+
+/** The resources sealed at genesis (id + media type + content digest). */
+export function celResources(cel: CelLog | null): CelResourceRef[] {
+  const create = cel?.events?.find((e) => e.type === 'create');
+  return create?.data?.resources ?? [];
+}
+
+/* ——— did:webvh log summary ——— */
+
+export interface DidLogSummary {
+  versions: number;
+  scid?: string;
+  did?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  updateKeys: string[];
+  verificationMethods: Array<{ id?: string; type?: string; publicKeyMultibase?: string }>;
+  /** The current DID document (the last entry's state). */
+  document?: Record<string, unknown>;
+}
+
+interface DidLogEntry {
+  versionId?: string;
+  versionTime?: string;
+  parameters?: { scid?: string; updateKeys?: string[] };
+  state?: Record<string, unknown> & {
+    id?: string;
+    verificationMethod?: Array<{ id?: string; type?: string; publicKeyMultibase?: string }>;
+  };
+}
+
+/** Parse a did.jsonl body into its entries (one JSON object per line). */
+export function parseDidLog(raw: string): DidLogEntry[] {
+  return raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as DidLogEntry);
+}
+
+/**
+ * Summarize a did:webvh log: SCID and update keys come from the latest entry
+ * that declares them (parameters carry over between versions), the DID document
+ * is the last entry's state.
+ */
+export function didLogSummary(entries: DidLogEntry[]): DidLogSummary | null {
+  if (entries.length === 0) return null;
+  let scid: string | undefined;
+  let updateKeys: string[] = [];
+  for (const entry of entries) {
+    if (entry.parameters?.scid) scid = entry.parameters.scid;
+    if (entry.parameters?.updateKeys?.length) updateKeys = entry.parameters.updateKeys;
+  }
+  const first = entries[0];
+  const last = entries[entries.length - 1];
+  return {
+    versions: entries.length,
+    scid,
+    did: last.state?.id,
+    createdAt: first.versionTime,
+    updatedAt: last.versionTime,
+    updateKeys,
+    verificationMethods: last.state?.verificationMethod ?? [],
+    document: last.state
+  };
+}
+
+/* ——— Content digests ——— */
+
+/**
+ * The sha-256 hex a `digestMultibase` declares, or null when it isn't a
+ * base64url multibase ('u' prefix) sha2-256 multihash (0x12 0x20 + 32 bytes).
+ * Lets the page recompute a resource's hash from its fetched bytes and compare.
+ */
+export function digestMultibaseSha256Hex(digestMultibase: string): string | null {
+  if (!digestMultibase.startsWith('u')) return null;
+  const b64 = digestMultibase.slice(1).replace(/-/g, '+').replace(/_/g, '/');
+  const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
+  let binary: string;
+  try {
+    binary = atob(padded);
+  } catch {
+    return null;
+  }
+  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+  if (bytes.length !== 34 || bytes[0] !== 0x12 || bytes[1] !== 0x20) return null;
+  return Array.from(bytes.slice(2), (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Rewrite an absolute artifact URL to an origin-relative one when it points at
+ * `currentHost` — the store hands back canonical https URLs, which a dev http
+ * origin can't load; same-host paths work on both. Foreign hosts pass through.
+ */
+export function sameOriginUrl(url: string, currentHost?: string): string {
+  if (!currentHost) return url;
+  try {
+    const parsed = new URL(url);
+    return parsed.host === currentHost ? `${parsed.pathname}${parsed.search}` : url;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * The multibase segment a published resource is HOSTED under. The SDK hosts
+ * resources at `…/resources/<base64url multibase of the RAW sha-256 bytes>`
+ * (LifecycleManager.publishResources), while the CEL create event records the
+ * multihash-wrapped `digestMultibase` — this converts the declared hex back to
+ * the hosted key segment.
+ */
+export function sha256HexToResourceMultibase(hex: string): string | null {
+  if (!/^[0-9a-f]{64}$/.test(hex)) return null;
+  const bytes = hex.match(/../g)!.map((b) => parseInt(b, 16));
+  const b64 = btoa(String.fromCharCode(...bytes));
+  return 'u' + b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/* ——— View selector ——— */
+
+export type DetailMode = 'signed-out' | 'loading' | 'not-found' | 'ready';
+
+/** Pure view selector for the detail page — testable without a DOM. */
+export function detailMode(input: {
+  authenticated: boolean;
+  loaded: boolean;
+  row: OriginalRow | null;
+}): DetailMode {
+  if (!input.authenticated) return 'signed-out';
+  if (!input.loaded) return 'loading';
+  if (!input.row) return 'not-found';
+  return 'ready';
+}

--- a/apps/landing/src/pages/original-detail.css
+++ b/apps/landing/src/pages/original-detail.css
@@ -1,0 +1,612 @@
+/* Original detail page ('/me/<did>') — hero, timeline, resources, identity. */
+
+.od { padding-top: 6rem; }
+
+.od-back {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  font-size: var(--text-sm);
+  font-weight: 550;
+  color: var(--text-secondary);
+  margin-bottom: var(--sp-6);
+  transition: color var(--dur-fast) var(--ease);
+}
+
+.od-back:hover { color: var(--text-primary); }
+
+.od-note {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-3);
+  margin-top: var(--sp-4);
+  color: var(--text-secondary);
+}
+
+.od-pulse {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--r-full);
+  background: var(--webvh);
+  animation: od-pulse 1.2s var(--ease) infinite;
+  flex-shrink: 0;
+}
+
+@keyframes od-pulse {
+  50% { opacity: 0.25; }
+}
+
+.od-empty {
+  margin-top: var(--sp-8);
+  display: grid;
+  gap: var(--sp-3);
+  justify-items: start;
+}
+
+.od-empty-title {
+  font-weight: 600;
+  font-size: var(--text-md);
+  color: var(--text-primary);
+}
+
+/* ——— hero ——— */
+
+.od-hero {
+  display: grid;
+  grid-template-columns: 1fr;
+  overflow: hidden;
+}
+
+@media (min-width: 860px) {
+  .od-hero {
+    grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
+  }
+}
+
+.od-art {
+  position: relative;
+  background: #0b0d13;
+  border-bottom: 1px solid var(--border);
+  aspect-ratio: 1;
+  max-height: 480px;
+}
+
+@media (min-width: 860px) {
+  .od-art {
+    border-bottom: none;
+    border-right: 1px solid var(--border);
+    aspect-ratio: auto;
+    max-height: none;
+  }
+}
+
+.od-art img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.od-art-placeholder {
+  width: 100%;
+  height: 100%;
+  min-height: 200px;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(76, 194, 255, 0.08), transparent 60%),
+    #0b0d13;
+}
+
+.od-hero-body {
+  padding: var(--sp-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-4);
+  min-width: 0;
+}
+
+@media (min-width: 860px) {
+  .od-hero-body { padding: var(--sp-8); }
+}
+
+.od-hero-pills {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  flex-wrap: wrap;
+}
+
+.od-hero-body h1 {
+  font-size: var(--text-xl);
+  line-height: 1.1;
+}
+
+@media (min-width: 860px) {
+  .od-hero-body h1 { font-size: var(--text-2xl); }
+}
+
+.od-hero-meta {
+  font-size: var(--text-sm);
+  color: var(--text-tertiary);
+  margin-top: calc(-1 * var(--sp-2));
+}
+
+.od-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  flex-shrink: 0;
+  padding: 4px 12px;
+  border-radius: var(--r-full);
+  font-size: var(--text-xs);
+  font-weight: 560;
+  border: 1px solid var(--border-strong);
+  color: var(--text-secondary);
+}
+
+.od-badge[data-state='ok'] {
+  border-color: rgba(63, 221, 157, 0.4);
+  background: rgba(63, 221, 157, 0.08);
+  color: var(--ok);
+}
+
+.od-badge[data-state='warn'] {
+  border-color: rgba(247, 147, 26, 0.4);
+  background: var(--accent-soft);
+  color: var(--accent-text);
+}
+
+.od-did {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  min-width: 0;
+  padding: var(--sp-3) var(--sp-4);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--bg);
+}
+
+.od-did code {
+  flex: 1;
+  min-width: 0;
+  font-size: var(--text-xs);
+  color: var(--webvh);
+  overflow-wrap: anywhere;
+}
+
+.od-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  padding: 4px 10px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-sm);
+  font-size: var(--text-xs);
+  font-weight: 550;
+  color: var(--text-secondary);
+  transition:
+    color var(--dur-fast) var(--ease),
+    border-color var(--dur-fast) var(--ease);
+}
+
+.od-copy:hover {
+  color: var(--text-primary);
+  border-color: rgba(255, 255, 255, 0.28);
+}
+
+.od-copy[data-copied] { color: var(--ok); border-color: rgba(63, 221, 157, 0.4); }
+
+.od-copy svg { width: 12px; height: 12px; }
+
+/* checks (mirrors the real-example checklist) */
+
+.od-checks {
+  list-style: none;
+  margin: 0;
+  padding: var(--sp-4) 0 0;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-4);
+}
+
+.od-checks li { display: flex; gap: var(--sp-3); }
+
+.od-check-mark {
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--r-full);
+  border: 1px solid var(--border-strong);
+  color: var(--text-tertiary);
+  margin-top: 1px;
+  transition: all var(--dur) var(--ease);
+}
+
+.od-check-mark svg { width: 12px; height: 12px; }
+
+.od-checks li[data-state='ok'] .od-check-mark {
+  border-color: transparent;
+  background: var(--ok);
+  color: #052;
+}
+
+.od-checks li[data-state='fail'] .od-check-mark {
+  border-color: rgba(255, 107, 107, 0.5);
+  color: #ff9c9c;
+}
+
+.od-check-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--r-full);
+  background: var(--text-tertiary);
+  animation: od-pulse 1.2s var(--ease) infinite;
+}
+
+.od-check-label {
+  font-size: var(--text-sm);
+  font-weight: 550;
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+.od-check-detail {
+  margin-top: 2px;
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--text-tertiary);
+  overflow-wrap: anywhere;
+}
+
+.od-verify-note {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}
+
+/* ——— sections ——— */
+
+.od-section { margin-top: var(--sp-16); }
+
+.od-section .section-head { margin-bottom: var(--sp-8); }
+
+/* ——— timeline ——— */
+
+.od-timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-6);
+  position: relative;
+}
+
+.od-step {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr);
+  gap: var(--sp-4);
+  position: relative;
+}
+
+/* connective spine between steps */
+.od-step:not(:last-child)::before {
+  content: '';
+  position: absolute;
+  left: 11px;
+  top: 28px;
+  bottom: calc(-1 * var(--sp-6));
+  width: 2px;
+  background: linear-gradient(var(--border-strong), var(--border));
+}
+
+.od-step-node {
+  width: 24px;
+  height: 24px;
+  border-radius: var(--r-full);
+  border: 2px solid var(--border-strong);
+  background: var(--bg-raised);
+  margin-top: 2px;
+  position: relative;
+  z-index: 1;
+}
+
+.od-step[data-layer='did:cel'][data-state='done'] .od-step-node {
+  border-color: var(--cel);
+  box-shadow: 0 0 0 4px var(--cel-soft);
+}
+
+.od-step[data-layer='did:webvh'][data-state='done'] .od-step-node {
+  border-color: var(--webvh);
+  box-shadow: 0 0 0 4px var(--webvh-soft);
+}
+
+.od-step[data-layer='did:btco'][data-state='done'] .od-step-node {
+  border-color: var(--btco);
+  box-shadow: 0 0 0 4px var(--btco-soft);
+}
+
+.od-step[data-state='upcoming'] .od-step-card { opacity: 0.6; }
+
+.od-step-card { padding: var(--sp-5) var(--sp-6); }
+
+.od-step-head {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  flex-wrap: wrap;
+}
+
+.od-step-head h3 { font-size: var(--text-md); }
+
+.od-step-time {
+  margin-left: auto;
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--text-tertiary);
+  white-space: nowrap;
+}
+
+.od-step-blurb {
+  margin-top: var(--sp-2);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  max-width: 60ch;
+}
+
+.od-step-facts {
+  margin: var(--sp-4) 0 0;
+  display: grid;
+  gap: var(--sp-2) var(--sp-6);
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 640px) {
+  .od-step-facts { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+}
+
+.od-step-facts div { display: grid; gap: 2px; min-width: 0; }
+
+.od-step-facts dt {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.od-step-facts dd {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  min-width: 0;
+}
+
+.od-step-facts dd code {
+  font-size: var(--text-xs);
+  overflow-wrap: anywhere;
+}
+
+.od-step-proof {
+  margin-top: var(--sp-4);
+  padding-top: var(--sp-3);
+  border-top: 1px dashed var(--border);
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  flex-wrap: wrap;
+}
+
+.od-step-proof-label {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--ok);
+}
+
+.od-step-proof code {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  overflow-wrap: anywhere;
+}
+
+/* ——— resources ——— */
+
+.od-resources {
+  display: grid;
+  gap: var(--sp-5);
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 760px) {
+  .od-resources { grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); }
+}
+
+.od-resource { overflow: hidden; display: flex; flex-direction: column; }
+
+.od-resource-preview {
+  background: #0b0d13;
+  border-bottom: 1px solid var(--border);
+  height: 220px;
+  overflow: hidden;
+}
+
+.od-resource-preview img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.od-resource-preview pre {
+  margin: 0;
+  padding: var(--sp-4) var(--sp-5);
+  height: 100%;
+  overflow: auto;
+  font-size: var(--text-xs);
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.od-resource-body {
+  padding: var(--sp-5) var(--sp-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+}
+
+.od-resource-body h3 code {
+  font-size: var(--text-base);
+  color: var(--text-primary);
+}
+
+.od-resource-facts {
+  margin: 0;
+  display: grid;
+  gap: var(--sp-2);
+}
+
+.od-resource-facts div {
+  display: flex;
+  gap: var(--sp-3);
+  align-items: baseline;
+  min-width: 0;
+}
+
+.od-resource-facts dt {
+  flex-shrink: 0;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.od-resource-facts dd { margin: 0; min-width: 0; }
+
+.od-resource-facts dd code {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  overflow-wrap: anywhere;
+}
+
+.od-raw-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  align-self: flex-start;
+  font-size: var(--text-sm);
+  font-weight: 550;
+  color: var(--text-secondary);
+  transition: color var(--dur-fast) var(--ease);
+}
+
+.od-raw-link:hover { color: var(--text-primary); }
+
+/* ——— identity ——— */
+
+.od-identity { padding: var(--sp-6); }
+
+@media (min-width: 860px) {
+  .od-identity { padding: var(--sp-8); }
+}
+
+.od-identity-kv {
+  margin: 0;
+  display: grid;
+  gap: var(--sp-4) var(--sp-8);
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 640px) {
+  .od-identity-kv { grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); }
+}
+
+.od-identity-kv div { display: grid; gap: 2px; min-width: 0; }
+
+.od-identity-kv dt {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.od-identity-kv dd {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  min-width: 0;
+}
+
+.od-identity-kv dd code {
+  font-size: var(--text-xs);
+  color: var(--webvh);
+  overflow-wrap: anywhere;
+}
+
+.od-doc { margin-top: var(--sp-6); }
+
+.od-doc summary {
+  cursor: pointer;
+  font-size: var(--text-sm);
+  font-weight: 550;
+  color: var(--text-secondary);
+  transition: color var(--dur-fast) var(--ease);
+}
+
+.od-doc summary:hover { color: var(--text-primary); }
+
+.od-doc pre {
+  margin-top: var(--sp-4);
+  padding: var(--sp-5);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--bg);
+  overflow: auto;
+  max-height: 420px;
+  font-size: var(--text-xs);
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+/* ——— raw artifacts ——— */
+
+.od-artifacts {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--sp-3);
+}
+
+.od-artifacts .od-raw-link {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+  width: 100%;
+  padding: var(--sp-4) var(--sp-5);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--bg-raised);
+  transition: border-color var(--dur) var(--ease), color var(--dur-fast) var(--ease);
+}
+
+.od-artifacts .od-raw-link:hover { border-color: var(--border-strong); }
+
+.od-artifacts .od-raw-link code {
+  font-size: var(--text-xs);
+  color: var(--webvh);
+  overflow-wrap: anywhere;
+}
+
+.od-artifacts .od-raw-link span {
+  margin-left: auto;
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  text-align: right;
+}

--- a/apps/landing/src/pages/your-originals-content.test.ts
+++ b/apps/landing/src/pages/your-originals-content.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { yourOriginals } from '../content';
+import { yourOriginals, originalDetail } from '../content';
 
 describe('yourOriginals copy', () => {
   test('has the strings the page renders', () => {
@@ -13,5 +13,34 @@ describe('yourOriginals copy', () => {
     expect(typeof yourOriginals.pendingBadge).toBe('string');
     expect(typeof yourOriginals.openLog).toBe('string');
     expect(typeof yourOriginals.navLabel).toBe('string');
+    expect(typeof yourOriginals.viewLabel).toBe('string');
+  });
+});
+
+describe('originalDetail copy', () => {
+  test('has the strings the detail page renders', () => {
+    expect(typeof originalDetail.backLabel).toBe('string');
+    expect(typeof originalDetail.signedOut).toBe('string');
+    expect(typeof originalDetail.loading).toBe('string');
+    expect(typeof originalDetail.notFoundTitle).toBe('string');
+    expect(typeof originalDetail.notFoundCta).toBe('string');
+    expect(typeof originalDetail.verifiedBadge).toBe('string');
+    expect(typeof originalDetail.verifyingBadge).toBe('string');
+    expect(typeof originalDetail.failedBadge).toBe('string');
+    expect(typeof originalDetail.checkLabels.hash).toBe('string');
+    expect(typeof originalDetail.checkLabels.log).toBe('string');
+    expect(typeof originalDetail.checkLabels.cel).toBe('string');
+  });
+  test('has a titled step for each lifecycle layer', () => {
+    for (const id of ['create', 'publish', 'inscribe'] as const) {
+      expect(originalDetail.timeline.steps[id].title.length).toBeGreaterThan(0);
+      expect(originalDetail.timeline.steps[id].blurb.length).toBeGreaterThan(0);
+    }
+  });
+  test('has the section headings', () => {
+    expect(originalDetail.timeline.heading.length).toBeGreaterThan(0);
+    expect(originalDetail.resources.heading.length).toBeGreaterThan(0);
+    expect(originalDetail.identity.heading.length).toBeGreaterThan(0);
+    expect(originalDetail.artifacts.heading.length).toBeGreaterThan(0);
   });
 });

--- a/apps/landing/src/pages/your-originals.css
+++ b/apps/landing/src/pages/your-originals.css
@@ -1,23 +1,138 @@
+/* Your Originals ('/me') — gallery of cards, each opening its detail page. */
+
 .your-originals { padding-top: 6rem; }
 .your-originals-sub { max-width: 46rem; color: var(--text-secondary, #666); }
 .your-originals-note { margin-top: 1.5rem; }
 .your-originals-empty { margin-top: 2rem; display: grid; gap: 0.75rem; justify-items: start; }
 .your-originals-empty-title { font-weight: 600; font-size: 1.1rem; }
-.your-originals-list { list-style: none; padding: 0; margin: 2rem 0 0; display: grid; gap: 1rem; }
-.your-original {
-  display: flex; gap: 1rem; align-items: flex-start;
-  padding: 1rem; border: 1px solid var(--border, rgba(128, 128, 128, 0.25)); border-radius: 12px;
+
+.your-originals-grid {
+  list-style: none;
+  padding: 0;
+  margin: var(--sp-8) 0 0;
+  display: grid;
+  gap: var(--sp-5);
+  grid-template-columns: 1fr;
 }
-.your-original-thumb { width: 72px; height: 72px; border-radius: 8px; object-fit: cover; flex: none; background: color-mix(in srgb, var(--webvh) 8%, transparent); }
-.your-original-thumb-empty { display: inline-block; }
-.your-original-body { display: grid; gap: 0.3rem; min-width: 0; }
-.your-original-body h2 { margin: 0; font-size: 1rem; }
-.your-original-did { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
-.your-original-did code { font-size: 0.72rem; word-break: break-all; color: var(--webvh); }
+
+@media (min-width: 640px) {
+  .your-originals-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (min-width: 980px) {
+  .your-originals-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+
+.your-original-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  transition:
+    border-color var(--dur) var(--ease),
+    transform var(--dur) var(--ease),
+    box-shadow var(--dur) var(--ease);
+}
+
+.your-original-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+}
+
+.your-original-cover {
+  position: relative;
+  display: block;
+  aspect-ratio: 4 / 3;
+  background: #0b0d13;
+  border-bottom: 1px solid var(--border);
+}
+
+.your-original-cover img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform var(--dur-slow) var(--ease);
+}
+
+.your-original-card:hover .your-original-cover img { transform: scale(1.03); }
+
+.your-original-cover-empty {
+  display: block;
+  width: 100%;
+  height: 100%;
+  background:
+    radial-gradient(circle at 50% 45%, rgba(76, 194, 255, 0.1), transparent 60%),
+    #0b0d13;
+}
+
 .your-original-badge {
-  font-size: 0.68rem; font-weight: 600; padding: 0.12rem 0.45rem; border-radius: 999px;
-  color: var(--text-tertiary, #888); background: color-mix(in srgb, currentColor 12%, transparent);
+  position: absolute;
+  top: var(--sp-3);
+  right: var(--sp-3);
+  font-size: 0.68rem;
+  font-weight: 600;
+  padding: 0.16rem 0.55rem;
+  border-radius: var(--r-full);
+  color: var(--text-tertiary, #888);
+  background: rgba(8, 9, 12, 0.78);
+  border: 1px solid var(--border-strong);
+  backdrop-filter: blur(6px);
 }
-.your-original-badge[data-ok] { color: var(--ok, #1a8f4a); }
-.your-original-log { font-size: 0.82rem; }
-.your-original-created { font-size: 0.75rem; color: var(--text-tertiary, #888); margin: 0; }
+
+.your-original-badge[data-ok] {
+  color: var(--ok, #1a8f4a);
+  border-color: rgba(63, 221, 157, 0.4);
+}
+
+.your-original-card-body {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--sp-2);
+  padding: var(--sp-4) var(--sp-5) var(--sp-5);
+  flex: 1;
+  min-width: 0;
+}
+
+.your-original-card-body h2 {
+  font-size: var(--text-md);
+  margin: 0;
+}
+
+.your-original-did {
+  font-size: 0.72rem;
+  color: var(--webvh);
+  overflow-wrap: anywhere;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.your-original-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  width: 100%;
+  margin-top: auto;
+  padding-top: var(--sp-3);
+}
+
+.your-original-created {
+  font-size: 0.75rem;
+  color: var(--text-tertiary, #888);
+}
+
+.your-original-view {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--text-secondary);
+  transition: color var(--dur-fast) var(--ease), gap var(--dur-fast) var(--ease);
+}
+
+.your-original-card:hover .your-original-view { color: var(--text-primary); gap: 7px; }

--- a/apps/landing/src/router.test.ts
+++ b/apps/landing/src/router.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect } from 'bun:test';
-import { routeForPath } from './router';
+import { routeForPath, originalPath, didFromPath } from './router';
+
+const DID = 'did:webvh:QmScid123:demo.example.com:user-abc:asset-1';
 
 describe('routeForPath', () => {
   test('/ → landing', () => {
@@ -8,7 +10,34 @@ describe('routeForPath', () => {
   test('/me → your-originals', () => {
     expect(routeForPath('/me')).toBe('your-originals');
   });
+  test('/me/<encoded did> → original-detail', () => {
+    expect(routeForPath(originalPath(DID))).toBe('original-detail');
+  });
+  test('/me/<non-did segment> → landing (SPA fallback)', () => {
+    expect(routeForPath('/me/not-a-did')).toBe('landing');
+  });
   test('unknown path → landing (SPA fallback)', () => {
     expect(routeForPath('/anything/else')).toBe('landing');
+  });
+});
+
+describe('originalPath / didFromPath', () => {
+  test('round-trips a DID through the path', () => {
+    expect(didFromPath(originalPath(DID))).toBe(DID);
+  });
+  test('encodes the DID as a single path segment', () => {
+    expect(originalPath(DID)).not.toContain(':');
+    expect(originalPath(DID).slice('/me/'.length)).not.toContain('/');
+  });
+  test('null for /me itself and for extra segments', () => {
+    expect(didFromPath('/me')).toBeNull();
+    expect(didFromPath('/me/')).toBeNull();
+    expect(didFromPath('/me/a/b')).toBeNull();
+  });
+  test('null for a segment that does not decode to a did', () => {
+    expect(didFromPath('/me/hello')).toBeNull();
+  });
+  test('null (not a throw) for malformed percent-encoding', () => {
+    expect(didFromPath('/me/%GG')).toBeNull();
   });
 });

--- a/apps/landing/src/router.tsx
+++ b/apps/landing/src/router.tsx
@@ -1,14 +1,38 @@
 /**
- * Minimal client-side routing — no react-router. Two views: the landing page
- * ('/') and Your Originals ('/me'). navigate() pushes history and notifies
- * subscribers; useLocationPath() re-renders on navigate + browser back/forward.
+ * Minimal client-side routing — no react-router. Three views: the landing page
+ * ('/'), Your Originals ('/me'), and a single Original's detail page
+ * ('/me/<encoded did>'). navigate() pushes history and notifies subscribers;
+ * useLocationPath() re-renders on navigate + browser back/forward.
  */
 import { useEffect, useState } from 'react';
 
-export type RouteName = 'landing' | 'your-originals';
+export type RouteName = 'landing' | 'your-originals' | 'original-detail';
 
 export function routeForPath(pathname: string): RouteName {
-  return pathname === '/me' ? 'your-originals' : 'landing';
+  if (pathname === '/me') return 'your-originals';
+  if (pathname.startsWith('/me/') && didFromPath(pathname)) return 'original-detail';
+  return 'landing';
+}
+
+/** Path for a single Original's detail page. The DID is one encoded segment. */
+export function originalPath(did: string): string {
+  return `/me/${encodeURIComponent(did)}`;
+}
+
+/**
+ * The DID encoded in an '/me/<did>' path, or null when the path isn't one
+ * (including a malformed percent-encoding, which decodeURIComponent throws on).
+ */
+export function didFromPath(pathname: string): string | null {
+  if (!pathname.startsWith('/me/')) return null;
+  const seg = pathname.slice('/me/'.length);
+  if (!seg || seg.includes('/')) return null;
+  try {
+    const did = decodeURIComponent(seg);
+    return did.startsWith('did:') ? did : null;
+  } catch {
+    return null;
+  }
 }
 
 const NAV_EVENT = 'originals:navigate';

--- a/apps/landing/src/sdk/verify-original.ts
+++ b/apps/landing/src/sdk/verify-original.ts
@@ -1,0 +1,105 @@
+/**
+ * Live, in-browser verification of one of the user's published Originals.
+ *
+ * Mirrors verify-example.ts, but runs against the artifacts the Original
+ * actually hosts at this origin (fetched by the detail page): the resource
+ * bytes are re-hashed, the did:webvh log's SCID + Ed25519 proof chain is
+ * re-verified via didwebvh-ts, and the CEL event log's whole signed chain is
+ * re-verified via the SDK — binding it to this DID through the migrate event.
+ * Nothing is taken on faith from the server; the checks are the proof.
+ */
+import '../shims/buffer-global';
+import { Ed25519Verifier, resolveDidCel } from '@originals/sdk';
+import { resolveDIDFromLog } from 'didwebvh-ts';
+import { sha256 } from '@noble/hashes/sha2.js';
+import type { CelLog } from '../pages/original-detail-data';
+
+export interface OriginalCheck {
+  id: 'hash' | 'log' | 'cel';
+  ok: boolean;
+  detail: string;
+}
+
+const toHex = (bytes: Uint8Array) =>
+  Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+
+const short = (did: string) => (did.length > 42 ? `${did.slice(0, 36)}…` : did);
+
+export async function verifyOriginal(input: {
+  /** The Original's did:webvh identifier. */
+  did: string;
+  /** Parsed did.jsonl entries, or null when the log couldn't be fetched. */
+  logEntries: unknown[] | null;
+  /** Parsed cel.json, or null when it couldn't be fetched. */
+  celLog: CelLog | null;
+  /** The primary resource's fetched bytes, or null. */
+  resourceBytes: Uint8Array | null;
+  /** The sha-256 hex the provenance declares for those bytes. */
+  declaredHash: string | null;
+}): Promise<OriginalCheck[]> {
+  const checks: OriginalCheck[] = [];
+
+  // 1 · Content integrity: recompute the resource's sha-256 from its bytes.
+  if (input.resourceBytes && input.declaredHash) {
+    const recomputed = toHex(sha256(input.resourceBytes));
+    checks.push({
+      id: 'hash',
+      ok: recomputed === input.declaredHash,
+      detail: `sha-256 recomputed from ${input.resourceBytes.length} bytes → ${recomputed.slice(0, 20)}…`
+    });
+  } else {
+    checks.push({ id: 'hash', ok: false, detail: 'Resource bytes could not be fetched' });
+  }
+
+  // 2 · Identity: verify the did:webvh log's SCID + Ed25519 proof chain and
+  //     confirm it derives THIS DID (no server, no trust in this page).
+  let logOk = false;
+  let logDetail = 'DID log could not be fetched';
+  if (input.logEntries?.length) {
+    try {
+      const resolved = (await resolveDIDFromLog(input.logEntries as never, {
+        verifier: new Ed25519Verifier()
+      } as never)) as unknown as { did?: string; doc?: Record<string, unknown> };
+      const resolvedDid = resolved.did ?? (resolved.doc?.id as string) ?? '';
+      logOk = !!resolved.doc && resolvedDid === input.did;
+      logDetail = logOk
+        ? `${input.logEntries.length} signed log ${input.logEntries.length === 1 ? 'entry' : 'entries'} verified → ${short(resolvedDid)}`
+        : 'DID log did not verify';
+    } catch (err) {
+      console.error('[originals-sdk] original DID log verification failed', err);
+      logDetail = 'DID log did not verify';
+    }
+  }
+  checks.push({ id: 'log', ok: logOk, detail: logDetail });
+
+  // 3 · Provenance: re-derive the did:cel genesis identity from the CEL log —
+  //     resolveDidCel verifies the WHOLE signed event chain and binds the DID
+  //     to it (null otherwise) — and confirm its migrate event targets this
+  //     did:webvh, chaining genesis → published identity.
+  let celOk = false;
+  let celDetail = 'CEL log could not be fetched';
+  const migrate = input.celLog?.events?.find(
+    (e) => e.type === 'migrate' && e.data?.layer === 'webvh'
+  );
+  const celDid = migrate?.data?.sourceDid;
+  if (input.celLog && celDid) {
+    try {
+      const celDoc = await resolveDidCel(celDid, input.celLog as never);
+      celOk = !!celDoc && migrate?.data?.targetDid === input.did;
+      celDetail = celOk
+        ? `${input.celLog.events.length} signed events verified → ${short(celDid)}`
+        : 'CEL event chain did not verify';
+    } catch (err) {
+      console.error('[originals-sdk] original CEL verification failed', err);
+      celDetail = 'CEL event chain did not verify';
+    }
+  }
+  checks.push({ id: 'cel', ok: celOk, detail: celDetail });
+
+  console.log(
+    '%c[originals-sdk] your-original verification',
+    'color:#f7931a;font-weight:600;font-family:ui-monospace,monospace',
+    { did: input.did, checks }
+  );
+  return checks;
+}


### PR DESCRIPTION
## What

Adds a new `/me/<did>` detail page for viewing a single Original's full provenance. The page displays:
- Hero section with artwork, title, DID, and verification status badges
- CEL-driven timeline showing the three-layer lifecycle (did:cel → did:webvh → did:btco)
- Sealed resources gallery with media previews and metadata
- Identity section summarizing the did:webvh version history
- Raw artifacts (did.jsonl, cel.json) for inspection

Includes in-browser verification that re-checks resource hashes and both proof chains (did:webvh SCID + Ed25519, CEL event chain) against the artifacts the Original actually hosts at this origin.

## Why

Users need to inspect the full cryptographic provenance of their Originals — not just see a thumbnail in a gallery. The detail page makes the three-layer lifecycle and signed event chain visible and verifiable locally, binding the page content to the artifacts themselves rather than a database row.

## How

**Data layer** (`original-detail-data.ts`):
- `webvhArtifacts()` derives artifact URLs from the DID (did.jsonl, cel.json, resources/*)
- `celTimeline()` folds CEL events into the three-step lifecycle with facts and proofs
- `parseDidLog()` and `didLogSummary()` parse the signed did:webvh version history
- Hash conversion utilities (`digestMultibaseSha256Hex`, `sha256HexToResourceMultibase`) bridge CEL multihash digests to hosted resource keys
- `detailMode()` determines UI state (signed-out, loading, not-found, ready)

**Component** (`OriginalDetail.tsx`):
- Fetches row from `/api/originals`, then the three artifacts (did.jsonl, cel.json) from the DID's host
- Lazy-loads text resources (JSON, markdown) and image previews
- Triggers async verification pass via `verify-original.ts` (re-hashes primary resource, re-verifies both proof chains)
- Renders Hero, Timeline, Resources, Identity, and Artifacts sections

**Verification** (`verify-original.ts`):
- Mirrors `verify-example.ts` but runs against user's hosted artifacts
- Three checks: resource sha-256 recompute, did:webvh log SCID + Ed25519 chain, CEL event chain back to did:cel genesis
- Results render as pass/fail badges and check marks in the hero

**Routing** (`router.tsx`):
- Added `original-detail` route; `originalPath(did)` encodes DIDs for URL safety
- `didFromPath()` decodes them back

**Styling** (`original-detail.css`):
- 612 lines of layout for hero (2-col on desktop), timeline with connective spine, resource grid, identity key-value pairs
- Responsive grid for resources (1 col mobile, 2–3 cols desktop)
- Pulse animations for pending verification, color-coded layer badges

**Gallery redesign** (`your-originals.css`):
- Refactored card layout from horizontal list to vertical grid (1 col mobile, 2 cols tablet, 3 cols desktop)
- Cover image with hover zoom, bottom-aligned metadata
- "View provenance" button opens the detail page

**Content** (`content.ts`):
- Added `originalDetail` strings for all UI labels, check descriptions, timeline step names, and error states

**Tests**:
- `original-detail-data.test.ts`: Unit tests for artifact URL derivation, timeline folding, hash conversion, mode logic
- `original-detail-artifacts.integration.test.ts`: End-to-end test that publishes a real Original via DemoEngine, verifies all artifact URLs resolve from the durable store, and confirms parsed data matches the timeline/summary/digests

## Type of Change

- [x] New feature (adds `/me/<did>` detail page with verification)
- [x] Refactoring (gallery redesign from list to grid)

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
-

https://claude.ai/code/session_016Mdw9n1bg2DJb1dFYyNaRt

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Original detail page with provenance timeline and in-browser cryptographic verification
> - Adds a new `/me/<encoded-did>` route rendered by [OriginalDetail.tsx](https://github.com/onionoriginals/sdk/pull/441/files#diff-864ece859d073e4fe19249967ddb44505d831bda6b38d937d2a99f1826821193) that fetches `did.jsonl` and `cel.json` artifacts, displays a provenance timeline derived from the CEL log, and shows identity details from the DID log.
> - Runs three in-browser cryptographic checks via [verify-original.ts](https://github.com/onionoriginals/sdk/pull/441/files#diff-fa525f734d519cd443a4c18b0947cf3d2e90c120a54f683f188a45207e310fa4): SHA-256 resource hash, `did:webvh` SCID and Ed25519 proof chain, and CEL event chain verification.
> - Reworks the Your Originals page into a clickable card grid linking to each Original's detail route; removes the previous direct 'Open the signed DID log' link from cards.
> - Adds utility functions in [original-detail-data.ts](https://github.com/onionoriginals/sdk/pull/441/files#diff-b11674140405bdc1ac8f3375b51e3362a47019c3fcbb6d2c8b80833054d66db8) for artifact URL derivation, CEL timeline folding, DID log parsing, and same-origin URL rewriting for dev/prod compatibility.
> - Extends the router with `originalPath` and `didFromPath` helpers and the `original-detail` route type.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 83daa5e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->