### PR TITLE
fix(batch): make fail-fast backoff sleep interruptible to eliminate timing flake

### DIFF
--- a/.changeset/batch-abort-sleep-interruptible.md
+++ b/.changeset/batch-abort-sleep-interruptible.md
@@ -1,0 +1,5 @@
+---
+"@originals/sdk": patch
+---
+
+Fix timing race in `BatchOperationExecutor` fail-fast mode: backoff sleeps are now interruptible via `AbortController`, so a sibling that exhausts its retries and aborts the batch immediately wakes any peers sleeping in backoff rather than requiring their full delay to elapse. This eliminates a race where, under CPU load, item 1's backoff could expire before item 0 had set the abort flag, causing item 1 to start a retry it should never have run.

--- a/packages/sdk/src/lifecycle/BatchOperations.ts
+++ b/packages/sdk/src/lifecycle/BatchOperations.ts
@@ -398,8 +398,10 @@ export class BatchOperationExecutor {
   private sleepCancellable(ms: number, signal: AbortSignal): Promise<void> {
     return new Promise((resolve) => {
       if (signal.aborted) { resolve(); return; }
-      const timer = setTimeout(resolve, ms);
-      signal.addEventListener('abort', () => { clearTimeout(timer); resolve(); }, { once: true });
+      const onTimeout = () => { signal.removeEventListener('abort', onAbort); resolve(); };
+      const onAbort = () => { clearTimeout(timer); resolve(); };
+      const timer = setTimeout(onTimeout, ms);
+      signal.addEventListener('abort', onAbort, { once: true });
     });
   }
   

--- a/packages/sdk/src/lifecycle/BatchOperations.ts
+++ b/packages/sdk/src/lifecycle/BatchOperations.ts
@@ -181,6 +181,11 @@ export class BatchOperationExecutor {
     // paid/non-idempotent operation after the batch has already failed and
     // (b) any not-yet-started item from starting.
     let aborted = false;
+    // AbortController whose signal is passed to interruptible backoff sleeps.
+    // When aborted=true fires, we also call batchAbortController.abort() so
+    // any sibling currently sleeping in backoff wakes immediately instead of
+    // waiting out its full delay before re-checking the abort flag.
+    const batchAbortController = new AbortController();
 
     // Process items with concurrency control
     const processItem = async (item: T, index: number): Promise<void> => {
@@ -229,10 +234,13 @@ export class BatchOperationExecutor {
             break;
           }
 
-          // If not last attempt, wait with exponential backoff
+          // If not last attempt, wait with exponential backoff.
+          // Use the cancellable sleep so a sibling abort wakes us immediately
+          // instead of requiring the full delay to elapse before the post-sleep
+          // check fires — critical under CPU load where sleep durations stretch.
           if (attempt < retryCount) {
             const delay = this.calculateRetryDelay(attempt, retryDelay);
-            await this.sleep(delay);
+            await this.sleepCancellable(delay, batchAbortController.signal);
             // Re-check AFTER the sleep: a sibling may have failed the batch
             // while this item was in backoff. Without this check the item
             // would wake and start another attempt — re-running a paid /
@@ -257,6 +265,9 @@ export class BatchOperationExecutor {
       // If fail-fast mode, abort the batch and throw error
       if (!continueOnError) {
         aborted = true;
+        // Wake any siblings sleeping in backoff so they re-check aborted
+        // immediately rather than waiting out their full delay.
+        batchAbortController.abort();
         throw lastError!;
       }
     };
@@ -377,6 +388,19 @@ export class BatchOperationExecutor {
    */
   private sleep(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  /**
+   * Sleep for specified milliseconds, resolving early if the signal fires.
+   * Resolves (does not reject) on abort so the post-sleep abort check handles
+   * the control flow — no try/catch needed at the call site.
+   */
+  private sleepCancellable(ms: number, signal: AbortSignal): Promise<void> {
+    return new Promise((resolve) => {
+      if (signal.aborted) { resolve(); return; }
+      const timer = setTimeout(resolve, ms);
+      signal.addEventListener('abort', () => { clearTimeout(timer); resolve(); }, { once: true });
+    });
   }
   
   /**


### PR DESCRIPTION
## What was red

**1 real failure** (not flaky — reproducible in the full suite, passes in isolation):

```
(fail) BatchOperationExecutor fail-fast > an item sleeping in retry backoff
       does not start another attempt after the batch aborts [520.92ms]
```

The test asserts `attempts[1] === 1` (item 1 must NOT start a second attempt after the batch is aborted by item 0). In the full suite it asserts `2` instead — item 1 retried when it should not have.

## Root cause

The test relies on item 0 setting `aborted = true` before item 1 wakes from its backoff sleep. With `retryDelay=100`:

| Time | Item 0 | Item 1 |
|------|--------|--------|
| t=0 | attempt 1, fails instantly → enters 100 ms backoff | attempt 1 starts |
| t≈40 ms | sleeping | fails → post-fail abort check (false) → enters 100 ms backoff sleep |
| t≈100 ms | wakes, attempt 2, fails → `aborted=true` | sleeping in backoff |
| t≈140 ms | done | wakes → post-sleep abort check → should see `aborted=true` → break |

Under the load of the full test suite (~200 files, 3576 tests), `setTimeout` durations stretch. Item 0's 100 ms backoff can take >140 ms, meaning item 0 hasn't set `aborted=true` yet when item 1 wakes at t≈140 ms and passes the post-sleep check. Item 1 proceeds to attempt 2, which violates the non-idempotent-operation guarantee.

The bug is a real race in `BatchOperationExecutor`, not a test defect: the post-sleep polling approach cannot handle the case where the aborting sibling's own sleep inflates under load.

## Fix

Add a per-batch `AbortController` alongside the `aborted` flag. Replace the bare `this.sleep(delay)` in the backoff path with a new `sleepCancellable(delay, signal)` helper that resolves immediately when the signal fires (and clears the timer). When `aborted = true` is set, `batchAbortController.abort()` is called simultaneously, waking all siblings currently sleeping in backoff so they re-check the flag without waiting for their natural sleep expiry.

```typescript
private sleepCancellable(ms: number, signal: AbortSignal): Promise<void> {
  return new Promise((resolve) => {
    if (signal.aborted) { resolve(); return; }
    const timer = setTimeout(resolve, ms);
    signal.addEventListener('abort', () => { clearTimeout(timer); resolve(); }, { once: true });
  });
}
```

`sleepCancellable` resolves (not rejects) on abort — the existing `if (aborted && !continueOnError) { break; }` guard is the control-flow point; no new try/catch is needed.

## Green invariant evidence

```
bunx tsc --noEmit      → 0 errors
bun run build          → 2 successful, 2 total
bun run test (sdk)     → 3576 tests, 154 skip, 0 fail  ✓
bun run test (auth)    → 241 tests, 0 fail              ✓
```

Previously failing test run 5 × in isolation after fix: 5/5 pass.

## Checklist

- [x] Root cause actually fixed (not masked)
- [x] No test skipped, deleted, weakened, or commented out
- [x] No cryptographic or provenance guarantee loosened
- [x] Full invariant green before opening PR

---
_Generated by [Claude Code](https://claude.ai/code/session_014bPTV37w2hMiw5T8vnPhVn)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make fail-fast backoff sleep interruptible in `BatchOperationExecutor`
> In fail-fast mode (`continueOnError=false`), sibling items sleeping in a retry backoff would wait out the full delay before discovering the batch was aborted, causing timing flakes.
>
> - Introduces a batch-scoped `AbortController` passed to a new `sleepCancellable` helper in [BatchOperations.ts](https://github.com/onionoriginals/sdk/pull/444/files#diff-d78ea33a28e17393413b1596ae9e809fe074bd54397c3a1f647c286c029042e8).
> - When one item exhausts retries and aborts the batch, `batchAbortController.abort()` is called to immediately wake any peers sleeping in backoff.
> - `sleepCancellable` resolves (never rejects) on cancellation so callers use a simple post-sleep abort check for control flow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20c31bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->