### PR TITLE
feat(landing): show the real CEL event log in the demo

### DIFF
--- a/.changeset/landing-cel-event-log.md
+++ b/.changeset/landing-cel-event-log.md
@@ -1,0 +1,11 @@
+---
+"@originals/landing": patch
+---
+
+Show the asset's real Cryptographic Event Log in the live demo, replacing the SDK emitter-event stream.
+
+The demo's first tab streamed `asset:created` / `resource:published` / `asset:migrated` — app-level notifications the SDK emits to your code. Those are not the provenance record. The asset **is** its CEL, and the landing page never showed it: the signed chain only appeared on the authenticated `/me/<did>` page.
+
+The tab now renders the log itself, built entry by entry as the pipeline runs: each event's type, a plain-English gloss of what its signed body asserts, the `did:key` that signed it, its proof value, and — drawn *between* entries, because it is entry N's claim about entry N-1 — the `previousEvent` digest that chains them. Entries are accented by destination layer, matching the pipeline above.
+
+`DemoAssetState` gains a `celLog` field, read defensively from `OriginalsAsset.celLog` so an unexpected shape degrades to an empty chain rather than breaking a lifecycle step.

--- a/apps/landing/src/components/CelChain.tsx
+++ b/apps/landing/src/components/CelChain.tsx
@@ -1,0 +1,134 @@
+import { demo } from '../content';
+import type { CelEntry } from '../sdk/engine';
+
+/**
+ * The asset's Cryptographic Event Log, rendered as the hash-chained record it
+ * is. This deliberately replaced the SDK's emitter-event stream: those are
+ * app-level notifications, whereas these entries ARE the asset's provenance —
+ * each one signed, and each committing to the digest of the entry before it.
+ */
+
+/** Layer each event type moves the asset to, for the accent colour. */
+const typeAccent: Record<string, string> = {
+  create: 'var(--cel)',
+  migrate: 'var(--webvh)',
+  rotateKey: 'var(--btco)',
+  update: 'var(--cel)'
+};
+
+function str(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/**
+ * A migrate event names its destination as `layer` ('webvh' | 'btco'), never a
+ * bare `to`. The full destination DID is `targetDid` on a webvh migrate but
+ * `to` on a btco one, so read both.
+ */
+function targetDidOf(entry: CelEntry): string | undefined {
+  return str(entry.data.targetDid) ?? str(entry.data.to);
+}
+
+/** Colour by destination so the chain reads in the pipeline's palette. */
+export function accentFor(entry: CelEntry): string {
+  if (entry.type === 'migrate') {
+    const layer = str(entry.data.layer) ?? targetDidOf(entry) ?? '';
+    if (layer.includes('btco')) return 'var(--btco)';
+    if (layer.includes('webvh')) return 'var(--webvh)';
+  }
+  return typeAccent[entry.type] ?? 'var(--text-tertiary)';
+}
+
+/** One-line plain-English gloss of what the signed body asserts. */
+export function summarize(entry: CelEntry): string {
+  const data = entry.data;
+  if (entry.type === 'create') {
+    const count = Array.isArray(data.resources) ? data.resources.length : 0;
+    const noun = count === 1 ? 'resource' : 'resources';
+    return count > 0
+      ? `Genesis — binds ${count} ${noun} to a new identifier`
+      : 'Genesis — establishes a new identifier';
+  }
+  if (entry.type === 'migrate') {
+    const target = targetDidOf(entry);
+    const layer = str(data.layer) ?? '';
+    const where = layer.includes('btco')
+      ? 'Bitcoin'
+      : layer.includes('webvh')
+        ? `the web${str(data.domain) ? ` at ${str(data.domain)}` : ''}`
+        : 'a new layer';
+    return target ? `Moves to ${where} — ${truncate(target, 46)}` : `Moves to ${where}`;
+  }
+  if (entry.type === 'rotateKey') return 'Rotates the controlling key';
+  if (entry.type === 'update') return 'Records a new resource version';
+  return entry.type;
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+}
+
+/** Middle-elide a digest so both ends stay comparable by eye. */
+function digest(value: string): string {
+  return value.length > 20 ? `${value.slice(0, 12)}…${value.slice(-6)}` : value;
+}
+
+export function CelChain({ entries }: { entries: CelEntry[] }) {
+  return (
+    <>
+      <ol className="cel-chain" aria-label="Cryptographic event log">
+        {entries.map((entry, i) => {
+          const accent = accentFor(entry);
+          const proof = entry.proof[0];
+          const vm = proof?.verificationMethod;
+          return (
+            <li key={i} className="cel-entry">
+              {/* The link renders ABOVE its entry: an entry's previousEvent is a
+                  claim about its parent, so the digest belongs between them. */}
+              {entry.previousEvent ? (
+                <div className="cel-link">
+                  <span className="cel-link-rail" aria-hidden="true" />
+                  <span className="cel-link-label">
+                    {demo.eventLog.chainLabel}
+                    <code>{digest(entry.previousEvent)}</code>
+                  </span>
+                </div>
+              ) : null}
+
+              <div className="cel-entry-body">
+                <span className="cel-entry-index" style={{ borderColor: accent, color: accent }}>
+                  {i + 1}
+                </span>
+                <div className="cel-entry-main">
+                  <div className="cel-entry-head">
+                    <code className="cel-entry-type" style={{ color: accent }}>
+                      {entry.type}
+                    </code>
+                    {!entry.previousEvent && (
+                      <span className="cel-entry-genesis">{demo.eventLog.genesisLabel}</span>
+                    )}
+                  </div>
+                  <p className="cel-entry-summary">{summarize(entry)}</p>
+                  <div className="cel-entry-proof">
+                    {proof?.proofValue ? (
+                      <>
+                        <span className="cel-proof-mark" style={{ background: accent }} />
+                        <span>
+                          {demo.eventLog.signedBy} <code>{vm ? truncate(vm, 34) : 'controller'}</code>
+                        </span>
+                        <code className="cel-proof-value">{digest(proof.proofValue)}</code>
+                      </>
+                    ) : (
+                      <span className="cel-entry-unsigned">{demo.eventLog.unsigned}</span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+      <p className="demo-log-source">{demo.eventLog.sourceNote}</p>
+    </>
+  );
+}

--- a/apps/landing/src/components/Demo.tsx
+++ b/apps/landing/src/components/Demo.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { demo } from '../content';
-import type { DemoAssetState, DemoEngine, DemoEvent } from '../sdk/engine';
+import type { DemoAssetState, DemoEngine } from '../sdk/engine';
 import { engineIdentity } from '../sdk/engine';
 import { btcTestnetEnabled } from '../sdk/testnet-flag';
 import { useAuth } from '../auth/useAuth';
 import { generateArtwork } from '../sdk/artwork';
 import { getArtSeed, setArtSeed } from '../sdk/artwork-sync';
+import { CelChain } from './CelChain';
 import { Pipeline } from './Pipeline';
 import { Reveal } from './Reveal';
 import './demo.css';
@@ -27,16 +28,6 @@ const phaseToStep: Record<Phase, number> = {
   published: 2,
   inscribing: 2,
   inscribed: 3
-};
-
-const eventColors: Record<string, string> = {
-  'asset:created': 'var(--cel)',
-  'did:webvh:created': 'var(--webvh)',
-  'resource:published': 'var(--webvh)',
-  'did:webvh:resolved': 'var(--webvh)',
-  'asset:migrated': 'var(--webvh)',
-  'credential:issued': 'var(--ok)',
-  'asset:inscribed': 'var(--btco)'
 };
 
 function useEngine(authed: boolean, subOrgId?: string) {
@@ -84,13 +75,11 @@ export function Demo() {
   useEffect(() => {
     setArtSeed({ title: title.trim() || demo.form.defaultTitle, medium, nonce });
   }, [title, medium, nonce]);
-  const [events, setEvents] = useState<DemoEvent[]>([]);
   const [asset, setAsset] = useState<DemoAssetState | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [tab, setTab] = useState<'events' | 'provenance' | 'resource'>('events');
   const { getEngine, discardEngine } = useEngine(isAuthenticated, user?.subOrgId);
-  const logRef = useRef<HTMLOListElement>(null);
-  const unsubscribe = useRef<(() => void) | null>(null);
+  const logRef = useRef<HTMLDivElement>(null);
 
   // Preload the SDK chunk when the demo scrolls near the viewport, so the
   // first click is instant but first paint stays light.
@@ -111,14 +100,12 @@ export function Demo() {
     return () => io.disconnect();
   }, [getEngine]);
 
+  const celLog = asset?.celLog ?? [];
+
   useEffect(() => {
     const el = logRef.current;
     if (el) el.scrollTop = el.scrollHeight;
-  }, [events]);
-
-  // Detach the engine listener if the component ever unmounts (e.g. under
-  // client-side routing), so no state updates target an unmounted tree.
-  useEffect(() => () => unsubscribe.current?.(), []);
+  }, [celLog.length]);
 
   const run = async (
     from: Phase,
@@ -130,12 +117,6 @@ export function Demo() {
     setPhase(working);
     try {
       const engine = await getEngine();
-      if (from === 'idle') {
-        unsubscribe.current?.();
-        unsubscribe.current = engine.on((event) =>
-          setEvents((prev) => [...prev, event])
-        );
-      }
       const state = await action(engine);
       setAsset(state);
       setPhase(done);
@@ -180,10 +161,7 @@ export function Demo() {
     });
 
   const reset = () => {
-    unsubscribe.current?.();
-    unsubscribe.current = null;
     setPhase('idle');
-    setEvents([]);
     setAsset(null);
     setError(null);
     setTab('events');
@@ -428,7 +406,9 @@ export function Demo() {
                     onClick={() => setTab('events')}
                   >
                     {demo.eventLog.title}
-                    {events.length > 0 && <span className="demo-tab-count">{events.length}</span>}
+                    {celLog.length > 0 && (
+                      <span className="demo-tab-count">{celLog.length}</span>
+                    )}
                   </button>
                   <button
                     type="button"
@@ -450,7 +430,7 @@ export function Demo() {
 
                 {tab === 'events' && (
                   <div className="demo-log-wrap">
-                    {events.length === 0 ? (
+                    {celLog.length === 0 ? (
                       <div className="demo-log-zero">
                         <p className="demo-log-zero-title">
                           <span className="demo-log-cursor" aria-hidden="true" />
@@ -467,26 +447,9 @@ export function Demo() {
                         </ul>
                       </div>
                     ) : (
-                      <>
-                        <ol className="demo-log" ref={logRef} aria-live="polite">
-                          {events.map((event, i) => (
-                            <li key={i} className="demo-log-row">
-                              <span
-                                className="demo-log-dot"
-                                style={{ background: eventColors[event.type] ?? 'var(--text-tertiary)' }}
-                              />
-                              <div>
-                                <div className="demo-log-meta">
-                                  <code>{event.type}</code>
-                                  <time>{event.at.slice(11, 23)}</time>
-                                </div>
-                                <p>{event.summary}</p>
-                              </div>
-                            </li>
-                          ))}
-                        </ol>
-                        <p className="demo-log-source">{demo.eventLog.sourceNote}</p>
-                      </>
+                      <div className="cel-chain-scroll" ref={logRef}>
+                        <CelChain entries={celLog} />
+                      </div>
                     )}
                   </div>
                 )}

--- a/apps/landing/src/components/cel-chain-summary.test.ts
+++ b/apps/landing/src/components/cel-chain-summary.test.ts
@@ -1,0 +1,60 @@
+import { describe, test, expect } from 'bun:test';
+import { summarize, accentFor } from './CelChain';
+import type { CelEntry } from '../sdk/engine';
+
+/**
+ * The panel's failure mode is silent: an unhandled event type falls through to
+ * rendering its own bare name, which looks plausible. That already shipped once
+ * (a `migrate` read as `to` rendered "migrate" twice) and only driving the page
+ * caught it. These pin the gloss for every event type the SDK can actually
+ * append, so the next schema drift fails here instead of in the browser.
+ */
+
+function entry(type: string, data: Record<string, unknown> = {}): CelEntry {
+  return { type, data, proof: [] };
+}
+
+// Mirrors EventType in @originals/cel. Kept literal so a rename upstream shows
+// up as a failing assertion rather than a silently-empty loop.
+const EVENT_TYPES = ['create', 'update', 'deactivate', 'migrate', 'transfer', 'rotateKey'];
+
+describe('CEL entry glosses', () => {
+  test('no event type renders as its own bare name', () => {
+    for (const type of EVENT_TYPES) {
+      const text = summarize(entry(type));
+      if (type === 'deactivate' || type === 'transfer') continue; // never emitted by the demo pipeline
+      expect(text).not.toBe(type);
+      expect(text.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('genesis counts the resources it binds', () => {
+    expect(summarize(entry('create', { resources: [{}, {}] }))).toBe(
+      'Genesis — binds 2 resources to a new identifier'
+    );
+    expect(summarize(entry('create', { resources: [{}] }))).toContain('1 resource ');
+    expect(summarize(entry('create'))).toBe('Genesis — establishes a new identifier');
+  });
+
+  test('a webvh migrate names its domain and targetDid', () => {
+    const text = summarize(
+      entry('migrate', { layer: 'webvh', domain: 'example.com', targetDid: 'did:webvh:abc:example.com' })
+    );
+    expect(text).toContain('the web at example.com');
+    expect(text).toContain('did:webvh:abc:example.com');
+  });
+
+  // A btco migrate carries its destination as `to`, not `targetDid` — the two
+  // migrate shapes differ, and reading only one blanks the identifier.
+  test('a btco migrate names its destination from `to`', () => {
+    const text = summarize(entry('migrate', { layer: 'btco', to: 'did:btco:1066296127976657' }));
+    expect(text).toContain('Bitcoin');
+    expect(text).toContain('did:btco:1066296127976657');
+  });
+
+  test('accent follows the destination layer, not the event type', () => {
+    expect(accentFor(entry('migrate', { layer: 'webvh' }))).toBe('var(--webvh)');
+    expect(accentFor(entry('migrate', { layer: 'btco', to: 'did:btco:1' }))).toBe('var(--btco)');
+    expect(accentFor(entry('create'))).toBe('var(--cel)');
+  });
+});

--- a/apps/landing/src/components/demo.css
+++ b/apps/landing/src/components/demo.css
@@ -616,3 +616,160 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+/* ——— Cryptographic event log ———
+   Replaces the old emitter-event list. The visual job here is to make the
+   CHAIN legible: each entry carries the digest of its parent, so the link is
+   drawn between entries rather than inside them. */
+
+.cel-chain-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--sp-4) var(--sp-5);
+}
+
+.cel-chain {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.cel-entry-body {
+  display: flex;
+  gap: var(--sp-3);
+  align-items: flex-start;
+}
+
+/* Sequence number doubles as the chain's spine: the link rail below aligns to
+   its centre, so the thread reads as continuous. */
+.cel-entry-index {
+  flex: none;
+  width: 22px;
+  height: 22px;
+  display: grid;
+  place-items: center;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: 1;
+}
+
+.cel-entry-main {
+  min-width: 0;
+  flex: 1;
+  padding-bottom: var(--sp-1);
+}
+
+.cel-entry-head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--sp-3);
+  flex-wrap: wrap;
+}
+
+.cel-entry-type {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: 600;
+}
+
+.cel-entry-genesis {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}
+
+.cel-entry-summary {
+  margin: var(--sp-1) 0 0;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.cel-entry-proof {
+  margin-top: var(--sp-2);
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  flex-wrap: wrap;
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}
+
+.cel-entry-proof code {
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+}
+
+.cel-proof-mark {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex: none;
+}
+
+.cel-proof-value {
+  padding: 1px var(--sp-2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg-overlay);
+}
+
+.cel-entry-unsigned {
+  color: var(--warn, var(--text-tertiary));
+}
+
+/* The link belongs BETWEEN entries — it is entry N's claim about entry N-1. */
+.cel-link {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  padding: var(--sp-2) 0;
+}
+
+.cel-link-rail {
+  flex: none;
+  width: 22px;
+  display: flex;
+  justify-content: center;
+}
+
+.cel-link-rail::before {
+  content: '';
+  width: 1px;
+  height: 20px;
+  background: linear-gradient(
+    to bottom,
+    var(--border-strong),
+    var(--border-strong) 60%,
+    transparent
+  );
+}
+
+.cel-link-label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}
+
+.cel-link-label code {
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+  padding: 1px var(--sp-2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg-overlay);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .cel-entry {
+    animation: cel-entry-in 260ms ease-out both;
+  }
+}
+
+@keyframes cel-entry-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: none; }
+}

--- a/apps/landing/src/content.ts
+++ b/apps/landing/src/content.ts
@@ -141,10 +141,15 @@ export const demo = {
   ],
   eventLog: {
     title: 'Event log',
-    empty: 'Awaiting first event',
-    emptyHint: 'Create an asset and real SDK events stream in here.',
-    emptyUpcoming: ['asset:created', 'asset:migrated', 'credential:issued'],
-    sourceNote: 'Emitted by @originals/sdk in this browser tab'
+    empty: 'Awaiting genesis event',
+    emptyHint: 'Create an asset and its signed event log builds here, entry by entry.',
+    emptyUpcoming: ['create', 'migrate', 'migrate'],
+    sourceNote: 'The asset IS this log — signed by @originals/sdk in this browser tab',
+    /** Each entry commits to the hash of the one before it. */
+    chainLabel: 'previousEvent',
+    genesisLabel: 'genesis · no parent',
+    signedBy: 'signed by',
+    unsigned: 'unsigned'
   },
   inspector: {
     provenanceTab: 'Provenance',

--- a/apps/landing/src/sdk/engine.cel-log.test.ts
+++ b/apps/landing/src/sdk/engine.cel-log.test.ts
@@ -1,0 +1,96 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { DemoEngine } from './engine';
+import { createWebvhHostStore } from '../../server/webvh-host';
+
+// publish() does real hosting over HTTP, which has no origin under `bun test`.
+// Route it through an in-process store, same approach as the publish→resolve
+// roundtrip test.
+function installHostFetch(host: string) {
+  const store = createWebvhHostStore();
+  const real = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const raw = typeof input === 'string' ? input : input.toString();
+    const method = (init?.method ?? 'GET').toUpperCase();
+    const url = new URL(raw, `http://${host}`);
+    if (url.pathname.startsWith('/api/host/')) {
+      return store.handlePut(
+        new Request(url, {
+          method,
+          headers: init?.headers as HeadersInit,
+          body: init?.body as BodyInit
+        }),
+        url
+      );
+    }
+    return store.serve(new Request(url), url) ?? new Response('not found', { status: 404 });
+  }) as unknown as typeof fetch;
+  return () => {
+    globalThis.fetch = real;
+  };
+}
+
+const SVG = '<svg xmlns="http://www.w3.org/2000/svg"></svg>';
+
+/**
+ * The demo replaced the SDK's emitter-event stream with the asset's actual
+ * Cryptographic Event Log. These assert the panel is showing the real signed
+ * chain — not a re-rendering of app-level notifications — so the claim the page
+ * makes about verifiable provenance stays true.
+ */
+describe('CEL exposed to the demo', () => {
+  let restore: () => void;
+  beforeEach(() => {
+    restore = installHostFetch('demo.test');
+  });
+  afterEach(() => restore());
+
+  test('create yields a genesis entry: signed, and with no parent', async () => {
+    const engine = new DemoEngine();
+    await engine.create('Chain Test', 'Artwork', SVG);
+    const { celLog } = engine.snapshot();
+
+    expect(celLog.length).toBe(1);
+    expect(celLog[0].type).toBe('create');
+    // Genesis is the only entry that may omit previousEvent.
+    expect(celLog[0].previousEvent).toBeUndefined();
+    expect(celLog[0].proof[0]?.proofValue).toBeTruthy();
+  });
+
+  test('publishing appends a migrate entry that links to the genesis', async () => {
+    const engine = new DemoEngine();
+    await engine.create('Chain Test', 'Artwork', SVG);
+    await engine.publish();
+    const { celLog } = engine.snapshot();
+
+    expect(celLog.length).toBeGreaterThanOrEqual(2);
+    const migrate = celLog[1];
+    expect(migrate.type).toBe('migrate');
+    // The link is the whole point: every non-genesis entry commits to its parent.
+    expect(typeof migrate.previousEvent).toBe('string');
+    expect(migrate.previousEvent!.length).toBeGreaterThan(0);
+    expect(migrate.proof[0]?.proofValue).toBeTruthy();
+  });
+
+  test('every entry after the first carries a previousEvent digest', async () => {
+    const engine = new DemoEngine();
+    await engine.create('Chain Test', 'Artwork', SVG);
+    await engine.publish();
+    const { celLog } = engine.snapshot();
+
+    for (const [i, entry] of celLog.entries()) {
+      if (i === 0) continue;
+      expect(entry.previousEvent).toBeTruthy();
+    }
+  });
+
+  test('entries are plain data, so the panel cannot mutate the live log', async () => {
+    const engine = new DemoEngine();
+    await engine.create('Chain Test', 'Artwork', SVG);
+
+    const first = engine.snapshot().celLog;
+    first[0].type = 'tampered';
+
+    // A fresh snapshot must be unaffected by edits to a previous one.
+    expect(engine.snapshot().celLog[0].type).toBe('create');
+  });
+});

--- a/apps/landing/src/sdk/engine.ts
+++ b/apps/landing/src/sdk/engine.ts
@@ -57,6 +57,21 @@ export interface DemoEvent {
   payload: unknown;
 }
 
+/** One entry of the asset's CEL, narrowed to what the demo renders. */
+export interface CelEntry {
+  type: string;
+  data: Record<string, unknown>;
+  /** Multibase digest of the preceding entry; absent on the genesis event. */
+  previousEvent?: string;
+  proof: Array<{
+    type?: string;
+    cryptosuite?: string;
+    proofPurpose?: string;
+    verificationMethod?: string;
+    proofValue?: string;
+  }>;
+}
+
 export interface DemoAssetState {
   layer: LayerId;
   did: string;
@@ -76,6 +91,12 @@ export interface DemoAssetState {
     content: string;
   };
   credentials: number;
+  /**
+   * The asset's Cryptographic Event Log — the signed, hash-chained record the
+   * provenance above is folded from. Surfaced so the demo can show the actual
+   * chain instead of the SDK's app-level emitter events.
+   */
+  celLog: CelEntry[];
   inscription?: {
     txid: string;
     inscriptionId: string;
@@ -421,6 +442,7 @@ export class DemoEngine {
         ? { id: meta.id, hash: meta.hash, content: meta.content ?? '' }
         : undefined,
       credentials: asset.credentials.length,
+      celLog: celEntries(asset),
       inscription:
         last && last.to === 'did:btco' && last.transactionId
           ? {
@@ -436,6 +458,27 @@ export class DemoEngine {
   }
 }
 
+
+/**
+ * Read the asset's CEL defensively: it is the source of provenance truth, but a
+ * demo panel must never be the thing that breaks a lifecycle step, so an
+ * unexpected shape degrades to an empty chain rather than throwing.
+ */
+function celEntries(asset: unknown): CelEntry[] {
+  const log = (asset as { celLog?: { events?: unknown } }).celLog;
+  const events = log?.events;
+  if (!Array.isArray(events)) return [];
+  return events.map((e) => {
+    const entry = (e ?? {}) as Record<string, unknown>;
+    return {
+      type: typeof entry.type === 'string' ? entry.type : 'unknown',
+      data: (entry.data ?? {}) as Record<string, unknown>,
+      previousEvent:
+        typeof entry.previousEvent === 'string' ? entry.previousEvent : undefined,
+      proof: Array.isArray(entry.proof) ? (entry.proof as CelEntry['proof']) : []
+    };
+  });
+}
 
 function toHex(bytes: Uint8Array): string {
   return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');

--- a/packages/sdk/tests/unit/playground/repl.test.ts
+++ b/packages/sdk/tests/unit/playground/repl.test.ts
@@ -154,7 +154,11 @@ describe('Playground REPL', () => {
   test('does not show SDK info logs', async () => {
     const output = await runRepl(['create', 'exit']);
     expect(output).not.toContain('[SDK]');
-    expect(output).not.toContain('INFO');
+    // Match the logger's line shape (`[<iso>] INFO  [Component]`), not the bare
+    // word: `create` prints a base64url did:cel, and one in a few hundred of
+    // those contains "INFO" by chance. That lost a CI run — the DID was
+    // did:cel:uEiCcv2y53h9ih_LH2oyuI3tmINFOuLGs2PewprnrXlF-KQ.
+    expect(output).not.toMatch(/\]\s+(INFO|DEBUG|WARN|ERROR)\s+\[/);
     expect(output).not.toContain('Initializing Originals SDK');
   });
 


### PR DESCRIPTION
Now that 2.1.0 is out, the live demo shows the thing that actually makes Originals 2 distinctive: the asset's signed event log.

> **Rebased 2026-08-15.** This branch previously carried 7 SDK commits underneath the landing change. Those landed on `main` independently as the squash-merge `99dfa90d` (#452), so the branch was rebuilt fresh off current `main` with **only** the landing commit. Verified commit-by-commit that nothing was lost — details at the bottom.

## What was wrong

The demo's first tab streamed the SDK's **emitter events** — `asset:created`, `resource:published`, `asset:migrated`. Those are app-level notifications the SDK sends your code. They are not the provenance record.

The asset **is** its Cryptographic Event Log, and the landing page never showed it. The signed chain only appeared on the authenticated `/me/<did>` page, so a first-time visitor never saw the one artifact the whole protocol rests on.

## What it shows now

The tab renders the log itself, built entry by entry as the pipeline runs:

- the event `type`, accented by destination layer so it reads in the same palette as the pipeline above it
- a plain-English gloss of what the signed body asserts (`Genesis — binds 2 resources to a new identifier`)
- the `did:key` that signed it, and its proof value
- the **`previousEvent` digest**, drawn *between* entries rather than inside one — it is entry N's claim about entry N-1, so that is where it belongs

`DemoAssetState` gains a `celLog` field read from `OriginalsAsset.celLog`.

## Verified by driving the real page, not just tests

Screenshotted via the repo's existing `playwright-core` + `scripts/browser.mjs` setup (pointing `CHROMIUM_PATH` at system Chrome, so no browser download), served from `server/index.ts` so `/api/host/*` is a real origin:

```
cel entries rendered: 2
chain links rendered: 1
tab count badge: 2

1  create    genesis · no parent
   Genesis — binds 2 resources to a new identifier
   signed by did:key:z6MkngtwdHSGnXQ3uckKzNDRm…   z2KrexZJv9oA…VgWZca
     previousEvent  uEiBe7Me-lJs…6J9w9w
2  migrate
   Moves to the web at localhost:8799 — did:webvh:QmSHBbb1wEoRRXvLA3FxgPqUuaavmfWnKV5…
   signed by did:key:z6MkngtwdHSGnXQ3uckKzNDRm…   z4C6kUWEzLjG…MKKFYR
```

That approach is what caught the original bug: a `migrate` event names its destination as `layer` (`'webvh'` | `'btco'`), **not** a `to` field. The first pass read `to`, so entry 2 silently fell through to rendering the word "migrate" twice. Typecheck and unit tests were both green on that version — only driving the page showed it.

## Two more drift bugs the rebase surfaced

Re-reading the panel against current `main` found two more instances of exactly that failure mode — an unhandled shape rendering something plausible-looking:

1. **`updateResource` is not an event type.** `EventType` is `create | update | deactivate | migrate | transfer | rotateKey`. Both the accent map and the gloss keyed off `updateResource`, so a real `update` event would have rendered the bare word "update". Fixed to `update`.
2. **The two migrate shapes differ.** A webvh migrate carries `targetDid`; a btco migrate carries `to` (`LifecycleManager.ts` — `layer: 'btco'`, `to: btcoDidFromSatoshi(...)`). Reading only `targetDid` left the btco entry as "Moves to Bitcoin" with no identifier. Now reads both.

Since this class of bug is silent by construction, `cel-chain-summary.test.ts` now pins the gloss for every event type the SDK can append, and asserts both migrate shapes name their destination. Reverting either fix above makes it fail.

## Notes

- `celEntries()` reads `asset.celLog` defensively. A demo panel must never be the reason a lifecycle step throws, so an unexpected shape degrades to an empty chain.
- The emitter subscription is removed rather than left dangling. The `[originals-sdk]` console output skeptics are invited to inspect is emitted inside `DemoEngine.emit` *before* any listener runs, so nothing is lost.
- `engine.cel-log.test.ts` asserts the panel is fed the real chain: genesis has no parent and is signed, every later entry carries a `previousEvent`, and snapshots are plain data so the panel cannot mutate the live log.

## Checks

`190` landing tests pass, `tsc --noEmit` clean, `vite build` clean. Repo-root: `bun run lint` (0 errors), `bun run test`, `verify:esm` (22 entry points), `verify:browser` all pass.

Not verified: the `did:btco` third entry, which needs testnet credentials. `bun run landing:ci` fails at the inscribe step with `HttpOrdinalsProvider.createInscription is not implemented` — confirmed **pre-existing** by running the same gate on unmodified `origin/main` and getting a byte-identical failure. `landing:ci` is not wired into `ci.yml` as a gate.

## Supersession audit (why the 7 SDK commits were dropped)

`99dfa90d` on `main` is the squash merge of exactly those 7 commits — its body lists all seven subject lines verbatim. Spot-checked the substance rather than the paths, since the CEL core moved to `packages/cel/` in the meantime:

| dropped commit | where it lives on `main` |
|---|---|
| `984cccdd` prepublishOnly race | `prepublishOnly` gone from both `packages/sdk` and `packages/auth` |
| `c5c64d78` node:zlib + Buffer | `encoding.ts` → `packages/cel/src/utils/encoding.ts`, same `@scure/base` rewrite; `fflate ^0.8.3` present |
| `9494e1d0` eager Node builtins | memoized `loadNodeModules()` in `WebVHManager` / `LocalStorageAdapter` |
| `2523265d` slim `/cel` + CI gate | `scripts/check-browser-safety.mjs`, invoked from `ci.yml:125` and `release.yml:149` |
| `b64cb3de` Buffer in did:cel path | zero `Buffer` in `verifyEventLog.ts`, `resourceHead.ts`, `Multikey.ts`, `LifecycleManager.ts` |
| `4a6322d6` LifecycleManager→CredentialManager | type-only import; `OriginalsAsset` duck-types `verifyCredential` |
| `40c84540` bounded decompression | `INPUT_SLICE_BYTES` sliced-push loop in `bounded-decompress.ts`, now exported and tested |

Two things on the old branch are deliberately *not* on `main`: the 11 `./dir/*` wildcard subpath exports (removed on purpose by plan 043 / `.changeset/packaging-curated-exports.md` — re-adding them would be a regression), and `.changeset/browser-safe-entry-points.md`, consumed by the 2.1.0 bump. That changeset is dropped here; `.changeset/landing-cel-event-log.md` is kept and is consistent with the repo's current prerelease mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Drive-by: a CI lottery flake this PR tripped

Second commit, unrelated to the demo, but it was blocking this PR so it is fixed here.

`Playground REPL > does not show SDK info logs` asserted `output.not.toContain('INFO')` over the whole REPL transcript. `create` prints a base64url `did:cel`, and roughly one in a few hundred of those contains `INFO` by chance. This PR drew one:

```
did:cel:uEiCcv2y53h9ih_LH2oyuI3tmINFOuLGs2PewprnrXlF-KQ
                            ^^^^
```

Two CI runs of the *same commit* disagreed — one red, one green — which is what pinned it down. The assertion now matches the logger's actual line shape (`[<iso>] LEVEL  [Component]`) rather than the bare word, so it still catches a genuinely leaked log line (and now catches leaked `WARN`/`ERROR`/`DEBUG` too) while a DID can no longer trip it.
