### PR TITLE
fix(vc)!: BBS+ selective disclosure fails closed instead of leaking

### DIFF
--- a/.changeset/bbs-selective-disclosure-fail-closed.md
+++ b/.changeset/bbs-selective-disclosure-fail-closed.md
@@ -1,0 +1,15 @@
+---
+"@originals/sdk": major
+---
+
+**Security:** BBS+ selective disclosure now fails closed. Both no-key paths threw away the caller's privacy intent while reporting success.
+
+`deriveSelectiveProof` fell back, for any credential without a `bbs-2023` proof, to returning the credential **unchanged** while listing the undisclosed paths in `hiddenFields`. A caller who trusted that report and forwarded `result.credential` published every field it claimed to withhold. It now throws `BBS_BASE_PROOF_REQUIRED`.
+
+`prepareSelectiveDisclosure` had the matching hole: given no key pair it returned a "metadata-only" result — the credential untouched, pointer arrays attached — which read as success but created no proof, so nothing could ever be derived from it. It now throws `BBS_KEY_REQUIRED`.
+
+These combined into one trap: the example in `docs/LLM_AGENT_GUIDE.md` passed no key, so it demonstrated the metadata-only path, and a reader following it got a credential with no proof and then a "derived" result that redacted nothing. The example is corrected to show the real flow.
+
+**Breaking:** calls that previously resolved now throw. Any code relying on either fallback was not performing selective disclosure — it was either producing an unusable credential or leaking. Pass a BBS+ key pair to `prepareSelectiveDisclosure` and derive from its output.
+
+Note the SDK still cannot generate BLS12-381 keys (`KeyManager` covers ES256K / Ed25519 / ES256), so issuers must bring their own via `@digitalbazaar/bbs-signatures`; `multikey.encodePublicKey(publicKey, 'Bls12381G2')` encodes it for the DID document. The documented example shows this.

--- a/docs/LLM_AGENT_GUIDE.md
+++ b/docs/LLM_AGENT_GUIDE.md
@@ -991,16 +991,36 @@ const result = await sdk.credentials.verifyCredentialChain(credentials);
 
 ### BBS+ Selective Disclosure
 
+Both calls REQUIRE a BBS+ base proof — they throw rather than silently
+returning an unredacted credential.
+
+The SDK does not generate BLS12-381 keys yet (`KeyManager` covers ES256K /
+Ed25519 / ES256), so bring your own:
+
 ```typescript
-// Prepare for selective disclosure
-const prepared = await sdk.credentials.prepareSelectiveDisclosure(credential, {
-  mandatoryPointers: ['/credentialSubject/id'],
-  selectivePointers: ['/credentialSubject/name', '/credentialSubject/email']
+import * as bbs from '@digitalbazaar/bbs-signatures';
+import { multikey } from '@originals/sdk';
+
+const { secretKey, publicKey } = await bbs.generateKeyPair({
+  ciphersuite: 'BLS12-381-SHA-256'
 });
 
-// Create derived proof
+// Publish the public key in the issuer's DID document so verifiers can resolve it.
+const publicKeyMultibase = multikey.encodePublicKey(publicKey, 'Bls12381G2');
+
+// 1. Issuer: sign a base proof. Without privateKey this throws BBS_KEY_REQUIRED.
+const prepared = await sdk.credentials.prepareSelectiveDisclosure(credential, {
+  mandatoryPointers: ['/credentialSubject/id'],
+  selectivePointers: ['/credentialSubject/name', '/credentialSubject/email'],
+  privateKey: secretKey,
+  publicKey,
+  verificationMethod: 'did:webvh:example.com:issuer#bbs-key-0'
+});
+
+// 2. Holder: derive a proof revealing only some fields. Deriving from a
+//    credential with no bbs-2023 proof throws BBS_BASE_PROOF_REQUIRED.
 const derived = await sdk.credentials.deriveSelectiveProof(
-  credential,
+  prepared.credential,
   ['/credentialSubject/id', '/credentialSubject/name']
 );
 // { credential, disclosedFields, hiddenFields }
@@ -1008,6 +1028,9 @@ const derived = await sdk.credentials.deriveSelectiveProof(
 // Get field by JSON Pointer
 const value = sdk.credentials.getFieldByPointer(credential, '/credentialSubject/name');
 ```
+
+Mandatory pointers are always revealed in every derived proof — that is what
+makes them usable as a stable identifier for the disclosure.
 
 ---
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/packages/sdk/src/vc/CredentialManager.ts
+++ b/packages/sdk/src/vc/CredentialManager.ts
@@ -27,6 +27,7 @@ import { Verifier, checkCredentialValidityPeriod } from './Verifier.js';
 import { validateStatusListCredentialTrust } from './statusListTrust.js';
 import { MultiSigManager } from './MultiSigManager.js';
 import type { MetricsCollector } from '../utils/MetricsCollector.js';
+import { StructuredError } from '../utils/telemetry.js';
 
 // ===== Credential Factory Types =====
 
@@ -1124,12 +1125,13 @@ export class CredentialManager {
       };
     }
 
-    // Fallback: return credential with metadata only (no BBS+ key provided)
-    return {
-      credential: { ...credential },
-      mandatoryPointers: options.mandatoryPointers,
-      selectivePointers,
-    };
+    // No key ⇒ no proof can be made. Previously this returned the credential
+    // untouched with the pointer lists attached, which looked like success and
+    // silently produced a credential that could never be selectively disclosed.
+    throw new StructuredError(
+      'BBS_KEY_REQUIRED',
+      'prepareSelectiveDisclosure requires a BBS+ key pair: pass `privateKey` (and `publicKey`) so a bbs-2023 base proof can be created. Without one there is nothing to derive a disclosure from. Generate a key with @digitalbazaar/bbs-signatures `generateKeyPair({ ciphersuite })`.'
+    );
   }
 
   /**
@@ -1155,9 +1157,11 @@ export class CredentialManager {
       }
     }
 
+    // Field paths of the ORIGINAL credential; the BBS branch subtracts what the
+    // derived proof actually reveals to report hiddenFields. (The removed
+    // fallback instead computed them from the caller's request and reported
+    // them against an unmodified credential.)
     const allFields = this.extractFieldPaths(credential as unknown as Record<string, unknown>);
-    const disclosedSet = new Set(fieldsToDisclose);
-    const hiddenFields = allFields.filter(f => !disclosedSet.has(f));
 
     // If the credential has a BBS+ proof, derive a real selective disclosure proof
     const proof = credential.proof as any;
@@ -1192,12 +1196,16 @@ export class CredentialManager {
       };
     }
 
-    // Fallback for non-BBS+ credentials
-    return {
-      credential: { ...credential },
-      disclosedFields: fieldsToDisclose,
-      hiddenFields,
-    };
+    // A credential without a bbs-2023 base proof cannot be redacted in any way a
+    // verifier would accept. This previously returned the credential UNCHANGED
+    // while reporting `hiddenFields` — so a caller who trusted that report and
+    // forwarded the credential disclosed every field it claimed to withhold.
+    throw new StructuredError(
+      'BBS_BASE_PROOF_REQUIRED',
+      `Cannot derive a selective disclosure: this credential has no bbs-2023 base proof (found ${
+        (credential.proof as { cryptosuite?: string } | undefined)?.cryptosuite ?? 'no proof'
+      }). Call prepareSelectiveDisclosure with a BBS+ key pair first — deriving from an unsigned credential would return every field while reporting some as hidden.`
+    );
   }
 
   /**

--- a/packages/sdk/tests/security/bbs-selective-disclosure-fail-open.test.ts
+++ b/packages/sdk/tests/security/bbs-selective-disclosure-fail-open.test.ts
@@ -1,0 +1,74 @@
+import { describe, test, expect } from 'bun:test';
+import { CredentialManager } from '../../src/vc/CredentialManager';
+import type { OriginalsConfig, VerifiableCredential } from '../../src/types';
+
+/**
+ * Regression tests for a fail-open selective-disclosure bug.
+ *
+ * `deriveSelectiveProof` used to fall back, for any credential without a
+ * bbs-2023 proof, to returning the credential UNCHANGED while reporting the
+ * undisclosed paths in `hiddenFields`. A caller who trusted that report and
+ * forwarded `result.credential` published every field it claimed to withhold.
+ *
+ * `prepareSelectiveDisclosure` had the matching hole: with no key it returned a
+ * "metadata-only" result that looked like success but created no proof — so the
+ * documented flow produced a credential that could never be disclosed, and then
+ * a derive that leaked. Both now throw.
+ */
+const config = { network: 'regtest', defaultKeyType: 'ES256K' } as unknown as OriginalsConfig;
+
+const SECRET = 'alice@example.com';
+
+const credential: VerifiableCredential = {
+  '@context': ['https://www.w3.org/ns/credentials/v2'],
+  type: ['VerifiableCredential'],
+  issuer: 'did:example:issuer',
+  validFrom: '2026-01-01T00:00:00Z',
+  credentialSubject: {
+    id: 'did:example:subject',
+    name: 'Alice',
+    email: SECRET
+  }
+} as unknown as VerifiableCredential;
+
+describe('selective disclosure fails closed', () => {
+  const cm = new CredentialManager(config);
+
+  test('derive on an unsigned credential throws instead of leaking withheld fields', async () => {
+    await expect(
+      cm.deriveSelectiveProof(credential, ['/credentialSubject/id'])
+    ).rejects.toThrow(/bbs-2023 base proof/);
+  });
+
+  test('no result object can carry the secret while calling it hidden', async () => {
+    // The precise shape of the old bug: hiddenFields named the email, and the
+    // returned credential still contained it.
+    let leaked: unknown;
+    try {
+      const result = await cm.deriveSelectiveProof(credential, ['/credentialSubject/id']);
+      leaked = result.credential;
+    } catch {
+      leaked = undefined;
+    }
+    expect(JSON.stringify(leaked ?? {})).not.toContain(SECRET);
+  });
+
+  test('prepare without a key throws rather than returning an unsigned credential', async () => {
+    await expect(
+      cm.prepareSelectiveDisclosure(credential, {
+        mandatoryPointers: ['/credentialSubject/id'],
+        selectivePointers: ['/credentialSubject/name']
+      })
+    ).rejects.toThrow(/BBS\+ key pair|privateKey/);
+  });
+
+  test('the errors are actionable — they name the missing input', async () => {
+    await expect(
+      cm.prepareSelectiveDisclosure(credential, { mandatoryPointers: ['/credentialSubject/id'] })
+    ).rejects.toThrow(/generateKeyPair|privateKey/);
+
+    await expect(cm.deriveSelectiveProof(credential, [])).rejects.toThrow(
+      /prepareSelectiveDisclosure/
+    );
+  });
+});

--- a/packages/sdk/tests/unit/vc/CredentialManager.helpers.test.ts
+++ b/packages/sdk/tests/unit/vc/CredentialManager.helpers.test.ts
@@ -350,7 +350,7 @@ describe('CredentialManager - Selective Disclosure', () => {
   const credentialManager = new CredentialManager(config);
 
   describe('prepareSelectiveDisclosure', () => {
-    test('prepares credential with mandatory pointers', async () => {
+    test('refuses to prepare without a BBS+ key instead of silently producing no proof', async () => {
       const credential: VerifiableCredential = {
         '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
         type: ['VerifiableCredential'],
@@ -364,15 +364,15 @@ describe('CredentialManager - Selective Disclosure', () => {
         }
       };
       
-      const result = await credentialManager.prepareSelectiveDisclosure(credential, {
-        mandatoryPointers: ['/issuer', '/issuanceDate', '/credentialSubject/id'],
-        selectivePointers: ['/credentialSubject/name', '/credentialSubject/age']
-      });
-      
-      expect(result.credential).toBeDefined();
-      expect(result.mandatoryPointers).toContain('/issuer');
-      expect(result.mandatoryPointers).toContain('/issuanceDate');
-      expect(result.selectivePointers).toContain('/credentialSubject/name');
+      // Previously this resolved with the credential untouched and the pointer
+      // lists attached, which read as success while producing nothing that could
+      // ever be selectively disclosed.
+      await expect(
+        credentialManager.prepareSelectiveDisclosure(credential, {
+          mandatoryPointers: ['/issuer', '/issuanceDate', '/credentialSubject/id'],
+          selectivePointers: ['/credentialSubject/name', '/credentialSubject/age']
+        })
+      ).rejects.toThrow(/BBS\+ key pair|privateKey/);
     });
 
     test('throws error for empty mandatory pointers', async () => {
@@ -409,7 +409,7 @@ describe('CredentialManager - Selective Disclosure', () => {
   });
 
   describe('deriveSelectiveProof', () => {
-    test('creates derived proof result with disclosed/hidden fields', async () => {
+    test('refuses to derive from a credential with no BBS+ base proof', async () => {
       const credential: VerifiableCredential = {
         '@context': ['https://www.w3.org/2018/credentials/v1', 'https://originals.build/context'],
         type: ['VerifiableCredential'],
@@ -422,15 +422,12 @@ describe('CredentialManager - Selective Disclosure', () => {
         }
       };
       
-      const result = await credentialManager.deriveSelectiveProof(
-        credential,
-        ['/issuer', '/credentialSubject/name']
-      );
-      
-      expect(result.credential).toBeDefined();
-      expect(result.disclosedFields).toContain('/issuer');
-      expect(result.disclosedFields).toContain('/credentialSubject/name');
-      expect(result.hiddenFields).toContain('/credentialSubject/email');
+      // Previously this resolved with the FULL credential while reporting
+      // /credentialSubject/email as hidden — a caller trusting that report and
+      // forwarding the credential disclosed the very field it withheld.
+      await expect(
+        credentialManager.deriveSelectiveProof(credential, ['/issuer', '/credentialSubject/name'])
+      ).rejects.toThrow(/bbs-2023 base proof/);
     });
 
     test('throws error for invalid JSON Pointer in disclosure', async () => {

--- a/packages/sdk/tests/unit/vc/vc-coverage.test.ts
+++ b/packages/sdk/tests/unit/vc/vc-coverage.test.ts
@@ -458,7 +458,7 @@ describe('VC-008/error – corporate policy with unassigned mandatory role is re
 
 // ─── VC-010 ──────────────────────────────────────────────────────────────────
 
-describe('VC-010/happy – prepareSelectiveDisclosure with mandatory + selective pointers', () => {
+describe('VC-010 – prepareSelectiveDisclosure requires a BBS+ key', () => {
   const cm = new CredentialManager(config);
 
   const credential: VerifiableCredential = {
@@ -474,27 +474,26 @@ describe('VC-010/happy – prepareSelectiveDisclosure with mandatory + selective
     },
   };
 
-  test('returns credential and pointer arrays without BBS+ key (metadata-only mode)', async () => {
-    const result = await cm.prepareSelectiveDisclosure(credential, {
-      mandatoryPointers: ['/issuer', '/issuanceDate', '/credentialSubject/id'],
-      selectivePointers: ['/credentialSubject/name', '/credentialSubject/age'],
-    });
-
-    expect(result.credential).toBeDefined();
-    expect(result.mandatoryPointers).toContain('/issuer');
-    expect(result.mandatoryPointers).toContain('/issuanceDate');
-    expect(result.mandatoryPointers).toContain('/credentialSubject/id');
-    expect(result.selectivePointers).toContain('/credentialSubject/name');
-    expect(result.selectivePointers).toContain('/credentialSubject/age');
-    // email is neither mandatory nor selective — not in selectivePointers
-    expect(result.selectivePointers).not.toContain('/credentialSubject/email');
+  // This described a "metadata-only mode": pointer arrays returned, no proof
+  // created. It read as success, so callers shipped credentials that could
+  // never be selectively disclosed — including the example in the LLM guide.
+  test('throws instead of returning a metadata-only result', async () => {
+    await expect(
+      cm.prepareSelectiveDisclosure(credential, {
+        mandatoryPointers: ['/issuer', '/issuanceDate', '/credentialSubject/id'],
+        selectivePointers: ['/credentialSubject/name', '/credentialSubject/age'],
+      })
+    ).rejects.toThrow(/BBS\+ key pair|privateKey/);
   });
 
-  test('works when selectivePointers is omitted (defaults to empty array)', async () => {
-    const result = await cm.prepareSelectiveDisclosure(credential, {
-      mandatoryPointers: ['/issuer'],
-    });
-    expect(result.selectivePointers).toHaveLength(0);
+  test('pointer validation still runs before the key check', async () => {
+    // Ordering matters: a caller with both problems should hear about the
+    // malformed pointer, which is the one they can see in their own code.
+    await expect(
+      cm.prepareSelectiveDisclosure(credential, {
+        mandatoryPointers: ['issuer'],
+      })
+    ).rejects.toThrow(/Invalid JSON Pointer/);
   });
 });
 
@@ -528,10 +527,10 @@ describe('VC-010/invalid-input – invalid JSON Pointer in selective or mandator
 
 // ─── VC-011 ──────────────────────────────────────────────────────────────────
 
-describe('VC-011/happy – deriveSelectiveProof (fallback without real BBS+ base proof)', () => {
-  // NOTE: BbsSimple.sign/createProof is not yet implemented (throws "not implemented").
-  // The fallback path in deriveSelectiveProof is exercised when the credential
-  // lacks a bbs-2023 proof — it returns the credential unchanged with field lists.
+describe('VC-011 – deriveSelectiveProof refuses a credential with no BBS+ base proof', () => {
+  // This used to assert the fallback: the credential returned UNCHANGED while
+  // hiddenFields claimed /credentialSubject/email was withheld. That is a
+  // fail-open disclosure bug, so the fallback now throws instead.
   const cm = new CredentialManager(config);
 
   const credential: VerifiableCredential = {
@@ -546,24 +545,16 @@ describe('VC-011/happy – deriveSelectiveProof (fallback without real BBS+ base
     },
   };
 
-  test('disclosedFields matches the provided pointer list', async () => {
-    const result = await cm.deriveSelectiveProof(credential, [
-      '/issuer',
-      '/credentialSubject/name',
-    ]);
-
-    expect(result.disclosedFields).toContain('/issuer');
-    expect(result.disclosedFields).toContain('/credentialSubject/name');
-    expect(result.hiddenFields).toContain('/credentialSubject/email');
-    expect(result.credential).toBeDefined();
+  test('throws rather than returning every field while reporting some as hidden', async () => {
+    await expect(
+      cm.deriveSelectiveProof(credential, ['/issuer', '/credentialSubject/name'])
+    ).rejects.toThrow(/bbs-2023 base proof/);
   });
 
-  test('hiddenFields and disclosedFields are disjoint', async () => {
-    const result = await cm.deriveSelectiveProof(credential, ['/issuer']);
-    const disclosedSet = new Set(result.disclosedFields);
-    for (const f of result.hiddenFields) {
-      expect(disclosedSet.has(f)).toBe(false);
-    }
+  test('the error names what is missing so the caller knows the fix', async () => {
+    await expect(
+      cm.deriveSelectiveProof(credential, ['/issuer'])
+    ).rejects.toThrow(/prepareSelectiveDisclosure/);
   });
 
   test('throws "Invalid JSON Pointer" for field path without leading slash', async () => {
@@ -573,7 +564,7 @@ describe('VC-011/happy – deriveSelectiveProof (fallback without real BBS+ base
   });
 });
 
-describe('VC-011/boundary – deriveSelectiveProof with only mandatory fields (empty selective)', () => {
+describe('VC-011/boundary – deriveSelectiveProof rejects unsigned credentials at every disclosure size', () => {
   const cm = new CredentialManager(config);
 
   const credential: VerifiableCredential = {
@@ -584,13 +575,15 @@ describe('VC-011/boundary – deriveSelectiveProof with only mandatory fields (e
     credentialSubject: { id: 'did:peer:subject', name: 'Alice' },
   };
 
-  test('empty disclosure list → zero disclosedFields, all fields in hiddenFields', async () => {
-    const result = await cm.deriveSelectiveProof(credential, []);
-    expect(result.disclosedFields).toHaveLength(0);
-    expect(result.hiddenFields.length).toBeGreaterThan(0);
+  // The empty list was the worst case of the old fallback: it reported EVERY
+  // field as hidden while returning all of them.
+  test('empty disclosure list throws rather than reporting every field as hidden', async () => {
+    await expect(cm.deriveSelectiveProof(credential, [])).rejects.toThrow(
+      /bbs-2023 base proof/
+    );
   });
 
-  test('disclosing all top-level paths → none appear in hiddenFields', async () => {
+  test('disclosing every path throws too — the credential is still unsigned', async () => {
     const allPaths = [
       '/@context',
       '/type',
@@ -600,11 +593,9 @@ describe('VC-011/boundary – deriveSelectiveProof with only mandatory fields (e
       '/credentialSubject/id',
       '/credentialSubject/name',
     ];
-    const result = await cm.deriveSelectiveProof(credential, allPaths);
-    const hiddenSet = new Set(result.hiddenFields);
-    for (const p of allPaths) {
-      expect(hiddenSet.has(p)).toBe(false);
-    }
+    await expect(cm.deriveSelectiveProof(credential, allPaths)).rejects.toThrow(
+      /bbs-2023 base proof/
+    );
   });
 });
 


### PR DESCRIPTION
P0 from the disclosable-attestations plan. Independent of that feature — this is a live fail-open bug in a privacy primitive.

## The bug

`deriveSelectiveProof` fell back, for any credential without a `bbs-2023` proof, to returning the credential **unchanged** while listing the undisclosed paths in `hiddenFields`:

```ts
// Fallback for non-BBS+ credentials
return {
  credential: { ...credential },   // every field still present
  disclosedFields: fieldsToDisclose,
  hiddenFields,                     // claims fields were withheld
};
```

A caller who trusted that report and forwarded `result.credential` published every field it claimed to withhold.

The old test suite **pinned this as intended behaviour** — `vc-coverage.test.ts` asserted `/credentialSubject/email` appeared in `hiddenFields` while the returned credential still carried `alice@example.com`, under a comment describing it as the happy path.

`prepareSelectiveDisclosure` had the matching hole: given no key pair it returned a "metadata-only" result — credential untouched, pointer arrays attached — which read as success but created no proof, so nothing could ever be derived from it.

## Why it was reachable

The two combined into one trap. The example in `docs/LLM_AGENT_GUIDE.md:995` passes **no key**, so it demonstrated the metadata-only path. A reader following the docs got a credential with no proof, then a "derived" result that redacted nothing — and no error at any point.

## The fix

Both paths throw typed `StructuredError`s that name the missing input:

- `BBS_KEY_REQUIRED` — pass `privateKey`/`publicKey`, and where to get one
- `BBS_BASE_PROOF_REQUIRED` — names the cryptosuite actually found, and points at `prepareSelectiveDisclosure`

The docs example is rewritten to show the real flow, including BLS key generation via `@digitalbazaar/bbs-signatures` — the SDK cannot generate BLS12-381 keys (`KeyManager` covers ES256K / Ed25519 / ES256), which is the reason the no-key path existed at all.

## Breaking

Calls that previously resolved now throw, so this is a major. Nothing relying on either fallback was performing selective disclosure — it was producing an unusable credential or leaking. The real BBS path (`CredentialManager.bbs-derive.test.ts`) is untouched and still passes.

## Tests

Six pinned tests rewritten from asserting the fallback to asserting the throw, with comments recording what each used to encode. New `tests/security/bbs-selective-disclosure-fail-open.test.ts` includes the direct regression: no result object may carry the secret while calling it hidden.

3,761 tests pass. Typecheck, lint (0 errors), ESM and browser-safety gates all green.

## Follow-up

`KeyManager` still can't generate BLS keys — that's P1 in the plan and the reason issuers need a direct `@digitalbazaar/bbs-signatures` dependency today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix BBS+ selective disclosure to fail closed instead of leaking credentials
> - `prepareSelectiveDisclosure` now throws `BBS_KEY_REQUIRED` when no BBS+ key pair is provided, instead of returning an unsigned credential with pointer metadata.
> - `deriveSelectiveProof` now throws `BBS_BASE_PROOF_REQUIRED` when the credential lacks a `bbs-2023` base proof, instead of returning the unredacted credential with misleading `hiddenFields`.
> - Regression tests added in [`bbs-selective-disclosure-fail-open.test.ts`](https://github.com/onionoriginals/sdk/pull/458/files#diff-941e72650275c9178c4966ec0954b7e92f76b863202c0052da72d3d950f553b1) to assert both fail-closed paths and confirm no credential data leaks on error.
> - Risk: Breaking change — callers relying on the previous fallback behavior (receiving the original credential unchanged) will now receive thrown errors instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a5062b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->