### PR TITLE
feat(sdk): remote-custody signer core + conformance harness (plans 039-040, 045)

### DIFF
--- a/.changeset/remote-custody-signer-core.md
+++ b/.changeset/remote-custody-signer-core.md
@@ -15,6 +15,8 @@
 
 **`@originals/auth`:** both Turnkey signers now implement `signBytes` via a single shared `turnkeySignBytes` primitive, so a Turnkey key satisfies `OriginalsSigner` and can author CEL events and sign credentials — not only did:webvh logs. The byte-level code already existed, duplicated across the two signers and kept in sync by comment.
 
+Custody is explicit at every append: a signer passed to `createAsset` is **not** retained on the asset. An asset holding a signer handed to it once is hidden state that outlives the call — a session-backed signer (a Turnkey browser session) goes stale inside it, and a serialized/reloaded asset has no binding at all. Later appends take a signer per call, or fall back to `config.signer`.
+
 **Breaking:**
 
 - `@originals/auth`'s root entry no longer re-exports `./server`. Importing so much as a type from `@originals/auth` pulled `jsonwebtoken`, `@turnkey/sdk-server` and Express into browser bundles. Import server utilities from `@originals/auth/server` and client utilities from `@originals/auth/client`; the root now exports types plus the isomorphic `turnkeySignBytes`.

--- a/.changeset/remote-custody-signer-core.md
+++ b/.changeset/remote-custody-signer-core.md
@@ -1,0 +1,24 @@
+---
+"@originals/sdk": major
+"@originals/auth": major
+---
+
+**Remote custody can author assets.** Turnkey, KMS, HSM, MPC and passkey backends never export a private key, and the SDK's authorship path required one — `KeyStore.getPrivateKey(vmId)`. Any such backend was locked out of the recommended tier entirely.
+
+**One signer interface.** `OriginalsSigner` is three members — `verificationMethodId`, `publicKeyMultibase`, and `signBytes(bytes)` — the smallest capability a custody backend can offer. The SDK canonicalizes and hashes; the signer only ever signs opaque bytes. It is accepted on `OriginalsConfig` and per call on `createAsset`, `publishToWeb`, `inscribeOnBitcoin`, `rotateBtcoKeys`, `authorizeSigner` and `addResourceVersion`. Adapters convert in both directions: `signerFromKeyPair`, `signerFromKeyStore`, `signerFromExternalSigner`, `toCelSigner`, `toExternalSigner`.
+
+**The provenance leak this closes:** `publishToWeb` accepted an `ExternalSigner`, but that signer only authorized the did:webvh log. The asset's own CEL `migrate` event was appended by a keyStore-only path, so a remote-custody caller doing everything right got a published asset whose provenance log was **missing its migration event** — reported as success. Every authorship append now accepts the configured or per-call signer.
+
+**One signing-input namespace.** `signingInput` exposes the four (and only four) preimages this SDK signs: `celEvent`, `witness`, `didWebvh`, `credential`. Every internal signing path routes through it, so "which bytes do I sign?" has one answer and the four cannot drift apart. Note `didWebvh` delegates to didwebvh-ts's own `prepareDataForSigning` — it is `sha256(JCS(proof)) || sha256(JCS(document))`, not JCS over the pair, and reimplementing it by hand produces proofs that never verify.
+
+**A conformance harness.** `assertSignerConformance(signer)` lets any custody backend prove its implementation before shipping, and `MockRemoteSigner` (signBytes-only, no key export) exercises the full create → publish → inscribe → rotate flow in the SDK's own tests. No test previously exercised a non-exporting backend, which is why this went unnoticed.
+
+**`@originals/auth`:** both Turnkey signers now implement `signBytes` via a single shared `turnkeySignBytes` primitive, so a Turnkey key satisfies `OriginalsSigner` and can author CEL events and sign credentials — not only did:webvh logs. The byte-level code already existed, duplicated across the two signers and kept in sync by comment.
+
+**Breaking:**
+
+- `@originals/auth`'s root entry no longer re-exports `./server`. Importing so much as a type from `@originals/auth` pulled `jsonwebtoken`, `@turnkey/sdk-server` and Express into browser bundles. Import server utilities from `@originals/auth/server` and client utilities from `@originals/auth/client`; the root now exports types plus the isomorphic `turnkeySignBytes`.
+- `ExternalSigner`, `CelSigner`, and using a `KeyStore` as a signing authority are deprecated in favour of `OriginalsSigner`. They still work; removal is a later release. `KeyStore` remains supported for key *persistence*.
+- The Turnkey signers' "no signature returned" error message is now one shared string naming the expected `activity.result.signRawPayloadResult.{r,s}` shape.
+
+Also adds `base58AddressToEd25519Multikey`: custody backends hand back an address, not a Multikey, and Turnkey's Ed25519 accounts use `ADDRESS_FORMAT_SOLANA` — base58 of the raw key, with no multicodec header. Building `did:key:${address}` from it yields something that is not a valid did:key, a mistake consumers kept re-deriving.

--- a/.changeset/remote-custody-signer-core.md
+++ b/.changeset/remote-custody-signer-core.md
@@ -19,7 +19,7 @@ Custody is explicit at every append: a signer passed to `createAsset` is **not**
 
 **Breaking:**
 
-- `@originals/auth`'s root entry no longer re-exports `./server`. Importing so much as a type from `@originals/auth` pulled `jsonwebtoken`, `@turnkey/sdk-server` and Express into browser bundles. Import server utilities from `@originals/auth/server` and client utilities from `@originals/auth/client`; the root now exports types plus the isomorphic `turnkeySignBytes`.
+- `@originals/auth`'s root entry no longer re-exports `./server`. Importing so much as a type from `@originals/auth` pulled `jsonwebtoken`, `@turnkey/sdk-server` and Express into browser bundles. Import server utilities from `@originals/auth/server` and client utilities from `@originals/auth/client`; the root now exports types plus `turnkeySignBytes`, which is browser-safe (hex via @noble/hashes, no `Buffer`).
 - `ExternalSigner`, `CelSigner`, and using a `KeyStore` as a signing authority are deprecated in favour of `OriginalsSigner`. They still work; removal is a later release. `KeyStore` remains supported for key *persistence*.
 - The Turnkey signers' "no signature returned" error message is now one shared string naming the expected `activity.result.signRawPayloadResult.{r,s}` shape.
 

--- a/packages/auth/src/client/turnkey-did-signer.ts
+++ b/packages/auth/src/client/turnkey-did-signer.ts
@@ -51,8 +51,13 @@ export class TurnkeyDIDSigner {
     return withTokenExpiration(async () => {
       try {
         // didwebvh's preimage, produced by the SDK — never by this signer.
-        const dataToSign = await signingInput.didWebvh(input.document, input.proof);
-        const { signature } = await this.signBytes(dataToSign);
+        // Narrowed explicitly: lint runs before @originals/sdk is built, so the
+        // return type is unresolved there and must not flow on unchecked.
+        const prepared: unknown = await signingInput.didWebvh(input.document, input.proof);
+        if (!(prepared instanceof Uint8Array)) {
+          throw new Error('signingInput.didWebvh did not return a Uint8Array');
+        }
+        const { signature } = await this.signBytes(prepared);
         return { proofValue: encoding.multibase.encode(signature, 'base58btc') };
       } catch (error) {
         console.error('[TurnkeyDIDSigner] Error signing with Turnkey:', error);

--- a/packages/auth/src/client/turnkey-did-signer.ts
+++ b/packages/auth/src/client/turnkey-did-signer.ts
@@ -5,7 +5,8 @@
  */
 
 import { Turnkey } from '@turnkey/sdk-server';
-import { OriginalsSDK, encoding } from '@originals/sdk';
+import { OriginalsSDK, encoding, signingInput } from '@originals/sdk';
+import { turnkeySignBytes } from '../turnkey-sign-bytes.js';
 import type { TurnkeyWalletAccount } from '../types.js';
 import { TurnkeySessionExpiredError, withTokenExpiration } from './turnkey-client.js';
 
@@ -49,65 +50,48 @@ export class TurnkeyDIDSigner {
   async sign(input: SigningInput): Promise<SigningOutput> {
     return withTokenExpiration(async () => {
       try {
-        // Use SDK's prepareDIDDataForSigning
-        const dataToSign = await OriginalsSDK.prepareDIDDataForSigning(input.document, input.proof);
-
-        // Sign with Turnkey via server SDK
-        const result = await this.turnkeyClient.apiClient().signRawPayload({
-          organizationId: this.subOrgId,
-          signWith: this.signWith,
-          payload: Buffer.from(dataToSign).toString('hex'),
-          encoding: 'PAYLOAD_ENCODING_HEXADECIMAL',
-          hashFunction: 'HASH_FUNCTION_NO_OP',
-        });
-
-        // Turnkey's signRawPayload nests the signature under
-        // activity.result.signRawPayloadResult.{r, s} (same shape the
-        // server-side signer reads). Reading result.r/result.s directly is
-        // always undefined and breaks every real Turnkey response.
-        const signRawResult = result.activity?.result?.signRawPayloadResult;
-        const r = signRawResult?.r;
-        const s = signRawResult?.s;
-
-        if (!r || !s) {
-          throw new Error('Invalid signature response from Turnkey');
-        }
-
-        // For Ed25519, combine r+s only (64 bytes total)
-        const cleanR = r.startsWith('0x') ? r.slice(2) : r;
-        const cleanS = s.startsWith('0x') ? s.slice(2) : s;
-        const combinedHex = cleanR + cleanS;
-
-        const signatureBytes = Uint8Array.from(Buffer.from(combinedHex, 'hex'));
-
-        if (signatureBytes.length !== 64) {
-          throw new Error(
-            `Invalid Ed25519 signature length: ${signatureBytes.length} (expected 64 bytes)`
-          );
-        }
-
-        const proofValue = encoding.multibase.encode(signatureBytes, 'base58btc');
-
-        return { proofValue };
+        // didwebvh's preimage, produced by the SDK — never by this signer.
+        const dataToSign = await signingInput.didWebvh(input.document, input.proof);
+        const { signature } = await this.signBytes(dataToSign);
+        return { proofValue: encoding.multibase.encode(signature, 'base58btc') };
       } catch (error) {
         console.error('[TurnkeyDIDSigner] Error signing with Turnkey:', error);
-
-        const errorStr = JSON.stringify(error);
-        if (
-          errorStr.toLowerCase().includes('api_key_expired') ||
-          errorStr.toLowerCase().includes('expired api key') ||
-          errorStr.toLowerCase().includes('"code":16')
-        ) {
-          console.warn('Detected expired API key in sign method, calling onExpired');
-          if (this.onExpired) {
-            this.onExpired();
-          }
-          throw new TurnkeySessionExpiredError();
-        }
-
-        throw error;
+        throw this.asExpiryError(error);
       }
     }, this.onExpired);
+  }
+
+  /**
+   * Signs pre-canonicalized, pre-hashed bytes — the capability that lets a
+   * Turnkey key author CEL events and sign credentials, not just did:webvh
+   * logs. `signerFromExternalSigner` requires exactly this.
+   */
+  async signBytes(data: Uint8Array): Promise<{ signature: Uint8Array }> {
+    return withTokenExpiration(async () => {
+      try {
+        const signature = await turnkeySignBytes(
+          { turnkeyClient: this.turnkeyClient, organizationId: this.subOrgId, signWith: this.signWith },
+          data
+        );
+        return { signature };
+      } catch (error) {
+        throw this.asExpiryError(error);
+      }
+    }, this.onExpired);
+  }
+
+  /** Turnkey reports an expired session as a generic error; surface it typed. */
+  private asExpiryError(error: unknown): unknown {
+    const errorStr = JSON.stringify(error);
+    if (
+      errorStr.toLowerCase().includes('api_key_expired') ||
+      errorStr.toLowerCase().includes('expired api key') ||
+      errorStr.toLowerCase().includes('"code":16')
+    ) {
+      this.onExpired?.();
+      return new TurnkeySessionExpiredError();
+    }
+    return error;
   }
 
   /**

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -19,14 +19,17 @@
  * ```
  */
 
-// Re-export types
+// Types only. The root MUST stay free of server code: re-exporting
+// './server/index.js' here pulled jsonwebtoken, @turnkey/sdk-server and the
+// Express middleware into any bundle that imported so much as a type from
+// '@originals/auth' — contradicting the docstring above it (plan 045).
 export * from './types.js';
 
-// Re-export server utilities (for convenience, though subpath is preferred)
-export * from './server/index.js';
+// Isomorphic: byte-level Turnkey signing, safe in either environment.
+export { turnkeySignBytes, type TurnkeySignBytesOptions } from './turnkey-sign-bytes.js';
 
-// Note: Client utilities should be imported from '@originals/auth/client'
-// to avoid bundling React in server environments
+// Server utilities: import from '@originals/auth/server'.
+// Client utilities: import from '@originals/auth/client'.
 
 
 

--- a/packages/auth/src/server/turnkey-signer.ts
+++ b/packages/auth/src/server/turnkey-signer.ts
@@ -9,7 +9,6 @@ import { Turnkey } from '@turnkey/sdk-server';
 import { ExternalSigner, ExternalVerifier, multikey, signingInput } from '@originals/sdk';
 import { turnkeySignBytes } from '../turnkey-sign-bytes.js';
 import { sha512 } from '@noble/hashes/sha2.js';
-import { bytesToHex } from '@noble/hashes/utils.js';
 import * as ed25519 from '@noble/ed25519';
 
 // Configure @noble/ed25519 with required SHA-512 function.
@@ -66,8 +65,13 @@ export class TurnkeyWebVHSigner implements ExternalSigner, ExternalVerifier {
   }): Promise<{ proofValue: string }> {
     try {
       // didwebvh's preimage, produced by the SDK — never by this signer.
-      const dataToSign = await signingInput.didWebvh(input.document, input.proof);
-      const { signature } = await this.signBytes(dataToSign);
+      // Narrowed explicitly: lint runs before @originals/sdk is built, so the
+      // return type is unresolved there and must not flow on unchecked.
+      const prepared: unknown = await signingInput.didWebvh(input.document, input.proof);
+      if (!(prepared instanceof Uint8Array)) {
+        throw new Error('signingInput.didWebvh did not return a Uint8Array');
+      }
+      const { signature } = await this.signBytes(prepared);
       return { proofValue: multikey.encodeMultibase(signature) };
     } catch (error) {
       console.error('Error signing with Turnkey:', error);

--- a/packages/auth/src/server/turnkey-signer.ts
+++ b/packages/auth/src/server/turnkey-signer.ts
@@ -6,7 +6,8 @@
  */
 
 import { Turnkey } from '@turnkey/sdk-server';
-import { ExternalSigner, ExternalVerifier, multikey, OriginalsSDK } from '@originals/sdk';
+import { ExternalSigner, ExternalVerifier, multikey, signingInput } from '@originals/sdk';
+import { turnkeySignBytes } from '../turnkey-sign-bytes.js';
 import { sha512 } from '@noble/hashes/sha2.js';
 import { bytesToHex } from '@noble/hashes/utils.js';
 import * as ed25519 from '@noble/ed25519';
@@ -64,64 +65,29 @@ export class TurnkeyWebVHSigner implements ExternalSigner, ExternalVerifier {
     proof: Record<string, unknown>;
   }): Promise<{ proofValue: string }> {
     try {
-      // Prepare the data for signing using the SDK's canonical approach
-      const prepared: unknown = await OriginalsSDK.prepareDIDDataForSigning(input.document, input.proof);
-      if (!(prepared instanceof Uint8Array)) {
-        throw new Error('prepareDIDDataForSigning did not return a Uint8Array');
-      }
-      const dataToSign = prepared;
-
-      // Convert canonical data to hex format for Turnkey's sign API
-      const dataHex = `0x${bytesToHex(dataToSign)}`;
-
-      // Sign using Turnkey's API
-      const result = await this.turnkeyClient.apiClient().signRawPayload({
-        organizationId: this.subOrgId,
-        signWith: this.keyId,
-        payload: dataHex,
-        encoding: 'PAYLOAD_ENCODING_HEXADECIMAL',
-        hashFunction: 'HASH_FUNCTION_NO_OP',
-      });
-
-      const signRawResult = result.activity?.result?.signRawPayloadResult;
-      if (!signRawResult?.r || !signRawResult?.s) {
-        throw new Error('No signature returned from Turnkey');
-      }
-
-      // Turnkey may return r and s with or without a leading '0x' prefix.
-      // Strip the prefix from each component SEPARATELY before concatenating:
-      // concatenating first and stripping a single leading '0x' would leave an
-      // embedded '0x' in the middle (e.g. 'aaaa...0xbbbb...') when both values
-      // are prefixed, corrupting Buffer.from(..., 'hex') and breaking the
-      // signature. This mirrors the client-side TurnkeyDIDSigner behaviour.
-      const r = signRawResult.r;
-      const s = signRawResult.s;
-      const cleanR = r.startsWith('0x') ? r.slice(2) : r;
-      const cleanS = s.startsWith('0x') ? s.slice(2) : s;
-      const cleanSig = cleanR + cleanS;
-      const signatureBytes = Uint8Array.from(Buffer.from(cleanSig, 'hex'));
-
-      // Ed25519 signatures must be exactly 64 bytes (32-byte r + 32-byte s).
-      // Never truncate: a 65-byte value is not a valid Ed25519 signature with a
-      // spare byte, and silently slicing it would produce an invalid signature
-      // that is accepted/stored here but fails later verification (did:webvh
-      // resolution / credential validation). Reject anything that is not 64
-      // bytes, matching the client-side TurnkeyDIDSigner contract.
-      if (signatureBytes.length !== 64) {
-        throw new Error(
-          `Invalid Ed25519 signature length: ${signatureBytes.length} (expected 64 bytes)`
-        );
-      }
-
-      // Encode signature as multibase
-      const proofValue = multikey.encodeMultibase(signatureBytes);
-      return { proofValue };
+      // didwebvh's preimage, produced by the SDK — never by this signer.
+      const dataToSign = await signingInput.didWebvh(input.document, input.proof);
+      const { signature } = await this.signBytes(dataToSign);
+      return { proofValue: multikey.encodeMultibase(signature) };
     } catch (error) {
       console.error('Error signing with Turnkey:', error);
       throw new Error(
         `Failed to sign with Turnkey: ${error instanceof Error ? error.message : String(error)}`
       );
     }
+  }
+
+  /**
+   * Signs pre-canonicalized, pre-hashed bytes — the capability that lets a
+   * Turnkey key author CEL events and sign credentials, not just did:webvh
+   * logs. `signerFromExternalSigner` requires exactly this.
+   */
+  async signBytes(data: Uint8Array): Promise<{ signature: Uint8Array }> {
+    const signature = await turnkeySignBytes(
+      { turnkeyClient: this.turnkeyClient, organizationId: this.subOrgId, signWith: this.keyId },
+      data
+    );
+    return { signature };
   }
 
   /**

--- a/packages/auth/src/turnkey-sign-bytes.ts
+++ b/packages/auth/src/turnkey-sign-bytes.ts
@@ -1,0 +1,69 @@
+/**
+ * The one place Turnkey actually signs (plan 045).
+ *
+ * Both the server and client signers had their own copy of this — hex-encode,
+ * `HASH_FUNCTION_NO_OP`, concatenate r‖s, check 64 bytes — kept in sync by
+ * comment. They now share it, and because it is byte-level it satisfies
+ * `OriginalsSigner.signBytes` / `ExternalSigner.signBytes` directly, so a
+ * Turnkey key can author CEL events and sign credentials rather than only
+ * did:webvh logs.
+ */
+
+import type { Turnkey } from '@turnkey/sdk-server';
+
+export interface TurnkeySignBytesOptions {
+  turnkeyClient: Turnkey;
+  /** Turnkey sub-organization id. */
+  organizationId: string;
+  /** The account to sign with (address or private key id). */
+  signWith: string;
+}
+
+/**
+ * Signs exactly `data` with a Turnkey-held Ed25519 key.
+ *
+ * The payload is sent pre-hashed with `HASH_FUNCTION_NO_OP`: the caller (the
+ * SDK) owns canonicalization and hashing, so Turnkey must sign the bytes
+ * verbatim and hash nothing itself.
+ *
+ * @returns the raw 64-byte Ed25519 signature
+ */
+export async function turnkeySignBytes(
+  { turnkeyClient, organizationId, signWith }: TurnkeySignBytesOptions,
+  data: Uint8Array
+): Promise<Uint8Array> {
+  const result = await turnkeyClient.apiClient().signRawPayload({
+    organizationId,
+    signWith,
+    payload: `0x${Buffer.from(data).toString('hex')}`,
+    encoding: 'PAYLOAD_ENCODING_HEXADECIMAL',
+    hashFunction: 'HASH_FUNCTION_NO_OP',
+  });
+
+  // Turnkey nests the signature under activity.result.signRawPayloadResult;
+  // reading result.r/result.s directly is always undefined.
+  const signRawResult = result.activity?.result?.signRawPayloadResult;
+  const r = signRawResult?.r;
+  const s = signRawResult?.s;
+  if (!r || !s) {
+    throw new Error(
+      'Invalid signature response from Turnkey: expected activity.result.signRawPayloadResult.{r,s}'
+    );
+  }
+
+  // Strip `0x` from each component SEPARATELY: concatenating first and
+  // stripping one leading prefix leaves an embedded '0x' in the middle when
+  // both are prefixed, corrupting the hex decode.
+  const cleanR = r.startsWith('0x') ? r.slice(2) : r;
+  const cleanS = s.startsWith('0x') ? s.slice(2) : s;
+  const signature = Uint8Array.from(Buffer.from(cleanR + cleanS, 'hex'));
+
+  // Ed25519 signatures are exactly 64 bytes (32-byte r + 32-byte s). Never
+  // truncate: a wrong length is not a valid signature with a spare byte, and
+  // slicing it yields something that is accepted here but fails verification
+  // far away.
+  if (signature.length !== 64) {
+    throw new Error(`Invalid Ed25519 signature length: ${signature.length} (expected 64 bytes)`);
+  }
+  return signature;
+}

--- a/packages/auth/src/turnkey-sign-bytes.ts
+++ b/packages/auth/src/turnkey-sign-bytes.ts
@@ -7,8 +7,13 @@
  * `OriginalsSigner.signBytes` / `ExternalSigner.signBytes` directly, so a
  * Turnkey key can author CEL events and sign credentials rather than only
  * did:webvh logs.
+ *
+ * Browser-safe: hex conversion goes through @noble/hashes, not `Buffer`. This
+ * is a root export of `@originals/auth` and the client signer runs in the
+ * browser, where `Buffer` is not defined without a bundler shim.
  */
 
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import type { Turnkey } from '@turnkey/sdk-server';
 
 export interface TurnkeySignBytesOptions {
@@ -35,7 +40,7 @@ export async function turnkeySignBytes(
   const result = await turnkeyClient.apiClient().signRawPayload({
     organizationId,
     signWith,
-    payload: `0x${Buffer.from(data).toString('hex')}`,
+    payload: `0x${bytesToHex(data)}`,
     encoding: 'PAYLOAD_ENCODING_HEXADECIMAL',
     hashFunction: 'HASH_FUNCTION_NO_OP',
   });
@@ -56,7 +61,7 @@ export async function turnkeySignBytes(
   // both are prefixed, corrupting the hex decode.
   const cleanR = r.startsWith('0x') ? r.slice(2) : r;
   const cleanS = s.startsWith('0x') ? s.slice(2) : s;
-  const signature = Uint8Array.from(Buffer.from(cleanR + cleanS, 'hex'));
+  const signature = hexToBytes(cleanR + cleanS);
 
   // Ed25519 signatures are exactly 64 bytes (32-byte r + 32-byte s). Never
   // truncate: a wrong length is not a valid signature with a spare byte, and

--- a/packages/auth/tests/turnkey-did-creation.integration.test.ts
+++ b/packages/auth/tests/turnkey-did-creation.integration.test.ts
@@ -88,7 +88,11 @@ function makeRealSigningClient(
       signRawPayload: async (request: { payload: string; [k: string]: unknown }) => {
         if (callSpy) callSpy.count++;
 
-        const payloadBytes = Buffer.from(request.payload, 'hex');
+        // Turnkey accepts PAYLOAD_ENCODING_HEXADECIMAL with or without the `0x`
+        // prefix; `Buffer.from(s, 'hex')` silently mis-parses the prefixed form,
+        // so strip it here rather than encode one signer's convention.
+        const hex = request.payload.startsWith('0x') ? request.payload.slice(2) : request.payload;
+        const payloadBytes = Buffer.from(hex, 'hex');
         const sigBytes = await ed.signAsync(payloadBytes, privateKeyBytes);
 
         // Ed25519 signature is always 64 bytes: first 32 = r, last 32 = s

--- a/packages/auth/tests/turnkey-signbytes.test.ts
+++ b/packages/auth/tests/turnkey-signbytes.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, test, expect, beforeAll } from 'bun:test';
 import * as ed25519Module from '@noble/ed25519';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import {
   signerFromExternalSigner,
   assertSignerConformance,
@@ -52,6 +53,28 @@ function makeTurnkey(privateKey: Uint8Array, spy?: { payloads: string[] }): Turn
   } as unknown as Turnkey;
 }
 
+/** Buffer-free variant of the double, for the no-Buffer environment test. */
+function makeTurnkeyNoBuffer(privateKey: Uint8Array): Turnkey {
+  return {
+    apiClient: () => ({
+      signRawPayload: async (req: { payload: string }) => {
+        const hex = req.payload.startsWith('0x') ? req.payload.slice(2) : req.payload;
+        const sig = await ed.signAsync(hexToBytes(hex), privateKey);
+        return {
+          activity: {
+            result: {
+              signRawPayloadResult: {
+                r: bytesToHex(sig.slice(0, 32)),
+                s: bytesToHex(sig.slice(32)),
+              },
+            },
+          },
+        };
+      },
+    }),
+  } as unknown as Turnkey;
+}
+
 describe('turnkeySignBytes', () => {
   const privateKey = ed.utils.randomSecretKey();
 
@@ -74,6 +97,26 @@ describe('turnkeySignBytes', () => {
       data
     );
     expect(spy.payloads[0].toLowerCase()).toContain('deadbeef');
+  });
+
+  test('works with no global Buffer — it is a browser-facing root export', async () => {
+    // The client signer runs in the browser, where `Buffer` is undefined
+    // without a bundler shim. Hex conversion must not depend on it.
+    const realBuffer = globalThis.Buffer;
+    // @ts-expect-error - deliberately removing a global for the duration
+    delete globalThis.Buffer;
+    try {
+      const data = new TextEncoder().encode('no Buffer here');
+      const sig = await turnkeySignBytes(
+        { turnkeyClient: makeTurnkeyNoBuffer(privateKey), organizationId: 'org', signWith: 'acct' },
+        data
+      );
+      expect(sig.length).toBe(64);
+      const publicKey = await ed.getPublicKeyAsync(privateKey);
+      expect(await ed.verifyAsync(sig, data, publicKey)).toBe(true);
+    } finally {
+      globalThis.Buffer = realBuffer;
+    }
   });
 
   test('rejects a legacy flat {r,s} response', async () => {

--- a/packages/auth/tests/turnkey-signbytes.test.ts
+++ b/packages/auth/tests/turnkey-signbytes.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Plan 045: a Turnkey key can author Originals provenance.
+ *
+ * Before this, both Turnkey signers implemented only the document-level
+ * `sign({document, proof})`, so `signerFromExternalSigner` threw on them and a
+ * Turnkey-backed consumer had to rebuild Turnkey signing itself. The
+ * byte-level primitive was already there — buried inside `sign()` and
+ * duplicated across the two signers, kept in sync by comment.
+ */
+
+import { describe, test, expect, beforeAll } from 'bun:test';
+import * as ed25519Module from '@noble/ed25519';
+import {
+  signerFromExternalSigner,
+  assertSignerConformance,
+  multikey,
+  encoding,
+  base58AddressToEd25519Multikey,
+} from '@originals/sdk';
+import { turnkeySignBytes } from '../src/turnkey-sign-bytes';
+import { TurnkeyWebVHSigner } from '../src/server/turnkey-signer';
+import type { Turnkey } from '@turnkey/sdk-server';
+
+// @noble/ed25519 v3 exports getPublicKeyAsync/signAsync/verifyAsync at module level.
+const ed = ed25519Module as unknown as {
+  utils: { randomSecretKey: () => Uint8Array };
+  getPublicKeyAsync: (priv: Uint8Array) => Promise<Uint8Array>;
+  signAsync: (msg: Uint8Array, priv: Uint8Array) => Promise<Uint8Array>;
+  verifyAsync: (sig: Uint8Array, msg: Uint8Array, pub: Uint8Array) => Promise<boolean>;
+};
+
+/** A Turnkey-shaped client that signs with a real Ed25519 key. */
+function makeTurnkey(privateKey: Uint8Array, spy?: { payloads: string[] }): Turnkey {
+  return {
+    apiClient: () => ({
+      signRawPayload: async (req: { payload: string }) => {
+        spy?.payloads.push(req.payload);
+        const hex = req.payload.startsWith('0x') ? req.payload.slice(2) : req.payload;
+        const sig = await ed.signAsync(Uint8Array.from(Buffer.from(hex, 'hex')), privateKey);
+        return {
+          activity: {
+            result: {
+              signRawPayloadResult: {
+                r: Buffer.from(sig.slice(0, 32)).toString('hex'),
+                s: Buffer.from(sig.slice(32)).toString('hex'),
+              },
+            },
+          },
+        };
+      },
+    }),
+  } as unknown as Turnkey;
+}
+
+describe('turnkeySignBytes', () => {
+  const privateKey = ed.utils.randomSecretKey();
+
+  test('signs the exact bytes it is given (nothing is hashed on the way)', async () => {
+    const data = new TextEncoder().encode('exactly these bytes');
+    const sig = await turnkeySignBytes(
+      { turnkeyClient: makeTurnkey(privateKey), organizationId: 'org', signWith: 'acct' },
+      data
+    );
+    expect(sig.length).toBe(64);
+    const publicKey = await ed.getPublicKeyAsync(privateKey);
+    expect(await ed.verifyAsync(sig, data, publicKey)).toBe(true);
+  });
+
+  test('sends the payload pre-hashed (HASH_FUNCTION_NO_OP) as hex', async () => {
+    const spy = { payloads: [] as string[] };
+    const data = Uint8Array.from([0xde, 0xad, 0xbe, 0xef]);
+    await turnkeySignBytes(
+      { turnkeyClient: makeTurnkey(privateKey, spy), organizationId: 'org', signWith: 'acct' },
+      data
+    );
+    expect(spy.payloads[0].toLowerCase()).toContain('deadbeef');
+  });
+
+  test('rejects a legacy flat {r,s} response', async () => {
+    const flat = {
+      apiClient: () => ({ signRawPayload: async () => ({ r: 'aa', s: 'bb' }) }),
+    } as unknown as Turnkey;
+    await expect(
+      turnkeySignBytes({ turnkeyClient: flat, organizationId: 'o', signWith: 'a' }, new Uint8Array(1))
+    ).rejects.toThrow(/Invalid signature response from Turnkey/);
+  });
+
+  test('rejects a signature that is not 64 bytes rather than truncating', async () => {
+    const short = {
+      apiClient: () => ({
+        signRawPayload: async () => ({
+          activity: { result: { signRawPayloadResult: { r: 'aa', s: 'bb' } } },
+        }),
+      }),
+    } as unknown as Turnkey;
+    await expect(
+      turnkeySignBytes({ turnkeyClient: short, organizationId: 'o', signWith: 'a' }, new Uint8Array(1))
+    ).rejects.toThrow(/Invalid Ed25519 signature length: 2/);
+  });
+});
+
+describe('TurnkeyWebVHSigner satisfies the SDK signer interface [plan 045]', () => {
+  const privateKey = ed.utils.randomSecretKey();
+  let publicKeyMultibase = '';
+  let vmId = '';
+  beforeAll(async () => {
+    publicKeyMultibase = multikey.encodePublicKey(await ed.getPublicKeyAsync(privateKey), 'Ed25519');
+    vmId = `did:key:${publicKeyMultibase}#${publicKeyMultibase}`;
+  });
+
+  const makeSigner = () =>
+    new TurnkeyWebVHSigner('sub-org', 'key-id', publicKeyMultibase, makeTurnkey(privateKey), vmId);
+
+  test('converts to an OriginalsSigner — this used to throw', async () => {
+    const signer = signerFromExternalSigner(makeSigner(), { publicKeyMultibase });
+    expect(signer.verificationMethodId).toBe(vmId);
+    expect(signer.publicKeyMultibase).toBe(publicKeyMultibase);
+  });
+
+  test('passes the conformance harness, so it can author CEL events', async () => {
+    await assertSignerConformance(signerFromExternalSigner(makeSigner(), { publicKeyMultibase }));
+  });
+});
+
+describe('base58AddressToEd25519Multikey bridges a Turnkey account address', () => {
+  test('an ADDRESS_FORMAT_SOLANA address becomes a usable Multikey', async () => {
+    const publicKey = await ed.getPublicKeyAsync(ed.utils.randomSecretKey());
+    // Turnkey Ed25519 accounts report ADDRESS_FORMAT_SOLANA: base58 of the raw key.
+    const address = encoding.base58.encode(publicKey);
+    expect(base58AddressToEd25519Multikey(address)).toBe(
+      multikey.encodePublicKey(publicKey, 'Ed25519')
+    );
+  });
+});

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -30,7 +30,7 @@ import { OriginalsSDK } from '@originals/sdk';
 const sdk = OriginalsSDK.create({
   network: 'mainnet',          // 'mainnet' | 'signet' | 'regtest'
   defaultKeyType: 'ES256K',    // 'ES256K' | 'Ed25519' | 'ES256'
-  keyStore: myKeyStore,        // REQUIRED to author events — see "Custody" below
+  keyStore: myKeyStore,        // custody: keyStore OR signer — see "Custody" below
 });
 
 // 1. Create an asset privately (did:cel genesis — offline, free)
@@ -63,7 +63,7 @@ Bitcoin operations (inscribe, transfer) require an `ordinalsProvider` in the con
 
 `createAsset` generates the asset's Ed25519 controller key and, **without a `keyStore`, has nowhere to put it.** The key is dropped, a `key:unpersisted` event is emitted, and the asset can never author another event: `publishToWeb` and `inscribeOnBitcoin` still succeed, but their CEL events are skipped with a `cel:append-skipped` event, so the asset's provenance log silently loses the migration.
 
-Configure a `keyStore` before minting anything you intend to keep, and subscribe to both signals:
+Configure custody — a `keyStore`, or a `signer` for remote custody (below) — before minting anything you intend to keep, and subscribe to both signals:
 
 ```typescript
 sdk.lifecycle.on('key:unpersisted', (e) => { throw new Error(`No custody for ${e.verificationMethod}`); });
@@ -72,14 +72,26 @@ sdk.lifecycle.on('cel:append-skipped', (e) => { throw new Error(`Provenance even
 
 A `keyStore` is `{ getPrivateKey(vmId), setPrivateKey(vmId, key) }` — it must be able to **return** the private key.
 
-> **Remote custody (Turnkey, KMS, HSM, passkeys) is not yet supported for authorship.**
-> The `keyStore` contract requires an exportable key, so custody that never releases
-> one cannot sign CEL events today. `ExternalSigner` authorizes the `did:webvh` DID
-> log only — it does not sign the asset's own provenance events. A single
-> `signBytes`-based signer interface accepted everywhere is in progress
-> ([plan 033](https://github.com/onionoriginals/sdk/blob/main/plans/033-sdk-v3-roadmap.md)).
-> Credentials already work with remote custody: `signCredentialWithExternalSigner`
-> requires `ExternalSigner.signBytes` and the SDK owns canonicalization.
+### Remote custody (Turnkey, KMS, HSM, passkeys)
+
+Custody that never exports a key implements `OriginalsSigner` — three members, no key export:
+
+```typescript
+import { OriginalsSigner, assertSignerConformance } from '@originals/sdk';
+
+const signer: OriginalsSigner = {
+  verificationMethodId: 'did:key:z6Mk…#z6Mk…', // absolute VM id
+  publicKeyMultibase: 'z6Mk…',                  // lets the SDK pick the suite + self-verify
+  signBytes: (bytes) => myCustody.sign(bytes),  // sign EXACTLY these bytes
+};
+await assertSignerConformance(signer);          // run this in your test suite
+
+const sdk = OriginalsSDK.create({ network: 'mainnet', defaultKeyType: 'Ed25519', signer });
+const asset = await sdk.lifecycle.createAsset(resources);        // genesis signed remotely
+await sdk.lifecycle.publishToWeb(asset, 'example.com');          // migrate event signed remotely
+```
+
+The SDK canonicalizes and hashes (`signingInput.celEvent/witness/didWebvh/credential`); the signer only ever signs opaque bytes. A `signer` is accepted on the config (default authorship signer) and per call on `createAsset`, `publishToWeb`, `inscribeOnBitcoin`, `rotateBtcoKeys`, `authorizeSigner`, and `addResourceVersion`. Adapters bridge the legacy shapes: `signerFromKeyPair`, `signerFromKeyStore`, `signerFromExternalSigner`, `toCelSigner`, `toExternalSigner`. CEL authorship is Ed25519-only.
 
 ## Documentation
 
@@ -93,7 +105,7 @@ A `keyStore` is `{ getPrivateKey(vmId), setPrivateKey(vmId, key) }` — it must 
 - **Signed provenance** — every authorship operation appends a hash-chained CEL event, verified end-to-end by `asset.verify()`
 - **Verifiable credentials** — W3C Data Integrity proofs (EdDSA and BBS+ cryptosuites), Multikey encoding
 - **Bitcoin Ordinals** — commit/reveal inscriptions with ordinal-aware UTXO selection (`sdk.bitcoin`)
-- **External signers** — Turnkey, AWS KMS and HSMs can issue **credentials** via `ExternalSigner.signBytes`, and authorize `did:webvh` logs; authorship custody is `keyStore`-only for now (see [Custody](#custody-configure-it-before-you-mint))
+- **Remote custody** — Turnkey, AWS KMS, HSMs and passkeys author assets, sign credentials, and authorize `did:webvh` logs through the sign-bytes-only `OriginalsSigner` interface (see [Custody](#custody-configure-it-before-you-mint)); `assertSignerConformance` validates any implementation
 - **Pluggable storage and providers** — bring your own storage adapter, ordinals backend, and fee oracle
 
 ## License

--- a/packages/sdk/src/cel/layers/PeerCelManager.ts
+++ b/packages/sdk/src/cel/layers/PeerCelManager.ts
@@ -71,6 +71,11 @@ export interface PeerAssetData {
 
 /**
  * Signer function type that produces a DataIntegrityProof
+ *
+ * @deprecated Implement {@link OriginalsSigner} instead (plan 039) — a
+ * CelSigner both canonicalizes and signs, so an incorrect implementation
+ * seals proofs that can never verify. Bridge with `toCelSigner(signer)`.
+ * Removal from the public API is planned for 3.0 (plan 041).
  */
 export type CelSigner = (data: unknown) => Promise<DataIntegrityProof>;
 

--- a/packages/sdk/src/cel/signerAdapter.ts
+++ b/packages/sdk/src/cel/signerAdapter.ts
@@ -5,7 +5,7 @@
  */
 import { ed25519 } from '@noble/curves/ed25519.js';
 import { multikey } from '../crypto/Multikey.js';
-import { canonicalizeEvent } from './canonicalize.js';
+import { signingInput } from '../crypto/signingInput.js';
 import { StructuredError } from '../utils/telemetry.js';
 import { multibase } from '../utils/encoding.js';
 import type { KeyStore } from '../types/common.js';
@@ -26,7 +26,10 @@ function assertEd25519(privateKeyMultibase: string): Uint8Array {
 
 function buildProof(secret: Uint8Array, verificationMethod: string, data: unknown): DataIntegrityProof {
   // @noble/curves' ed25519.sign is synchronous (unlike @noble/ed25519's signAsync).
-  const sig = ed25519.sign(canonicalizeEvent(data), secret);
+  const sig = ed25519.sign(
+    signingInput.celEvent(data as { type: unknown; data?: unknown; previousEvent?: unknown }),
+    secret
+  );
   return {
     type: 'DataIntegrityProof',
     cryptosuite: 'eddsa-jcs-2022',

--- a/packages/sdk/src/crypto/MockRemoteSigner.ts
+++ b/packages/sdk/src/crypto/MockRemoteSigner.ts
@@ -1,0 +1,35 @@
+/**
+ * In-repo model of a NON-EXPORTING custody backend (plan 040): implements ONLY
+ * `signBytes`. No key export, no document-level `sign()` — if an SDK path needs
+ * anything beyond sign-bytes, tests running under this signer fail, which is
+ * the point. Every documented end-to-end flow has a test that runs under it.
+ */
+
+import { ed25519 } from '@noble/curves/ed25519.js';
+import { multikey } from './Multikey.js';
+import { canonicalDidKeyVm, type OriginalsSigner } from './OriginalsSigner.js';
+
+export class MockRemoteSigner implements OriginalsSigner {
+  readonly verificationMethodId: string;
+  readonly publicKeyMultibase: string;
+  /** Number of signBytes calls served — lets tests assert the SDK actually signed remotely. */
+  signBytesCalls = 0;
+  // Held privately, like an HSM: nothing on this class can ever surface it.
+  #secretKey: Uint8Array;
+
+  constructor() {
+    this.#secretKey = ed25519.utils.randomSecretKey();
+    this.publicKeyMultibase = multikey.encodePublicKey(ed25519.getPublicKey(this.#secretKey), 'Ed25519');
+    this.verificationMethodId = canonicalDidKeyVm(this.publicKeyMultibase);
+  }
+
+  async signBytes(bytes: Uint8Array): Promise<Uint8Array> {
+    if (!(bytes instanceof Uint8Array)) {
+      throw new TypeError('MockRemoteSigner.signBytes expects Uint8Array bytes');
+    }
+    this.signBytesCalls++;
+    // Yield a microtask so callers cannot depend on synchronous completion.
+    await Promise.resolve();
+    return ed25519.sign(bytes, this.#secretKey);
+  }
+}

--- a/packages/sdk/src/crypto/OriginalsSigner.ts
+++ b/packages/sdk/src/crypto/OriginalsSigner.ts
@@ -1,0 +1,190 @@
+/**
+ * The one root signer interface (plan 039). The smallest capability a custody
+ * backend (Turnkey, KMS, HSM, MPC, passkey) can implement: sign opaque bytes.
+ * The SDK owns canonicalization and hashing (see `signingInput`); the signer
+ * owns the key and nothing else.
+ */
+
+import { ed25519 } from '@noble/curves/ed25519.js';
+import { multikey } from './Multikey.js';
+import { signerForKeyType } from './Signer.js';
+import { signingInput } from './signingInput.js';
+import { StructuredError } from '../utils/telemetry.js';
+import type { KeyStore, ExternalSigner } from '../types/common.js';
+import type { KeyPair } from '../types/bitcoin.js';
+import type { DataIntegrityProof } from '../cel/types.js';
+import type { CelSigner } from '../cel/layers/PeerCelManager.js';
+
+export interface OriginalsSigner {
+  /** Absolute verification method id, e.g. "did:key:z6Mk…#z6Mk…". */
+  readonly verificationMethodId: string;
+  /** Multikey-encoded public key — lets the SDK pick the suite and self-verify offline. */
+  readonly publicKeyMultibase: string;
+  /** Sign exactly these bytes. The SDK owns canonicalization; the signer owns the key. */
+  signBytes(bytes: Uint8Array): Promise<Uint8Array>;
+}
+
+/**
+ * The canonical `did:key` verification method for a Multikey public key —
+ * the identity CEL authorship uses regardless of the signer's ambient
+ * `verificationMethodId` (CEL verification is offline did:key-only).
+ */
+export function canonicalDidKeyVm(publicKeyMultibase: string): string {
+  return `did:key:${publicKeyMultibase}#${publicKeyMultibase}`;
+}
+
+/** Derive a Multikey public key from a `did:key` VM id; null for other methods. */
+function publicKeyFromDidKeyVm(vmId: string): string | null {
+  if (!vmId.startsWith('did:key:')) return null;
+  const mk = vmId.slice('did:key:'.length).split('#')[0];
+  return mk.startsWith('z') ? mk : null;
+}
+
+/**
+ * Wraps a raw multibase key pair as an {@link OriginalsSigner} under its
+ * canonical `did:key` identity. Supports every Multikey type; the signature
+ * scheme is the one `signerForKeyType` pins to the key's multicodec header.
+ */
+export function signerFromKeyPair(keyPair: KeyPair): OriginalsSigner {
+  const pub = multikey.decodePublicKey(keyPair.publicKey);
+  const priv = multikey.decodePrivateKey(keyPair.privateKey);
+  if (priv.type !== pub.type) {
+    throw new StructuredError('INVALID_KEY_PAIR',
+      `Key pair type mismatch: private key is ${priv.type}, public key is ${pub.type}.`);
+  }
+  // Ed25519 pairs are cheap to derive-check; a mismatched pair must fail here,
+  // not as an unverifiable proof later.
+  if (pub.type === 'Ed25519') {
+    const derived = multikey.encodePublicKey(ed25519.getPublicKey(priv.key), 'Ed25519');
+    if (derived !== keyPair.publicKey) {
+      throw new StructuredError('INVALID_KEY_PAIR',
+        'The supplied private key does not derive the supplied public key.');
+    }
+  }
+  const signer = signerForKeyType(pub.type);
+  return {
+    verificationMethodId: canonicalDidKeyVm(keyPair.publicKey),
+    publicKeyMultibase: keyPair.publicKey,
+    async signBytes(bytes: Uint8Array): Promise<Uint8Array> {
+      return new Uint8Array(await signer.sign(Buffer.from(bytes), keyPair.privateKey));
+    },
+  };
+}
+
+/**
+ * Wraps a {@link KeyStore} entry as an {@link OriginalsSigner}. The private key
+ * is looked up lazily on EVERY sign (matching `createKeyStoreCelSigner`):
+ * rotation-fresh, and key absence fails at sign time, not construction time.
+ *
+ * The public key is taken from `publicKeyMultibase` when given, else derived
+ * from a `did:key` VM id — for any other DID method it must be supplied.
+ */
+export function signerFromKeyStore(
+  keyStore: KeyStore,
+  verificationMethodId: string,
+  opts?: { publicKeyMultibase?: string }
+): OriginalsSigner {
+  const pub = opts?.publicKeyMultibase ?? publicKeyFromDidKeyVm(verificationMethodId);
+  if (!pub) {
+    throw new StructuredError('SIGNER_PUBLIC_KEY_REQUIRED',
+      `Cannot derive a public key from ${verificationMethodId}; pass opts.publicKeyMultibase.`);
+  }
+  const pubType = multikey.decodePublicKey(pub).type;
+  return {
+    verificationMethodId,
+    publicKeyMultibase: pub,
+    async signBytes(bytes: Uint8Array): Promise<Uint8Array> {
+      const priv = await keyStore.getPrivateKey(verificationMethodId);
+      if (!priv) {
+        throw new StructuredError('SIGNING_KEY_NOT_FOUND',
+          `No private key in keyStore for ${verificationMethodId}`);
+      }
+      return new Uint8Array(await signerForKeyType(pubType).sign(Buffer.from(bytes), priv));
+    },
+  };
+}
+
+/**
+ * Adapts a legacy {@link ExternalSigner} to {@link OriginalsSigner}. Requires
+ * the byte-level `signBytes` capability — a document-level `sign()`-only signer
+ * chooses its own canonicalization, which is exactly the layering mistake this
+ * interface removes, so it throws loudly instead of adapting wrong.
+ */
+export function signerFromExternalSigner(
+  s: ExternalSigner,
+  opts?: { publicKeyMultibase?: string }
+): OriginalsSigner {
+  if (typeof s.signBytes !== 'function') {
+    throw new StructuredError('EXTERNAL_SIGNER_SIGNBYTES_REQUIRED',
+      'ExternalSigner must implement signBytes(data) to be adapted to OriginalsSigner; ' +
+      'a document-level sign()-only signer canonicalizes for itself and cannot sign SDK-owned preimages.');
+  }
+  const vmId = s.getVerificationMethodId();
+  const pub = opts?.publicKeyMultibase ?? publicKeyFromDidKeyVm(vmId);
+  if (!pub) {
+    throw new StructuredError('SIGNER_PUBLIC_KEY_REQUIRED',
+      `Cannot derive a public key from ${vmId}; pass opts.publicKeyMultibase.`);
+  }
+  return {
+    verificationMethodId: vmId,
+    publicKeyMultibase: pub,
+    async signBytes(bytes: Uint8Array): Promise<Uint8Array> {
+      const result = await s.signBytes!(bytes);
+      const signature = result?.signature;
+      if (!(signature instanceof Uint8Array)) {
+        throw new StructuredError('EXTERNAL_SIGNER_INVALID_RESULT',
+          `ExternalSigner.signBytes for ${vmId} must return { signature: Uint8Array }.`);
+      }
+      return signature;
+    },
+  };
+}
+
+/**
+ * Legacy bridge: an {@link OriginalsSigner} as a CEL signer. Ed25519-only (CEL
+ * is Ed25519 end-to-end — anything else throws). Proofs are stamped with the
+ * canonical `did:key` VM derived from the signer's public key, NOT its ambient
+ * `verificationMethodId`: CEL verification is offline did:key-only, and this is
+ * what `celSignerFromKeyPair` has always done.
+ */
+export function toCelSigner(s: OriginalsSigner): CelSigner {
+  const decoded = multikey.decodePublicKey(s.publicKeyMultibase);
+  if (decoded.type !== 'Ed25519') {
+    throw new StructuredError('CEL_ED25519_REQUIRED',
+      `CEL events must be signed with Ed25519; got ${decoded.type}. Use a dedicated Ed25519 signer.`);
+  }
+  const verificationMethod = canonicalDidKeyVm(s.publicKeyMultibase);
+  return async (data: unknown): Promise<DataIntegrityProof> => {
+    const sig = await s.signBytes(
+      signingInput.celEvent(data as { type: unknown; data?: unknown; previousEvent?: unknown })
+    );
+    return {
+      type: 'DataIntegrityProof',
+      cryptosuite: 'eddsa-jcs-2022',
+      created: new Date().toISOString(),
+      verificationMethod,
+      proofPurpose: 'assertionMethod',
+      proofValue: multikey.encodeMultibase(sig),
+    };
+  };
+}
+
+/**
+ * Legacy bridge: an {@link OriginalsSigner} as a didwebvh-compatible
+ * {@link ExternalSigner}. Correct by construction — its `sign()` is exactly
+ * `signingInput.didWebvh` + `signBytes`, so it can never sign the wrong bytes.
+ */
+export function toExternalSigner(s: OriginalsSigner): ExternalSigner {
+  return {
+    async sign(input: { document: Record<string, unknown>; proof: Record<string, unknown> }) {
+      const bytes = await signingInput.didWebvh(input.document, input.proof);
+      return { proofValue: multikey.encodeMultibase(await s.signBytes(bytes)) };
+    },
+    async signBytes(data: Uint8Array) {
+      return { signature: await s.signBytes(data) };
+    },
+    getVerificationMethodId(): string {
+      return s.verificationMethodId;
+    },
+  };
+}

--- a/packages/sdk/src/crypto/addressToMultikey.ts
+++ b/packages/sdk/src/crypto/addressToMultikey.ts
@@ -1,0 +1,64 @@
+/**
+ * Converting a base58 raw-Ed25519-key address into a Multikey (plan 045).
+ *
+ * Custody backends commonly hand back an *address*, not a Multikey. Turnkey's
+ * Ed25519 accounts use `ADDRESS_FORMAT_SOLANA`, whose address is plain base58
+ * of the raw 32-byte public key — no multicodec header and no multibase `z`
+ * prefix. Building `did:key:${address}` from it therefore produces an
+ * identifier that is not a valid did:key at all: the raw key's base58 usually
+ * starts with a non-`z` character, and `parseDidKeyVerificationMethod` throws
+ * on it.
+ *
+ * Consumers keep re-deriving this by hand and getting it wrong, so it lives
+ * here rather than in an integration package.
+ */
+
+import { base58 } from '@scure/base';
+import { multikey } from './Multikey.js';
+import { StructuredError } from '../utils/telemetry.js';
+
+/**
+ * Decodes a base58 raw Ed25519 public-key address (Solana address format) and
+ * re-encodes it as a Multikey.
+ *
+ * @param address - base58 of the raw 32-byte Ed25519 public key
+ * @returns the `z…` Multikey form, suitable for `did:key:` and DID documents
+ * @throws StructuredError `INVALID_ADDRESS` if it is not base58 of 32 bytes
+ *
+ * @example
+ * ```typescript
+ * const mk = base58AddressToEd25519Multikey(account.address);
+ * const did = `did:key:${mk}`;                 // a REAL did:key
+ * ```
+ */
+export function base58AddressToEd25519Multikey(address: string): string {
+  if (typeof address !== 'string' || address.length === 0) {
+    throw new StructuredError('INVALID_ADDRESS', 'Address must be a non-empty base58 string.');
+  }
+  // A multibase Multikey was passed instead of an address — accept it as-is so
+  // callers can hand through whichever form they hold.
+  if (address.startsWith('z')) {
+    try {
+      const decoded = multikey.decodePublicKey(address);
+      if (decoded.type === 'Ed25519') return address;
+    } catch {
+      // Not a Multikey after all; fall through and treat it as an address.
+    }
+  }
+
+  let raw: Uint8Array;
+  try {
+    raw = base58.decode(address);
+  } catch {
+    throw new StructuredError('INVALID_ADDRESS', `Address is not valid base58: ${address}`);
+  }
+  if (raw.length !== 32) {
+    throw new StructuredError(
+      'INVALID_ADDRESS',
+      `Expected a raw 32-byte Ed25519 public key, got ${raw.length} bytes. ` +
+      `An ADDRESS_FORMAT_SOLANA address is base58 of the raw key — not a Multikey, ` +
+      `and not a secp256k1 or Bitcoin address.`
+    );
+  }
+  return multikey.encodePublicKey(raw, 'Ed25519');
+}

--- a/packages/sdk/src/crypto/signerConformance.ts
+++ b/packages/sdk/src/crypto/signerConformance.ts
@@ -1,0 +1,89 @@
+/**
+ * Published conformance harness for {@link OriginalsSigner} implementations
+ * (plan 040). Any custody backend (Turnkey, KMS, HSM, MPC, passkey) can run
+ * this against its signer before wiring it into the SDK; every check failure
+ * throws a `SIGNER_NONCONFORMANT` StructuredError naming the exact violation.
+ */
+
+import { multikey, type MultikeyType } from './Multikey.js';
+import { signerForKeyType } from './Signer.js';
+import { StructuredError } from '../utils/telemetry.js';
+import type { OriginalsSigner } from './OriginalsSigner.js';
+
+// Ed25519/Bls signatures have fixed lengths; ECDSA compact signatures are 64.
+const EXPECTED_SIG_LENGTHS: Record<string, number> = {
+  Ed25519: 64,
+  Secp256k1: 64,
+  P256: 64,
+  Bls12381G2: 48,
+};
+
+function fail(reason: string): never {
+  throw new StructuredError('SIGNER_NONCONFORMANT', `Signer conformance failed: ${reason}`);
+}
+
+/**
+ * Asserts that `signer` upholds the OriginalsSigner contract:
+ *
+ * 1. `verificationMethodId` is an ABSOLUTE VM id (`did:…#fragment`).
+ * 2. `publicKeyMultibase` decodes as a Multikey public key.
+ * 3. `signBytes` returns a `Uint8Array` of the expected length for the key type.
+ * 4. The signature VERIFIES against `publicKeyMultibase` under the key type's
+ *    signature scheme — the signer signs the bytes it was given, with the key
+ *    it claims.
+ * 5. Signatures are message-bound: a signature over one message must not
+ *    verify another (catches fixed-output and input-ignoring signers).
+ *
+ * @throws StructuredError `SIGNER_NONCONFORMANT` naming the failed check.
+ */
+export async function assertSignerConformance(signer: OriginalsSigner): Promise<void> {
+  // 1 — absolute VM id
+  const vm = signer.verificationMethodId;
+  if (typeof vm !== 'string' || !vm.startsWith('did:')) {
+    fail(`verificationMethodId must be a DID URL string, got ${JSON.stringify(vm)}`);
+  }
+  const hashIdx = vm.indexOf('#');
+  if (hashIdx <= 0 || hashIdx === vm.length - 1) {
+    fail(`verificationMethodId must be absolute ("did:…#fragment"), got "${vm}"`);
+  }
+
+  // 2 — decodable public key
+  let keyType: MultikeyType;
+  try {
+    keyType = multikey.decodePublicKey(signer.publicKeyMultibase).type;
+  } catch (e) {
+    fail(`publicKeyMultibase does not decode as a Multikey public key: ${(e as Error).message}`);
+  }
+
+  // 3 — signBytes shape
+  const message1 = new TextEncoder().encode('originals-signer-conformance-probe-1');
+  const message2 = new TextEncoder().encode('originals-signer-conformance-probe-2');
+  let sig1: Uint8Array;
+  try {
+    sig1 = await signer.signBytes(message1);
+  } catch (e) {
+    fail(`signBytes threw: ${(e as Error).message}`);
+  }
+  if (!(sig1 instanceof Uint8Array)) {
+    fail(`signBytes must return a Uint8Array, got ${typeof sig1}`);
+  }
+  const expectedLen = EXPECTED_SIG_LENGTHS[keyType];
+  if (expectedLen !== undefined && sig1.length !== expectedLen) {
+    fail(`signBytes returned ${sig1.length} bytes; ${keyType} signatures are ${expectedLen} bytes`);
+  }
+
+  // 4 — signature verifies against the claimed public key
+  const verifier = signerForKeyType(keyType);
+  if (!(await verifier.verify(Buffer.from(message1), Buffer.from(sig1), signer.publicKeyMultibase))) {
+    fail(
+      'the signature does not verify against publicKeyMultibase. The signer must sign EXACTLY ' +
+      'the bytes it is given (no extra hashing or canonicalization) with the key it claims.'
+    );
+  }
+
+  // 5 — message-bound signatures
+  const sig2 = await signer.signBytes(message2);
+  if (await verifier.verify(Buffer.from(message1), Buffer.from(sig2), signer.publicKeyMultibase)) {
+    fail('a signature over one message verified a different message — the signer is ignoring its input');
+  }
+}

--- a/packages/sdk/src/crypto/signingInput.ts
+++ b/packages/sdk/src/crypto/signingInput.ts
@@ -1,0 +1,80 @@
+/**
+ * The four signing preimages of this SDK, consolidated (plan 039).
+ *
+ * Invariant: the SDK canonicalizes and hashes; a signer only ever signs the
+ * opaque bytes these functions return. Every internal signing path routes
+ * through here, so "which bytes do I sign?" has exactly one answer per context
+ * and the four constructions cannot drift apart again.
+ *
+ * Heavy dependencies (jsonld, didwebvh-ts) are loaded lazily so this module is
+ * safe to import from the browser-slim entry points.
+ */
+
+import { canonicalizeEntryForChain, witnessSigningBytes } from '../cel/canonicalize.js';
+import { sha256Bytes } from '../utils/hash.js';
+import { StructuredError } from '../utils/telemetry.js';
+
+/** Minimal documentLoader shape (same contract the VC stack uses). */
+export type SigningDocumentLoader = (url: string) => Promise<{ document: unknown }>;
+
+function concat(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const out = new Uint8Array(a.length + b.length);
+  out.set(a, 0);
+  out.set(b, a.length);
+  return out;
+}
+
+export const signingInput = {
+  /**
+   * CEL controller-proof preimage: JCS bytes of the committed fields
+   * `{ type, data, previousEvent? }` — exactly what `verifyEventLog`
+   * reconstructs and verifies. Stray keys are never signed.
+   */
+  celEvent(entry: { type: unknown; data?: unknown; previousEvent?: unknown }): Uint8Array {
+    return canonicalizeEntryForChain(entry as { type: unknown; data: unknown; previousEvent?: unknown });
+  },
+
+  /**
+   * CEL witness-attestation preimage: UTF-8 bytes of the JSON-quoted digest
+   * (surrounding quotes INCLUDED). See `witnessSigningBytes` for why signing
+   * the raw digest bytes instead silently never verifies.
+   */
+  witness(digestMultibase: string): Uint8Array {
+    return witnessSigningBytes(digestMultibase);
+  },
+
+  /**
+   * did:webvh log-entry preimage, exactly didwebvh-ts's construction:
+   * sha256(JCS(proof)) || sha256(JCS(document)). Delegates to the library so
+   * the SDK and didwebvh-ts can never disagree on the bytes.
+   */
+  async didWebvh(document: Record<string, unknown>, proof: Record<string, unknown>): Promise<Uint8Array> {
+    const mod = await import('didwebvh-ts') as {
+      prepareDataForSigning?: (document: unknown, proof: unknown) => Promise<Uint8Array>;
+    };
+    if (typeof mod.prepareDataForSigning !== 'function') {
+      throw new StructuredError('DIDWEBVH_UNAVAILABLE', 'didwebvh-ts does not export prepareDataForSigning');
+    }
+    return mod.prepareDataForSigning(document, proof);
+  },
+
+  /**
+   * eddsa-rdfc-2022 credential preimage: sha256(RDFC(proofConfig)) ||
+   * sha256(RDFC(document)). `proofValue`/`jws` are stripped from the config
+   * before canonicalization, and a `proof` on the document is ignored, so the
+   * same call serves both the signing and the verification side.
+   */
+  async credential(
+    document: Record<string, unknown>,
+    proofConfig: Record<string, unknown>,
+    { documentLoader }: { documentLoader: SigningDocumentLoader }
+  ): Promise<Uint8Array> {
+    // jsonld is heavy and node-leaning; load it only when a credential is signed.
+    const { canonize, canonizeProof } = await import('../vc/utils/jsonld.js');
+    const unsigned: Record<string, unknown> = { ...document };
+    delete unsigned.proof;
+    const transformed = await canonize(unsigned, { documentLoader });
+    const canonicalProofConfig = await canonizeProof(proofConfig, { documentLoader });
+    return concat(await sha256Bytes(canonicalProofConfig), await sha256Bytes(transformed));
+  },
+};

--- a/packages/sdk/src/did/WebVHManager.ts
+++ b/packages/sdk/src/did/WebVHManager.ts
@@ -1,5 +1,6 @@
 import { KeyManager } from './KeyManager.js';
 import { multikey } from '../crypto/Multikey.js';
+import { signingInput } from '../crypto/signingInput.js';
 import { Ed25519Signer } from '../crypto/Signer.js';
 import { DIDDocument, KeyPair, ExternalSigner, ExternalVerifier, VerificationMethod as DidDocVerificationMethod } from '../types/index.js';
 import { StructuredError } from '../utils/telemetry.js';
@@ -131,24 +132,21 @@ class OriginalsWebVHSigner implements Signer, Verifier {
   private signer: Ed25519Signer;
   protected verificationMethod?: VerificationMethod | null;
   protected useStaticId: boolean;
-  private prepareDataForSigning: (document: Record<string, unknown>, proof: Record<string, unknown>) => Promise<Uint8Array>;
 
   constructor(
     privateKeyMultibase: string,
     verificationMethod: VerificationMethod,
-    prepareDataForSigning: (document: Record<string, unknown>, proof: Record<string, unknown>) => Promise<Uint8Array>,
     options: SignerOptions = {}
   ) {
     this.privateKeyMultibase = privateKeyMultibase;
     this.verificationMethod = options.verificationMethod || verificationMethod;
     this.useStaticId = options.useStaticId || false;
     this.signer = new Ed25519Signer();
-    this.prepareDataForSigning = prepareDataForSigning;
   }
 
   async sign(input: SigningInput): Promise<SigningOutput> {
-    // Prepare the data for signing using didwebvh-ts's canonical approach
-    const dataToSign = await this.prepareDataForSigning(input.document, input.proof);
+    // The SDK's single did:webvh preimage (plan 039) — delegates to didwebvh-ts.
+    const dataToSign = await signingInput.didWebvh(input.document, input.proof);
     
     // Sign using our Ed25519 signer
     const signature: Buffer = await this.signer.sign(
@@ -450,7 +448,6 @@ export class WebVHManager {
       const internalSigner = new OriginalsWebVHSigner(
         keyPair.privateKey,
         verificationMethods[0],
-        prepareDataForSigning,
         { verificationMethod: verificationMethods[0] }
       );
 
@@ -727,7 +724,7 @@ export class WebVHManager {
         proof: Record<string, unknown>
       ) => Promise<Uint8Array>;
     };
-    const { updateDID, prepareDataForSigning } = mod;
+    const { updateDID } = mod;
 
     if (typeof updateDID !== 'function') {
       throw new Error('Failed to load didwebvh-ts: invalid module exports');
@@ -752,7 +749,6 @@ export class WebVHManager {
       const internalSigner = new OriginalsWebVHSigner(
         keyPair.privateKey,
         verificationMethod,
-        prepareDataForSigning,
         { verificationMethod }
       );
       
@@ -1184,7 +1180,7 @@ export class WebVHManager {
         proof: Record<string, unknown>
       ) => Promise<Uint8Array>;
     };
-    const { updateDID, prepareDataForSigning } = mod;
+    const { updateDID } = mod;
     if (typeof updateDID !== 'function') {
       throw new Error('Failed to load didwebvh-ts: invalid module exports');
     }
@@ -1202,7 +1198,6 @@ export class WebVHManager {
     const signer = new OriginalsWebVHSigner(
       currentKeyPair.privateKey,
       currentVerificationMethod,
-      prepareDataForSigning,
       { verificationMethod: currentVerificationMethod }
     );
 
@@ -1260,7 +1255,7 @@ export class WebVHManager {
         proof: Record<string, unknown>
       ) => Promise<Uint8Array>;
     };
-    const { updateDID, prepareDataForSigning } = mod;
+    const { updateDID } = mod;
     if (typeof updateDID !== 'function') {
       throw new Error('Failed to load didwebvh-ts: invalid module exports');
     }
@@ -1300,7 +1295,6 @@ export class WebVHManager {
     const signer = new OriginalsWebVHSigner(
       activeKeyPair.privateKey,
       activeVerificationMethod,
-      prepareDataForSigning,
       { verificationMethod: activeVerificationMethod }
     );
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -54,7 +54,9 @@ export {
   type MigrationValidation,
   type LifecycleProgress,
   type ProgressCallback,
-  type LifecycleOperationOptions
+  type LifecycleOperationOptions,
+  type CreateAssetOptions,
+  type InscribeOnBitcoinOptions
 } from './lifecycle/LifecycleManager.js';
 export { BitcoinManager } from './bitcoin/BitcoinManager.js';
 export { OrdinalsClient } from './bitcoin/OrdinalsClient.js';
@@ -93,6 +95,21 @@ export { MIME_TYPE_MAP, DEFAULT_RESOURCE_CONFIG } from './resources/index.js';
 export { Signer, ES256KSigner, Ed25519Signer, ES256Signer, Bls12381G2Signer } from './crypto/Signer.js';
 export { multikey } from './crypto/Multikey.js';
 export type { MultikeyType } from './crypto/Multikey.js';
+
+// Signer abstraction (plan 039): one root interface, one signing-input
+// namespace, adapters in both directions, and the conformance harness (040).
+export type { OriginalsSigner } from './crypto/OriginalsSigner.js';
+export {
+  canonicalDidKeyVm,
+  signerFromKeyPair,
+  signerFromKeyStore,
+  signerFromExternalSigner,
+  toCelSigner,
+  toExternalSigner,
+} from './crypto/OriginalsSigner.js';
+export { signingInput, type SigningDocumentLoader } from './crypto/signingInput.js';
+export { assertSignerConformance } from './crypto/signerConformance.js';
+export { MockRemoteSigner } from './crypto/MockRemoteSigner.js';
 
 // Event system exports
 export * from './events/index.js';

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -110,6 +110,8 @@ export {
 export { signingInput, type SigningDocumentLoader } from './crypto/signingInput.js';
 export { assertSignerConformance } from './crypto/signerConformance.js';
 export { MockRemoteSigner } from './crypto/MockRemoteSigner.js';
+// Custody backends hand back addresses, not Multikeys (plan 045).
+export { base58AddressToEd25519Multikey } from './crypto/addressToMultikey.js';
 
 // Event system exports
 export * from './events/index.js';

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -413,9 +413,12 @@ export class LifecycleManager {
     const asset = new OriginalsAsset(resources, didDoc, [], log);
     // Bind the controller append path so addResourceVersion can write signed
     // `update` events with the same degrade contract as the other authorship
-    // ops. The signer that minted the asset stays its default authorship signer.
+    // ops. The minting signer is deliberately NOT retained: an asset holding a
+    // live reference to a signer passed once is hidden state that outlives the
+    // call, and a session-backed signer (a Turnkey browser session, say) goes
+    // stale inside it. Later appends take a signer per call, or `config.signer`.
     asset._bindCelAppender((type, data, opts) =>
-      this.appendCelEventAndMaybeInscribe(asset, type, data, { ...opts, signer: opts?.signer ?? suppliedSigner }));
+      this.appendCelEventAndMaybeInscribe(asset, type, data, opts));
 
     // Persist the genesis CEL at the conventional cel/<suffix>.json key so
     // the did:cel resolves from storage immediately (best-effort, never gates).

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -13,7 +13,7 @@ import {
 } from '../types/index.js';
 import { BitcoinManager, MAX_REASONABLE_FEE_RATE } from '../bitcoin/BitcoinManager.js';
 import { inscribeOnSat } from '../bitcoin/inscribe-on-sat.js';
-import type { Utxo } from '../types/bitcoin.js';
+import type { Utxo, KeyPair } from '../types/bitcoin.js';
 import type { BitcoinSigner } from '../types/common.js';
 import { DIDManager } from '../did/DIDManager.js';
 import type { CredentialManager } from '../vc/CredentialManager.js';
@@ -32,6 +32,8 @@ import { parseSatoshiIdentifier, validateSatoshiNumber } from '../utils/satoshi-
 import { btcoDidPrefix, btcoDidFromSatoshi } from '../cel/btcoDid.js';
 import { KeyManager } from '../did/KeyManager.js';
 import { celSignerFromKeyPair, hexSha256ToDigestMultibase, createKeyStoreCelSigner, currentControllerVm } from '../cel/signerAdapter.js';
+import { toCelSigner, canonicalDidKeyVm, type OriginalsSigner } from '../crypto/OriginalsSigner.js';
+import type { CelSigner } from '../cel/layers/PeerCelManager.js';
 import { createCelDidDocument, didCelMatchesLog, deriveDidCel, DID_CEL_PREFIX } from '../cel/celDid.js';
 import { verifyEventLog } from '../cel/algorithms/verifyEventLog.js';
 import { createDidManagerKeyResolver } from '../cel/keyResolver.js';
@@ -156,6 +158,18 @@ export interface InscribeOnBitcoinOptions {
   satSigner?: BitcoinSigner;
   /** Change/reveal destination address. Required alongside fundingUtxo. */
   changeAddress?: string;
+  /** Signs the asset's CEL `migrate` event (remote custody, plan 039). */
+  signer?: OriginalsSigner;
+}
+
+/**
+ * Options for `createAsset` (plan 039). With a `signer`, the asset's genesis is
+ * signed by that (possibly remote) key: no controller key is generated, nothing
+ * is written to the keyStore, and `key:unpersisted` is never emitted.
+ */
+export interface CreateAssetOptions {
+  /** Authorship signer for the genesis `create` event (overrides `config.signer`). */
+  signer?: OriginalsSigner;
 }
 
 /**
@@ -177,6 +191,8 @@ export interface LifecycleOperationOptions {
    * are irreversible by nature and are NOT affected by this flag.
    */
   atomicRollback?: boolean;
+  /** Signs the asset's CEL `migrate` event (remote custody, plan 039). */
+  signer?: OriginalsSigner;
 }
 
 /**
@@ -290,7 +306,7 @@ export class LifecycleManager {
     await this.keyStore.setPrivateKey(verificationMethodId, privateKey);
   }
 
-  async createAsset(resources: AssetResource[]): Promise<OriginalsAsset> {
+  async createAsset(resources: AssetResource[], options?: CreateAssetOptions): Promise<OriginalsAsset> {
     const stopTimer = this.logger.startTimer('createAsset');
     const metricsStart = performance.now();
     this.logger.info('Creating asset', { resourceCount: resources.length });
@@ -335,10 +351,24 @@ export class LifecycleManager {
     
     // Mint the asset's genesis identity as a did:cel derived from a signed CEL
     // create event. The controller key is ALWAYS Ed25519 (CEL is Ed25519-only),
-    // independent of config.defaultKeyType. LifecycleManager holds no KeyManager;
-    // KeyManager is stateless, so we instantiate one locally.
-    const controllerKp = await new KeyManager().generateKeyPair('Ed25519');
-    const { signer, verificationMethod } = celSignerFromKeyPair(controllerKp);
+    // independent of config.defaultKeyType. With a supplied OriginalsSigner
+    // (per-call or config) the controller IS that signer's key — no key is
+    // generated, nothing touches the keyStore, key:unpersisted never fires.
+    const suppliedSigner = options?.signer ?? this.config.signer;
+    let signer: CelSigner;
+    let verificationMethod: string;
+    let controllerPublicKey: string;
+    let controllerKp: KeyPair | undefined;
+    if (suppliedSigner) {
+      signer = toCelSigner(suppliedSigner); // throws CEL_ED25519_REQUIRED for non-Ed25519 keys
+      verificationMethod = canonicalDidKeyVm(suppliedSigner.publicKeyMultibase);
+      controllerPublicKey = suppliedSigner.publicKeyMultibase;
+    } else {
+      // KeyManager is stateless, so we instantiate one locally.
+      controllerKp = await new KeyManager().generateKeyPair('Ed25519');
+      ({ signer, verificationMethod } = celSignerFromKeyPair(controllerKp));
+      controllerPublicKey = controllerKp.publicKey;
+    }
 
     // Bridge AssetResource hashes (hex sha256) to CEL ExternalReferences. The
     // resource id is bound into the genesis reference (#401) so the verifier can
@@ -355,15 +385,17 @@ export class LifecycleManager {
     const manager = new PeerCelManager(signer, { verificationMethod });
     const { log, did } = await manager.create(resources[0]?.id ?? 'asset', externalRefs);
 
-    const didDoc = createCelDidDocument(did, controllerKp.publicKey);
+    const didDoc = createCelDidDocument(did, controllerPublicKey);
 
-    // Register the controller key under BOTH the did:key VM (CEL signing) and
-    // `${did}#key-0` (so signWithKeyStore's `${issuer}#key-0` probe resolves).
+    // Locally generated controller key only (a supplied signer's key lives in
+    // its own custody — nothing to persist, nothing to warn about):
+    // register it under BOTH the did:key VM (CEL signing) and `${did}#key-0`
+    // (so signWithKeyStore's `${issuer}#key-0` probe resolves).
     // keyStore-less SDKs still get a fully-formed did:cel asset with its log.
-    if (this.keyStore) {
+    if (controllerKp && this.keyStore) {
       await this.keyStore.setPrivateKey(verificationMethod, controllerKp.privateKey);
       await this.keyStore.setPrivateKey(`${did}#key-0`, controllerKp.privateKey);
-    } else {
+    } else if (controllerKp) {
       // No keyStore: the freshly minted controller private key is held nowhere
       // and is dropped here, so the asset cannot author CEL events — publish/
       // inscribe/authorizeSigner appends will degrade (cel:append-skipped)
@@ -380,8 +412,10 @@ export class LifecycleManager {
 
     const asset = new OriginalsAsset(resources, didDoc, [], log);
     // Bind the controller append path so addResourceVersion can write signed
-    // `update` events with the same degrade contract as the other authorship ops.
-    asset._bindCelAppender((type, data, opts) => this.appendCelEventAndMaybeInscribe(asset, type, data, opts));
+    // `update` events with the same degrade contract as the other authorship
+    // ops. The signer that minted the asset stays its default authorship signer.
+    asset._bindCelAppender((type, data, opts) =>
+      this.appendCelEventAndMaybeInscribe(asset, type, data, { ...opts, signer: opts?.signer ?? suppliedSigner }));
 
     // Persist the genesis CEL at the conventional cel/<suffix>.json key so
     // the did:cel resolves from storage immediately (best-effort, never gates).
@@ -1575,7 +1609,7 @@ export class LifecycleManager {
           layer: 'webvh',
           domain: minted.domain,
           migratedAt
-        });
+        }, options?.signer);
         const celAppended = celHeadDigest !== null;
 
         // Host the signed DID log so the DID actually resolves.
@@ -2268,8 +2302,14 @@ export class LifecycleManager {
   /**
    * Append-first lifecycle CEL event with the same degrade contract as
    * publishToWeb: signed by the CURRENT controller folded from the log; when
-   * no keyStore / no CEL log / no signing key, skip and emit
-   * `cel:append-skipped` instead of failing the lifecycle operation.
+   * no custody (keyStore or signer) / no CEL log / no signing key, skip and
+   * emit `cel:append-skipped` instead of failing the lifecycle operation.
+   *
+   * Custody resolution (plan 039): a supplied OriginalsSigner — per-call
+   * override, else `config.signer` — signs WHEN its key is the current
+   * controller; otherwise the keyStore is probed for the controller's key.
+   * This is the fix for the headline bug: a remote-custody caller's CEL events
+   * now actually get signed instead of silently skipped.
    *
    * @returns the head digest (chain-link expression over the appended entry —
    * stable across later witness-proof attachment, since chain canonicalization
@@ -2278,16 +2318,23 @@ export class LifecycleManager {
   private async appendCelEventOrSkip(
     asset: OriginalsAsset,
     type: 'migrate' | 'rotateKey' | 'update',
-    data: unknown
+    data: unknown,
+    signerOverride?: OriginalsSigner
   ): Promise<string | null> {
     const logBefore = asset.celLog;
+    const candidate = signerOverride ?? this.config.signer;
     let skipReason: 'NO_KEYSTORE' | 'NO_CEL_LOG' | 'NO_SIGNING_KEY' =
-      !this.keyStore ? 'NO_KEYSTORE' : 'NO_CEL_LOG';
-    if (this.keyStore && logBefore) {
+      !this.keyStore && !candidate ? 'NO_KEYSTORE' : 'NO_CEL_LOG';
+    if ((this.keyStore || candidate) && logBefore) {
       const vm = currentControllerVm(logBefore);
-      if (await this.keyStore.getPrivateKey(vm)) {
-        const signer = createKeyStoreCelSigner(this.keyStore, vm);
-        const newLog = await appendEvent(logBefore, type, data, { signer, verificationMethod: vm });
+      let celSigner: CelSigner | undefined;
+      if (candidate && canonicalDidKeyVm(candidate.publicKeyMultibase) === vm) {
+        celSigner = toCelSigner(candidate);
+      } else if (this.keyStore && (await this.keyStore.getPrivateKey(vm))) {
+        celSigner = createKeyStoreCelSigner(this.keyStore, vm);
+      }
+      if (celSigner) {
+        const newLog = await appendEvent(logBefore, type, data, { signer: celSigner, verificationMethod: vm });
         asset._replaceCelLog(newLog);
         // Keep the hosted CEL copies fresh AFTER the append committed.
         await this.persistCelArtifacts(asset);
@@ -2322,7 +2369,7 @@ export class LifecycleManager {
     asset: OriginalsAsset,
     type: 'migrate' | 'rotateKey' | 'update',
     data: unknown,
-    opts?: { inscribeConfirm?: InscribeConfirm }
+    opts?: { inscribeConfirm?: InscribeConfirm; signer?: OriginalsSigner }
   ): Promise<string | null> {
     // Confirm gate (#407 phase 4): consent to the unavoidable on-chain cost BEFORE
     // any log mutation. Only paid appends prompt — a btco asset WITH a provider (the
@@ -2361,7 +2408,7 @@ export class LifecycleManager {
     // restore the log to itself, leaving it permanently ahead of the chain and
     // bricking future updates via UNPROVABLE_BASE). Fable I1.
     const celLogBefore = asset.celLog;
-    const digest = await this.appendCelEventOrSkip(asset, type, data);
+    const digest = await this.appendCelEventOrSkip(asset, type, data, opts?.signer);
     // Only inscribe genuine authorship appends that LANDED on a btco asset.
     if (digest === null || asset.currentLayer !== 'did:btco') {
       return digest;
@@ -2658,7 +2705,7 @@ export class LifecycleManager {
         network,
         to: btcoDidFromSatoshi(satoshi, network),
         migratedAt: new Date().toISOString()
-      });
+      }, options.signer);
       const btcoDoc = await this.didManager.migrateToDIDBTCO(asset.did, satoshi);
       btcoDoc.alsoKnownAs = backLinks;
       btcoDoc.service = [
@@ -2921,7 +2968,7 @@ export class LifecycleManager {
         inscriptionId: inscription.inscriptionId,
         txid: revealTxId,
         witnessedEventDigest: celHeadDigest
-      });
+      }, options.signer);
     }
 
     // Recoverable reveal failure: the asset is now fully in the migrated btco
@@ -3298,7 +3345,8 @@ export class LifecycleManager {
    */
   private async appendWitnessAcknowledgment(
     asset: OriginalsAsset,
-    ack: { satoshi: string; inscriptionId: string; txid?: string; witnessedEventDigest: string }
+    ack: { satoshi: string; inscriptionId: string; txid?: string; witnessedEventDigest: string },
+    signer?: OriginalsSigner
   ): Promise<void> {
     try {
       await this.appendCelEventOrSkip(asset, 'update', {
@@ -3307,7 +3355,7 @@ export class LifecycleManager {
         inscriptionId: ack.inscriptionId,
         ...(ack.txid ? { txid: ack.txid } : {}),
         witnessedEventDigest: ack.witnessedEventDigest
-      });
+      }, signer);
     } catch (err) {
       this.logger.warn('witness acknowledgment append failed (non-gating)', {
         assetId: asset.id,
@@ -3340,7 +3388,7 @@ export class LifecycleManager {
     asset: OriginalsAsset,
     newVerificationMethod: { publicKeyMultibase: string; privateKey?: string },
     feeRate?: number,
-    opts?: { inscribeConfirm?: InscribeConfirm }
+    opts?: { inscribeConfirm?: InscribeConfirm; signer?: OriginalsSigner }
   ): Promise<{ inscriptionId: string; did: string }> {
     if (asset.currentLayer !== 'did:btco') {
       throw new StructuredError('INVALID_STATE', 'Key rotation requires the asset to be on the did:btco layer.');
@@ -3419,10 +3467,12 @@ export class LifecycleManager {
     }
 
     const celLogBefore = asset.celLog;
+    // opts.signer is the OUTGOING controller's signer (the cooperative-rotation
+    // contract: the rotateKey is authorized by the outgoing authority).
     const celHeadDigest = await this.appendCelEventOrSkip(asset, 'rotateKey', {
       newController,
       rotatedAt: new Date().toISOString()
-    });
+    }, opts?.signer);
     // Re-embed #cel with the FRESH head (the rotateKey entry). On degrade the
     // event was not appended and no anchor is embedded.
     if (celHeadDigest !== null) {
@@ -3436,8 +3486,11 @@ export class LifecycleManager {
     // Key-custody probe: no private key was supplied, and a keyStore exists but
     // doesn't hold the new controller's key. Post-rotation appends will degrade
     // (nothing was SKIPPED here — the rotation succeeded — so cel:append-skipped
-    // is the wrong signal; key:unpersisted names the unpersisted VM).
+    // is the wrong signal; key:unpersisted names the unpersisted VM). Suppressed
+    // when config.signer IS the incoming controller — its custody is remote by
+    // design and future appends will sign through it.
     if (!newVerificationMethod.privateKey && this.keyStore &&
+        this.config.signer?.publicKeyMultibase !== newVerificationMethod.publicKeyMultibase &&
         !(await this.keyStore.getPrivateKey(newControllerVm))) {
       await this.eventEmitter.emit({
         type: 'key:unpersisted',
@@ -3461,12 +3514,14 @@ export class LifecycleManager {
     // reinscription. Folds to the CURRENT (post-rotation) controller; degrades
     // to a skip when that key isn't held. Only when the rotateKey landed.
     if (celHeadDigest !== null) {
+      // opts.signer is the OUTGOING controller — it cannot sign for the new
+      // one, but passing it yields the accurate NO_SIGNING_KEY degrade signal.
       await this.appendWitnessAcknowledgment(asset, {
         satoshi,
         inscriptionId: inscription.inscriptionId,
         txid: inscription.revealTxId ?? inscription.txid,
         witnessedEventDigest: celHeadDigest
-      });
+      }, opts?.signer);
     }
 
     await this.eventEmitter.emit({
@@ -3500,19 +3555,22 @@ export class LifecycleManager {
    * Differs from {@link rotateBtcoKeys} (the COOPERATIVE arm): the rotateKey is
    * SELF-SIGNED with the new key (explicitly NOT the standard append path,
    * which folds to the prior controller the sat holder does not hold),
-   * `privateKey` is REQUIRED (the signer must be able to sign), and a bitcoin
-   * witness proof is attached to the rotateKey post-inscription — that is what
-   * satisfies the verifier's check (a).
+   * signing capability for the NEW key is REQUIRED — either `privateKey` or a
+   * remote `opts.signer` holding it (plan 039) — and a bitcoin witness proof is
+   * attached to the rotateKey post-inscription — that is what satisfies the
+   * verifier's check (a).
    *
    * @throws INVALID_STATE when the asset is not on did:btco / has no binding.
-   * @throws INVALID_INPUT when no privateKey is supplied.
+   * @throws INVALID_INPUT when neither privateKey nor opts.signer is supplied,
+   *   or opts.signer's key differs from publicKeyMultibase.
    * @throws INVALID_KEY_PAIR / CEL_ED25519_REQUIRED for a bad keypair.
    * @throws OPERATION_IN_PROGRESS on a concurrent call for the same asset.
    */
   async authorizeSigner(
     asset: OriginalsAsset,
-    newVerificationMethod: { publicKeyMultibase: string; privateKey: string },
-    feeRate?: number
+    newVerificationMethod: { publicKeyMultibase: string; privateKey?: string },
+    feeRate?: number,
+    opts?: { signer?: OriginalsSigner }
   ): Promise<{ inscriptionId: string; did: string }> {
     if (asset.currentLayer !== 'did:btco') {
       throw new StructuredError('INVALID_STATE', 'Authorizing a signer requires the asset to be on the did:btco layer.');
@@ -3521,10 +3579,16 @@ export class LifecycleManager {
     if (!btcoDid) {
       throw new StructuredError('INVALID_STATE', 'Asset has no did:btco binding to authorize a signer for.');
     }
-    // privateKey is REQUIRED: the sat holder self-signs the rotateKey with it
-    // (the prior controller is unavailable to fold onto).
-    if (!newVerificationMethod?.privateKey) {
-      throw new StructuredError('INVALID_INPUT', 'authorizeSigner requires the signer\'s private key to self-sign the rotation.');
+    // Signing capability for the NEW key is REQUIRED: the sat holder
+    // self-signs the rotateKey with it (the prior controller is unavailable to
+    // fold onto). Either a raw private key or a remote signer (plan 039).
+    if (!newVerificationMethod?.privateKey && !opts?.signer) {
+      throw new StructuredError('INVALID_INPUT',
+        'authorizeSigner requires signing capability for the new key to self-sign the rotation: pass privateKey or opts.signer.');
+    }
+    if (opts?.signer && opts.signer.publicKeyMultibase !== newVerificationMethod?.publicKeyMultibase) {
+      throw new StructuredError('INVALID_INPUT',
+        'opts.signer must hold the key being authorized: its publicKeyMultibase differs from newVerificationMethod.publicKeyMultibase.');
     }
     // Concurrency guard (issue #255, same pattern as rotateBtcoKeys): reserve the
     // asset synchronously before the first await so two overlapping calls
@@ -3543,9 +3607,11 @@ export class LifecycleManager {
     return await asset.runExclusive(async () => {
     const satoshi = btcoDid.split(':').pop()!;
     const pkm = newVerificationMethod.publicKeyMultibase;
-    // Derive-check the new signer's keypair (privateKey REQUIRED); register it
-    // so subsequent appends by the new controller can sign.
-    this.assertRotationKeyPair(pkm, newVerificationMethod.privateKey);
+    // Derive-check a RAW keypair; a remote signer has no exportable key — its
+    // pair check IS the seal-time self-verify of the rotateKey proof below.
+    if (newVerificationMethod.privateKey) {
+      this.assertRotationKeyPair(pkm, newVerificationMethod.privateKey);
+    }
     const newController = `did:key:${pkm}`;
     const newControllerVm = `${newController}#${pkm}`;
 
@@ -3558,17 +3624,18 @@ export class LifecycleManager {
       throw new StructuredError('INVALID_STATE', 'Asset has no CEL log to append the rotation to.');
     }
     // Guard above must run BEFORE registering the key: a doomed call (no CEL
-    // log) should not leave an unused key sitting in the keyStore.
-    if (this.keyStore) {
+    // log) should not leave an unused key sitting in the keyStore. A remote
+    // signer's key never touches the keyStore (nothing to persist).
+    if (this.keyStore && newVerificationMethod.privateKey) {
       await this.keyStore.setPrivateKey(newControllerVm, newVerificationMethod.privateKey);
     }
 
     // Shared rotated-doc build (backLinks + manifest + NETWORK_MISMATCH guard).
     const rotatedDoc = this.buildRotatedBtcoDoc(asset, satoshi, btcoDid, pkm);
 
-    const { signer, verificationMethod } = celSignerFromKeyPair(
-      { publicKey: pkm, privateKey: newVerificationMethod.privateKey }
-    );
+    const { signer, verificationMethod } = newVerificationMethod.privateKey
+      ? celSignerFromKeyPair({ publicKey: pkm, privateKey: newVerificationMethod.privateKey })
+      : { signer: toCelSigner(opts!.signer!), verificationMethod: newControllerVm };
     const rotatedLog = await appendEvent(
       celLogBefore,
       'rotateKey',
@@ -3629,7 +3696,7 @@ export class LifecycleManager {
       inscriptionId: inscription.inscriptionId,
       txid: inscription.revealTxId ?? inscription.txid,
       witnessedEventDigest: celHeadDigest
-    });
+    }, opts?.signer);
 
     await this.eventEmitter.emit({
       type: 'key:rotated',

--- a/packages/sdk/src/lifecycle/OriginalsAsset.ts
+++ b/packages/sdk/src/lifecycle/OriginalsAsset.ts
@@ -7,6 +7,7 @@ import {
 } from '../types/index.js';
 import { validateDIDDocument, validateCredential, hashResource } from '../utils/validation.js';
 import { StructuredError } from '../utils/telemetry.js';
+import type { OriginalsSigner } from '../crypto/OriginalsSigner.js';
 import type { CredentialManager } from '../vc/CredentialManager.js';
 import { DIDManager } from '../did/DIDManager.js';
 import { ProvenanceQuery, Migration } from './ProvenanceQuery.js';
@@ -76,7 +77,7 @@ export class OriginalsAsset {
   #celAppender?: (
     type: 'migrate' | 'rotateKey' | 'update',
     data: unknown,
-    opts?: { inscribeConfirm?: InscribeConfirm }
+    opts?: { inscribeConfirm?: InscribeConfirm; signer?: OriginalsSigner }
   ) => Promise<string | null>;
   // The SOLE per-asset lock for CEL #celLog read-modify-write (#400). The
   // sync→async cutover made every head→sign→_replaceCelLog span cross await
@@ -229,7 +230,7 @@ export class OriginalsAsset {
     fn: (
       type: 'migrate' | 'rotateKey' | 'update',
       data: unknown,
-      opts?: { inscribeConfirm?: InscribeConfirm }
+      opts?: { inscribeConfirm?: InscribeConfirm; signer?: OriginalsSigner }
     ) => Promise<string | null>
   ): void {
     this.#celAppender = fn;
@@ -643,7 +644,7 @@ export class OriginalsAsset {
     newContent: string,
     contentType: string,
     changes?: string,
-    opts?: { inscribeConfirm?: InscribeConfirm }
+    opts?: { inscribeConfirm?: InscribeConfirm; signer?: OriginalsSigner }
   ): Promise<AssetResource> {
     // AssetResource.content is a string; a Buffer used to be silently dropped
     // (only its hash was stored), unrecoverably losing the binary content
@@ -695,7 +696,7 @@ export class OriginalsAsset {
     newContent: string,
     contentType: string,
     changes?: string,
-    opts?: { inscribeConfirm?: InscribeConfirm }
+    opts?: { inscribeConfirm?: InscribeConfirm; signer?: OriginalsSigner }
   ): Promise<AssetResource> {
     // RE-READ the current head inside the turn (a prior queued call may have
     // just committed a new version).

--- a/packages/sdk/src/types/common.ts
+++ b/packages/sdk/src/types/common.ts
@@ -5,6 +5,7 @@ import type { EventLoggingConfig } from '../utils/EventLogger.js';
 import type { WebVHNetworkName } from './network.js';
 import type { DIDCacheConfig } from '../did/DIDCache.js';
 import type { OperationLock } from '../utils/OperationLock.js';
+import type { OriginalsSigner } from '../crypto/OriginalsSigner.js';
 
 // Base types for the Originals protocol
 export type LayerType = 'did:cel' | 'did:webvh' | 'did:btco';
@@ -55,6 +56,14 @@ export interface OriginalsConfig {
   bitcoinRpcUrl?: string;
   defaultKeyType: 'ES256K' | 'Ed25519' | 'ES256';
   keyStore?: KeyStore;
+  /**
+   * Default authorship signer (plan 039). When set, lifecycle authorship ops
+   * (createAsset, publishToWeb, inscribeOnBitcoin, rotateBtcoKeys,
+   * addResourceVersion) sign CEL events with it instead of looking a private
+   * key up in `keyStore` — the path for custody that never exports keys
+   * (Turnkey, KMS, HSM, passkeys). Overridable per call via `{ signer }`.
+   */
+  signer?: OriginalsSigner;
   enableLogging?: boolean;
   // WebVH network selection (defaults to 'pichu' - production)
   webvhNetwork?: WebVHNetworkName;
@@ -105,6 +114,16 @@ export interface AssetResource {
   createdAt?: string;              // ISO timestamp of when this version was created
 }
 
+/**
+ * Key-persistence interface: stores and retrieves multibase-encoded private
+ * keys by verification method id.
+ *
+ * As a SIGNING authority, KeyStore is deprecated (plan 039): it requires the
+ * private key to be exportable, which locks out Turnkey/KMS/HSM/passkey
+ * custody. Prefer configuring an {@link OriginalsSigner} (`config.signer` or
+ * per-call `{ signer }`) — or wrap a KeyStore entry via `signerFromKeyStore`.
+ * KeyStore itself survives as the key-persistence interface.
+ */
 export interface KeyStore {
   getPrivateKey(verificationMethodId: string): Promise<string | null>;
   setPrivateKey(verificationMethodId: string, privateKey: string): Promise<void>;
@@ -113,6 +132,13 @@ export interface KeyStore {
 /**
  * External signer interface for DID operations (compatible with didwebvh-ts)
  * This allows integration with external key management systems like Turnkey
+ *
+ * @deprecated Use {@link OriginalsSigner} (plan 039): the document-level
+ * `sign()` here delegates canonicalization to the signer, which is the
+ * layering mistake that produced never-verifying proofs. Adapt an existing
+ * implementation with `signerFromExternalSigner`, or produce a didwebvh-
+ * compatible signer from an OriginalsSigner with `toExternalSigner`.
+ * Removal is planned for 3.0 (plan 041).
  */
 export interface ExternalSigner {
   /**

--- a/packages/sdk/src/vc/cryptosuites/eddsa.ts
+++ b/packages/sdk/src/vc/cryptosuites/eddsa.ts
@@ -1,8 +1,7 @@
 import { base58 } from '@scure/base';
 import * as ed25519 from '@noble/ed25519';
-import { canonize, canonizeProof } from '../utils/jsonld.js';
 import { multikey } from '../../crypto/Multikey.js';
-import { sha256Bytes } from '../../utils/hash.js';
+import { signingInput } from '../../crypto/signingInput.js';
 
 // Re-export canonical DataIntegrityProof from shared types
 export type { DataIntegrityProof } from '../../types/proof.js';
@@ -45,8 +44,9 @@ export class EdDSACryptosuiteManager {
    */
   static async computeSigningInput(document: any, options: any): Promise<{ hashData: Uint8Array; proofConfig: Record<string, unknown> }> {
     const proofConfig = await this.createProofConfiguration(options, document?.['@context']);
-    const transformedData = await this.transform(document, options);
-    const hashData = await this.hash(transformedData, proofConfig, options);
+    // Routed through the SDK's single credential preimage (plan 039) so the
+    // local-key, external-signer, and verify paths cannot drift.
+    const hashData = await signingInput.credential(document, proofConfig, { documentLoader: options.documentLoader });
     return { hashData, proofConfig: proofConfig as Record<string, unknown> };
   }
 
@@ -59,11 +59,11 @@ export class EdDSACryptosuiteManager {
     try {
       const documentToVerify = { ...document };
       delete (documentToVerify).proof;
-      const transformedData = await this.transform(documentToVerify, options);
-      const hashData = await this.hash(
-        transformedData,
+      // Same single credential preimage as computeSigningInput (plan 039).
+      const hashData = await signingInput.credential(
+        documentToVerify,
         { '@context': document['@context'] ?? 'https://w3id.org/security/data-integrity/v2', ...proof },
-        options
+        { documentLoader: options.documentLoader }
       );
       const vmDoc = await options.documentLoader(proof.verificationMethod);
       // Fail closed on retired keys. A verification method that has been
@@ -103,17 +103,6 @@ export class EdDSACryptosuiteManager {
       ...(options.challenge && { challenge: options.challenge }),
       ...(options.domain && { domain: options.domain })
     };
-  }
-
-  private static async transform(document: any, options: any): Promise<string> {
-    return await canonize(document, { documentLoader: options.documentLoader });
-  }
-
-  private static async hash(transformedData: string, proofConfig: any, options: any): Promise<Uint8Array> {
-    const canonicalProofConfig = await canonizeProof(proofConfig, { documentLoader: options.documentLoader });
-    const proofConfigHash = await sha256Bytes(canonicalProofConfig);
-    const documentHash = await sha256Bytes(transformedData);
-    return new Uint8Array([...proofConfigHash, ...documentHash]);
   }
 
   static async sign({ data, privateKey }: { data: Uint8Array; privateKey: Uint8Array }): Promise<Uint8Array> {

--- a/packages/sdk/tests/integration/RemoteSignerLifecycle.e2e.test.ts
+++ b/packages/sdk/tests/integration/RemoteSignerLifecycle.e2e.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Plan 039/040 headline: the full documented flow under a NON-EXPORTING
+ * custody backend (MockRemoteSigner — signBytes only, no key export, no
+ * keyStore configured anywhere).
+ *
+ * Before plan 039, a remote-custody caller doing everything right got a
+ * published asset whose CEL was silently missing its migrate event
+ * (`appendCelEventOrSkip` was keyStore-only), reported as success. These tests
+ * pin the fix: every authorship event is signed by the remote signer and the
+ * whole chain verifies.
+ */
+import { describe, test, expect } from 'bun:test';
+import { OriginalsSDK } from '../../src';
+import { OrdMockProvider } from '../../src/adapters/providers/OrdMockProvider';
+import { MemoryStorageAdapter } from '../../src/storage/MemoryStorageAdapter';
+import { MockRemoteSigner } from '../../src/crypto/MockRemoteSigner';
+import { assertSignerConformance } from '../../src/crypto/signerConformance';
+import { canonicalDidKeyVm } from '../../src/crypto/OriginalsSigner';
+import { verifyEventLog } from '../../src/cel/algorithms/verifyEventLog';
+import { createHash } from 'crypto';
+import type { EventTypeMap } from '../../src/events/types';
+
+const contentHash = (c: string) => createHash('sha256').update(c, 'utf8').digest('hex');
+
+function makeSdk(opts?: { signer?: MockRemoteSigner }) {
+  const ordinalsProvider = new OrdMockProvider();
+  const sdk = OriginalsSDK.create({
+    network: 'regtest',
+    defaultKeyType: 'Ed25519',
+    ordinalsProvider,
+    storageAdapter: new MemoryStorageAdapter(),
+    // Deliberately NO keyStore: custody never exports a key.
+    ...(opts?.signer ? { signer: opts.signer } : {}),
+  });
+  return { sdk, ordinalsProvider };
+}
+
+// Fresh per test: addResourceVersion mutates the resources array it was given.
+const freshResources = () => [{
+  id: 'art', type: 'image', contentType: 'image/png',
+  hash: contentHash('remote-art'), content: 'remote-art',
+}];
+
+describe('remote-custody lifecycle (MockRemoteSigner, no keyStore)', () => {
+  test('MockRemoteSigner passes the conformance harness', async () => {
+    await assertSignerConformance(new MockRemoteSigner());
+  });
+
+  test('create -> publish -> inscribe -> rotate -> authorizeSigner: every event signed remotely, chain verifies', async () => {
+    const remote = new MockRemoteSigner();
+    const { sdk, ordinalsProvider } = makeSdk();
+
+    const skipped: EventTypeMap['cel:append-skipped'][] = [];
+    const unpersisted: EventTypeMap['key:unpersisted'][] = [];
+    sdk.lifecycle.on('cel:append-skipped', (e) => { skipped.push(e); });
+    sdk.lifecycle.on('key:unpersisted', (e) => { unpersisted.push(e); });
+
+    // ---- create: the genesis is signed by the remote key; no key is
+    // generated, so key:unpersisted must NOT fire. ----
+    const asset = await sdk.lifecycle.createAsset(freshResources(), { signer: remote });
+    await new Promise((r) => setTimeout(r, 0)); // flush the deferred asset:created turn
+    expect(unpersisted).toHaveLength(0);
+    expect(asset.currentLayer).toBe('did:cel');
+    expect(asset.celLog!.events[0].proof[0].verificationMethod)
+      .toBe(remote.verificationMethodId);
+    expect(remote.signBytesCalls).toBeGreaterThan(0);
+
+    // ---- publish: THE headline fix — the migrate event lands, signed
+    // remotely, instead of degrading to cel:append-skipped. ----
+    await sdk.lifecycle.publishToWeb(asset, 'example.com', { signer: remote });
+    expect(asset.currentLayer).toBe('did:webvh');
+    expect(skipped).toHaveLength(0);
+    expect(asset.celLog!.events.map(e => e.type)).toEqual(['create', 'migrate']);
+    // publish DOES emit key:unpersisted for the minted did:webvh UPDATE key
+    // (separate honest signal about the webvh log, not the CEL) — tolerated.
+
+    // ---- inscribe: btco migrate + witness acknowledgment, both remote-signed. ----
+    await sdk.lifecycle.inscribeOnBitcoin(asset, { signer: remote });
+    expect(asset.currentLayer).toBe('did:btco');
+    expect(skipped).toHaveLength(0);
+    expect(asset.celLog!.events.map(e => e.type))
+      .toEqual(['create', 'migrate', 'migrate', 'update']);
+
+    // ---- cooperative rotate to a SECOND remote key: the rotateKey is signed
+    // by the OUTGOING remote controller. ----
+    const remote2 = new MockRemoteSigner();
+    await sdk.lifecycle.rotateBtcoKeys(
+      asset, { publicKeyMultibase: remote2.publicKeyMultibase }, undefined, { signer: remote }
+    );
+    const rotate1 = asset.celLog!.events.find(e => e.type === 'rotateKey')!;
+    expect(rotate1.proof[0].verificationMethod).toBe(remote.verificationMethodId);
+    // The post-rotation witness ack folds to remote2, whose signer was not
+    // supplied on THIS call — that single append degrades honestly.
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0].reason).toBe('NO_SIGNING_KEY');
+
+    // ---- non-cooperative authorizeSigner with a THIRD remote key: the
+    // rotateKey is SELF-signed by the incoming remote signer (no privateKey
+    // anywhere), and its witness ack signs with it too. ----
+    const remote3 = new MockRemoteSigner();
+    await sdk.lifecycle.authorizeSigner(
+      asset, { publicKeyMultibase: remote3.publicKeyMultibase }, undefined, { signer: remote3 }
+    );
+    const types = asset.celLog!.events.map(e => e.type);
+    expect(types).toEqual(['create', 'migrate', 'migrate', 'update', 'rotateKey', 'rotateKey', 'update']);
+    const rotate2 = asset.celLog!.events[5];
+    expect(rotate2.proof[0].verificationMethod).toBe(remote3.verificationMethodId);
+
+    // ---- the WHOLE chain verifies, including the non-cooperative rotation's
+    // bitcoin witness proof, with zero private keys ever leaving custody. ----
+    const result = await verifyEventLog(asset.celLog!, { expectedDid: asset.id, ordinalsProvider });
+    expect(result.verified).toBe(true);
+    expect(await asset.verify({ ordinalsProvider })).toBe(true);
+  });
+
+  test('config-level signer: OriginalsSDK.create({ signer }) is the ambient authorship signer', async () => {
+    const remote = new MockRemoteSigner();
+    const { sdk } = makeSdk({ signer: remote });
+
+    const skipped: unknown[] = [];
+    const unpersisted: unknown[] = [];
+    sdk.lifecycle.on('cel:append-skipped', (e) => { skipped.push(e); });
+    sdk.lifecycle.on('key:unpersisted', (e) => { unpersisted.push(e); });
+
+    // No per-call signer anywhere below — everything flows from config.
+    const asset = await sdk.lifecycle.createAsset(freshResources());
+    await new Promise((r) => setTimeout(r, 0));
+    expect(unpersisted).toHaveLength(0);
+    expect(asset.celLog!.events[0].proof[0].verificationMethod).toBe(remote.verificationMethodId);
+
+    // addResourceVersion signs its update event through the config signer.
+    await asset.addResourceVersion('art', 'remote-art-v2', 'image/png');
+    expect(skipped).toHaveLength(0);
+    expect(asset.celLog!.events.map(e => e.type)).toEqual(['create', 'update']);
+
+    await sdk.lifecycle.publishToWeb(asset, 'example.com');
+    expect(skipped).toHaveLength(0);
+    expect(asset.celLog!.events.map(e => e.type)).toEqual(['create', 'update', 'migrate']);
+    expect(await asset.verify()).toBe(true);
+  });
+
+  test('createAsset per-call signer stays the asset default for later appends', async () => {
+    const remote = new MockRemoteSigner();
+    const { sdk } = makeSdk();
+    const asset = await sdk.lifecycle.createAsset(freshResources(), { signer: remote });
+    // No config signer, no per-call signer here — the minting signer carries.
+    await asset.addResourceVersion('art', 'remote-art-v2', 'image/png');
+    expect(asset.celLog!.events.map(e => e.type)).toEqual(['create', 'update']);
+    expect(asset.celLog!.events[1].proof[0].verificationMethod)
+      .toBe(canonicalDidKeyVm(remote.publicKeyMultibase));
+    expect(await asset.verify()).toBe(true);
+  });
+
+  test('a non-Ed25519 signer is rejected loudly at createAsset (CEL is Ed25519-only)', async () => {
+    const { sdk } = makeSdk();
+    const { KeyManager } = await import('../../src/did/KeyManager');
+    const { signerFromKeyPair } = await import('../../src/crypto/OriginalsSigner');
+    const secp = signerFromKeyPair(await new KeyManager().generateKeyPair('ES256K'));
+    await expect(sdk.lifecycle.createAsset(freshResources(), { signer: secp })).rejects.toThrow(/Ed25519/);
+  });
+
+  test('without any custody the old degrade contract is unchanged (cel:append-skipped)', async () => {
+    const { sdk } = makeSdk();
+    const skipped: EventTypeMap['cel:append-skipped'][] = [];
+    sdk.lifecycle.on('cel:append-skipped', (e) => { skipped.push(e); });
+    const asset = await sdk.lifecycle.createAsset(freshResources());
+    await sdk.lifecycle.publishToWeb(asset, 'example.com');
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0].reason).toBe('NO_KEYSTORE');
+    expect(asset.celLog!.events.map(e => e.type)).toEqual(['create']);
+  });
+});

--- a/packages/sdk/tests/integration/RemoteSignerLifecycle.e2e.test.ts
+++ b/packages/sdk/tests/integration/RemoteSignerLifecycle.e2e.test.ts
@@ -139,15 +139,46 @@ describe('remote-custody lifecycle (MockRemoteSigner, no keyStore)', () => {
     expect(await asset.verify()).toBe(true);
   });
 
-  test('createAsset per-call signer stays the asset default for later appends', async () => {
+  test('the minting signer is NOT retained — a later append with no signer degrades', async () => {
+    // An asset holding a signer passed once is hidden state that outlives the
+    // call: a session-backed signer goes stale inside it, and a reloaded asset
+    // has no binding at all. Custody is explicit at every append.
+    const remote = new MockRemoteSigner();
+    const { sdk } = makeSdk();
+    const skipped: EventTypeMap['cel:append-skipped'][] = [];
+    sdk.lifecycle.on('cel:append-skipped', (e) => { skipped.push(e); });
+
+    const asset = await sdk.lifecycle.createAsset(freshResources(), { signer: remote });
+    await asset.addResourceVersion('art', 'remote-art-v2', 'image/png');
+
+    expect(asset.celLog!.events.map(e => e.type)).toEqual(['create']);
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0].reason).toBe('NO_KEYSTORE');
+  });
+
+  test('the same append signs once the signer is passed explicitly', async () => {
+    // A separate asset: once an update has degraded, that resource's in-memory
+    // head has advanced past the on-log head and further appends are refused
+    // (UNPROVABLE_BASE) rather than chained from a base no verifier can see.
     const remote = new MockRemoteSigner();
     const { sdk } = makeSdk();
     const asset = await sdk.lifecycle.createAsset(freshResources(), { signer: remote });
-    // No config signer, no per-call signer here — the minting signer carries.
-    await asset.addResourceVersion('art', 'remote-art-v2', 'image/png');
+
+    await asset.addResourceVersion('art', 'remote-art-v2', 'image/png', undefined, { signer: remote });
+
     expect(asset.celLog!.events.map(e => e.type)).toEqual(['create', 'update']);
     expect(asset.celLog!.events[1].proof[0].verificationMethod)
       .toBe(canonicalDidKeyVm(remote.publicKeyMultibase));
+    expect(await asset.verify()).toBe(true);
+  });
+
+  test('config.signer still serves later appends — explicit config, not carried state', async () => {
+    const remote = new MockRemoteSigner();
+    const { sdk } = makeSdk({ signer: remote });
+    const asset = await sdk.lifecycle.createAsset(freshResources(), { signer: remote });
+
+    await asset.addResourceVersion('art', 'remote-art-v2', 'image/png');
+    expect(asset.celLog!.events.map(e => e.type)).toEqual(['create', 'update']);
     expect(await asset.verify()).toBe(true);
   });
 

--- a/packages/sdk/tests/unit/crypto/OriginalsSigner.test.ts
+++ b/packages/sdk/tests/unit/crypto/OriginalsSigner.test.ts
@@ -1,0 +1,168 @@
+/**
+ * OriginalsSigner adapters (plan 039): raw-key/keyStore/ExternalSigner inward,
+ * CelSigner/ExternalSigner outward. The outward bridges are correct by
+ * construction — their outputs must verify through the SDK's own verifiers.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { ed25519 } from '@noble/curves/ed25519.js';
+import {
+  canonicalDidKeyVm,
+  signerFromKeyPair,
+  signerFromKeyStore,
+  signerFromExternalSigner,
+  toCelSigner,
+  toExternalSigner,
+  type OriginalsSigner,
+} from '../../../src/crypto/OriginalsSigner';
+import { MockRemoteSigner } from '../../../src/crypto/MockRemoteSigner';
+import { signingInput } from '../../../src/crypto/signingInput';
+import { multikey } from '../../../src/crypto/Multikey';
+import { KeyManager } from '../../../src/did/KeyManager';
+import { verifyDidKeyProof } from '../../../src/cel/proofVerification';
+import { MockKeyStore } from '../../mocks/MockKeyStore';
+import type { ExternalSigner } from '../../../src/types';
+
+async function ed25519KeyPair() {
+  return new KeyManager().generateKeyPair('Ed25519');
+}
+
+describe('signerFromKeyPair', () => {
+  test('exposes the canonical did:key VM and signs verifiably', async () => {
+    const kp = await ed25519KeyPair();
+    const signer = signerFromKeyPair(kp);
+    expect(signer.publicKeyMultibase).toBe(kp.publicKey);
+    expect(signer.verificationMethodId).toBe(canonicalDidKeyVm(kp.publicKey));
+
+    const msg = new TextEncoder().encode('bytes-to-sign');
+    const sig = await signer.signBytes(msg);
+    const pub = multikey.decodePublicKey(kp.publicKey).key;
+    expect(ed25519.verify(sig, msg, pub)).toBe(true);
+  });
+
+  test('rejects a mismatched Ed25519 pair loudly', async () => {
+    const a = await ed25519KeyPair();
+    const b = await ed25519KeyPair();
+    expect(() => signerFromKeyPair({ privateKey: a.privateKey, publicKey: b.publicKey }))
+      .toThrow(/does not derive/);
+  });
+
+  test('rejects a cross-type pair', async () => {
+    const ed = await ed25519KeyPair();
+    const secp = await new KeyManager().generateKeyPair('ES256K');
+    expect(() => signerFromKeyPair({ privateKey: secp.privateKey, publicKey: ed.publicKey }))
+      .toThrow(/type mismatch/);
+  });
+});
+
+describe('signerFromKeyStore', () => {
+  test('lazy per-sign lookup: key registered AFTER construction still signs', async () => {
+    const kp = await ed25519KeyPair();
+    const keyStore = new MockKeyStore();
+    const vm = canonicalDidKeyVm(kp.publicKey);
+    const signer = signerFromKeyStore(keyStore, vm);
+
+    // Not registered yet — fails at sign time, not construction time.
+    await expect(signer.signBytes(new Uint8Array([1]))).rejects.toThrow(/No private key/);
+
+    await keyStore.setPrivateKey(vm, kp.privateKey);
+    const msg = new TextEncoder().encode('late-bound');
+    const sig = await signer.signBytes(msg);
+    expect(ed25519.verify(sig, msg, multikey.decodePublicKey(kp.publicKey).key)).toBe(true);
+  });
+
+  test('derives the public key from a did:key VM; requires it otherwise', async () => {
+    const kp = await ed25519KeyPair();
+    const keyStore = new MockKeyStore();
+    expect(signerFromKeyStore(keyStore, canonicalDidKeyVm(kp.publicKey)).publicKeyMultibase)
+      .toBe(kp.publicKey);
+    expect(() => signerFromKeyStore(keyStore, 'did:webvh:example.com:user#key-0'))
+      .toThrow(/publicKeyMultibase/);
+    const explicit = signerFromKeyStore(keyStore, 'did:webvh:example.com:user#key-0',
+      { publicKeyMultibase: kp.publicKey });
+    expect(explicit.publicKeyMultibase).toBe(kp.publicKey);
+  });
+});
+
+describe('signerFromExternalSigner', () => {
+  function externalOf(kp: { privateKey: string; publicKey: string }): ExternalSigner {
+    const secret = multikey.decodePrivateKey(kp.privateKey).key;
+    return {
+      getVerificationMethodId: () => canonicalDidKeyVm(kp.publicKey),
+      sign: async () => { throw new Error('document-level sign() must not be used'); },
+      signBytes: async (data: Uint8Array) => ({ signature: ed25519.sign(data, secret) }),
+    };
+  }
+
+  test('adapts a signBytes-capable ExternalSigner', async () => {
+    const kp = await ed25519KeyPair();
+    const signer = signerFromExternalSigner(externalOf(kp));
+    expect(signer.publicKeyMultibase).toBe(kp.publicKey);
+    const msg = new TextEncoder().encode('adapted');
+    const sig = await signer.signBytes(msg);
+    expect(ed25519.verify(sig, msg, multikey.decodePublicKey(kp.publicKey).key)).toBe(true);
+  });
+
+  test('throws loudly for a sign()-only ExternalSigner', async () => {
+    const kp = await ed25519KeyPair();
+    const signOnly: ExternalSigner = {
+      getVerificationMethodId: () => canonicalDidKeyVm(kp.publicKey),
+      sign: async () => ({ proofValue: 'zWhatever' }),
+    };
+    expect(() => signerFromExternalSigner(signOnly)).toThrow(/signBytes/);
+  });
+});
+
+describe('toCelSigner', () => {
+  test('produces an eddsa-jcs-2022 proof that self-verifies (did:key, offline)', async () => {
+    const remote = new MockRemoteSigner();
+    const celSigner = toCelSigner(remote);
+    const eventBase = { type: 'create', data: { name: 'asset', controller: `did:key:${remote.publicKeyMultibase}` } };
+    const proof = await celSigner(eventBase);
+    expect(proof.cryptosuite).toBe('eddsa-jcs-2022');
+    expect(proof.verificationMethod).toBe(remote.verificationMethodId);
+    expect((await verifyDidKeyProof(proof, eventBase)).verified).toBe(true);
+    expect(remote.signBytesCalls).toBe(1);
+  });
+
+  test('throws CEL_ED25519_REQUIRED for a non-Ed25519 signer', async () => {
+    const secp = await new KeyManager().generateKeyPair('ES256K');
+    expect(() => toCelSigner(signerFromKeyPair(secp))).toThrow(/Ed25519/);
+  });
+
+  test('stamps the canonical did:key VM even for an ambient non-did:key identity', async () => {
+    const inner = new MockRemoteSigner();
+    const foreignVm: OriginalsSigner = {
+      verificationMethodId: 'did:webvh:example.com:user#key-1',
+      publicKeyMultibase: inner.publicKeyMultibase,
+      signBytes: (b) => inner.signBytes(b),
+    };
+    const proof = await toCelSigner(foreignVm)({ type: 'update', data: { a: 1 } });
+    expect(proof.verificationMethod).toBe(canonicalDidKeyVm(inner.publicKeyMultibase));
+  });
+});
+
+describe('toExternalSigner', () => {
+  test('sign() is signingInput.didWebvh + signBytes, by construction', async () => {
+    const remote = new MockRemoteSigner();
+    const external = toExternalSigner(remote);
+    expect(external.getVerificationMethodId()).toBe(remote.verificationMethodId);
+
+    const document = { id: 'did:webvh:example.com:user', value: 42 };
+    const proof = { type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022' };
+    const { proofValue } = await external.sign({ document, proof });
+
+    const expectedBytes = await signingInput.didWebvh(document, proof);
+    const sig = multikey.decodeMultibase(proofValue);
+    const pub = multikey.decodePublicKey(remote.publicKeyMultibase).key;
+    expect(ed25519.verify(sig, expectedBytes, pub)).toBe(true);
+  });
+
+  test('exposes signBytes for the credential/multisig byte-level path', async () => {
+    const remote = new MockRemoteSigner();
+    const external = toExternalSigner(remote);
+    const msg = new TextEncoder().encode('hash-data');
+    const { signature } = await external.signBytes!(msg);
+    expect(ed25519.verify(signature, msg, multikey.decodePublicKey(remote.publicKeyMultibase).key)).toBe(true);
+  });
+});

--- a/packages/sdk/tests/unit/crypto/addressToMultikey.test.ts
+++ b/packages/sdk/tests/unit/crypto/addressToMultikey.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Plan 045: turning a custody backend's ADDRESS into a Multikey.
+ *
+ * Turnkey's Ed25519 accounts use ADDRESS_FORMAT_SOLANA — base58 of the raw
+ * 32-byte public key, with no multicodec header and no multibase prefix.
+ * Consumers kept building `did:key:${address}` from it, which is not a valid
+ * did:key at all.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { base58 } from '@scure/base';
+import { ed25519 } from '@noble/curves/ed25519.js';
+import { base58AddressToEd25519Multikey } from '../../../src/crypto/addressToMultikey';
+import { multikey } from '../../../src/crypto/Multikey';
+
+describe('base58AddressToEd25519Multikey', () => {
+  const publicKey = ed25519.getPublicKey(ed25519.utils.randomSecretKey());
+  const solanaAddress = base58.encode(publicKey);
+  const expected = multikey.encodePublicKey(publicKey, 'Ed25519');
+
+  test('converts a Solana-format address to the Multikey for the same key', () => {
+    expect(base58AddressToEd25519Multikey(solanaAddress)).toBe(expected);
+  });
+
+  test('the result round-trips back to the original public key', () => {
+    const decoded = multikey.decodePublicKey(base58AddressToEd25519Multikey(solanaAddress));
+    expect(decoded.type).toBe('Ed25519');
+    expect(Buffer.from(decoded.key).toString('hex')).toBe(Buffer.from(publicKey).toString('hex'));
+  });
+
+  test('the raw address is NOT itself a usable Multikey — the bug this prevents', () => {
+    // Why the helper exists: did:key:<address> is not a did:key.
+    expect(() => multikey.decodePublicKey(solanaAddress)).toThrow();
+  });
+
+  test('an existing Ed25519 Multikey passes through unchanged', () => {
+    expect(base58AddressToEd25519Multikey(expected)).toBe(expected);
+  });
+
+  test('rejects a non-32-byte key with a message naming the address format', () => {
+    expect(() => base58AddressToEd25519Multikey(base58.encode(new Uint8Array(33)))).toThrow(
+      /ADDRESS_FORMAT_SOLANA/
+    );
+  });
+
+  test('rejects non-base58 and empty input', () => {
+    expect(() => base58AddressToEd25519Multikey('not base58!!! 0OIl')).toThrow(/base58/);
+    expect(() => base58AddressToEd25519Multikey('')).toThrow(/non-empty/);
+  });
+});

--- a/packages/sdk/tests/unit/crypto/signerConformance.test.ts
+++ b/packages/sdk/tests/unit/crypto/signerConformance.test.ts
@@ -1,0 +1,124 @@
+/**
+ * assertSignerConformance (plan 040) — the published harness a custody backend
+ * runs against its OriginalsSigner. Each contract violation must fail with a
+ * SIGNER_NONCONFORMANT error naming the violated check.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { ed25519 } from '@noble/curves/ed25519.js';
+import { assertSignerConformance } from '../../../src/crypto/signerConformance';
+import { MockRemoteSigner } from '../../../src/crypto/MockRemoteSigner';
+import { signerFromKeyPair } from '../../../src/crypto/OriginalsSigner';
+import { KeyManager } from '../../../src/did/KeyManager';
+import { multikey } from '../../../src/crypto/Multikey';
+import { sha256Bytes } from '../../../src/utils/hash';
+import { StructuredError } from '../../../src/utils/telemetry';
+import type { OriginalsSigner } from '../../../src/crypto/OriginalsSigner';
+
+async function expectNonconformant(signer: OriginalsSigner, pattern: RegExp) {
+  try {
+    await assertSignerConformance(signer);
+    throw new Error('expected SIGNER_NONCONFORMANT');
+  } catch (e) {
+    expect(e).toBeInstanceOf(StructuredError);
+    expect((e as StructuredError).code).toBe('SIGNER_NONCONFORMANT');
+    expect((e as Error).message).toMatch(pattern);
+  }
+}
+
+describe('assertSignerConformance', () => {
+  test('MockRemoteSigner (signBytes-only custody) is conformant', async () => {
+    await assertSignerConformance(new MockRemoteSigner());
+  });
+
+  test('every key type from signerFromKeyPair is conformant', async () => {
+    const km = new KeyManager();
+    for (const type of ['Ed25519', 'ES256K', 'ES256'] as const) {
+      await assertSignerConformance(signerFromKeyPair(await km.generateKeyPair(type)));
+    }
+  });
+
+  test('rejects a relative (fragment-less) verificationMethodId', async () => {
+    const good = new MockRemoteSigner();
+    await expectNonconformant(
+      { ...asPlain(good), verificationMethodId: `did:key:${good.publicKeyMultibase}` },
+      /absolute/
+    );
+  });
+
+  test('rejects a non-DID verificationMethodId', async () => {
+    const good = new MockRemoteSigner();
+    await expectNonconformant(
+      { ...asPlain(good), verificationMethodId: 'urn:not-a-did#key' },
+      /DID URL/
+    );
+  });
+
+  test('rejects an undecodable publicKeyMultibase', async () => {
+    const good = new MockRemoteSigner();
+    await expectNonconformant(
+      { ...asPlain(good), publicKeyMultibase: 'zNotAKey' },
+      /does not decode/
+    );
+  });
+
+  test('rejects a wrong-length signature', async () => {
+    const good = new MockRemoteSigner();
+    await expectNonconformant(
+      { ...asPlain(good), signBytes: async () => new Uint8Array(32) },
+      /64 bytes/
+    );
+  });
+
+  test('rejects a non-Uint8Array signBytes result', async () => {
+    const good = new MockRemoteSigner();
+    await expectNonconformant(
+      { ...asPlain(good), signBytes: (async () => 'zSig') as unknown as OriginalsSigner['signBytes'] },
+      /Uint8Array/
+    );
+  });
+
+  test('rejects a signer whose key does not match its signatures', async () => {
+    const a = new MockRemoteSigner();
+    const b = new MockRemoteSigner();
+    // Signs with a's key but claims b's public key.
+    await expectNonconformant(
+      { verificationMethodId: b.verificationMethodId, publicKeyMultibase: b.publicKeyMultibase, signBytes: (x) => a.signBytes(x) },
+      /does not verify/
+    );
+  });
+
+  test('rejects a signer that hashes or canonicalizes before signing', async () => {
+    const secret = ed25519.utils.randomSecretKey();
+    const pub = multikey.encodePublicKey(ed25519.getPublicKey(secret), 'Ed25519');
+    // The classic remote-custody mistake: sign sha256(bytes) instead of bytes.
+    const hashingSigner: OriginalsSigner = {
+      verificationMethodId: `did:key:${pub}#${pub}`,
+      publicKeyMultibase: pub,
+      signBytes: async (bytes) => ed25519.sign(await sha256Bytes(bytes), secret),
+    };
+    await expectNonconformant(hashingSigner, /EXACTLY/);
+  });
+
+  test('rejects an input-ignoring (fixed-message) signer', async () => {
+    const secret = ed25519.utils.randomSecretKey();
+    const pub = multikey.encodePublicKey(ed25519.getPublicKey(secret), 'Ed25519');
+    const probe1 = new TextEncoder().encode('originals-signer-conformance-probe-1');
+    const fixed: OriginalsSigner = {
+      verificationMethodId: `did:key:${pub}#${pub}`,
+      publicKeyMultibase: pub,
+      // Always signs probe-1 regardless of input.
+      signBytes: async () => ed25519.sign(probe1, secret),
+    };
+    await expectNonconformant(fixed, /ignoring its input/);
+  });
+});
+
+/** Spread helper: MockRemoteSigner's method must stay bound to its instance. */
+function asPlain(s: MockRemoteSigner): OriginalsSigner {
+  return {
+    verificationMethodId: s.verificationMethodId,
+    publicKeyMultibase: s.publicKeyMultibase,
+    signBytes: (b) => s.signBytes(b),
+  };
+}

--- a/packages/sdk/tests/unit/crypto/signingInput.test.ts
+++ b/packages/sdk/tests/unit/crypto/signingInput.test.ts
@@ -1,0 +1,137 @@
+/**
+ * signingInput (plan 039) — the four signing preimages, consolidated.
+ *
+ * Each context's preimage must byte-match what the corresponding verifier
+ * reconstructs; these tests pin that equivalence so the four cannot drift.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { ed25519 } from '@noble/curves/ed25519.js';
+import { signingInput } from '../../../src/crypto/signingInput';
+import { canonicalizeEvent, canonicalizeEntryForChain, witnessSigningBytes } from '../../../src/cel/canonicalize';
+import { verifyDidKeyProof } from '../../../src/cel/proofVerification';
+import { multikey } from '../../../src/crypto/Multikey';
+import { EdDSACryptosuiteManager } from '../../../src/vc/cryptosuites/eddsa';
+
+describe('signingInput.celEvent', () => {
+  test('matches the chain-canonicalization of the committed fields', () => {
+    const entry = { type: 'update', data: { a: 1, z: [2, 3] }, previousEvent: 'uEiDprev' };
+    expect(signingInput.celEvent(entry)).toEqual(canonicalizeEntryForChain(entry));
+  });
+
+  test('omits previousEvent for a genesis-shaped entry', () => {
+    const entry = { type: 'create', data: { name: 'x' } };
+    expect(new TextDecoder().decode(signingInput.celEvent(entry)))
+      .toBe('{"data":{"name":"x"},"type":"create"}');
+  });
+
+  test('never signs stray keys (proof etc. excluded from the preimage)', () => {
+    const clean = { type: 'update', data: { a: 1 } };
+    const dirty = { ...clean, proof: [{ proofValue: 'zXX' }], extra: true };
+    expect(signingInput.celEvent(dirty)).toEqual(signingInput.celEvent(clean));
+  });
+
+  test('a signature over celEvent verifies through the CEL proof verifier', async () => {
+    const secret = ed25519.utils.randomSecretKey();
+    const pub = multikey.encodePublicKey(ed25519.getPublicKey(secret), 'Ed25519');
+    const eventBase = { type: 'create', data: { name: 'asset', controller: `did:key:${pub}` } };
+    const proof = {
+      type: 'DataIntegrityProof',
+      cryptosuite: 'eddsa-jcs-2022',
+      created: new Date().toISOString(),
+      verificationMethod: `did:key:${pub}#${pub}`,
+      proofPurpose: 'assertionMethod',
+      proofValue: multikey.encodeMultibase(ed25519.sign(signingInput.celEvent(eventBase), secret)),
+    };
+    const check = await verifyDidKeyProof(proof, eventBase);
+    expect(check.verified).toBe(true);
+  });
+});
+
+describe('signingInput.witness', () => {
+  test('is exactly witnessSigningBytes (JSON-quoted digest, quotes included)', () => {
+    const digest = 'uEiDexampledigest';
+    expect(signingInput.witness(digest)).toEqual(witnessSigningBytes(digest));
+    expect(new TextDecoder().decode(signingInput.witness(digest))).toBe(`"${digest}"`);
+    expect(signingInput.witness(digest)).toEqual(canonicalizeEvent(digest));
+  });
+});
+
+describe('signingInput.didWebvh', () => {
+  test('matches didwebvh-ts prepareDataForSigning byte-for-byte', async () => {
+    const mod = await import('didwebvh-ts') as unknown as {
+      prepareDataForSigning: (d: unknown, p: unknown) => Promise<Uint8Array>;
+    };
+    const document = { id: 'did:webvh:example.com:user', foo: { b: 2, a: 1 } };
+    const proof = { type: 'DataIntegrityProof', cryptosuite: 'eddsa-jcs-2022', proofPurpose: 'assertionMethod' };
+    const ours = await signingInput.didWebvh(document, proof);
+    const theirs = await mod.prepareDataForSigning(document, proof);
+    expect(ours).toEqual(new Uint8Array(theirs));
+    // sha256(JCS(proof)) || sha256(JCS(document)) — two 32-byte hashes.
+    expect(ours.length).toBe(64);
+  });
+});
+
+describe('signingInput.credential', () => {
+  const documentLoader = async (url: string) => {
+    // Enough loader for the data-integrity context the proof config uses.
+    const { createDocumentLoader } = await import('../../../src/vc/documentLoader');
+    const { DIDManager } = await import('../../../src/did/DIDManager');
+    const loader = createDocumentLoader(new DIDManager({
+      network: 'regtest', defaultKeyType: 'Ed25519', enableLogging: false,
+    } as never));
+    return loader(url);
+  };
+
+  const credential = {
+    '@context': ['https://www.w3.org/ns/credentials/v2', 'https://originals.build/context'],
+    type: ['VerifiableCredential', 'ResourceCreated'],
+    issuer: 'did:example:issuer',
+    validFrom: '2026-01-01T00:00:00Z',
+    credentialSubject: {
+      resourceId: 'res-1', resourceType: 'text', createdAt: '2026-01-01T00:00:00Z',
+      creator: 'did:example:issuer'
+    },
+  } as Record<string, unknown>;
+
+  const proofConfig = {
+    '@context': credential['@context'],
+    type: 'DataIntegrityProof',
+    cryptosuite: 'eddsa-rdfc-2022',
+    created: '2026-01-01T00:00:00Z',
+    verificationMethod: 'did:example:issuer#key-0',
+    proofPurpose: 'assertionMethod',
+  } as Record<string, unknown>;
+
+  test('is the RDFC-2022 hashData: sha256(proofConfig) || sha256(document)', async () => {
+    const bytes = await signingInput.credential(credential, proofConfig, { documentLoader });
+    expect(bytes.length).toBe(64);
+    // computeSigningInput routes through the same preimage — identical bytes
+    // for identical proof configs (created is pinned above).
+    const viaSuite = await signingInput.credential({ ...credential }, { ...proofConfig }, { documentLoader });
+    expect(viaSuite).toEqual(bytes);
+  });
+
+  test('ignores an existing proof on the document and proofValue on the config', async () => {
+    const clean = await signingInput.credential(credential, proofConfig, { documentLoader });
+    const dirty = await signingInput.credential(
+      { ...credential, proof: { type: 'DataIntegrityProof', proofValue: 'zEXISTING' } },
+      { ...proofConfig, proofValue: 'zSHOULD_BE_STRIPPED' },
+      { documentLoader }
+    );
+    expect(dirty).toEqual(clean);
+  });
+
+  test('a signature over credential() verifies through EdDSACryptosuiteManager.verifyProof', async () => {
+    const secret = ed25519.utils.randomSecretKey();
+    const pub = multikey.encodePublicKey(ed25519.getPublicKey(secret), 'Ed25519');
+    const vmId = `did:key:${pub}#${pub}`;
+    const config = { ...proofConfig, verificationMethod: vmId };
+    const hashData = await signingInput.credential(credential, config, { documentLoader });
+    const proof = { ...config, proofValue: EdDSACryptosuiteManager.encodeProofValue(ed25519.sign(hashData, secret)) };
+    delete (proof as Record<string, unknown>)['@context'];
+    const result = await EdDSACryptosuiteManager.verifyProof(
+      { ...credential, proof }, proof as never, { documentLoader });
+    expect(result.verified).toBe(true);
+  });
+});


### PR DESCRIPTION
Phase 1 of [plan 033](https://github.com/onionoriginals/sdk/blob/main/plans/033-sdk-v3-roadmap.md), stacked on Phase 0 (#464). Additive — every existing API keeps working.

## The problem

Turnkey, KMS, HSM, MPC and passkey backends never export a private key. The SDK's authorship path required one (`KeyStore.getPrivateKey(vmId)`), so all of them were locked out of the recommended tier. Our first remote-custody consumer had to route around all three headline abstractions to ship.

**The concrete leak:** `publishToWeb` accepted an `ExternalSigner` — but that signer only authorized the did:webvh log. The asset's own CEL `migrate` event went through a keyStore-only path, so a remote-custody caller doing everything right got a published asset whose provenance log was **missing its migration event**, reported as success.

## What's here

**One signer interface.** `OriginalsSigner` is three members — `verificationMethodId`, `publicKeyMultibase`, `signBytes(bytes)` — the smallest thing a custody backend can implement. The SDK canonicalizes and hashes; the signer only ever signs opaque bytes. Accepted on `OriginalsConfig` and per call on `createAsset` (which gains an options bag), `publishToWeb`, `inscribeOnBitcoin`, `rotateBtcoKeys`, `authorizeSigner`, `addResourceVersion`. Adapters both directions: `signerFromKeyPair`, `signerFromKeyStore`, `signerFromExternalSigner`, `toCelSigner`, `toExternalSigner`.

**One signing-input namespace.** `signingInput` exposes the four — and only four — preimages this SDK signs: `celEvent`, `witness`, `didWebvh`, `credential`. Every internal signing path routes through it, so "which bytes do I sign?" has one answer and the four cannot drift.

**A conformance harness (the durable part).** `assertSignerConformance(signer)` lets any backend prove its implementation, and `MockRemoteSigner` — signBytes-only, no key export — drives an e2e test through create → publish → inscribe → rotate → authorizeSigner **with no keyStore configured anywhere**, with the whole chain verifying.

No test previously exercised a non-exporting custody backend. That is why this rotted undetected, and it's the same disease Phase 0 found in the CEL suite.

**Plan 045, pulled forward from Phase 4.** Without it Phase 1 ships an interface no signer we actually ship can satisfy: `signerFromExternalSigner` throws without `signBytes`, and neither Turnkey signer had it. Both now share one `turnkeySignBytes` primitive (the byte-level code already existed, duplicated across the two signers and kept in sync by comment). `@originals/auth`'s root no longer re-exports `./server` — importing a single type pulled `jsonwebtoken`, `@turnkey/sdk-server` and Express into browser bundles. Adds `base58AddressToEd25519Multikey`, because Turnkey's Ed25519 accounts use `ADDRESS_FORMAT_SOLANA` (base58 of the raw key, no multicodec header), so `did:key:${address}` is not a valid did:key — a mistake consumers keep re-deriving.

## Three places the plan was wrong when it met the code

1. **`signingInput.didWebvh` is not "JCS over `{document, proof}`"** as the plan specified. didwebvh-ts's `prepareDataForSigning` is `sha256(JCS(proof)) || sha256(JCS(document))` — concatenated hashes, proof first. It now delegates to didwebvh-ts's own export so the two can't drift; implementing the plan's description literally would have produced webvh proofs that never verify.
2. **CEL proofs can't use a signer's ambient `verificationMethodId`.** CEL verification is offline did:key-only, so a signer whose VM lives in another DID method would mint logs whose controller never verifies. `toCelSigner` stamps the canonical did:key VM derived from `publicKeyMultibase`.
3. **`publicKeyMultibase` isn't obtainable from `KeyStore`/`ExternalSigner`** — neither exposes a public key. Those adapters derive it from a did:key VM id or require it explicitly (`SIGNER_PUBLIC_KEY_REQUIRED`). The plan's one-arg adapter signatures were underspecified.

## Verification

- `@originals/sdk`: tsc 0, **3841 pass / 0 fail** (+46 over Phase 0's 3795)
- `@originals/auth`: tsc 0, **245 pass / 0 fail** (+7)
- `verify:browser` and `verify:esm` gates green, `bun run build` succeeds

## Reviewer notes

- `ExternalSigner`, `CelSigner` and KeyStore-as-signing-authority are `@deprecated` but still work; removal is a later phase. `KeyStore` remains supported for key persistence.
- One append still degrades honestly rather than throwing: `rotateBtcoKeys`' post-rotation witness ack, when the *incoming* controller is remote and its signer wasn't passed. The e2e test asserts this explicitly rather than hiding it.
- The two Turnkey signers had different error messages for the same malformed response, and sent hex differently (`0x`-prefixed vs bare — Turnkey accepts both). Unified; the integration test's mock decoded with `Buffer.from(s,'hex')`, which silently mis-parses the prefixed form, so the double was corrected rather than the signers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)