### PR TITLE
fix(sdk): browser/edge-safe entry points + slim @originals/sdk/cel

### DIFF
--- a/.changeset/browser-safe-entry-points.md
+++ b/.changeset/browser-safe-entry-points.md
@@ -1,0 +1,22 @@
+---
+"@originals/sdk": minor
+---
+
+Make the SDK importable in browsers and edge runtimes, and add a slim genesis-only entry point.
+
+**`@originals/sdk` no longer pulls Node builtins at import time.** Previously the package entry point statically reached `fs`, `path`, `fs/promises`, a bare `crypto`, and `node:zlib`, so it failed to load outside Node regardless of which features you used.
+
+- Status-list GZIP moves from `node:zlib` to `fflate`. `BitstringStatusList.encode()`/`decode()` and `StatusListManager.encodeBitstring`/`decodeBitstring` stay **synchronous** — a lazy `await import('node:zlib')` would have forced those public methods async. The wire format is unchanged and verified round-trip against `node:zlib` in both directions, including the legacy ZLIB-wrapped DEFLATE encoding.
+- `utils/encoding` uses `@scure/base` instead of `Buffer` for base64/base64url/base58. Drops the `b58` dependency.
+- `LocalStorageAdapter` and `WebVHManager` load `fs`/`path` lazily on first use, matching `FileLogOutput`. Node-only behaviour is unchanged; the path-traversal guards keep Node's exact `path` semantics.
+- Selective disclosure uses the Web Crypto `crypto.randomUUID` global rather than importing `crypto`.
+
+**New `@originals/sdk/cel` entry point** for genesis-only (`did:cel`) consumers: 34 modules and 248 KB versus 116 modules and 1201 KB for the root barrel, dropping `bitcoinjs-lib`, `jsonld`, `@digitalbazaar/bbs-signatures`, `didwebvh-ts`, `@scure/btc-signer` and more. `@originals/sdk/cel/*` deep imports are exported too.
+
+**`LifecycleManager` no longer pulls the VC stack.** `CredentialManager` is injected, so it is now a type-only import; `OriginalsAsset` duck-types its credential check instead of `instanceof`. Importing `lifecycle/LifecycleManager` drops from 75 modules / 821 KB to 59 / 653 KB and no longer drags in `jsonld`.
+
+**Bug fix:** `OrdinalsLookup.content` is typed `Uint8Array`, but four call sites in `verifyEventLog` and `LifecycleManager` called `.toString('utf8')` on it — a `Buffer`-only overload. Any `OrdinalsProvider` returning a plain `Uint8Array` produced a comma-separated digit string and threw in `JSON.parse`. They now use `TextDecoder`.
+
+A new `scripts/check-browser-safety.mjs` CI gate fails the build if a guarded entry point regains a static Node-builtin import, and runs as a publish gate alongside the ESM check.
+
+Note: the Bitcoin modules (`bitcoin/transactions/commit`, `QuickNodeProvider`, `crypto/Signer`) still require `Buffer` at runtime, because `bitcoinjs-lib`'s API is Buffer-based. They are not reachable from the `cel` entry point.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,12 @@ jobs:
       - name: Verify built packages import under Node ESM
         run: node scripts/verify-esm.mjs
 
+      # Node-only features must load their modules lazily so browser/edge
+      # consumers can still import the package. One static `import 'node:fs'`
+      # in the graph breaks that for everyone and is invisible until bundling.
+      - name: Verify browser-facing entry points have no eager Node builtins
+        run: node scripts/check-browser-safety.mjs
+
   changeset:
     name: Changeset present
     # Only on PRs, and skip the "Version Packages" PR (which intentionally has no

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,11 @@ jobs:
       - name: Verify built packages import under Node ESM
         run: node scripts/verify-esm.mjs
 
+      # Same idea for non-Node consumers: never publish a dist that a browser or
+      # edge runtime cannot import because a Node builtin is pulled in eagerly.
+      - name: Verify browser-facing entry points have no eager Node builtins
+        run: node scripts/check-browser-safety.mjs
+
       # Publish via changesets/action so npm publish, git tag creation/push, and
       # GitHub Release creation happen as one managed step — avoiding the
       # publish-succeeds-but-tag-push-fails gap where tags would be missing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,12 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      # The ONLY build before publish. The packages deliberately have no
+      # `prepublishOnly`: `changeset publish` runs packages concurrently, so a
+      # per-package rebuild had sdk's tsc rewriting dist/*.d.ts while auth's tsc
+      # was reading them (auth imports @originals/sdk) — a race that also rebuilt
+      # artifacts *after* the ESM gate below had verified them. Turbo builds in
+      # dependency order, once.
       - name: Build
         run: bun run build
 

--- a/bun.lock
+++ b/bun.lock
@@ -92,6 +92,7 @@
         "bitcoinjs-lib": "^6.1.0",
         "cborg": "^5.1.6",
         "didwebvh-ts": "^2.8.0",
+        "fflate": "^0.8.3",
         "jsonld": "^8.3.3",
         "micro-ordinals": "^0.2.2",
         "uuid": "^14.0.1",
@@ -570,6 +571,8 @@
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
+    "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "landing": "turbo run build --filter='./packages/*' && cd apps/landing && bunx vite build && bunx vite preview",
     "landing:ci": "bun apps/landing/scripts/ci.mjs",
     "verify:esm": "node scripts/verify-esm.mjs",
+  "verify:browser": "node scripts/check-browser-safety.mjs",
     "test": "turbo run test --filter='./packages/*'",
     "typecheck": "turbo run typecheck --filter='./packages/*'",
     "test:coverage": "turbo run test:coverage --filter='./packages/*'",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -37,7 +37,6 @@
   },
   "scripts": {
     "build": "bunx tsc && bunx tsc-alias",
-    "prepublishOnly": "npm run build",
     "test": "bun test tests/",
     "lint": "eslint src/**/*.ts",
     "format": "prettier --write src/**/*.ts"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -20,6 +20,16 @@
       "default": "./dist/index.js"
     },
     "./package.json": "./package.json",
+    "./cel": {
+      "types": "./dist/cel/index.d.ts",
+      "import": "./dist/cel/index.js",
+      "default": "./dist/cel/index.js"
+    },
+    "./cel/*": {
+      "types": "./dist/cel/*.d.ts",
+      "import": "./dist/cel/*.js",
+      "default": "./dist/cel/*.js"
+    },
     "./core/*": {
       "types": "./dist/core/*.d.ts",
       "import": "./dist/core/*.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -84,7 +84,6 @@
   "scripts": {
     "build": "tsc && tsc-alias",
     "typecheck": "tsc --noEmit -p .",
-    "prepublishOnly": "npm run build",
     "test": "bun test tests/integration && bun test tests/unit && bun test tests/security && bun test tests/stress",
     "test:coverage": "bun test tests/integration tests/unit --coverage",
     "check-coverage": "bun run ../../scripts/check-coverage.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -126,6 +126,7 @@
     "bitcoinjs-lib": "^6.1.0",
     "cborg": "^5.1.6",
     "didwebvh-ts": "^2.8.0",
+    "fflate": "^0.8.3",
     "jsonld": "^8.3.3",
     "micro-ordinals": "^0.2.2",
     "uuid": "^14.0.1"

--- a/packages/sdk/src/cel/algorithms/verifyEventLog.ts
+++ b/packages/sdk/src/cel/algorithms/verifyEventLog.ts
@@ -8,6 +8,7 @@
  */
 
 import { verifyAsync } from '@noble/ed25519';
+import { bytesToHex } from '@noble/hashes/utils.js';
 import type {
   EventLog,
   LogEntry,
@@ -42,7 +43,7 @@ function didDocumentFromInscription(inscription: FetchedInscription): unknown {
   if (metaDoc && typeof metaDoc === 'object') return metaDoc;
   if (inscription?.content === undefined) return undefined;
   try {
-    return JSON.parse(inscription.content.toString('utf8'));
+    return JSON.parse(new TextDecoder().decode(inscription.content));
   } catch {
     return undefined;
   }
@@ -229,7 +230,7 @@ async function selfCertifyingKeyHexes(did: unknown): Promise<Set<string> | null>
     // non-Ed25519 key means no Ed25519 proof can be bound to it (empty set →
     // fail closed at the caller).
     const key = extractEd25519FromDidKey(did);
-    return new Set(key ? [Buffer.from(key).toString('hex')] : []);
+    return new Set(key ? [bytesToHex(key)] : []);
   }
 
   if (did.startsWith('did:peer:4')) {
@@ -248,7 +249,7 @@ async function selfCertifyingKeyHexes(did: unknown): Promise<Set<string> | null>
           if (vm && typeof vm.publicKeyMultibase === 'string') {
             try {
               const dec = multikey.decodePublicKey(vm.publicKeyMultibase);
-              if (dec.type === 'Ed25519') keys.add(Buffer.from(dec.key).toString('hex'));
+              if (dec.type === 'Ed25519') keys.add(bytesToHex(dec.key));
             } catch {
               // skip non-decodable verification methods
             }
@@ -437,7 +438,7 @@ async function verifyBitcoinWitnessProof(
   let attestation: unknown;
   if (inscription.content !== undefined) {
     try {
-      attestation = JSON.parse(inscription.content.toString('utf8'));
+      attestation = JSON.parse(new TextDecoder().decode(inscription.content));
     } catch {
       attestation = undefined; // content is media (phase 2) — shape (a) N/A
     }
@@ -820,7 +821,7 @@ async function verifyAnchorContentMatchesHead(
   // asset — no inline media to inscribe).
   let asJson: unknown;
   try {
-    asJson = JSON.parse(inscription.content.toString('utf8'));
+    asJson = JSON.parse(new TextDecoder().decode(inscription.content));
   } catch {
     asJson = undefined;
   }
@@ -884,7 +885,7 @@ function ed25519KeyHexesFromDidDocument(content: unknown): Set<string> {
     if (typeof pkm !== 'string') continue;
     try {
       const dec = multikey.decodePublicKey(pkm);
-      if (dec.type === 'Ed25519') keys.add(Buffer.from(dec.key).toString('hex'));
+      if (dec.type === 'Ed25519') keys.add(bytesToHex(dec.key));
     } catch {
       // skip non-decodable verification methods
     }
@@ -1110,7 +1111,7 @@ async function resolveControllerKeyHex(
       key = null;
     }
   }
-  return key ? Buffer.from(key).toString('hex') : null;
+  return key ? bytesToHex(key) : null;
 }
 
 /**

--- a/packages/sdk/src/cel/index.ts
+++ b/packages/sdk/src/cel/index.ts
@@ -21,4 +21,7 @@ export {
   createKeyStoreCelSigner,
   hexSha256ToDigestMultibase,
 } from './signerAdapter.js';
-export { main as celCli } from './cli/index.js';
+// The CLI is intentionally NOT re-exported here. It statically imports fs and
+// path and pulls in all of OriginalsSDK, which would make this barrel — the
+// genesis-only entry point for browser consumers — unloadable outside Node.
+// It ships as the `originals-cel` bin (dist/cel/cli/index.js) instead.

--- a/packages/sdk/src/cel/layers/BtcoCelManager.ts
+++ b/packages/sdk/src/cel/layers/BtcoCelManager.ts
@@ -298,7 +298,7 @@ export class BtcoCelManager {
             },
           ],
         };
-        return Buffer.from(JSON.stringify(btcoDoc));
+        return new TextEncoder().encode(JSON.stringify(btcoDoc));
       },
       'application/did+json',
       this.config.feeRate,

--- a/packages/sdk/src/cel/resourceHead.ts
+++ b/packages/sdk/src/cel/resourceHead.ts
@@ -16,6 +16,7 @@
  */
 import type { EventLog } from './types.js';
 import { decodeDigestMultibase } from './hash.js';
+import { bytesToHex } from '@noble/hashes/utils.js';
 
 export interface ResourceHead {
   /** Logical resource id (may be '' for legacy id-less genesis). */
@@ -64,7 +65,7 @@ export function mostRecentResourceHead(log: EventLog): ResourceHead | undefined 
   if (typeof first.digestMultibase !== 'string') return undefined;
   let hash: string;
   try {
-    hash = Buffer.from(decodeDigestMultibase(first.digestMultibase)).toString('hex');
+    hash = bytesToHex(decodeDigestMultibase(first.digestMultibase));
   } catch {
     return undefined;
   }

--- a/packages/sdk/src/cel/types.ts
+++ b/packages/sdk/src/cel/types.ts
@@ -163,7 +163,7 @@ export interface OrdinalsLookup {
   getInscriptionById(id: string): Promise<{
     inscriptionId: string;
     // Optional: deferred-content providers may not echo built content back.
-    content?: Buffer;
+    content?: Uint8Array;
     contentType: string;
     txid?: string;
     satoshi?: string;

--- a/packages/sdk/src/crypto/Multikey.ts
+++ b/packages/sdk/src/crypto/Multikey.ts
@@ -1,4 +1,5 @@
 import { base58 } from '@scure/base';
+import { base64url } from '../utils/encoding.js';
 
 // Multicodec headers (varint encodings of the registry codes) for supported
 // key types. Private-key codes: ed25519-priv 0x1300, secp256k1-priv 0x1301,
@@ -159,8 +160,8 @@ export const multikey = {
     return 'z' + base58.encode(mcBytes);
   },
 
-  encodeMultibase: (data: Uint8Array | Buffer): string => {
-    return 'z' + base58.encode(data instanceof Buffer ? new Uint8Array(data) : data);
+  encodeMultibase: (data: Uint8Array): string => {
+    return 'z' + base58.encode(data);
   },
 
   decodeMultibase: (encoded: string): Uint8Array => {
@@ -176,8 +177,8 @@ export const multikey = {
       return base58.decode(encoded.slice(1));
     }
     if (encoded[0] === 'u') {
-      // Validate before decoding. `Buffer.from(..., 'base64url')` silently drops
-      // invalid characters (e.g. "@@@" -> empty buffer) instead of throwing, so
+      // Validate before decoding: lenient base64url decoders silently drop
+      // invalid characters (e.g. "@@@" -> empty result) instead of throwing, so
       // malformed input would otherwise be accepted as an empty result — unlike
       // the base58 branch, which throws. Reject anything that is not non-empty
       // unpadded base64url.
@@ -185,7 +186,7 @@ export const multikey = {
       if (!/^[A-Za-z0-9_-]+$/.test(payload)) {
         throw new Error('Invalid Multibase encoding: malformed u-base64url payload');
       }
-      return new Uint8Array(Buffer.from(payload, 'base64url'));
+      return base64url.decode(payload);
     }
     throw new Error('Invalid Multibase encoding: only z-base58btc and u-base64url are supported');
   },

--- a/packages/sdk/src/did/WebVHManager.ts
+++ b/packages/sdk/src/did/WebVHManager.ts
@@ -678,7 +678,7 @@ export class WebVHManager {
    * @returns The loaded DID log
    */
   async loadDIDLog(logPath: string): Promise<DIDLog> {
-    const { fs, path } = await loadNodeModules();
+    const { fs } = await loadNodeModules();
     const content = await fs.promises.readFile(logPath, 'utf8');
     const lines = content.trim().split('\n');
     return lines.map(line => JSON.parse(line) as DIDLogEntry);

--- a/packages/sdk/src/did/WebVHManager.ts
+++ b/packages/sdk/src/did/WebVHManager.ts
@@ -5,8 +5,20 @@ import { DIDDocument, KeyPair, ExternalSigner, ExternalVerifier, VerificationMet
 import { StructuredError } from '../utils/telemetry.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { base58 } from '@scure/base';
-import * as fs from 'fs';
-import * as path from 'path';
+/**
+ * Node-only modules, loaded on first use. Only saveDIDLog/loadDIDLog touch the
+ * filesystem, but a static import here made every entry point that reaches
+ * DIDManager unloadable in browsers/edge.
+ */
+let fs: typeof import('fs') | null = null;
+let path: typeof import('path') | null = null;
+
+async function loadNodeModules(): Promise<{ fs: typeof import('fs'); path: typeof import('path') }> {
+  if (!fs || !path) {
+    [fs, path] = await Promise.all([import('fs'), import('path')]);
+  }
+  return { fs, path };
+}
 
 /**
  * Compute the pre-rotation key hash for an update key.
@@ -545,8 +557,11 @@ export class WebVHManager {
       return false;
     }
     
-    // Reject absolute paths (starting with / or drive letter on Windows)
-    if (path.isAbsolute(segment)) {
+    // Reject absolute paths (leading separator, or a Windows drive prefix).
+    // Checked inline rather than via node:path so this validator stays usable
+    // without a Node runtime — separators are already rejected above, leaving
+    // only the drive-letter form to catch.
+    if (segment.startsWith('/') || /^[a-zA-Z]:/.test(segment)) {
       return false;
     }
     
@@ -585,6 +600,7 @@ export class WebVHManager {
    * @returns The full path where the log was saved
    */
   async saveDIDLog(did: string, log: DIDLog, baseDir: string): Promise<string> {
+    const { fs, path } = await loadNodeModules();
     // Parse the DID per the did:webvh method spec (and didwebvh-ts, which
     // produced it): did:webvh:{SCID}:{domain}[:path1:path2...]. The SCID comes
     // BEFORE the domain — treating segment 2 as the domain (the old behavior)
@@ -662,6 +678,7 @@ export class WebVHManager {
    * @returns The loaded DID log
    */
   async loadDIDLog(logPath: string): Promise<DIDLog> {
+    const { fs, path } = await loadNodeModules();
     const content = await fs.promises.readFile(logPath, 'utf8');
     const lines = content.trim().split('\n');
     return lines.map(line => JSON.parse(line) as DIDLogEntry);

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -857,7 +857,7 @@ export class LifecycleManager {
       didDocument: unknown;
       snapshotEvents?: unknown[]; // full celLog (checkpoint) → REPLACE
       deltaEvents?: unknown[];    // events delta → APPEND
-      content?: Buffer;
+      content?: Uint8Array;
       txid?: string;
     };
     const links: Link[] = [];
@@ -980,7 +980,7 @@ export class LifecycleManager {
     // most-recent-resource head (a rotation's newest inscription carries no new
     // media, so the media may live in an earlier resource-update inscription).
     const head = mostRecentResourceHead(reconstructedLog);
-    let headContent: Buffer | undefined;
+    let headContent: Uint8Array | undefined;
     if (head) {
       for (let i = links.length - 1; i >= 0; i--) {
         const c = links[i].content;
@@ -1043,7 +1043,7 @@ export class LifecycleManager {
    * blob↔toHash gate (which independently re-checks it) passes; a
    * non-utf8-roundtrippable or mismatched blob is left as a pure reference.
    */
-  private reconstructResourcesFromLog(log: EventLog, headContent: Buffer | undefined): AssetResource[] {
+  private reconstructResourcesFromLog(log: EventLog, headContent: Uint8Array | undefined): AssetResource[] {
     const resources: AssetResource[] = [];
     const genesis = log.events[0]?.data as { resources?: unknown } | undefined;
     const gres: Array<Record<string, unknown>> = Array.isArray(genesis?.resources) ? genesis.resources : [];
@@ -1083,7 +1083,7 @@ export class LifecycleManager {
     // head hash (loadAsset re-verifies hash(content) == signed toHash).
     const head = mostRecentResourceHead(log);
     if (headContent && head) {
-      const contentStr = headContent.toString('utf8');
+      const contentStr = new TextDecoder().decode(headContent);
       if (hashResource(Buffer.from(contentStr, 'utf8')).toLowerCase() === head.hash.toLowerCase()) {
         const target = resources.find(r => (!head.resourceId || r.id === head.resourceId) && r.hash === head.hash && r.content === undefined);
         if (target) target.content = contentStr;

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -16,7 +16,7 @@ import { inscribeOnSat } from '../bitcoin/inscribe-on-sat.js';
 import type { Utxo } from '../types/bitcoin.js';
 import type { BitcoinSigner } from '../types/common.js';
 import { DIDManager } from '../did/DIDManager.js';
-import { CredentialManager } from '../vc/CredentialManager.js';
+import type { CredentialManager } from '../vc/CredentialManager.js';
 import { OriginalsAsset, type ProvenanceChain } from './OriginalsAsset.js';
 import { replayProvenance } from './replayProvenance.js';
 import { checkGenesisResourceBinding } from './genesisBinding.js';

--- a/packages/sdk/src/lifecycle/OriginalsAsset.ts
+++ b/packages/sdk/src/lifecycle/OriginalsAsset.ts
@@ -7,7 +7,7 @@ import {
 } from '../types/index.js';
 import { validateDIDDocument, validateCredential, hashResource } from '../utils/validation.js';
 import { StructuredError } from '../utils/telemetry.js';
-import { CredentialManager } from '../vc/CredentialManager.js';
+import type { CredentialManager } from '../vc/CredentialManager.js';
 import { DIDManager } from '../did/DIDManager.js';
 import { ProvenanceQuery, Migration } from './ProvenanceQuery.js';
 import { EventEmitter } from '../events/EventEmitter.js';
@@ -540,8 +540,12 @@ export class OriginalsAsset {
         }
       }
 
-      // If a credentialManager with didManager is provided, verify each credential cryptographically
-      if (deps?.credentialManager && deps.credentialManager instanceof CredentialManager && deps?.didManager) {
+      // If a credentialManager with didManager is provided, verify each credential cryptographically.
+      // Duck-typed rather than `instanceof`: importing CredentialManager for the
+      // check alone dragged jsonld into every genesis consumer's bundle, and
+      // instanceof is unreliable anyway when a bundler yields two copies of the
+      // module.
+      if (deps?.credentialManager && typeof deps.credentialManager.verifyCredential === 'function' && deps?.didManager) {
         for (const cred of this.credentials) {
           const ok = await deps.credentialManager.verifyCredential(cred);
           if (!ok) return false;

--- a/packages/sdk/src/storage/LocalStorageAdapter.ts
+++ b/packages/sdk/src/storage/LocalStorageAdapter.ts
@@ -1,10 +1,35 @@
 // Local adapter is optional in this environment; keeping implementation but avoid Node typings
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import * as fs from 'fs/promises';
-import * as path from 'path';
 import { GetObjectResult, LocalStorageAdapterOptions, StorageAdapter } from './StorageAdapter.js';
 import { StructuredError } from '../utils/telemetry.js';
+
+/**
+ * Node-only modules, loaded on first use rather than at import time. This
+ * adapter is re-exported from the package barrel, so a static import made the
+ * whole SDK unloadable in browsers/edge — same reasoning as FileLogOutput.
+ *
+ * They stay memoized in module scope so the path-traversal guards below can
+ * remain synchronous with Node's exact `path` semantics; reimplementing
+ * resolve/relative/sep portably would put those security checks at risk.
+ */
+let fs: typeof import('fs/promises') | null = null;
+let path: typeof import('path') | null = null;
+
+async function loadNodeModules(): Promise<void> {
+  if (fs && path) return;
+  [fs, path] = await Promise.all([import('fs/promises'), import('path')]);
+}
+
+function requirePath(): typeof import('path') {
+  if (!path) {
+    throw new StructuredError(
+      'STORAGE_NOT_INITIALIZED',
+      'LocalStorageAdapter requires a Node-like runtime; call an async method first so node:path can load.'
+    );
+  }
+  return path;
+}
 
 export class LocalStorageAdapter implements StorageAdapter {
   private baseDir: string;
@@ -27,6 +52,7 @@ export class LocalStorageAdapter implements StorageAdapter {
   }
 
   private resolvePath(domain: string, objectPath: string): string {
+    const path = requirePath();
     const safeDomain = this.sanitizeDomain(domain);
     const cleanPath = objectPath.replace(/^\/+/, '');
     const base = path.resolve(this.baseDir, safeDomain);
@@ -66,14 +92,16 @@ export class LocalStorageAdapter implements StorageAdapter {
   }
 
   async putObject(domain: string, objectPath: string, content: Uint8Array | string): Promise<string> {
+    await loadNodeModules();
     const fullPath = this.resolvePath(domain, objectPath);
     await fs.mkdir(path.dirname(fullPath), { recursive: true });
-    const data = typeof content === 'string' ? Buffer.from(content) : Buffer.from(content);
+    const data = typeof content === 'string' ? new TextEncoder().encode(content) : content;
     await fs.writeFile(fullPath, data);
     return this.toUrl(domain, objectPath);
   }
 
   async getObject(domain: string, objectPath: string): Promise<GetObjectResult | null> {
+    await loadNodeModules();
     const fullPath = this.resolvePath(domain, objectPath);
     try {
       const content = await fs.readFile(fullPath);
@@ -88,6 +116,7 @@ export class LocalStorageAdapter implements StorageAdapter {
   }
 
   async exists(domain: string, objectPath: string): Promise<boolean> {
+    await loadNodeModules();
     const fullPath = this.resolvePath(domain, objectPath);
     try {
       await fs.access(fullPath);
@@ -112,6 +141,7 @@ export class LocalStorageAdapter implements StorageAdapter {
    * round-trip through getObject. A never-written domain yields [].
    */
   async listObjects(domain: string, prefix: string): Promise<string[]> {
+    await loadNodeModules();
     // Reuse resolvePath's traversal containment for the domain directory.
     const base = this.resolvePath(domain, '');
     const cleanPrefix = prefix.replace(/^\/+/, '');

--- a/packages/sdk/src/utils/cbor.ts
+++ b/packages/sdk/src/utils/cbor.ts
@@ -46,12 +46,12 @@ function mapsToObjects(value: unknown): unknown {
   return value;
 }
 
-export function decode<T = unknown>(bytes: Uint8Array | ArrayBuffer | Buffer): T {
+export function decode<T = unknown>(bytes: Uint8Array | ArrayBuffer): T {
   let u8: Uint8Array;
   if (bytes instanceof ArrayBuffer) {
     u8 = new Uint8Array(bytes);
   } else {
-    // Uint8Array and Buffer both expose buffer/byteOffset/byteLength
+    // Uint8Array (and Buffer, which extends it) expose buffer/byteOffset/byteLength
     u8 = new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength);
   }
   const decoded = cborgDecode(u8, {

--- a/packages/sdk/src/utils/encoding.ts
+++ b/packages/sdk/src/utils/encoding.ts
@@ -1,7 +1,14 @@
-import b58 from 'b58';
+// @scure/base rather than Buffer: this module is on the import path of nearly
+// every entry point, so a Node-only dependency here makes the whole SDK
+// unloadable in browsers/edge runtimes.
+import {
+  base58 as scureBase58,
+  base64 as scureBase64,
+  base64urlnopad as scureBase64UrlNoPad
+} from '@scure/base';
 
 export function encodeBase64UrlMultibase(bytes: Uint8Array): string {
-  return 'u' + Buffer.from(bytes).toString('base64url');
+  return 'u' + scureBase64UrlNoPad.encode(bytes);
 }
 
 export function decodeBase64UrlMultibase(s: string): Uint8Array {
@@ -9,13 +16,13 @@ export function decodeBase64UrlMultibase(s: string): Uint8Array {
     throw new Error('Invalid Multibase encoding');
   }
   const payload = s.slice(1);
-  // Buffer.from(..., 'base64url') silently skips characters outside the
-  // alphabet, so distinct proofValue strings would decode to the same bytes
-  // (signature malleability). Validate strictly instead.
+  // Decoders that skip characters outside the alphabet would let distinct
+  // proofValue strings decode to the same bytes (signature malleability).
+  // Validate strictly instead.
   if (!/^[A-Za-z0-9_-]*$/.test(payload)) {
     throw new Error('Invalid Multibase encoding: not base64url');
   }
-  return Uint8Array.from(Buffer.from(payload, 'base64url'));
+  return scureBase64UrlNoPad.decode(payload);
 }
 
 export function hexToBytes(hex: string): Uint8Array {
@@ -60,13 +67,18 @@ export const MULTICODEC_BLS12381_G2_PRIV_HEADER = new Uint8Array([0x8a, 0x26]);
 
 export const base64 = {
 	encode: (unencoded: string | Uint8Array): string => {
-		return Buffer.from(unencoded || '').toString('base64');
+		const bytes = typeof unencoded === 'string'
+			? utf8.encode(unencoded)
+			: (unencoded ?? new Uint8Array());
+		return scureBase64.encode(bytes);
 	},
 	decode: (encoded: string): Uint8Array => {
-		// Copy instead of wrapping `.buffer`: on Node, small Buffers are views
-		// into a shared pool, so wrapping the backing ArrayBuffer without
-		// byteOffset/byteLength returns unrelated pool memory.
-		return Uint8Array.from(Buffer.from(encoded || '', 'base64'));
+		if (!encoded) return new Uint8Array();
+		// @scure/base requires canonical padding; Buffer did not. Pad rather than
+		// reject so callers holding unpadded base64 keep working.
+		let padded = encoded;
+		while (padded.length % 4) padded += '=';
+		return scureBase64.decode(padded);
 	}
 };
 
@@ -81,30 +93,24 @@ export const utf8 = {
 
 export const base64url = {
 	encode: (unencoded: string | Uint8Array): string => {
-		const encoded = base64.encode(unencoded);
-		return encoded.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+		const bytes = typeof unencoded === 'string'
+			? utf8.encode(unencoded)
+			: (unencoded ?? new Uint8Array());
+		return scureBase64UrlNoPad.encode(bytes);
 	},
 	decode: (encoded: string): Uint8Array => {
-		let padded = encoded.replace(/-/g, '+').replace(/_/g, '/');
-		while (padded.length % 4) padded += '=';
-		return base64.decode(padded);
+		if (!encoded) return new Uint8Array();
+		// Tolerate the padded form; the nopad decoder rejects trailing '='.
+		return scureBase64UrlNoPad.decode(encoded.replace(/=+$/, ''));
 	}
 };
 
-// Type assertion for b58 library which doesn't have proper types
-interface B58Module {
-  encode: (unencoded: Uint8Array) => string;
-  decode: (encoded: string) => Uint8Array;
-}
-
-const b58Typed = b58 as unknown as B58Module;
-
 export const base58 = {
 	encode: (unencoded: Uint8Array): string => {
-		return b58Typed.encode(unencoded);
+		return scureBase58.encode(unencoded);
 	},
 	decode: (encoded: string): Uint8Array => {
-		return b58Typed.decode(encoded);
+		return scureBase58.decode(encoded);
 	}
 };
 

--- a/packages/sdk/src/vc/BitstringStatusList.ts
+++ b/packages/sdk/src/vc/BitstringStatusList.ts
@@ -1,4 +1,5 @@
-import { gzipSync, gunzipSync, inflateSync } from 'node:zlib';
+import { gzipBytes, boundedGunzip, boundedUnzlib } from './utils/bounded-decompress.js';
+import { base64url } from '../utils/encoding.js';
 import { MAX_DECOMPRESSED_BITSTRING_BYTES } from './StatusListManager.js';
 
 const MINIMUM_LIST_SIZE = 131072; // 16KB = 131072 bits per W3C spec recommendation
@@ -67,8 +68,8 @@ export class BitstringStatusList {
    * readable by any spec-compliant consumer.
    */
   encode(): string {
-    const compressed = gzipSync(Buffer.from(this.bits));
-    return 'u' + base64urlEncode(compressed);
+    const compressed = gzipBytes(this.bits);
+    return 'u' + base64url.encode(compressed);
   }
 
   /**
@@ -80,14 +81,14 @@ export class BitstringStatusList {
     // Cap decompression: encodedList may come from an untrusted status list
     // credential, and unbounded gunzip/inflate of a small gzip bomb can
     // allocate gigabytes (verifier DoS).
-    const limit = { maxOutputLength: MAX_DECOMPRESSED_BITSTRING_BYTES };
+    const limit = MAX_DECOMPRESSED_BITSTRING_BYTES;
     let decompressed: Uint8Array;
     try {
       if (encoded.startsWith('u')) {
-        decompressed = new Uint8Array(gunzipSync(base64urlDecode(encoded.slice(1)), limit));
+        decompressed = boundedGunzip(base64url.decode(encoded.slice(1)), limit);
       } else {
-        // Legacy pre-spec encoding: bare base64url, raw DEFLATE stream.
-        decompressed = new Uint8Array(inflateSync(base64urlDecode(encoded), limit));
+        // Legacy pre-spec encoding: bare base64url, ZLIB-wrapped DEFLATE stream.
+        decompressed = boundedUnzlib(base64url.decode(encoded), limit);
       }
     } catch (err) {
       throw new Error(
@@ -113,12 +114,3 @@ export class BitstringStatusList {
   }
 }
 
-function base64urlEncode(data: Uint8Array): string {
-  const b64 = Buffer.from(data).toString('base64');
-  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
-
-function base64urlDecode(str: string): Uint8Array {
-  const padded = str.replace(/-/g, '+').replace(/_/g, '/');
-  return new Uint8Array(Buffer.from(padded, 'base64'));
-}

--- a/packages/sdk/src/vc/StatusListManager.ts
+++ b/packages/sdk/src/vc/StatusListManager.ts
@@ -4,7 +4,8 @@ import {
   BitstringStatusListSubject,
   StatusPurpose,
 } from '../types/index.js';
-import { gzipSync, gunzipSync } from 'node:zlib';
+import { gzipBytes, boundedGunzip } from './utils/bounded-decompress.js';
+import { base64url } from '../utils/encoding.js';
 
 /**
  * Options for creating a new status list.
@@ -375,10 +376,8 @@ export class StatusListManager {
    * Format: 'u' (multibase base64url) prefix + base64url(gzip(bitstring))
    */
   static encodeBitstring(bitstring: Uint8Array): string {
-    const compressed = gzipSync(Buffer.from(bitstring));
-    const base64url = Buffer.from(compressed)
-      .toString('base64url');
-    return 'u' + base64url;
+    const compressed = gzipBytes(bitstring);
+    return 'u' + base64url.encode(compressed);
   }
 
   /**
@@ -394,11 +393,9 @@ export class StatusListManager {
         'Invalid encoded bitstring: must start with multibase base64url prefix "u"'
       );
     }
-    const compressed = Buffer.from(encoded.slice(1), 'base64url');
+    const compressed = base64url.decode(encoded.slice(1));
     try {
-      return new Uint8Array(
-        gunzipSync(compressed, { maxOutputLength: MAX_DECOMPRESSED_BITSTRING_BYTES })
-      );
+      return boundedGunzip(compressed, MAX_DECOMPRESSED_BITSTRING_BYTES);
     } catch (err) {
       throw new Error(
         `Invalid encoded bitstring: decompression failed or exceeded the ${MAX_DECOMPRESSED_BITSTRING_BYTES}-byte limit: ${

--- a/packages/sdk/src/vc/utils/bounded-decompress.ts
+++ b/packages/sdk/src/vc/utils/bounded-decompress.ts
@@ -1,0 +1,65 @@
+import { gzipSync as fflateGzipSync, Gunzip, Unzlib } from 'fflate';
+
+/**
+ * GZIP helpers backed by fflate rather than `node:zlib`, so status lists work in
+ * browsers and edge runtimes. Signatures stay synchronous — a lazy
+ * `await import('node:zlib')` would have forced every caller async.
+ */
+
+export function gzipBytes(data: Uint8Array): Uint8Array {
+  return fflateGzipSync(data);
+}
+
+type StreamCtor = typeof Gunzip | typeof Unzlib;
+
+/**
+ * Decompress with a hard output budget.
+ *
+ * fflate has no `maxOutputLength` equivalent: passing a pre-sized `out` buffer
+ * makes it **silently truncate** rather than throw, which for a status list
+ * would read as "not revoked" for entries past the cut — fail-open. So stream
+ * instead and abort as soon as the budget is passed.
+ */
+function boundedDecompress(data: Uint8Array, maxBytes: number, Ctor: StreamCtor): Uint8Array {
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  let overflowed = false;
+
+  const stream = new Ctor((chunk) => {
+    if (overflowed) return;
+    total += chunk.length;
+    if (total > maxBytes) {
+      overflowed = true;
+      return;
+    }
+    chunks.push(chunk);
+  });
+
+  stream.push(data, true);
+
+  if (overflowed) {
+    throw new Error(`decompressed output exceeded the ${maxBytes}-byte limit`);
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return merged;
+}
+
+/** GZIP (RFC 1952), the W3C Bitstring Status List wire format. */
+export function boundedGunzip(data: Uint8Array, maxBytes: number): Uint8Array {
+  return boundedDecompress(data, maxBytes, Gunzip);
+}
+
+/**
+ * ZLIB-wrapped DEFLATE (RFC 1950) — what `node:zlib`'s `inflateSync` accepted,
+ * used by the legacy pre-spec encoding. fflate's `inflateSync` is *raw* deflate
+ * and rejects this framing, so the equivalent is `Unzlib`.
+ */
+export function boundedUnzlib(data: Uint8Array, maxBytes: number): Uint8Array {
+  return boundedDecompress(data, maxBytes, Unzlib);
+}

--- a/packages/sdk/src/vc/utils/bounded-decompress.ts
+++ b/packages/sdk/src/vc/utils/bounded-decompress.ts
@@ -13,12 +13,22 @@ export function gzipBytes(data: Uint8Array): Uint8Array {
 type StreamCtor = typeof Gunzip | typeof Unzlib;
 
 /**
- * Decompress with a hard output budget.
+ * Compressed input is fed in slices this size so the output budget can be
+ * re-checked between pushes. fflate inflates an entire `push()` before
+ * returning, so pushing the whole payload at once would spend the full CPU cost
+ * of a bomb before the budget could stop it — the point is to bound work, not
+ * just memory. Measured on a 400 MB bomb: ~920ms in one push vs ~12ms sliced.
+ */
+const INPUT_SLICE_BYTES = 4096;
+
+/**
+ * Decompress with a hard output budget, bounding both memory and CPU.
  *
  * fflate has no `maxOutputLength` equivalent: passing a pre-sized `out` buffer
  * makes it **silently truncate** rather than throw, which for a status list
  * would read as "not revoked" for entries past the cut — fail-open. So stream
- * instead and abort as soon as the budget is passed.
+ * instead: stop retaining chunks the moment the budget is passed (bounding
+ * memory), and stop feeding input (bounding the remaining inflate work).
  */
 function boundedDecompress(data: Uint8Array, maxBytes: number, Ctor: StreamCtor): Uint8Array {
   const chunks: Uint8Array[] = [];
@@ -29,13 +39,23 @@ function boundedDecompress(data: Uint8Array, maxBytes: number, Ctor: StreamCtor)
     if (overflowed) return;
     total += chunk.length;
     if (total > maxBytes) {
+      // Drop this chunk and every later one: memory stays bounded even if the
+      // remainder of the current slice still inflates.
       overflowed = true;
       return;
     }
     chunks.push(chunk);
   });
 
-  stream.push(data, true);
+  if (data.length === 0) {
+    stream.push(data, true);
+  } else {
+    for (let offset = 0; offset < data.length; offset += INPUT_SLICE_BYTES) {
+      const end = Math.min(offset + INPUT_SLICE_BYTES, data.length);
+      stream.push(data.subarray(offset, end), end === data.length);
+      if (overflowed) break;
+    }
+  }
 
   if (overflowed) {
     throw new Error(`decompressed output exceeded the ${maxBytes}-byte limit`);

--- a/packages/sdk/src/vc/utils/selective-disclosure.ts
+++ b/packages/sdk/src/vc/utils/selective-disclosure.ts
@@ -11,17 +11,14 @@
 import jsonld from 'jsonld';
 import { hmac } from '@noble/hashes/hmac.js';
 import { sha256 } from '@noble/hashes/sha2.js';
+import { base64url } from '../../utils/encoding.js';
 
 // Specification default recommended URN scheme to use for skolemization
 const CUSTOM_URN_SCHEME = 'custom-scheme';
 
 /** base64url-no-pad encoding (replaces jose's base64url.encode). */
 function base64urlEncode(bytes: Uint8Array): string {
-  return Buffer.from(bytes)
-    .toString('base64')
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/g, '');
+  return base64url.encode(bytes);
 }
 
 export type GroupDefinitions = {

--- a/packages/sdk/src/vc/utils/selective-disclosure.ts
+++ b/packages/sdk/src/vc/utils/selective-disclosure.ts
@@ -3,12 +3,12 @@
  *
  * Ported from aviarytech/di-wings (src/lib/vcs/v2/utils/selective-disclosure.ts)
  * and adapted to the Originals SDK: jose's base64url is replaced with a local
- * helper and Node's `crypto.randomUUID` is used for skolemization nonces.
+ * helper and the Web Crypto `crypto.randomUUID` global is used for
+ * skolemization nonces (available in browsers and Node >= 19, so no import).
  *
  * Algorithm step numbers reference the W3C VC Data Integrity ECDSA/BBS specs.
  */
 import jsonld from 'jsonld';
-import crypto from 'crypto';
 import { hmac } from '@noble/hashes/hmac.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 
@@ -202,7 +202,7 @@ export function skolemizeExpandedJsonLd(
   // branch reuses the same skolem URN and two distinct blank nodes collapse
   // into one after deskolemization (issue #316).
   if (!options.urnScheme) options.urnScheme = CUSTOM_URN_SCHEME;
-  if (!options.randomString) options.randomString = crypto.randomUUID();
+  if (!options.randomString) options.randomString = globalThis.crypto.randomUUID();
   if (options.count === undefined) options.count = 0;
 
   const generateId = (blankNodeId?: string): string => {
@@ -266,7 +266,7 @@ export const skolemizeCompactJsonLd = async (
     const expanded = await jsonld.expand(document, { safe: true, documentLoader: options.documentLoader } as any);
     const skolemizedExpandedDocument = skolemizeExpandedJsonLd(
       expanded as Record<string, unknown>[],
-      { urnScheme, randomString: crypto.randomUUID(), count: 0 }
+      { urnScheme, randomString: globalThis.crypto.randomUUID(), count: 0 }
     );
     const skolemizedCompactDocument = await jsonld.compact(
       skolemizedExpandedDocument,

--- a/packages/sdk/tests/security/gzip-bomb-bounded-decompress.test.ts
+++ b/packages/sdk/tests/security/gzip-bomb-bounded-decompress.test.ts
@@ -37,6 +37,22 @@ describe('bounded decompression (gzip bomb defence)', () => {
     expect(() => boundedGunzip(justOver, MAX)).toThrow(/exceeded/i);
   });
 
+  test('stops decompressing on overflow rather than only dropping output', () => {
+    // Bounding memory is not enough: fflate inflates an entire push() before
+    // returning, so feeding the whole payload at once burns the full CPU cost of
+    // a bomb even though the bytes are discarded. Input is sliced so the budget
+    // halts the work. Measured on this 400 MB bomb: ~920ms unsliced vs ~12ms.
+    const bomb = gzipBytes(new Uint8Array(400_000_000));
+
+    const started = performance.now();
+    expect(() => boundedGunzip(bomb, MAX)).toThrow(/exceeded/i);
+    const elapsed = performance.now() - started;
+
+    // Generous bound (full inflate is ~900ms on CI-class hardware): this fails
+    // loudly if someone reverts to a single push, without being flaky.
+    expect(elapsed).toBeLessThan(300);
+  });
+
   test('rejects truncated and garbage input instead of returning partial data', () => {
     const valid = gzipBytes(new Uint8Array(1000).fill(1));
     expect(() => boundedGunzip(valid.slice(0, 12), MAX)).toThrow();

--- a/packages/sdk/tests/security/gzip-bomb-bounded-decompress.test.ts
+++ b/packages/sdk/tests/security/gzip-bomb-bounded-decompress.test.ts
@@ -1,0 +1,102 @@
+import { describe, test, expect } from 'bun:test';
+import { gzipSync as nodeGzip, gunzipSync as nodeGunzip, deflateSync as nodeDeflate } from 'node:zlib';
+import {
+  gzipBytes,
+  boundedGunzip,
+  boundedUnzlib
+} from '../../src/vc/utils/bounded-decompress';
+import { BitstringStatusList } from '../../src/vc/BitstringStatusList';
+import { StatusListManager } from '../../src/vc/StatusListManager';
+
+/**
+ * Status lists moved from node:zlib to fflate so the SDK loads in browsers.
+ * node:zlib's `maxOutputLength` threw on a gzip bomb; fflate has no equivalent,
+ * and its nearest option (a pre-sized `out` buffer) SILENTLY TRUNCATES. For a
+ * status list a truncated bitstring reads as "not revoked" for every entry past
+ * the cut — a fail-open verifier. These tests pin the throwing behaviour.
+ */
+describe('bounded decompression (gzip bomb defence)', () => {
+  const MAX = 1_000_000;
+
+  test('rejects a gzip bomb rather than truncating it', () => {
+    const bomb = gzipBytes(new Uint8Array(50_000_000));
+    expect(bomb.length).toBeLessThan(100_000); // small on the wire, huge inflated
+    expect(() => boundedGunzip(bomb, MAX)).toThrow(/exceeded/i);
+  });
+
+  test('accepts payloads at or under the budget', () => {
+    const payload = new Uint8Array(MAX).fill(0x5a);
+    const round = boundedGunzip(gzipBytes(payload), MAX);
+    expect(round.length).toBe(MAX);
+    expect(round[0]).toBe(0x5a);
+    expect(round[MAX - 1]).toBe(0x5a);
+  });
+
+  test('rejects one byte over the budget', () => {
+    const justOver = gzipBytes(new Uint8Array(MAX + 1));
+    expect(() => boundedGunzip(justOver, MAX)).toThrow(/exceeded/i);
+  });
+
+  test('rejects truncated and garbage input instead of returning partial data', () => {
+    const valid = gzipBytes(new Uint8Array(1000).fill(1));
+    expect(() => boundedGunzip(valid.slice(0, 12), MAX)).toThrow();
+    expect(() => boundedGunzip(new Uint8Array([1, 2, 3, 4, 5]), MAX)).toThrow();
+  });
+
+  test('stays wire-compatible with node:zlib in both directions', () => {
+    const data = new Uint8Array(50_000);
+    for (let i = 0; i < data.length; i++) data[i] = i % 251;
+
+    // fflate reads what node:zlib wrote — existing published status lists.
+    const fromNode = new Uint8Array(nodeGzip(Buffer.from(data)));
+    expect(Array.from(boundedGunzip(fromNode, MAX))).toEqual(Array.from(data));
+
+    // node:zlib reads what fflate writes — other implementations consuming ours.
+    expect(Array.from(new Uint8Array(nodeGunzip(Buffer.from(gzipBytes(data))))))
+      .toEqual(Array.from(data));
+  });
+
+  test('legacy zlib-wrapped DEFLATE decodes via boundedUnzlib', () => {
+    // node:zlib's inflateSync accepted ZLIB framing; fflate's inflateSync is raw
+    // DEFLATE and rejects it, so the legacy path must use Unzlib.
+    const data = new Uint8Array(5000).fill(0x11);
+    const legacy = new Uint8Array(nodeDeflate(Buffer.from(data)));
+    expect(Array.from(boundedUnzlib(legacy, MAX))).toEqual(Array.from(data));
+  });
+});
+
+describe('status list encode/decode survives the fflate swap', () => {
+  test('BitstringStatusList round-trips a set bit', () => {
+    const list = new BitstringStatusList(131072);
+    list.set(42);
+    list.set(131071);
+
+    const decoded = BitstringStatusList.decode(list.encode());
+    expect(decoded.get(42)).toBe(true);
+    expect(decoded.get(131071)).toBe(true);
+    expect(decoded.get(43)).toBe(false);
+  });
+
+  test('BitstringStatusList.encode stays multibase-u and spec-readable', () => {
+    const list = new BitstringStatusList(131072);
+    list.set(7);
+    const encoded = list.encode();
+    expect(encoded.startsWith('u')).toBe(true);
+
+    // Cross-check: StatusListManager decodes what BitstringStatusList produced.
+    const bits = StatusListManager.decodeBitstring(encoded);
+    expect(bits[0] & (1 << (7 - 7))).toBe(1);
+  });
+
+  test('a bomb in encodedList is rejected by both decoders', () => {
+    const bomb = gzipBytes(new Uint8Array(50_000_000));
+    let b64 = '';
+    for (let i = 0; i < bomb.length; i += 0x8000) {
+      b64 += String.fromCharCode(...bomb.subarray(i, i + 0x8000));
+    }
+    const encoded = 'u' + btoa(b64).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+    expect(() => BitstringStatusList.decode(encoded)).toThrow(/limit|exceeded/i);
+    expect(() => StatusListManager.decodeBitstring(encoded)).toThrow(/limit|exceeded/i);
+  });
+});

--- a/scripts/check-browser-safety.mjs
+++ b/scripts/check-browser-safety.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Fail the build if a browser-facing entry point statically imports a Node
+ * builtin.
+ *
+ * Node-only features (filesystem logging, LocalStorageAdapter, did:webvh log
+ * persistence) are fine — they just have to load their modules lazily, so a
+ * browser or edge runtime can import the package and use everything else. A
+ * single static `import 'node:fs'` anywhere in the graph breaks that for every
+ * consumer, which is easy to reintroduce and invisible until someone bundles.
+ *
+ * Dynamic `import()` is deliberately not counted: that is the fix, not the bug.
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, resolve, relative } from 'node:path';
+import { builtinModules } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const DIST = resolve(dirname(fileURLToPath(import.meta.url)), '../packages/sdk/dist');
+
+/** Entry points that must stay importable in a browser. */
+const GUARDED_ENTRIES = [
+  'index.js',
+  'lifecycle/LifecycleManager.js',
+  'lifecycle/OriginalsAsset.js',
+  'cel/index.js',
+];
+
+const builtins = new Set([...builtinModules, ...builtinModules.map((m) => `node:${m}`)]);
+
+const STATIC_FROM = /(?:^|\n)\s*(?:import|export)\b[^;'"]*?from\s*['"]([^'"]+)['"]/g;
+const BARE_IMPORT = /(?:^|\n)\s*import\s*['"]([^'"]+)['"]/g;
+
+function staticSpecifiers(file) {
+  const src = readFileSync(file, 'utf8');
+  const out = [];
+  for (const re of [STATIC_FROM, BARE_IMPORT]) {
+    re.lastIndex = 0;
+    let m;
+    while ((m = re.exec(src))) out.push(m[1]);
+  }
+  return out;
+}
+
+function resolveRelative(fromFile, spec) {
+  if (!spec.startsWith('.')) return null;
+  const base = resolve(dirname(fromFile), spec);
+  if (base.endsWith('.js') && existsSync(base)) return base;
+  for (const candidate of [`${base}.js`, `${base}/index.js`]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/** Breadth-first so the reported chain is the shortest one that pulls the builtin in. */
+function findEagerBuiltins(entry) {
+  const seen = new Set();
+  const violations = new Map();
+  const queue = [[entry, [relative(DIST, entry)]]];
+  while (queue.length) {
+    const [file, chain] = queue.shift();
+    if (seen.has(file)) continue;
+    seen.add(file);
+    for (const spec of staticSpecifiers(file)) {
+      if (builtins.has(spec)) {
+        if (!violations.has(spec)) violations.set(spec, chain);
+        continue;
+      }
+      const next = resolveRelative(file, spec);
+      if (next && !seen.has(next)) queue.push([next, [...chain, relative(DIST, next)]]);
+    }
+  }
+  return violations;
+}
+
+let failed = false;
+for (const entry of GUARDED_ENTRIES) {
+  const abs = resolve(DIST, entry);
+  if (!existsSync(abs)) {
+    console.error(`✗ ${entry} — not found in dist. Run \`bun run build\` first.`);
+    failed = true;
+    continue;
+  }
+  const violations = findEagerBuiltins(abs);
+  if (violations.size === 0) {
+    console.log(`✓ ${entry} — no Node builtins statically reachable`);
+    continue;
+  }
+  failed = true;
+  console.error(`✗ ${entry} — ${violations.size} Node builtin(s) statically reachable:`);
+  for (const [builtin, chain] of violations) {
+    console.error(`    ${builtin}`);
+    console.error(`      via ${chain.join(' -> ')}`);
+  }
+}
+
+if (failed) {
+  console.error(
+    '\nBrowser-safety check failed. Load the Node module lazily instead:\n' +
+      "  let fs = null;\n" +
+      "  async function loadNodeModules() { fs ??= await import('node:fs/promises'); return fs; }\n" +
+      '\nSee FileLogOutput in src/utils/Logger.ts for the established pattern.'
+  );
+  process.exit(1);
+}
+
+console.log('\nBrowser-safety check passed: every guarded entry point is free of eager Node builtins.');


### PR DESCRIPTION
Addresses the three upstream asks from the boop feedback. Findings differed from the report in a few places, noted below.

## 1. Node-only bits are lazy — but the report was incomplete

`Logger`'s file sink was **already** lazy (`utils/Logger.ts:87` memoizes `import('node:fs/promises')`), so there was nothing to do there. The genuine problem was larger: `@originals/sdk` statically reached **five** Node builtins, so fixing only `zlib` would have left the package unloadable anyway.

```
crypto      via vc/cryptosuites/bbsCryptosuite.js -> vc/utils/selective-disclosure.js
fs, path    via did/WebVHManager.js
fs/promises via storage/index.js -> storage/LocalStorageAdapter.js
node:zlib   via vc/StatusListManager.js
```

All five are gone. `selective-disclosure` only wanted `randomUUID`, a Web Crypto global. `LocalStorageAdapter`/`WebVHManager` load `fs`/`path` lazily.

### zlib: fflate, not a lazy import — and the security trap in it

`BitstringStatusList.encode()`/`.decode()` are **synchronous public methods**, so `await import('node:zlib')` would have made them async — a breaking change to a package published as 2.0.0 today. `fflate` keeps them sync with no API change.

The catch: fflate has no `maxOutputLength`, and its nearest option — a pre-sized `out` buffer — **silently truncates instead of throwing**. For a status list, a truncated bitstring reads as *not revoked* for every entry past the cut: a fail-open verifier. `bounded-decompress.ts` streams and aborts once the budget is passed. Also, the legacy pre-spec encoding is ZLIB-wrapped DEFLATE, whose fflate equivalent is `Unzlib`, **not** `inflateSync` (raw DEFLATE) — verified round-trip against `node:zlib` in both directions.

## 2. The CredentialManager edge — no laziness required

`CredentialManager` is injected via `LifecycleManager`'s constructor, so it was only ever a type. `import type` erases it. `OriginalsAsset`'s `instanceof` guard is now duck-typed, which additionally survives a bundler emitting two copies of the module.

```
lifecycle/LifecycleManager: 75 modules / 821 KB -> 59 / 653 KB   (jsonld dropped)
```

## 3. Slim `@originals/sdk/cel`

`@originals/sdk/cel` **was not importable at all** — no `./cel/*` in the exports map — and the `cel` barrel re-exported the CLI, which drags in `fs`, `path` and all of `OriginalsSDK`. `celCli` is referenced nowhere and the barrel was unreachable, so removing it breaks no one; the CLI still ships as the `originals-cel` bin.

```
index.js      116 modules, 1201 KB, 14 third-party packages
cel/index.js   34 modules,  248 KB,  5 third-party packages
```

Dropped: `bitcoinjs-lib`, `jsonld`, `@digitalbazaar/bbs-signatures`, `didwebvh-ts`, `@scure/btc-signer`, `micro-ordinals`, `uuid`, `@noble/secp256k1`, `fflate`. Well past a megabyte once `node_modules` is counted.

## Bug found on the way

`OrdinalsLookup.content` is typed `Uint8Array`, but four sites in `verifyEventLog`/`LifecycleManager` called `.toString('utf8')` on it — a `Buffer`-only overload. Any provider returning a plain `Uint8Array` (which the interface permits, and a browser implementation would) yielded `"123,34,64..."` and threw in `JSON.parse`. Now `TextDecoder`.

## Guard

`scripts/check-browser-safety.mjs` walks `dist` for **static** Node-builtin imports from each guarded entry (dynamic `import()` is the fix, so it isn't counted) and prints the shortest offending chain. Wired into `ci.yml` and as a publish gate in `release.yml` next to `verify-esm`. It caught the `cel/cli` edge on its first run.

## Scope boundary

The Bitcoin modules still need `Buffer` at runtime — `bitcoinjs-lib`'s API is Buffer-based, so shedding it means replacing that dependency. They are not reachable from the `cel` entry point. Everything reachable from `@originals/sdk/cel` is Buffer-free.

## Verification

3,756 tests pass (9 new security tests covering bomb rejection, the one-byte-over boundary, truncated/garbage input, and node:zlib wire-compat). Typecheck, lint, `verify-esm` (102 entry points) and the new browser-safety gate all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add browser/edge-safe entry points to `@originals/sdk` with lazy Node builtin loading
> - Replaces static `node:fs`, `node:path`, and `node:zlib` imports with lazy dynamic loaders in [`WebVHManager`](https://github.com/onionoriginals/sdk/pull/452/files#diff-a05602b4df1aa89c88af6ada4ba720ae968fb5871c4aa433ecf90d4ce71dfb9a), [`LocalStorageAdapter`](https://github.com/onionoriginals/sdk/pull/452/files#diff-9b98c17231563c02582d30c94b845aa775653add822c8f207f216af08ada175c), [`BitstringStatusList`](https://github.com/onionoriginals/sdk/pull/452/files#diff-dbf966dd846479e7eb78702508961005c761a6a00270fb984274bffcff42a009), and [`StatusListManager`](https://github.com/onionoriginals/sdk/pull/452/files#diff-9f48ae59337cfe3987100dd00f6ed149638906efcb02af9512ad83ce24442887).
> - Adds a new `@originals/sdk/cel` subpath export that excludes the CLI barrel export, preventing CLI-only Node modules from being pulled in when importing CEL.
> - Replaces `Buffer`-based encoding throughout with `TextEncoder`/`TextDecoder` and `@scure/base` equivalents; `base64url` decoding is now stricter and rejects invalid characters.
> - Switches compression in the VC status list from `node:zlib` to [`fflate`](https://github.com/onionoriginals/sdk/pull/452/files#diff-22940014847da90539d9d64da7c26075734a9aaf3d32f728b6e601395e4b419b), adding bounded decompression that rejects gzip bombs by enforcing a hard output size limit.
> - Adds a [`check-browser-safety.mjs`](https://github.com/onionoriginals/sdk/pull/452/files#diff-ddcd1c405868511406a6c4346fd08d16ccaa0ca7bc3deea35fa63e13960acfb7) CI script that fails the build if guarded entry points statically import Node builtins.
> - Risk: `base64url` decoding is stricter — previously accepted malformed inputs will now throw.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 40c8454.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->