### PR TITLE
feat(sdk): sign the inscribed did:btco document (#442)

### DIFF
--- a/.changeset/sign-btco-doc.md
+++ b/.changeset/sign-btco-doc.md
@@ -1,0 +1,5 @@
+---
+"@originals/sdk": patch
+---
+
+Sign the inscribed did:btco document (#442). The on-chain did:btco doc is now signed by the current controller's Ed25519 key (`eddsa-jcs-2022`) at inscribe + reinscribe time, making it self-authenticating — consistent with did:cel events and did:webvh docs, which were already signed. This completes #402's competitor authentication: an honest cross-sat legit-dupe of a did:cel is now detected (the earlier anchoring authenticates against the log's controller key) instead of being silently dropped. Backward-compatible: resolvers that predate the proof ignore it and still cross-check the `#cel` anchor + verification method; the `#cel` head and bitcoin witness commit to the CEL event/head (not the doc), so they're unaffected.

--- a/packages/sdk/src/cel/signerAdapter.ts
+++ b/packages/sdk/src/cel/signerAdapter.ts
@@ -37,6 +37,26 @@ function buildProof(secret: Uint8Array, verificationMethod: string, data: unknow
   };
 }
 
+/**
+ * Signs a fully-built did:btco document with a controller's Ed25519 key so the
+ * on-chain doc is self-authenticating (#442). Attaches a DataIntegrityProof
+ * (eddsa-jcs-2022) over the PROOFLESS document — the exact primitive
+ * `verifyEventLog`'s `anchoringDocAuthenticated`/`dispatchVerify` checks against
+ * (`ed25519` over `canonicalizeEvent(docWithoutProof)`). `verificationMethod`
+ * MUST be a `did:key` VM so the verifier resolves the key offline. Mutates `doc`
+ * in place (sets `doc.proof`); any pre-existing proof is stripped before signing.
+ */
+export function attachBtcoDocProof(
+  doc: Record<string, unknown>,
+  privateKeyMultibase: string,
+  verificationMethod: string
+): void {
+  const secret = assertEd25519(privateKeyMultibase);
+  const docWithoutProof = { ...doc };
+  delete (docWithoutProof as { proof?: unknown }).proof;
+  doc.proof = buildProof(secret, verificationMethod, docWithoutProof);
+}
+
 export function celSignerFromKeyPair(keyPair: KeyPair): {
   signer: CelSigner; controller: string; verificationMethod: string;
 } {

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -31,7 +31,7 @@ import { validateBitcoinAddress } from '../utils/bitcoin-address.js';
 import { parseSatoshiIdentifier, validateSatoshiNumber } from '../utils/satoshi-validation.js';
 import { btcoDidPrefix, btcoDidFromSatoshi } from '../cel/btcoDid.js';
 import { KeyManager } from '../did/KeyManager.js';
-import { celSignerFromKeyPair, hexSha256ToDigestMultibase, createKeyStoreCelSigner, currentControllerVm } from '../cel/signerAdapter.js';
+import { celSignerFromKeyPair, hexSha256ToDigestMultibase, createKeyStoreCelSigner, currentControllerVm, attachBtcoDocProof } from '../cel/signerAdapter.js';
 import { createCelDidDocument, didCelMatchesLog, deriveDidCel, DID_CEL_PREFIX } from '../cel/celDid.js';
 import { verifyEventLog } from '../cel/algorithms/verifyEventLog.js';
 import { createDidManagerKeyResolver } from '../cel/keyResolver.js';
@@ -2403,6 +2403,9 @@ export class LifecycleManager {
     const controllerPubMb = vm.split('#')[0].slice('did:key:'.length);
     const btcoDoc = this.buildRotatedBtcoDoc(asset, satoshi, btcoDid, controllerPubMb);
     this.embedCelAnchor(btcoDoc, headDigest);
+    // #442: sign the reinscribed doc with the current controller (the append
+    // that triggered this reinscription was signed by the same key).
+    await this.signBtcoDocWithController(btcoDoc, vm);
 
     // Delta since the last on-chain head, else a full snapshot (safe checkpoint).
     const metadata: Record<string, unknown> = { didDocument: btcoDoc };
@@ -2673,6 +2676,14 @@ export class LifecycleManager {
           serviceEndpoint: { headDigestMultibase: celHeadDigest }
         }] : [])
       ];
+      // #442: sign the fully-built doc with the controller that signed the
+      // migrate event (same key, in the log's authorized-key set). Only when the
+      // migrate append landed (celHeadDigest !== null ⇒ that key is in the
+      // keyStore); a degraded append leaves the doc unsigned AND anchor-less.
+      // migrate never rotates, so the current controller VM IS the migrate signer.
+      if (celHeadDigest !== null && asset.celLog) {
+        await this.signBtcoDocWithController(btcoDoc, currentControllerVm(asset.celLog));
+      }
       inscribedBtcoDoc = btcoDoc;
       // Metadata = { didDocument, celLog }. Snapshot the log AFTER the migrate
       // append so the embedded celLog head equals the #cel anchor digest.
@@ -3209,6 +3220,24 @@ export class LifecycleManager {
   }
 
   /**
+   * Self-authenticating did:btco doc (#442): sign the FULLY-built doc
+   * (alsoKnownAs + services + `#cel` all set) with the controller's Ed25519 key
+   * — the SAME identity that signed the corresponding CEL event — so #402's
+   * `anchoringDocAuthenticated` accepts an HONEST anchoring. The key is fetched
+   * from the keyStore under its did:key VM; that VM becomes the proof's
+   * `verificationMethod` so the verifier resolves it offline. Best-effort: a
+   * missing keyStore/key or a non-did:key controller VM leaves the doc unsigned
+   * (backward-compat — resolution still gates on the `#cel` anchor + VM). The
+   * proof commits to the doc only; it does NOT touch the `#cel` head or witness.
+   */
+  private async signBtcoDocWithController(doc: DIDDocument, controllerVm: string): Promise<void> {
+    if (!controllerVm.startsWith('did:key:') || !this.keyStore) return;
+    const priv = await this.keyStore.getPrivateKey(controllerVm);
+    if (!priv) return;
+    attachBtcoDocProof(doc as unknown as Record<string, unknown>, priv, controllerVm);
+  }
+
+  /**
    * Reinscribes the rotated document on the SAME sat (targetSatoshi). On
    * failure — nothing is paid before the broadcast fails — restores the
    * pre-append CEL log (`restoreLog`) so the in-memory log never runs ahead of
@@ -3427,6 +3456,14 @@ export class LifecycleManager {
     // event was not appended and no anchor is embedded.
     if (celHeadDigest !== null) {
       this.embedCelAnchor(rotatedDoc, celHeadDigest);
+      // #442: sign the reinscribed doc with the OUTGOING controller — the same
+      // identity that (cooperatively) signed this rotateKey event, and a key in
+      // the log's authorized-key history. NOT the new key: the rotated doc's VM
+      // is the new key, but authentication compares the resolved key against the
+      // whole key history, so the outgoing key authenticates the anchoring.
+      if (celLogBefore) {
+        await this.signBtcoDocWithController(rotatedDoc, currentControllerVm(celLogBefore));
+      }
     }
 
     const inscription = await this.reinscribeRotatedDoc(
@@ -3582,6 +3619,16 @@ export class LifecycleManager {
     // #cel anchor = the rotateKey event's chain digest (commits the on-chain
     // doc to the rotation the reinscription witnesses).
     this.embedCelAnchor(rotatedDoc, celHeadDigest);
+    // #442: sign the reinscribed doc with the NEW self-certified key — the same
+    // identity that self-signed this rotateKey event (privateKey is REQUIRED
+    // here). That key is added to the log's authorized-key history by the
+    // accepted rotation, so it authenticates the anchoring. Signed directly from
+    // the supplied privateKey so it works even without a keyStore.
+    attachBtcoDocProof(
+      rotatedDoc as unknown as Record<string, unknown>,
+      newVerificationMethod.privateKey,
+      newControllerVm
+    );
 
     // Reinscribe on the SAME sat; restore the pre-append log on failure.
     const inscription = await this.reinscribeRotatedDoc(asset, rotatedDoc, satoshi, feeRate, celLogBefore);

--- a/packages/sdk/src/types/did.ts
+++ b/packages/sdk/src/types/did.ts
@@ -1,3 +1,5 @@
+import type { DataIntegrityProof } from './proof.js';
+
 // W3C DID Document types
 export interface DIDDocument {
   '@context': string[];
@@ -11,6 +13,12 @@ export interface DIDDocument {
   service?: ServiceEndpoint[];
   controller?: string[];
   alsoKnownAs?: string[];
+  /**
+   * Self-authenticating controller signature over the proofless document
+   * (#442). Present on inscribed did:btco documents (eddsa-jcs-2022); ignored by
+   * resolvers that predate it, which still cross-check the `#cel` anchor + VM.
+   */
+  proof?: DataIntegrityProof | DataIntegrityProof[];
 }
 
 export interface VerificationMethod {

--- a/packages/sdk/tests/unit/lifecycle/btco-doc-signing.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/btco-doc-signing.test.ts
@@ -1,0 +1,221 @@
+/**
+ * #442 — the inscribed did:btco document is signed by the current controller's
+ * Ed25519 key so it is self-authenticating, completing #402's competitor
+ * authentication for HONEST anchorings.
+ *
+ * These are SDK-LEVEL tests: the docs are signed by LifecycleManager itself
+ * (inscribe / rotate / authorizeSigner), NOT hand-signed by the test. The
+ * legit-dupe regression relies on that: two honest anchorings of one did:cel on
+ * different sats must now compete (NON_CANONICAL_ANCHOR) without any manual
+ * signing — proving the vestigial gap #402 documented is closed.
+ */
+import { describe, test, expect } from 'bun:test';
+import * as ed25519 from '@noble/ed25519';
+import { OriginalsSDK } from '../../../src';
+import { OrdMockProvider } from '../../../src/adapters/providers/OrdMockProvider';
+import { MockKeyStore } from '../../mocks/MockKeyStore';
+import { multikey } from '../../../src/crypto/Multikey';
+import { canonicalizeEvent } from '../../../src/cel/canonicalize';
+import { verifyEventLog } from '../../../src/cel/algorithms/verifyEventLog';
+import { deriveDidCel } from '../../../src/cel/celDid';
+
+/**
+ * Independently re-checks a signed did:btco doc the exact way verifyEventLog's
+ * `anchoringDocAuthenticated`/`dispatchVerify` does: Ed25519 over
+ * `canonicalizeEvent(docWithoutProof)`, key extracted from the proof's did:key
+ * verificationMethod. Returns the controller pubkey hex on success (so callers
+ * can assert WHICH key signed), or null on any failure.
+ */
+async function verifyBtcoDocProof(doc: any): Promise<string | null> {
+  const rawProof = doc?.proof;
+  const proofs = Array.isArray(rawProof) ? rawProof : rawProof ? [rawProof] : [];
+  const docWithoutProof = { ...doc };
+  delete docWithoutProof.proof;
+  for (const proof of proofs) {
+    if (proof?.type !== 'DataIntegrityProof' || proof?.cryptosuite !== 'eddsa-jcs-2022') continue;
+    if (proof?.proofPurpose !== 'assertionMethod') continue;
+    const vm: string = proof.verificationMethod ?? '';
+    if (!vm.startsWith('did:key:')) continue;
+    const pubMb = vm.slice('did:key:'.length).split('#')[0];
+    const { key: pub, type } = multikey.decodePublicKey(pubMb);
+    if (type !== 'Ed25519') continue;
+    const sig = multikey.decodeMultibase(proof.proofValue);
+    const ok = await ed25519.verifyAsync(sig, canonicalizeEvent(docWithoutProof), pub);
+    if (ok) return Buffer.from(pub).toString('hex');
+  }
+  return null;
+}
+
+const makeSDK = (provider: any) =>
+  OriginalsSDK.create({
+    network: 'regtest',
+    defaultKeyType: 'Ed25519',
+    ordinalsProvider: provider,
+    keyStore: new MockKeyStore(),
+  });
+
+const RES = () => [{ id: 'r', type: 'data', contentType: 'text/plain', hash: '56'.repeat(32) }];
+
+/**
+ * Wraps an OrdMockProvider to pin each inscribe onto a chosen sat and stamp a
+ * chosen confirmed block height (OrdMock hardcodes height 1 for all, which the
+ * uniqueness ordering would read as a same-block tie). The plan is consumed in
+ * createInscription call order (migrate #1, migrate #2, …).
+ */
+function withControlledSats(inner: OrdMockProvider, plan: Array<{ satoshi: string; blockHeight: number }>) {
+  const heights = new Map<string, number>();
+  let i = 0;
+  const overrides: Record<string, any> = {
+    async createInscription(params: any) {
+      const step = plan[Math.min(i++, plan.length - 1)];
+      const res = await inner.createInscription({ ...params, targetSatoshi: step.satoshi });
+      heights.set(res.inscriptionId, step.blockHeight);
+      return res;
+    },
+    async getInscriptionById(id: string) {
+      const rec = await inner.getInscriptionById(id);
+      if (rec && heights.has(id)) return { ...rec, blockHeight: heights.get(id)! };
+      return rec;
+    },
+    async getAnchoringsForDidCel(didCel: string) {
+      const arr = await inner.getAnchoringsForDidCel!(didCel);
+      return arr.map((a: any) => (heights.has(a.inscriptionId) ? { ...a, blockHeight: heights.get(a.inscriptionId)! } : a));
+    },
+  };
+  return new Proxy(inner, {
+    get(target, prop, receiver) {
+      if (prop in overrides) return overrides[prop as string];
+      const val = Reflect.get(target, prop, receiver);
+      return typeof val === 'function' ? val.bind(target) : val;
+    },
+  });
+}
+
+describe('#442 — self-authenticating did:btco document', () => {
+  test('honest inscribeOnBitcoin signs the doc with the controller key; it self-authenticates and the log still verifies', async () => {
+    const provider = new OrdMockProvider();
+    const sdk = makeSDK(provider);
+    const asset = await sdk.lifecycle.createAsset(RES());
+    await sdk.lifecycle.inscribeOnBitcoin(asset);
+
+    const didCel = deriveDidCel(asset.celLog!);
+    const anchorings = await (provider as any).getAnchoringsForDidCel(didCel);
+    expect(anchorings.length).toBe(1);
+    const inscribedDoc = anchorings[0].didDocument;
+
+    // The on-chain doc carries a proof that verifies with the SAME primitive
+    // the verifier uses — no manual signing anywhere in this test.
+    expect(inscribedDoc.proof).toBeDefined();
+    const signerKeyHex = await verifyBtcoDocProof(inscribedDoc);
+    expect(signerKeyHex).not.toBeNull();
+
+    // The signer is the genesis controller key (the same identity that signed
+    // the migrate event).
+    const genesisController = (asset.celLog!.events[0].data as any).controller as string;
+    const genesisPubMb = genesisController.slice('did:key:'.length);
+    expect(signerKeyHex).toBe(Buffer.from(multikey.decodePublicKey(genesisPubMb).key).toString('hex'));
+
+    // Backward-compat: the #cel anchor is still present and the log still verifies.
+    const celService = inscribedDoc.service.find((s: any) => s.type === 'OriginalsCelAnchor');
+    expect(celService).toBeDefined();
+    const result = await verifyEventLog(asset.celLog!, { ordinalsProvider: provider });
+    expect(result.errors).toEqual([]);
+    expect(result.verified).toBe(true);
+
+    // The captured (serialized) btco doc matches the inscribed one — round-trips.
+    expect((asset.serialize().didDocuments['did:btco'] as any).proof).toBeDefined();
+  });
+
+  test('legit-dupe: two honest anchorings of ONE did:cel on DIFFERENT sats — the later log trips NON_CANONICAL_ANCHOR without any manual signing', async () => {
+    const inner = new OrdMockProvider();
+    const X = '100000001';
+    const Y = '200000002';
+    const provider = withControlledSats(inner, [
+      { satoshi: X, blockHeight: 100 }, // branch A (earlier → canonical)
+      { satoshi: Y, blockHeight: 200 }, // branch B (later → dupe)
+    ]);
+    const sdk = makeSDK(provider);
+
+    // Genesis, then TWO branches sharing that exact genesis (same did:cel).
+    const assetA = await sdk.lifecycle.createAsset(RES());
+    const envelope = assetA.serialize(); // pre-inscribe snapshot
+    const didCel = deriveDidCel(assetA.celLog!);
+
+    await sdk.lifecycle.inscribeOnBitcoin(assetA); // → sat X, block 100
+
+    const { asset: assetB } = await sdk.lifecycle.loadAsset(envelope, { skipVerification: true });
+    await sdk.lifecycle.inscribeOnBitcoin(assetB); // → sat Y, block 200
+
+    // Sanity: both anchor the SAME did:cel on different sats, both auto-signed.
+    const anchorings = await (provider as any).getAnchoringsForDidCel(didCel);
+    expect(anchorings.map((a: any) => a.satoshi).sort()).toEqual([X, Y]);
+    for (const a of anchorings) expect(await verifyBtcoDocProof(a.didDocument)).not.toBeNull();
+
+    // Branch B (later, sat Y): branch A is now an AUTHENTICATED earlier
+    // competitor on a different sat → non-canonical.
+    const rB = await verifyEventLog(assetB.celLog!, { ordinalsProvider: provider });
+    expect(rB.verified).toBe(false);
+    expect(rB.errors.some((e) => e.includes('NON_CANONICAL_ANCHOR'))).toBe(true);
+
+    // Branch A (earlier, sat X): canonical → verifies clean.
+    const rA = await verifyEventLog(assetA.celLog!, { ordinalsProvider: provider });
+    expect(rA.errors).toEqual([]);
+    expect(rA.verified).toBe(true);
+  });
+
+  test('cooperative rotateBtcoKeys reinscribes a signed doc (authenticated by the outgoing controller key)', async () => {
+    const provider = new OrdMockProvider();
+    const sdk = makeSDK(provider);
+    const asset = await sdk.lifecycle.createAsset(RES());
+    await sdk.lifecycle.inscribeOnBitcoin(asset);
+    const btcoDid = asset.bindings!['did:btco']!;
+    const outgoingController = (asset.celLog!.events[0].data as any).controller as string;
+
+    // New controller keypair (real Ed25519 so it derives + self-signs later appends).
+    const priv = crypto.getRandomValues(new Uint8Array(32));
+    const pub = await ed25519.getPublicKeyAsync(priv);
+    const newKey = multikey.encodePublicKey(pub, 'Ed25519');
+    await sdk.lifecycle.rotateBtcoKeys(asset, {
+      publicKeyMultibase: newKey,
+      privateKey: multikey.encodePrivateKey(priv, 'Ed25519'),
+    });
+
+    const rotatedDoc = asset.serialize().didDocuments['did:btco'] as any;
+    const signerKeyHex = await verifyBtcoDocProof(rotatedDoc);
+    expect(signerKeyHex).not.toBeNull();
+    // Cooperative rotation: the doc is signed by the OUTGOING controller (the
+    // rotateKey signer), whose key is in the log's authorized-key history.
+    const outgoingPubMb = outgoingController.slice('did:key:'.length);
+    expect(signerKeyHex).toBe(Buffer.from(multikey.decodePublicKey(outgoingPubMb).key).toString('hex'));
+
+    // The rotated doc still resolves (proof does not break resolution).
+    const resolved = await sdk.did.resolveDID(btcoDid, { skipCache: true });
+    expect(resolved!.verificationMethod?.[0]?.publicKeyMultibase).toBe(newKey);
+  });
+
+  test('authorizeSigner reinscribes a signed doc (authenticated by the NEW self-certified key)', async () => {
+    const provider = new OrdMockProvider();
+    const sdk = makeSDK(provider);
+    const asset = await sdk.lifecycle.createAsset(RES());
+    await sdk.lifecycle.inscribeOnBitcoin(asset);
+
+    const priv = crypto.getRandomValues(new Uint8Array(32));
+    const pub = await ed25519.getPublicKeyAsync(priv);
+    const newKey = multikey.encodePublicKey(pub, 'Ed25519');
+    await sdk.lifecycle.authorizeSigner(asset, {
+      publicKeyMultibase: newKey,
+      privateKey: multikey.encodePrivateKey(priv, 'Ed25519'),
+    });
+
+    const doc = asset.serialize().didDocuments['did:btco'] as any;
+    const signerKeyHex = await verifyBtcoDocProof(doc);
+    expect(signerKeyHex).not.toBeNull();
+    // Non-cooperative: self-signed with the NEW key.
+    expect(signerKeyHex).toBe(Buffer.from(pub).toString('hex'));
+
+    // And the whole log still verifies with the provider.
+    const result = await verifyEventLog(asset.celLog!, { ordinalsProvider: provider });
+    expect(result.errors).toEqual([]);
+    expect(result.verified).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #442. **Stacked on #440 (#402)** — it needs that PR's `anchoringDocAuthenticated` verifier. The changed files are disjoint from #402's, so after #440 merges I'll retarget this to `main` cleanly.

## Why
did:cel events and did:webvh docs are **signed**; the inscribed **did:btco doc was not** — the signature was dropped at the on-chain layer. This signs it with the controller's Ed25519 key (`eddsa-jcs-2022`, the same primitive CEL events use) at inscribe + all reinscribe paths.

## Effect
- **Self-authenticating** btco docs (verify integrity + controller from the doc + key alone).
- **Completes #402:** `anchoringDocAuthenticated` now accepts an *honest* anchoring, so a real cross-sat legit-dupe is detected instead of silently dropped. Previously only a test-signed doc authenticated.

## Signer identity per path (each = the corresponding CEL-event signer)
| Path | Signs with |
|------|-----------|
| migrate (`inscribeOnBitcoin`) | genesis/current controller |
| cooperative rotate (`rotateBtcoKeys`) | **outgoing** controller ⚠️ *see below* |
| authorize signer | the new self-certified key |
| resource-update reinscription | current controller |

All keys are in the log's authorized-key history, so the verifier accepts them. Best-effort: no keyStore/key or a non-`did:key` controller VM → doc left unsigned (backward-compat).

## ⚠️ One decision to confirm
For **cooperative rotate**, the doc's advertised VM is the **new** key, but I sign with the **outgoing** controller (matching the rotateKey event's signer). Both are authorized, so #402 works either way. Trade-off: signing with the outgoing key matches "who authorized this inscription"; signing with the **new** key would make the doc self-consistent (proof matches its own advertised VM), which is arguably better for standalone self-authentication. Easy to flip — flagging for a call.

## Invariants
Adding the `proof` doesn't touch the `#cel` head or the bitcoin witness (both commit to the CEL event/head, not the doc). Old resolvers ignore the proof and still cross-check `#cel` + VM.

## Tests
- Honest `inscribeOnBitcoin` produces a doc that self-authenticates against the genesis key; `#cel` present; log verifies; serialized doc round-trips the proof.
- **Legit-dupe regression:** one genesis inscribed on two sats (both SDK-auto-signed, **no manual signing**) — the later log now trips `NON_CANONICAL_ANCHOR`.
- Rotate + authorizeSigner reinscriptions authenticate.

Full SDK suite **3849 pass / 0 fail**; build + lint clean. Reviewed the diff line-by-line (canonicalization matches the verifier, per-path signer identity, backward-compat invariants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sign inscribed did:btco documents with eddsa-jcs-2022 DataIntegrityProof
> - Adds `attachBtcoDocProof` in [`signerAdapter.ts`](https://github.com/onionoriginals/sdk/pull/443/files#diff-84ece722027829c10f06d904fb01b16192462eb1b16b8bf916c6421883493f35) to attach an eddsa-jcs-2022 `DataIntegrityProof` to a did:btco document using an Ed25519 private key and did:key verification method.
> - Updates `LifecycleManager` to call signing after document construction in inscribe, reinscribe, `rotateBtcoKeys`, and `authorizeSigner` flows, using the relevant controller key (current, outgoing, or newly authorized).
> - Adds a private `signBtcoDocWithController` helper that resolves the private key from the keyStore and no-ops silently when the key is unavailable or the VM is not did:key.
> - Adds an optional `proof` field to the `DIDDocument` interface in [`did.ts`](https://github.com/onionoriginals/sdk/pull/443/files#diff-69f43e3f0603da10c3ff5af18d1e06b026b90b4ea089549dc1fa3afbab8e9b54).
> - Behavioral Change: degraded append paths leave documents unsigned; any pre-existing proof on a document is discarded before signing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fcb4433.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->