### PR TITLE
feat(sdk)!: tree-shakeable entry, curated exports, Buffer purged from public API (plans 043-044)

### DIFF
--- a/.changeset/buffer-purged-from-public-api.md
+++ b/.changeset/buffer-purged-from-public-api.md
@@ -1,0 +1,19 @@
+---
+"@originals/sdk": major
+---
+
+**`Buffer` is purged from every public signature — the API speaks `Uint8Array`** (plan 044).
+
+`Buffer` is a Node global; any browser consumer without a bundler shim got `ReferenceError` the moment a Buffer-typed path executed. Public signatures now use `Uint8Array` throughout, and the browser-reachable entry points (`index`, `LifecycleManager`, `OriginalsAsset`, `cel`) no longer construct Buffers at runtime.
+
+**Signature changes** (callers passing `Buffer` still compile — `Buffer` extends `Uint8Array`; code that called Buffer methods on *returned* values must convert):
+
+- `Signer` and all four implementations (`ES256KSigner`, `Ed25519Signer`, `ES256Signer`, `Bls12381G2Signer`): `sign`/`verify` take and return `Uint8Array`. The returned signature is no longer a `Buffer` instance — use `Buffer.from(sig)` in Node if you need one.
+- `OrdinalsProvider` (and every shipped provider): `createInscription({ data })`, `InscriptionParts`, and returned/`getInscriptionById` `content` are `Uint8Array`. Decode text content with `new TextDecoder().decode(content)`, not `content.toString('utf8')`.
+- `StorageAdapter.put(data: Uint8Array | string)` and `StorageGetResult.content: Uint8Array`.
+- `OrdinalsInscription.content?: Uint8Array` (`types/bitcoin`).
+- `ResourceManager.createResource` / `updateResource` / `hashContent` accept `Uint8Array | string`.
+- `KeyManager.encodePublicKeyMultibase(publicKey: Uint8Array, …)` / `decodePublicKeyMultibase` returns `{ key: Uint8Array, … }`.
+- `LifecycleManager.estimateAppendCost` `content` option: `string | Uint8Array`.
+
+Internal Node-only paths (transaction building, CLI, server providers) still use `Buffer` where appropriate — the guarantee is about the public surface and the browser-reachable graph.

--- a/.changeset/packaging-curated-exports.md
+++ b/.changeset/packaging-curated-exports.md
@@ -1,0 +1,13 @@
+---
+"@originals/sdk": major
+---
+
+**Packaging: tree-shakeable entry, curated `exports`, test doubles moved to `/testing`** (plan 043).
+
+The package is no longer hostile to bundlers, and the export surface now matches what a remote-custody integrator needs instead of what the repo happened to contain.
+
+- **`"sideEffects": false`.** The root entry's side-effect-only `import './crypto/noble-init.js'` is gone; the noble sync-hash configuration now happens explicitly (an idempotent `initNobleCrypto()` call) inside the modules that use sync noble APIs (`crypto/Signer.ts`, `did/KeyManager.ts`). A bundler can now drop the ~150-module graph (jsonld included) when you only import types. If you imported the SDK purely for its import-time noble setup, call the exported `initNobleCrypto` — but no SDK path requires you to.
+- **Curated `exports` map.** The 11 internal `./dir/*` wildcards are gone; every internal file is no longer a semver commitment. The supported entry points are now exactly: `.` (root), `./cel` (browser-safe genesis entry), `./testing` (test doubles), `./types`, and `./package.json`. Deep imports like `@originals/sdk/crypto/Multikey` no longer resolve — everything public is exported from the root (e.g. `multikey`).
+- **Test doubles off the root.** `OrdMockProvider` and `FeeOracleMock` moved from the root entry to `@originals/sdk/testing`. Update imports: `import { OrdMockProvider, FeeOracleMock } from '@originals/sdk/testing'`. Production bundles no longer carry mock providers.
+- **Remote-signer toolkit added to the root:** `Verifier` (issuer-bound credential verification), `EdDSACryptosuiteManager` (shared signing-input construction), `createDocumentLoader` (JSON-LD loader bound to a `DIDManager`), and `currentControllerVm` (fold a CEL log to the current controller's verification method; also exported from `./cel`).
+- **Dropped from the root:** `withRetry`/`RetryOptions` (`utils/retry`) and `CircuitBreaker`/`withCircuitBreaker` (`utils/circuit-breaker`). These are internal infrastructure, not Originals API; vendor your own if you depended on them.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ npm install @originals/sdk
 ## Quick Start
 
 ```typescript
-import { OriginalsSDK, OrdMockProvider } from '@originals/sdk';
+import { OriginalsSDK } from '@originals/sdk';
+import { OrdMockProvider } from '@originals/sdk/testing';
 
 // For testing/development - use mock provider
 const originals = OriginalsSDK.create({
@@ -108,7 +109,8 @@ Bitcoin operations (inscribing and transferring) require an `ordinalsProvider` t
 For testing and local development, use the built-in mock provider:
 
 ```typescript
-import { OriginalsSDK, OrdMockProvider } from '@originals/sdk';
+import { OriginalsSDK } from '@originals/sdk';
+import { OrdMockProvider } from '@originals/sdk/testing';
 
 const sdk = OriginalsSDK.create({
   network: 'regtest',

--- a/apps/landing/scripts/make-example.ts
+++ b/apps/landing/scripts/make-example.ts
@@ -12,13 +12,13 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   OriginalsSDK,
-  OrdMockProvider,
   MemoryStorageAdapter,
   Ed25519Signer,
   Ed25519Verifier,
-  KeyManager
+  KeyManager,
+  multikey
 } from '@originals/sdk';
-import { multikey } from '@originals/sdk/crypto/Multikey';
+import { OrdMockProvider } from '@originals/sdk/testing';
 import { prepareDataForSigning } from 'didwebvh-ts';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { generateArtwork } from '../src/sdk/artwork';

--- a/apps/landing/src/pages/YourOriginals.tsx
+++ b/apps/landing/src/pages/YourOriginals.tsx
@@ -47,7 +47,8 @@ export async function fetchOriginals(): Promise<OriginalRow[]> {
 // https, so a dev http origin returns false; the card still renders).
 async function resolveLive(did: string): Promise<boolean> {
   try {
-    const { OriginalsSDK, OrdMockProvider } = await import('@originals/sdk');
+    const { OriginalsSDK } = await import('@originals/sdk');
+    const { OrdMockProvider } = await import('@originals/sdk/testing');
     const { HttpHostingStorageAdapter } = await import('../sdk/http-hosting-adapter');
     const sdk = OriginalsSDK.create({
       network: 'regtest',

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -21,7 +21,8 @@ The main entry point for the Originals SDK. Orchestrates all managers and provid
 ### Creating an Instance
 
 ```typescript
-import { OriginalsSDK, OrdMockProvider } from '@originals/sdk';
+import { OriginalsSDK } from '@originals/sdk';
+import { OrdMockProvider } from '@originals/sdk/testing';
 
 // Basic creation with defaults
 const sdk = OriginalsSDK.create();

--- a/docs/IPFS_INTEGRATION_SPEC.md
+++ b/docs/IPFS_INTEGRATION_SPEC.md
@@ -252,6 +252,13 @@ interface SerializedIPFSIndex {
 
 ## 6. Configuration
 
+> **Packaging note (plan 043).** The `exports` map is now a curated list rather
+> than a set of directory wildcards, so the `@originals/sdk/storage/ipfs` and
+> `.../storage/hybrid` subpaths used in the examples below do **not** resolve
+> today — this remains a proposal, and neither adapter exists yet. Whoever
+> implements it must add those subpaths to `packages/sdk/package.json`
+> explicitly; the old `./storage/*` wildcard would have covered them silently.
+
 ### 6.1 SDK Integration
 
 ```typescript

--- a/docs/LLM_AGENT_GUIDE.md
+++ b/docs/LLM_AGENT_GUIDE.md
@@ -10,7 +10,8 @@
 ## Quick Reference
 
 ```typescript
-import { OriginalsSDK, OrdMockProvider } from '@originals/sdk';
+import { OriginalsSDK } from '@originals/sdk';
+import { OrdMockProvider } from '@originals/sdk/testing';
 
 // Create SDK instance (minimal)
 const sdk = OriginalsSDK.create({ network: 'regtest' });
@@ -1251,7 +1252,7 @@ interface OrdinalsProvider {
 ### Using OrdMockProvider (Testing)
 
 ```typescript
-import { OrdMockProvider } from '@originals/sdk';
+import { OrdMockProvider } from '@originals/sdk/testing';
 
 const sdk = OriginalsSDK.create({
   network: 'regtest',
@@ -1292,10 +1293,8 @@ const multibaseEncoded = multikey.encodeMultibase(dataBytes);
 ### Basic Lifecycle Flow
 
 ```typescript
-import { 
-  OriginalsSDK, 
-  OrdMockProvider
-} from '@originals/sdk';
+import { OriginalsSDK } from '@originals/sdk';
+import { OrdMockProvider } from '@originals/sdk/testing';
 import { sha256 } from '@noble/hashes/sha2.js';
 
 // 1. Configure SDK
@@ -1360,7 +1359,8 @@ console.log('Transfer txid:', tx.txid);
 ### Creating a Typed Module Original
 
 ```typescript
-import { OriginalsSDK, OriginalKind, OrdMockProvider } from '@originals/sdk';
+import { OriginalsSDK, OriginalKind } from '@originals/sdk';
+import { OrdMockProvider } from '@originals/sdk/testing';
 import { sha256 } from '@noble/hashes/sha2.js';
 
 const sdk = OriginalsSDK.create({
@@ -1671,9 +1671,8 @@ export { multikey } from './crypto/Multikey';
 // Storage
 export { MemoryStorageAdapter, LocalStorageAdapter } from './storage';
 
-// Adapters
-export { OrdMockProvider } from './adapters/providers/OrdMockProvider';
-export { FeeOracleMock } from './adapters/FeeOracleMock';
+// Test doubles live in the '@originals/sdk/testing' subpath, not the root:
+// import { OrdMockProvider, FeeOracleMock } from '@originals/sdk/testing';
 
 // Types - all exported from './types'
 export * from './types';

--- a/docs/LLM_QUICK_REFERENCE.md
+++ b/docs/LLM_QUICK_REFERENCE.md
@@ -3,7 +3,8 @@
 ## Initialization
 
 ```typescript
-import { OriginalsSDK, OrdMockProvider } from '@originals/sdk';
+import { OriginalsSDK } from '@originals/sdk';
+import { OrdMockProvider } from '@originals/sdk/testing';
 
 const sdk = OriginalsSDK.create({
   network: 'regtest',           // 'mainnet' | 'regtest' | 'signet'

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -13,6 +13,7 @@
   "bin": {
     "originals-cel": "./dist/cel/cli/index.js"
   },
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -25,70 +26,15 @@
       "import": "./dist/cel/index.js",
       "default": "./dist/cel/index.js"
     },
-    "./cel/*": {
-      "types": "./dist/cel/*.d.ts",
-      "import": "./dist/cel/*.js",
-      "default": "./dist/cel/*.js"
-    },
-    "./core/*": {
-      "types": "./dist/core/*.d.ts",
-      "import": "./dist/core/*.js",
-      "default": "./dist/core/*.js"
-    },
-    "./did/*": {
-      "types": "./dist/did/*.d.ts",
-      "import": "./dist/did/*.js",
-      "default": "./dist/did/*.js"
-    },
-    "./vc/*": {
-      "types": "./dist/vc/*.d.ts",
-      "import": "./dist/vc/*.js",
-      "default": "./dist/vc/*.js"
-    },
-    "./vc/cryptosuites/*": {
-      "types": "./dist/vc/cryptosuites/*.d.ts",
-      "import": "./dist/vc/cryptosuites/*.js",
-      "default": "./dist/vc/cryptosuites/*.js"
-    },
-    "./bitcoin/*": {
-      "types": "./dist/bitcoin/*.d.ts",
-      "import": "./dist/bitcoin/*.js",
-      "default": "./dist/bitcoin/*.js"
-    },
-    "./lifecycle/*": {
-      "types": "./dist/lifecycle/*.d.ts",
-      "import": "./dist/lifecycle/*.js",
-      "default": "./dist/lifecycle/*.js"
-    },
-    "./crypto/*": {
-      "types": "./dist/crypto/*.d.ts",
-      "import": "./dist/crypto/*.js",
-      "default": "./dist/crypto/*.js"
-    },
-    "./resources/*": {
-      "types": "./dist/resources/*.d.ts",
-      "import": "./dist/resources/*.js",
-      "default": "./dist/resources/*.js"
-    },
-    "./storage/*": {
-      "types": "./dist/storage/*.d.ts",
-      "import": "./dist/storage/*.js",
-      "default": "./dist/storage/*.js"
+    "./testing": {
+      "types": "./dist/testing/index.d.ts",
+      "import": "./dist/testing/index.js",
+      "default": "./dist/testing/index.js"
     },
     "./types": {
       "types": "./dist/types/index.d.ts",
       "import": "./dist/types/index.js",
       "default": "./dist/types/index.js"
-    },
-    "./types/*": {
-      "types": "./dist/types/*.d.ts",
-      "import": "./dist/types/*.js",
-      "default": "./dist/types/*.js"
-    },
-    "./utils/*": {
-      "types": "./dist/utils/*.d.ts",
-      "import": "./dist/utils/*.js",
-      "default": "./dist/utils/*.js"
     }
   },
   "scripts": {

--- a/packages/sdk/src/adapters/providers/OrdHttpProvider.ts
+++ b/packages/sdk/src/adapters/providers/OrdHttpProvider.ts
@@ -258,7 +258,7 @@ export class OrdHttpProvider implements OrdinalsProvider {
   }
 
   createInscription(params: {
-    data?: Buffer;
+    data?: Uint8Array;
     buildContent?: (satoshi: string) => InscriptionParts | Promise<InscriptionParts>;
     contentType: string;
     feeRate?: number;
@@ -272,7 +272,7 @@ export class OrdHttpProvider implements OrdinalsProvider {
     txid?: string;
     vout?: number;
     blockHeight?: number;
-    content?: Buffer;
+    content?: Uint8Array;
     contentType?: string;
     feeRate?: number;
     metadata?: Record<string, unknown>;

--- a/packages/sdk/src/adapters/providers/OrdMockProvider.ts
+++ b/packages/sdk/src/adapters/providers/OrdMockProvider.ts
@@ -3,7 +3,7 @@ import { OrdinalsProvider, InscriptionParts } from '../types.js';
 export interface OrdMockState {
   inscriptionsById: Map<string, {
     inscriptionId: string;
-    content: Buffer;
+    content: Uint8Array;
     contentType: string;
     txid: string;
     vout: number;
@@ -76,7 +76,7 @@ export class OrdMockProvider implements OrdinalsProvider {
   }
 
   async createInscription(params: {
-    data?: Buffer;
+    data?: Uint8Array;
     buildContent?: (satoshi: string) => InscriptionParts | Promise<InscriptionParts>;
     contentType: string;
     feeRate?: number;
@@ -91,21 +91,21 @@ export class OrdMockProvider implements OrdinalsProvider {
     // Pin the sat FIRST (mirrors real commit-phase sat assignment), then let
     // deferred content embed it.
     const satoshi = params.targetSatoshi ?? `${Math.floor(Math.random() * 1e12)}`;
-    // Normalize the deferred build result: a bare Buffer (content only) or
+    // Normalize the deferred build result: bare bytes (content only) or
     // `{ content, metadata }` (#407 phase 2). Deferred metadata wins over the
     // static `metadata` param.
-    let content: Buffer;
+    let content: Uint8Array;
     let deferredMetadata: Record<string, unknown> | undefined;
     if (params.buildContent) {
       const built = await params.buildContent(satoshi);
-      if (Buffer.isBuffer(built)) {
-        content = Buffer.from(built);
+      if (built instanceof Uint8Array) {
+        content = new Uint8Array(built);
       } else {
-        content = Buffer.from(built.content);
+        content = new Uint8Array(built.content);
         deferredMetadata = built.metadata;
       }
     } else {
-      content = params.data!;
+      content = new Uint8Array(params.data!);
     }
     const metadata = deferredMetadata ?? params.metadata;
     const vout = 0;
@@ -166,7 +166,7 @@ export class OrdMockProvider implements OrdinalsProvider {
       let doc: unknown = (rec.metadata as { didDocument?: unknown } | undefined)?.didDocument;
       if (doc === undefined) {
         try {
-          doc = JSON.parse(rec.content.toString('utf8'));
+          doc = JSON.parse(new TextDecoder().decode(rec.content));
         } catch {
           continue; // non-JSON, no metadata DID doc — not an anchoring inscription
         }

--- a/packages/sdk/src/adapters/providers/QuickNodeProvider.ts
+++ b/packages/sdk/src/adapters/providers/QuickNodeProvider.ts
@@ -642,7 +642,7 @@ export class QuickNodeProvider implements OrdinalsProvider {
   // transaction locally, sign it, and submit via broadcastTransaction.
 
   createInscription(params: {
-    data?: Buffer;
+    data?: Uint8Array;
     buildContent?: (satoshi: string) => InscriptionParts | Promise<InscriptionParts>;
     contentType: string;
     feeRate?: number;
@@ -656,7 +656,7 @@ export class QuickNodeProvider implements OrdinalsProvider {
     txid?: string;
     vout?: number;
     blockHeight?: number;
-    content?: Buffer;
+    content?: Uint8Array;
     contentType?: string;
     feeRate?: number;
     metadata?: Record<string, unknown>;

--- a/packages/sdk/src/adapters/types.ts
+++ b/packages/sdk/src/adapters/types.ts
@@ -3,7 +3,7 @@
  * or content plus the CBOR metadata to attach (the anchoring inscription's
  * `{ didDocument, celLog }` provenance).
  */
-export type InscriptionParts = Buffer | { content: Buffer; metadata?: Record<string, unknown> };
+export type InscriptionParts = Uint8Array | { content: Uint8Array; metadata?: Record<string, unknown> };
 
 export interface StoragePutOptions {
   contentType?: string;
@@ -11,12 +11,12 @@ export interface StoragePutOptions {
 }
 
 export interface StorageGetResult {
-  content: Buffer;
+  content: Uint8Array;
   contentType: string;
 }
 
 export interface StorageAdapter {
-  put(objectKey: string, data: Buffer | string, options?: StoragePutOptions): Promise<string>;
+  put(objectKey: string, data: Uint8Array | string, options?: StoragePutOptions): Promise<string>;
   get(objectKey: string): Promise<StorageGetResult | null>;
   delete?(objectKey: string): Promise<boolean>;
 }
@@ -30,7 +30,7 @@ export interface OrdinalsProvider {
   getInscriptionById(id: string): Promise<{
     inscriptionId: string;
     // Optional: deferred-content providers may not echo built content back.
-    content?: Buffer;
+    content?: Uint8Array;
     contentType: string;
     txid: string;
     vout: number;
@@ -61,12 +61,12 @@ export interface OrdinalsProvider {
   estimateFee(blocks?: number): Promise<number>;
   createInscription(params: {
     /** Static content. Provide exactly one of data / buildContent. */
-    data?: Buffer;
+    data?: Uint8Array;
     /**
      * Deferred content: called with the pinned satoshi between commit and
      * reveal, so content (and metadata) that must embed its own sat (a did:btco
      * DID document / the byte-light celLog) can be constructed. Provide exactly
-     * one of data / buildContent. May return a bare Buffer (content only) or
+     * one of data / buildContent. May return bare bytes (content only) or
      * `{ content, metadata }` — the returned metadata wins over the static
      * `metadata` param below (#407 phase 2).
      */
@@ -88,7 +88,7 @@ export interface OrdinalsProvider {
     txid?: string;
     vout?: number;
     blockHeight?: number;
-    content?: Buffer;
+    content?: Uint8Array;
     contentType?: string;
     feeRate?: number;
     metadata?: Record<string, unknown>;

--- a/packages/sdk/src/bitcoin/BitcoinManager.ts
+++ b/packages/sdk/src/bitcoin/BitcoinManager.ts
@@ -170,7 +170,7 @@ export class BitcoinManager {
         'ORD_PROVIDER_REQUIRED',
         'Ordinals provider must be configured to inscribe data on Bitcoin. ' +
         'Please provide an ordinalsProvider in your SDK configuration. ' +
-        'For testing, use: import { OrdMockProvider } from \'@originals/sdk\';'
+        'For testing, use: import { OrdMockProvider } from \'@originals/sdk/testing\';'
       );
     }
 
@@ -326,7 +326,7 @@ export class BitcoinManager {
         'ORD_PROVIDER_REQUIRED',
         'Ordinals provider must be configured to transfer inscriptions on Bitcoin. ' +
         'Please provide an ordinalsProvider in your SDK configuration. ' +
-        'For testing, use: import { OrdMockProvider } from \'@originals/sdk\';'
+        'For testing, use: import { OrdMockProvider } from \'@originals/sdk/testing\';'
       );
     }
 

--- a/packages/sdk/src/bitcoin/BitcoinManager.ts
+++ b/packages/sdk/src/bitcoin/BitcoinManager.ts
@@ -254,10 +254,10 @@ export class BitcoinManager {
       satoshi,
       inscriptionId: creation.inscriptionId,
       // On the deferred path `data` is a content-BUILDER function, never valid
-      // inscription content — only fall back to it when it is a real Buffer,
+      // inscription content — only fall back to it when it is real bytes,
       // else leave content undefined (a function here crashes downstream JSON
       // parsing after migrate + payment).
-      content: creation.content ?? (Buffer.isBuffer(data) ? data : undefined),
+      content: creation.content ?? (data instanceof Uint8Array ? data : undefined),
       contentType: creation.contentType ?? contentType,
       txid,
       vout: typeof creation.vout === 'number' ? creation.vout : 0,

--- a/packages/sdk/src/bitcoin/OrdinalsClient.ts
+++ b/packages/sdk/src/bitcoin/OrdinalsClient.ts
@@ -189,7 +189,7 @@ export class OrdinalsClient {
     if (contentArrayBuf.byteLength > this.maxContentBytes) {
       throw new Error(`OrdinalsClient: inscription content exceeds ${this.maxContentBytes} bytes`);
     }
-    const content = Buffer.from(new Uint8Array(contentArrayBuf));
+    const content = new Uint8Array(contentArrayBuf);
 
     // owner_output may be 'txid:vout'
     let txid = 'unknown';

--- a/packages/sdk/src/bitcoin/inscribe-on-sat.ts
+++ b/packages/sdk/src/bitcoin/inscribe-on-sat.ts
@@ -8,7 +8,7 @@ import { createCommitTransaction, createRevealTransaction } from './transactions
 import { scriptPubKeyForAddress } from './transfer.js';
 
 export interface InscribeOnSatParams {
-  buildContent: (satoshi: string) => Promise<{ content: Buffer; contentType: string; metadata?: Record<string, unknown> }>;
+  buildContent: (satoshi: string) => Promise<{ content: Uint8Array; contentType: string; metadata?: Record<string, unknown> }>;
   fundingUtxo: Utxo;
   satSigner: BitcoinSigner;
   changeAddress: string;

--- a/packages/sdk/src/bitcoin/providers/SignetProvider.ts
+++ b/packages/sdk/src/bitcoin/providers/SignetProvider.ts
@@ -176,7 +176,7 @@ export class SignetProvider implements OrdinalsProvider {
 
   // eslint-disable-next-line @typescript-eslint/require-await
   async createInscription(_params: {
-    data: Buffer;
+    data: Uint8Array;
     contentType: string;
     feeRate?: number;
   }): Promise<never> {

--- a/packages/sdk/src/bitcoin/transactions/commit.ts
+++ b/packages/sdk/src/bitcoin/transactions/commit.ts
@@ -66,8 +66,8 @@ export function getScureNetwork(network: BitcoinNetwork): typeof btc.NETWORK {
  * Parameters for creating a commit transaction
  */
 export interface CommitTransactionParams {
-  /** Inscription content as Buffer */
-  content: Buffer;
+  /** Inscription content bytes */
+  content: Uint8Array;
   /** MIME type of the content (e.g., 'text/plain', 'image/png') */
   contentType: string;
   /** Available UTXOs to fund the transaction */

--- a/packages/sdk/src/bitcoin/transfer.ts
+++ b/packages/sdk/src/bitcoin/transfer.ts
@@ -1,4 +1,5 @@
 import * as btc from '@scure/btc-signer';
+import { bytesToHex } from '@noble/hashes/utils.js';
 import { BitcoinTransaction, TransactionInput, TransactionOutput, Utxo, DUST_LIMIT_SATS } from '../types/index.js';
 import { validateBitcoinAddress } from '../utils/bitcoin-address.js';
 import { selectUtxos, SelectionOptions, SelectionResult } from './utxo.js';
@@ -45,7 +46,7 @@ export function addressToScriptPubKey(address: string, network: typeof btc.NETWO
     throw new Error(`Invalid address: ${address}`);
   }
   const script = btc.OutScript.encode(decoded);
-  return Buffer.from(script).toString('hex');
+  return bytesToHex(script);
 }
 
 /**

--- a/packages/sdk/src/cel/index.ts
+++ b/packages/sdk/src/cel/index.ts
@@ -19,6 +19,7 @@ export * from './keyResolver.js';
 export {
   celSignerFromKeyPair,
   createKeyStoreCelSigner,
+  currentControllerVm,
   hexSha256ToDigestMultibase,
 } from './signerAdapter.js';
 // The CLI is intentionally NOT re-exported here. It statically imports fs and

--- a/packages/sdk/src/crypto/OriginalsSigner.ts
+++ b/packages/sdk/src/crypto/OriginalsSigner.ts
@@ -67,7 +67,7 @@ export function signerFromKeyPair(keyPair: KeyPair): OriginalsSigner {
     verificationMethodId: canonicalDidKeyVm(keyPair.publicKey),
     publicKeyMultibase: keyPair.publicKey,
     async signBytes(bytes: Uint8Array): Promise<Uint8Array> {
-      return new Uint8Array(await signer.sign(Buffer.from(bytes), keyPair.privateKey));
+      return await signer.sign(bytes, keyPair.privateKey);
     },
   };
 }
@@ -100,7 +100,7 @@ export function signerFromKeyStore(
         throw new StructuredError('SIGNING_KEY_NOT_FOUND',
           `No private key in keyStore for ${verificationMethodId}`);
       }
-      return new Uint8Array(await signerForKeyType(pubType).sign(Buffer.from(bytes), priv));
+      return await signerForKeyType(pubType).sign(bytes, priv);
     },
   };
 }

--- a/packages/sdk/src/crypto/Signer.ts
+++ b/packages/sdk/src/crypto/Signer.ts
@@ -1,6 +1,6 @@
 export abstract class Signer {
-  abstract sign(data: Buffer, privateKeyMultibase: string): Promise<Buffer>;
-  abstract verify(data: Buffer, signature: Buffer, publicKeyMultibase: string): Promise<boolean>;
+  abstract sign(data: Uint8Array, privateKeyMultibase: string): Promise<Uint8Array>;
+  abstract verify(data: Uint8Array, signature: Uint8Array, publicKeyMultibase: string): Promise<boolean>;
 }
 
 import { bls12_381 as bls } from '@noble/curves/bls12-381.js';
@@ -37,7 +37,7 @@ export function signerForKeyType(type: MultikeyType): Signer {
 }
 
 export class ES256KSigner extends Signer {
-  async sign(data: Buffer, privateKeyMultibase: string): Promise<Buffer> {
+  async sign(data: Uint8Array, privateKeyMultibase: string): Promise<Uint8Array> {
     if (!privateKeyMultibase || privateKeyMultibase[0] !== 'z') {
       throw new Error('Invalid multibase key format. Keys must use multicodec headers.');
     }
@@ -70,10 +70,10 @@ export class ES256KSigner extends Signer {
           ? sigAny.toRawBytes()
           : new Uint8Array(sigAny);
     /* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
-    return Buffer.from(sigBytes);
+    return sigBytes;
   }
 
-  async verify(data: Buffer, signature: Buffer, publicKeyMultibase: string): Promise<boolean> {
+  async verify(data: Uint8Array, signature: Uint8Array, publicKeyMultibase: string): Promise<boolean> {
     if (!publicKeyMultibase || publicKeyMultibase[0] !== 'z') {
       throw new Error('Invalid multibase key format. Keys must use multicodec headers.');
     }
@@ -104,7 +104,7 @@ export class ES256KSigner extends Signer {
 }
 
 export class Ed25519Signer extends Signer {
-  async sign(data: Buffer, privateKeyMultibase: string): Promise<Buffer> {
+  async sign(data: Uint8Array, privateKeyMultibase: string): Promise<Uint8Array> {
     if (!privateKeyMultibase || privateKeyMultibase[0] !== 'z') {
       throw new Error('Invalid multibase key format. Keys must use multicodec headers.');
     }
@@ -127,10 +127,10 @@ export class Ed25519Signer extends Signer {
     const privateKey = decoded.key;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     const signature = await (ed25519 as any).signAsync(data, privateKey);
-    return Buffer.from(signature);
+    return signature as Uint8Array;
   }
 
-  async verify(data: Buffer, signature: Buffer, publicKeyMultibase: string): Promise<boolean> {
+  async verify(data: Uint8Array, signature: Uint8Array, publicKeyMultibase: string): Promise<boolean> {
     if (!publicKeyMultibase || publicKeyMultibase[0] !== 'z') {
       throw new Error('Invalid multibase key format. Keys must use multicodec headers.');
     }
@@ -161,7 +161,7 @@ export class Ed25519Signer extends Signer {
 }
 
 export class ES256Signer extends Signer {
-  async sign(data: Buffer, privateKeyMultibase: string): Promise<Buffer> {
+  async sign(data: Uint8Array, privateKeyMultibase: string): Promise<Uint8Array> {
     if (!privateKeyMultibase || privateKeyMultibase[0] !== 'z') {
       throw new Error('Invalid multibase key format. Keys must use multicodec headers.');
     }
@@ -194,10 +194,10 @@ export class ES256Signer extends Signer {
           ? sigAny.toRawBytes()
           : new Uint8Array(sigAny);
     /* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
-    return await Promise.resolve(Buffer.from(sigBytes));
+    return await Promise.resolve(sigBytes);
   }
 
-  async verify(data: Buffer, signature: Buffer, publicKeyMultibase: string): Promise<boolean> {
+  async verify(data: Uint8Array, signature: Uint8Array, publicKeyMultibase: string): Promise<boolean> {
     if (!publicKeyMultibase || publicKeyMultibase[0] !== 'z') {
       throw new Error('Invalid multibase key format. Keys must use multicodec headers.');
     }
@@ -228,7 +228,7 @@ export class ES256Signer extends Signer {
 }
 
 export class Bls12381G2Signer extends Signer {
-  async sign(data: Buffer, privateKeyMultibase: string): Promise<Buffer> {
+  async sign(data: Uint8Array, privateKeyMultibase: string): Promise<Uint8Array> {
     if (!privateKeyMultibase || privateKeyMultibase[0] !== 'z') {
       throw new Error('Invalid multibase key format. Keys must use multicodec headers.');
     }
@@ -251,10 +251,10 @@ export class Bls12381G2Signer extends Signer {
     const sk = decoded.key;
     const hashedMessage = bls.shortSignatures.hash(data);
     const sig = bls.shortSignatures.sign(hashedMessage, sk);
-    return await Promise.resolve(Buffer.from(sig.toBytes()));
+    return await Promise.resolve(sig.toBytes());
   }
 
-  async verify(data: Buffer, signature: Buffer, publicKeyMultibase: string): Promise<boolean> {
+  async verify(data: Uint8Array, signature: Uint8Array, publicKeyMultibase: string): Promise<boolean> {
     if (!publicKeyMultibase || publicKeyMultibase[0] !== 'z') {
       throw new Error('Invalid multibase key format. Keys must use multicodec headers.');
     }

--- a/packages/sdk/src/crypto/Signer.ts
+++ b/packages/sdk/src/crypto/Signer.ts
@@ -1,6 +1,3 @@
-// Initialize noble crypto libraries first (idempotent - safe to import multiple times)
-import './noble-init.js';
-
 export abstract class Signer {
   abstract sign(data: Buffer, privateKeyMultibase: string): Promise<Buffer>;
   abstract verify(data: Buffer, signature: Buffer, publicKeyMultibase: string): Promise<boolean>;
@@ -12,6 +9,11 @@ import { sha256 } from '@noble/hashes/sha2.js';
 import * as secp256k1 from '@noble/secp256k1';
 import * as ed25519 from '@noble/ed25519';
 import { multikey, MultikeyType } from './Multikey.js';
+import { initNobleCrypto } from './noble-init.js';
+
+// secp256k1.verify (sync) needs hashes.sha256 configured; explicit call, not a
+// side-effect import, so bundlers can tree-shake with sideEffects: false.
+initNobleCrypto();
 
 /**
  * Return the Signer that matches a key's multicodec type. The multikey header

--- a/packages/sdk/src/crypto/noble-init.ts
+++ b/packages/sdk/src/crypto/noble-init.ts
@@ -156,14 +156,17 @@ export function initEd25519(
   }
 }
 
+// Once-guard: modules that use noble sync APIs call this at module scope, so
+// there is no import-time side effect for bundlers to preserve (sideEffects: false).
+let initialized = false;
+
 /**
- * Initialize all noble crypto libraries
- * This should be called once at SDK startup
+ * Initialize all noble crypto libraries. Idempotent; call before any sync
+ * noble API use (`sign`, `verify`, `getPublicKey`). Async variants need no init.
  */
 export function initNobleCrypto(): void {
+  if (initialized) return;
+  initialized = true;
   initSecp256k1();
   initEd25519();
 }
-
-// Auto-initialize when this module is imported
-initNobleCrypto();

--- a/packages/sdk/src/crypto/signerConformance.ts
+++ b/packages/sdk/src/crypto/signerConformance.ts
@@ -74,7 +74,7 @@ export async function assertSignerConformance(signer: OriginalsSigner): Promise<
 
   // 4 — signature verifies against the claimed public key
   const verifier = signerForKeyType(keyType);
-  if (!(await verifier.verify(Buffer.from(message1), Buffer.from(sig1), signer.publicKeyMultibase))) {
+  if (!(await verifier.verify(message1, sig1, signer.publicKeyMultibase))) {
     fail(
       'the signature does not verify against publicKeyMultibase. The signer must sign EXACTLY ' +
       'the bytes it is given (no extra hashing or canonicalization) with the key it claims.'
@@ -83,7 +83,7 @@ export async function assertSignerConformance(signer: OriginalsSigner): Promise<
 
   // 5 — message-bound signatures
   const sig2 = await signer.signBytes(message2);
-  if (await verifier.verify(Buffer.from(message1), Buffer.from(sig2), signer.publicKeyMultibase)) {
+  if (await verifier.verify(message1, sig2, signer.publicKeyMultibase)) {
     fail('a signature over one message verified a different message — the signer is ignoring its input');
   }
 }

--- a/packages/sdk/src/did/DIDManager.ts
+++ b/packages/sdk/src/did/DIDManager.ts
@@ -20,6 +20,7 @@ import { resolveDidCel, DID_CEL_PREFIX } from '../cel/celDid.js';
 import { parseEventLogJson } from '../cel/serialization/json.js';
 import { createDidManagerKeyResolver } from '../cel/keyResolver.js';
 import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex } from '@noble/hashes/utils.js';
 import { DIDCache } from './DIDCache.js';
 import type { MetricsCollector } from '../utils/MetricsCollector.js';
 
@@ -184,7 +185,7 @@ export class DIDManager {
       .toLowerCase();
     const slug = rawSlug.length <= MAX_HUMAN_READABLE_SLUG_LENGTH
       ? rawSlug
-      : Buffer.from(sha256(new TextEncoder().encode(originalSuffix))).toString('hex').slice(0, 32);
+      : bytesToHex(sha256(new TextEncoder().encode(originalSuffix))).slice(0, 32);
 
     // Carry the source document's multikey verification methods over as
     // verification-only keys (they do not become updateKeys — log updates are

--- a/packages/sdk/src/did/KeyManager.ts
+++ b/packages/sdk/src/did/KeyManager.ts
@@ -1,11 +1,13 @@
-// Initialize noble crypto libraries first (idempotent - safe to import multiple times)
-import '../crypto/noble-init.js';
-
 import { DIDDocument, KeyPair, KeyType, KeyRecoveryCredential } from '../types/index.js';
 import * as secp256k1 from '@noble/secp256k1';
 import * as ed25519 from '@noble/ed25519';
 import { p256 } from '@noble/curves/nist.js';
 import { multikey, MultikeyType } from '../crypto/Multikey.js';
+import { initNobleCrypto } from '../crypto/noble-init.js';
+
+// secp256k1.getPublicKey (sync) is used below; explicit call, not a side-effect
+// import, so bundlers can tree-shake with sideEffects: false.
+initNobleCrypto();
 
 function toMultikeyType(type: KeyType): MultikeyType {
         if (type === 'ES256K') return 'Secp256k1';

--- a/packages/sdk/src/did/KeyManager.ts
+++ b/packages/sdk/src/did/KeyManager.ts
@@ -220,18 +220,18 @@ export class KeyManager {
 		return { didDocument: updatedDidDocument, recoveryCredential, newKeyPair };
 	}
 
-        encodePublicKeyMultibase(publicKey: Buffer, type: KeyType): string {
+        encodePublicKeyMultibase(publicKey: Uint8Array, type: KeyType): string {
                 const mkType = toMultikeyType(type);
-                return multikey.encodePublicKey(new Uint8Array(publicKey), mkType);
+                return multikey.encodePublicKey(publicKey, mkType);
         }
 
-        decodePublicKeyMultibase(encoded: string): { key: Buffer; type: KeyType } {
+        decodePublicKeyMultibase(encoded: string): { key: Uint8Array; type: KeyType } {
                 if (!encoded || typeof encoded !== 'string') {
                         throw new Error('Invalid multibase string');
                 }
                 try {
                         const decoded = multikey.decodePublicKey(encoded);
-                        return { key: Buffer.from(decoded.key), type: fromMultikeyType(decoded.type) };
+                        return { key: decoded.key, type: fromMultikeyType(decoded.type) };
                 } catch {
                         throw new Error('Invalid multibase string');
                 }

--- a/packages/sdk/src/did/WebVHManager.ts
+++ b/packages/sdk/src/did/WebVHManager.ts
@@ -149,10 +149,7 @@ class OriginalsWebVHSigner implements Signer, Verifier {
     const dataToSign = await signingInput.didWebvh(input.document, input.proof);
     
     // Sign using our Ed25519 signer
-    const signature: Buffer = await this.signer.sign(
-      Buffer.from(dataToSign),
-      this.privateKeyMultibase
-    );
+    const signature = await this.signer.sign(dataToSign, this.privateKeyMultibase);
 
     // Encode signature as multibase
     const proofValue = multikey.encodeMultibase(signature);
@@ -165,14 +162,7 @@ class OriginalsWebVHSigner implements Signer, Verifier {
     const publicKeyMultibase = multikey.encodePublicKey(publicKey, 'Ed25519');
     
     // Verify using our Ed25519 signer
-    const messageBuffer: Buffer = Buffer.from(message);
-    const signatureBuffer: Buffer = Buffer.from(signature);
-    
-    return this.signer.verify(
-      messageBuffer,
-      signatureBuffer,
-      publicKeyMultibase
-    );
+    return this.signer.verify(message, signature, publicKeyMultibase);
   }
 
   getVerificationMethodId(): string {

--- a/packages/sdk/src/did/providers/OrdinalsProviderResolverAdapter.ts
+++ b/packages/sdk/src/did/providers/OrdinalsProviderResolverAdapter.ts
@@ -75,6 +75,6 @@ export class OrdinalsProviderResolverAdapter implements ResourceProviderLike {
     if (inscription.content === undefined) {
       return respond(false, 404, 'Not Found', `Inscription ${inscriptionId} has no content to serve`);
     }
-    return respond(true, 200, 'OK', inscription.content.toString('utf8'));
+    return respond(true, 200, 'OK', new TextDecoder().decode(inscription.content));
   };
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,6 +1,6 @@
 /* istanbul ignore file */
-// Initialize noble crypto libraries first (must run before any crypto operations)
-import './crypto/noble-init.js';
+// No side-effect imports here: noble sync-hash config happens at point of use
+// (crypto/Signer.ts, did/KeyManager.ts), so `sideEffects: false` holds.
 
 import { OriginalsSDK } from './core/OriginalsSDK.js';
 
@@ -73,7 +73,12 @@ export { calculateFee } from './bitcoin/fee-calculation.js';
 export { BBSCryptosuiteUtils } from './vc/cryptosuites/bbs.js';
 export { BBSCryptosuiteManager } from './vc/cryptosuites/bbsCryptosuite.js';
 export type { BBSProofOptions, BBSDeriveOptions, BBSVerifyOptions } from './vc/cryptosuites/bbsCryptosuite.js';
+// Remote-signer verification toolkit (plan 043): the verifier, the EdDSA suite
+// (shared signing-input construction), and the JSON-LD document loader.
+export { Verifier } from './vc/Verifier.js';
 export type { StatusListResolver } from './vc/Verifier.js';
+export { EdDSACryptosuiteManager } from './vc/cryptosuites/eddsa.js';
+export { createDocumentLoader } from './vc/documentLoader.js';
 export { MultiSigManager } from './vc/MultiSigManager.js';
 export * from './storage/index.js';
 
@@ -190,19 +195,17 @@ export { EventLogger } from './utils/EventLogger.js';
 export type { EventLoggingConfig } from './utils/EventLogger.js';
 export { OperationLock } from './utils/OperationLock.js';
 
-// Utility exports
+// Utility exports. retry/circuit-breaker are internal infrastructure, not API
+// (plan 043); they remain importable in-repo but are no longer re-exported.
 export * from './utils/validation.js';
 export * from './utils/bitcoin-address.js';
 export * from './utils/satoshi-validation.js';
 export * from './utils/serialization.js';
-export * from './utils/retry.js';
 export * from './utils/telemetry.js';
-export * from './utils/circuit-breaker.js';
 export { sha256Bytes } from './utils/hash.js';
 
-// Adapter exports (for testing and custom integrations)
-export { OrdMockProvider } from './adapters/providers/OrdMockProvider.js';
-export { FeeOracleMock } from './adapters/FeeOracleMock.js';
+// Adapter exports (custom integrations). Test doubles (OrdMockProvider,
+// FeeOracleMock) moved to '@originals/sdk/testing' (plan 043).
 export { SignetProvider } from './bitcoin/providers/SignetProvider.js';
 export type { SignetProviderOptions } from './bitcoin/providers/SignetProvider.js';
 export { QuickNodeProvider } from './adapters/providers/QuickNodeProvider.js';
@@ -288,6 +291,7 @@ export {
 export {
   celSignerFromKeyPair,
   createKeyStoreCelSigner,
+  currentControllerVm,
   hexSha256ToDigestMultibase,
 } from './cel/signerAdapter.js';
 

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -26,6 +26,7 @@ import {
   type AssetEnvelope
 } from './assetEnvelope.js';
 import { encodeBase64UrlMultibase, hexToBytes } from '../utils/encoding.js';
+import { bytesToHex } from '@noble/hashes/utils.js';
 import { hashResource, validateCredential } from '../utils/validation.js';
 import { validateBitcoinAddress } from '../utils/bitcoin-address.js';
 import { parseSatoshiIdentifier, validateSatoshiNumber } from '../utils/satoshi-validation.js';
@@ -680,7 +681,7 @@ export class LifecycleManager {
       }
       for (const res of env.resources) {
         if (typeof res.content === 'string') {
-          const computed = hashResource(Buffer.from(res.content, 'utf8'));
+          const computed = hashResource(new TextEncoder().encode(res.content));
           if (computed.toLowerCase() !== String(res.hash).toLowerCase()) {
             throw new StructuredError(
               'ASSET_LOAD_VERIFICATION_FAILED',
@@ -728,7 +729,7 @@ export class LifecycleManager {
         // carries the bytes inline (AssetResource.content); a resource that omits
         // them is a pure reference and rides on the res.hash↔toHash match above.
         if (typeof res.content === 'string') {
-          const computed = hashResource(Buffer.from(res.content, 'utf8'));
+          const computed = hashResource(new TextEncoder().encode(res.content));
           if (computed.toLowerCase() !== match.toHash.toLowerCase()) {
             throw new StructuredError(
               'ASSET_LOAD_VERIFICATION_FAILED',
@@ -1175,7 +1176,7 @@ export class LifecycleManager {
       const dm = ref.digestMultibase;
       if (typeof dm !== 'string') continue;
       let hash: string;
-      try { hash = Buffer.from(decodeDigestMultibase(dm)).toString('hex'); } catch { continue; }
+      try { hash = bytesToHex(decodeDigestMultibase(dm)); } catch { continue; }
       const url = Array.isArray(ref.url) && typeof ref.url[0] === 'string' ? ref.url[0] : undefined;
       resources.push({
         id: typeof ref.id === 'string' ? ref.id : '',
@@ -1208,7 +1209,7 @@ export class LifecycleManager {
     const head = mostRecentResourceHead(log);
     if (headContent && head) {
       const contentStr = new TextDecoder().decode(headContent);
-      if (hashResource(Buffer.from(contentStr, 'utf8')).toLowerCase() === head.hash.toLowerCase()) {
+      if (hashResource(new TextEncoder().encode(contentStr)).toLowerCase() === head.hash.toLowerCase()) {
         const target = resources.find(r => (!head.resourceId || r.id === head.resourceId) && r.hash === head.hash && r.content === undefined);
         if (target) target.content = contentStr;
       }
@@ -1518,7 +1519,7 @@ export class LifecycleManager {
       if (resource.size) {
         dataSize += resource.size;
       } else if (resource.content) {
-        dataSize += Buffer.from(resource.content).length;
+        dataSize += new TextEncoder().encode(resource.content).length;
       } else {
         // Estimate based on hash length (assume average resource size)
         dataSize += 1000;
@@ -1539,7 +1540,7 @@ export class LifecycleManager {
       metadata: manifest.metadata,
       timestamp: new Date().toISOString()
     };
-    dataSize += Buffer.from(JSON.stringify(inscriptionManifest)).length;
+    dataSize += new TextEncoder().encode(JSON.stringify(inscriptionManifest)).length;
     
     // Get fee rate from oracle or use provided/default
     let effectiveFeeRate = feeRate;
@@ -1931,7 +1932,7 @@ export class LifecycleManager {
    */
   private assertContentMatchesDeclaredHash(resource: AssetResource, operation: string): void {
     if (typeof resource.content !== 'string') return;
-    const computed = hashResource(Buffer.from(resource.content, 'utf8'));
+    const computed = hashResource(new TextEncoder().encode(resource.content));
     if (computed.toLowerCase() !== resource.hash.toLowerCase()) {
       throw new StructuredError(
         'RESOURCE_HASH_MISMATCH',
@@ -1989,11 +1990,11 @@ export class LifecycleManager {
     const jsonl = log.map((e) => JSON.stringify(e)).join('\n');
 
     const storage = (this.config as { storageAdapter?: unknown }).storageAdapter;
-    const withPut = storage as { put?: (key: string, data: Buffer, options: { contentType: string }) => Promise<unknown> } | undefined;
+    const withPut = storage as { put?: (key: string, data: Uint8Array, options: { contentType: string }) => Promise<unknown> } | undefined;
     const withPutObject = storage as { putObject?: (domain: string, path: string, data: Uint8Array) => Promise<unknown> } | undefined;
 
     if (withPut && typeof withPut.put === 'function') {
-      await withPut.put(`${domain}/${relativePath}`, Buffer.from(jsonl), { contentType: 'application/jsonl' });
+      await withPut.put(`${domain}/${relativePath}`, new TextEncoder().encode(jsonl), { contentType: 'application/jsonl' });
       writtenObjects?.push({ domain, relativePath });
     } else if (withPutObject && typeof withPutObject.putObject === 'function') {
       await withPutObject.putObject(domain, relativePath, new TextEncoder().encode(jsonl));
@@ -2023,11 +2024,11 @@ export class LifecycleManager {
     const json = serializeEventLogJson(log);
 
     const storage = (this.config as { storageAdapter?: unknown }).storageAdapter;
-    const withPut = storage as { put?: (key: string, data: Buffer, options: { contentType: string }) => Promise<unknown> } | undefined;
+    const withPut = storage as { put?: (key: string, data: Uint8Array, options: { contentType: string }) => Promise<unknown> } | undefined;
     const withPutObject = storage as { putObject?: (domain: string, path: string, data: Uint8Array) => Promise<unknown> } | undefined;
 
     if (withPut && typeof withPut.put === 'function') {
-      await withPut.put(`${domain}/${relativePath}`, Buffer.from(json), { contentType: 'application/json' });
+      await withPut.put(`${domain}/${relativePath}`, new TextEncoder().encode(json), { contentType: 'application/json' });
       writtenObjects?.push({ domain, relativePath });
     } else if (withPutObject && typeof withPutObject.putObject === 'function') {
       await withPutObject.putObject(domain, relativePath, new TextEncoder().encode(json));
@@ -2055,10 +2056,10 @@ export class LifecycleManager {
     try {
       const suffix = deriveDidCel(log).slice(DID_CEL_PREFIX.length);
       const json = serializeEventLogJson(log);
-      const withPut = storage as { put?: (key: string, data: Buffer, options: { contentType: string }) => Promise<unknown> };
+      const withPut = storage as { put?: (key: string, data: Uint8Array, options: { contentType: string }) => Promise<unknown> };
       const withPutObject = storage as { putObject?: (domain: string, path: string, data: Uint8Array) => Promise<unknown> };
       if (typeof withPut.put === 'function') {
-        await withPut.put(`cel/${suffix}.json`, Buffer.from(json), { contentType: 'application/json' });
+        await withPut.put(`cel/${suffix}.json`, new TextEncoder().encode(json), { contentType: 'application/json' });
       } else if (typeof withPutObject.putObject === 'function') {
         await withPutObject.putObject('cel', `${suffix}.json`, new TextEncoder().encode(json));
       }
@@ -2156,9 +2157,9 @@ export class LifecycleManager {
       // hash (issue #347).
       this.assertContentMatchesDeclaredHash(resource, 'publish');
 
-      const data = Buffer.from(resource.content);
+      const data = new TextEncoder().encode(resource.content);
 
-      const storageWithPut = storage as { put?: (key: string, data: Buffer, options: { contentType: string }) => Promise<void> };
+      const storageWithPut = storage as { put?: (key: string, data: Uint8Array, options: { contentType: string }) => Promise<void> };
       const storageWithPutObject = storage as { putObject?: (domain: string, path: string, data: Uint8Array) => Promise<void> };
 
       if (typeof storageWithPut.put === 'function') {
@@ -2583,12 +2584,12 @@ export class LifecycleManager {
     const bitcoinManager = this.deps?.bitcoinManager ?? new BitcoinManager(this.config);
     const headMedia = this.tryResolveHeadMedia(asset);
     // Cost surfacing (spec §0/§5): estimate + emit BEFORE the paid broadcast.
-    await this.emitInscribeCost(bitcoinManager, asset, headMedia?.content ?? Buffer.from(JSON.stringify(btcoDoc)));
+    await this.emitInscribeCost(bitcoinManager, asset, headMedia?.content ?? new TextEncoder().encode(JSON.stringify(btcoDoc)));
 
     let inscription: { inscriptionId: string; satoshi?: string; txid?: string; revealTxId?: string };
     try {
       inscription = await bitcoinManager.inscribeData(
-        headMedia ? headMedia.content : Buffer.from(JSON.stringify(btcoDoc)),
+        headMedia ? headMedia.content : new TextEncoder().encode(JSON.stringify(btcoDoc)),
         headMedia ? headMedia.contentType : 'application/did+json',
         undefined,
         { targetSatoshi: satoshi, metadata, lockKey: asset.id }
@@ -2642,7 +2643,7 @@ export class LifecycleManager {
    * cost (fee rate × rough vsize). Never gates — an estimator failure must not
    * block the paid op the caller already intends.
    */
-  private async emitInscribeCost(bitcoinManager: BitcoinManager, asset: OriginalsAsset, content: Buffer): Promise<void> {
+  private async emitInscribeCost(bitcoinManager: BitcoinManager, asset: OriginalsAsset, content: Uint8Array): Promise<void> {
     try {
       const feeRate = await bitcoinManager.estimateFeeRate();
       // Rough commit+reveal vsize: content bytes / 4 (witness discount) + ~200
@@ -2675,7 +2676,7 @@ export class LifecycleManager {
    * so such assets carry NO media on-chain (honest, per the reference-only
    * pattern this SDK supports — content-as-ordinal applies to inline media only).
    */
-  private tryResolveHeadMedia(asset: OriginalsAsset): { content: Buffer; contentType: string } | null {
+  private tryResolveHeadMedia(asset: OriginalsAsset): { content: Uint8Array; contentType: string } | null {
     const log = asset.celLog;
     if (!log) return null;
     const head = mostRecentResourceHead(log);
@@ -2686,14 +2687,14 @@ export class LifecycleManager {
     const pending = asset.pendingHeadMedia;
     if (pending && pending.hash === head.hash && (!head.resourceId || pending.resourceId === head.resourceId)) {
       return {
-        content: Buffer.from(pending.content, 'utf8'),
+        content: new TextEncoder().encode(pending.content),
         contentType: pending.contentType ?? head.contentType ?? 'application/octet-stream'
       };
     }
     const res = asset.resources.find(r => (!head.resourceId || r.id === head.resourceId) && r.hash === head.hash);
     if (!res || typeof res.content !== 'string') return null;
     return {
-      content: Buffer.from(res.content, 'utf8'),
+      content: new TextEncoder().encode(res.content),
       contentType: res.contentType ?? head.contentType ?? 'application/octet-stream'
     };
   }
@@ -2837,7 +2838,7 @@ export class LifecycleManager {
       // Metadata = { didDocument, celLog }. Snapshot the log AFTER the migrate
       // append so the embedded celLog head equals the #cel anchor digest.
       return {
-        content: headMedia ? headMedia.content : Buffer.from(JSON.stringify(btcoDoc)),
+        content: headMedia ? headMedia.content : new TextEncoder().encode(JSON.stringify(btcoDoc)),
         contentType: inscriptionContentType,
         metadata: {
           didDocument: btcoDoc,
@@ -2853,7 +2854,7 @@ export class LifecycleManager {
       inscriptionId: string;
       satoshi?: string;
       feeRate?: number;
-      content?: Buffer;
+      content?: Uint8Array;
       metadata?: Record<string, unknown>;
     };
     // Set only on a RECOVERABLE reveal-broadcast failure (sat-selected path): the
@@ -3218,7 +3219,7 @@ export class LifecycleManager {
     const inscription = {
       satoshi,
       inscriptionId,
-      content: Buffer.alloc(0),
+      content: new Uint8Array(0),
       contentType: 'application/octet-stream',
       // Not used by transferInscription (which reads only inscriptionId); kept
       // for shape. Empty rather than a fabricated 'unknown-tx'.
@@ -3395,7 +3396,7 @@ export class LifecycleManager {
     };
     try {
       return await bitcoinManager.inscribeData(
-        headMedia ? headMedia.content : Buffer.from(JSON.stringify(rotatedDoc)),
+        headMedia ? headMedia.content : new TextEncoder().encode(JSON.stringify(rotatedDoc)),
         headMedia ? headMedia.contentType : 'application/did+json',
         feeRate,
         { targetSatoshi: satoshi, metadata }
@@ -4284,7 +4285,7 @@ export class LifecycleManager {
   async estimateAppendCost(
     asset: OriginalsAsset,
     appendKind: AppendKind,
-    opts?: { content?: string | Buffer; contentType?: string; feeRate?: number }
+    opts?: { content?: string | Uint8Array; contentType?: string; feeRate?: number }
   ): Promise<AppendCostEstimate> {
     const provider = this.config.ordinalsProvider ?? this.deps?.bitcoinManager?.ordinalsProvider;
     if (!provider) {
@@ -4331,14 +4332,14 @@ export class LifecycleManager {
   private resolveAppendPayloadBytes(
     asset: OriginalsAsset,
     appendKind: AppendKind,
-    opts?: { content?: string | Buffer }
+    opts?: { content?: string | Uint8Array }
   ): number {
     if (opts?.content !== undefined) {
-      const buf = Buffer.isBuffer(opts.content) ? opts.content : Buffer.from(String(opts.content), 'utf8');
+      const buf = typeof opts.content === 'string' ? new TextEncoder().encode(opts.content) : opts.content;
       return buf.byteLength;
     }
     if (appendKind === 'update' && asset.pendingHeadMedia) {
-      return Buffer.from(asset.pendingHeadMedia.content, 'utf8').byteLength;
+      return new TextEncoder().encode(asset.pendingHeadMedia.content).byteLength;
     }
     // Head media is the inscribed CONTENT for BOTH kinds when present (update:
     // reinscribeCelAppend; rotate: reinscribeRotatedDoc) — so this is the paid size.
@@ -4353,7 +4354,7 @@ export class LifecycleManager {
       const vm = currentControllerVm(log);
       const controllerPubMb = vm.split('#')[0].slice('did:key:'.length);
       const btcoDoc = this.buildRotatedBtcoDoc(asset, satoshi, btcoDid, controllerPubMb);
-      return Buffer.from(JSON.stringify(btcoDoc)).byteLength;
+      return new TextEncoder().encode(JSON.stringify(btcoDoc)).byteLength;
     }
     return 0;
   }
@@ -4409,7 +4410,7 @@ export class LifecycleManager {
         })),
         timestamp: new Date().toISOString()
       };
-      const dataSize = Buffer.from(JSON.stringify(manifest)).length;
+      const dataSize = new TextEncoder().encode(JSON.stringify(manifest)).length;
       
       // Get fee rate from oracle or use provided/default
       let effectiveFeeRate = feeRate;

--- a/packages/sdk/src/lifecycle/OriginalsAsset.ts
+++ b/packages/sdk/src/lifecycle/OriginalsAsset.ts
@@ -503,7 +503,7 @@ export class OriginalsAsset {
 
         // If inline content is present, verify by hashing it
         if (typeof res.content === 'string') {
-          const data = Buffer.from(res.content, 'utf8');
+          const data = new TextEncoder().encode(res.content);
           const computed = hashResource(data);
           const expected = (res.hash || '').toLowerCase();
           if (computed.toLowerCase() !== expected) {
@@ -522,7 +522,7 @@ export class OriginalsAsset {
           }
           try {
             const response = await deps.fetch(res.url);
-            const buf = Buffer.from(await response.arrayBuffer());
+            const buf = new Uint8Array(await response.arrayBuffer());
             const computed = hashResource(buf);
             const expected = (res.hash || '').toLowerCase();
             if (computed.toLowerCase() !== expected) {
@@ -714,7 +714,7 @@ export class OriginalsAsset {
     })[0];
 
     // Compute new hash
-    const contentBuffer = Buffer.from(newContent, 'utf-8');
+    const contentBuffer = new TextEncoder().encode(newContent);
     const newHash = hashResource(contentBuffer);
 
     // Check if content has actually changed

--- a/packages/sdk/src/playground/repl.ts
+++ b/packages/sdk/src/playground/repl.ts
@@ -7,13 +7,15 @@
  */
 
 import * as readline from 'node:readline';
-import '../crypto/noble-init.js';
+import { initNobleCrypto } from '../crypto/noble-init.js';
 import { OriginalsSDK } from '../core/OriginalsSDK.js';
 import { OrdMockProvider } from '../adapters/providers/OrdMockProvider.js';
 import { ResourceManager } from '../resources/index.js';
 import { MemoryStorageAdapter } from '../storage/MemoryStorageAdapter.js';
 import type { OriginalsAsset } from '../lifecycle/OriginalsAsset.js';
 import { sha256 } from '@noble/hashes/sha2.js';
+
+initNobleCrypto();
 
 interface SessionState {
   sdk: OriginalsSDK;

--- a/packages/sdk/src/resources/ResourceManager.ts
+++ b/packages/sdk/src/resources/ResourceManager.ts
@@ -38,6 +38,7 @@ import type {
   ResourceType,
 } from './types.js';
 import { MIME_TYPE_MAP, DEFAULT_RESOURCE_CONFIG } from './types.js';
+import { base64, utf8 } from '../utils/encoding.js';
 
 /**
  * Regular expression for validating MIME types according to RFC 6838.
@@ -66,7 +67,7 @@ export class ResourceManager {
   /**
    * Create a new resource from content.
    * 
-   * @param content - The resource content (string for text, Buffer for binary)
+   * @param content - The resource content (string for text, bytes for binary)
    * @param options - Creation options including type and contentType
    * @returns The created Resource
    * @throws Error if content or options are invalid
@@ -80,14 +81,14 @@ export class ResourceManager {
    * });
    * 
    * // Create a binary resource (image)
-   * const imageBuffer = fs.readFileSync('image.png');
-   * const imageResource = manager.createResource(imageBuffer, {
+   * const imageBytes = fs.readFileSync('image.png');
+   * const imageResource = manager.createResource(imageBytes, {
    *   type: 'image',
    *   contentType: 'image/png'
    * });
    * ```
    */
-  createResource(content: Buffer | string, options: ResourceOptions): Resource {
+  createResource(content: Uint8Array | string, options: ResourceOptions): Resource {
     // Validate inputs
     if (content === null || content === undefined) {
       throw new Error('Content is required');
@@ -153,9 +154,9 @@ export class ResourceManager {
     // Store content if configured to do so
     if (this.config.storeContent) {
       if (this.isBinaryContent(content)) {
-        resource.contentBase64 = contentBuffer.toString('base64');
+        resource.contentBase64 = base64.encode(contentBuffer);
       } else {
-        resource.content = typeof content === 'string' ? content : contentBuffer.toString('utf-8');
+        resource.content = typeof content === 'string' ? content : utf8.decode(contentBuffer);
       }
     }
 
@@ -187,7 +188,7 @@ export class ResourceManager {
    */
   updateResource(
     resource: Resource | string,
-    newContent: Buffer | string,
+    newContent: Uint8Array | string,
     options?: ResourceUpdateOptions
   ): Resource {
     const resourceId = typeof resource === 'string' ? resource : resource.id;
@@ -252,9 +253,9 @@ export class ResourceManager {
     // Store content if configured
     if (this.config.storeContent) {
       if (this.isBinaryContent(newContent)) {
-        newVersion.contentBase64 = contentBuffer.toString('base64');
+        newVersion.contentBase64 = base64.encode(contentBuffer);
       } else {
-        newVersion.content = typeof newContent === 'string' ? newContent : contentBuffer.toString('utf-8');
+        newVersion.content = typeof newContent === 'string' ? newContent : utf8.decode(contentBuffer);
       }
     }
 
@@ -439,9 +440,9 @@ export class ResourceManager {
 
     // Content hash verification (if content is present)
     if (resource.content || resource.contentBase64) {
-      const content = resource.content 
-        ? Buffer.from(resource.content, 'utf-8')
-        : Buffer.from(resource.contentBase64 || '', 'base64');
+      const content = resource.content
+        ? utf8.encode(resource.content)
+        : base64.decode(resource.contentBase64 || '');
       const computedHash = this.hashContent(content);
       
       if (computedHash !== resource.hash) {
@@ -513,7 +514,7 @@ export class ResourceManager {
   /**
    * Hash content using SHA-256.
    * 
-   * @param content - Content to hash (string or Buffer)
+   * @param content - Content to hash (string or bytes)
    * @returns Hex-encoded SHA-256 hash
    * 
    * @example
@@ -522,7 +523,7 @@ export class ResourceManager {
    * console.log(hash); // 64-character hex string
    * ```
    */
-  hashContent(content: Buffer | string): string {
+  hashContent(content: Uint8Array | string): string {
     const buffer = this.toBuffer(content);
     const hash = sha256(buffer);
     return bytesToHex(hash);
@@ -666,20 +667,20 @@ export class ResourceManager {
   }
 
   /**
-   * Convert content to Buffer.
+   * Normalize content to bytes (browser-safe: no Buffer).
    */
-  private toBuffer(content: Buffer | string): Buffer {
-    if (Buffer.isBuffer(content)) {
-      return content;
+  private toBuffer(content: Uint8Array | string): Uint8Array {
+    if (typeof content === 'string') {
+      return new TextEncoder().encode(content);
     }
-    return Buffer.from(content, 'utf-8');
+    return content;
   }
 
   /**
-   * Check if content is binary (Buffer) rather than text.
+   * Check if content is binary (bytes) rather than text.
    */
-  private isBinaryContent(content: Buffer | string): boolean {
-    return Buffer.isBuffer(content);
+  private isBinaryContent(content: Uint8Array | string): boolean {
+    return typeof content !== 'string';
   }
 }
 

--- a/packages/sdk/src/testing/index.ts
+++ b/packages/sdk/src/testing/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Test doubles for consumer test suites — import from '@originals/sdk/testing'.
+ * Deliberately NOT part of the root entry: production bundles should never
+ * carry mock providers (plan 043).
+ */
+export { OrdMockProvider } from '../adapters/providers/OrdMockProvider.js';
+export { FeeOracleMock } from '../adapters/FeeOracleMock.js';

--- a/packages/sdk/src/types/bitcoin.ts
+++ b/packages/sdk/src/types/bitcoin.ts
@@ -4,7 +4,7 @@ export interface OrdinalsInscription {
   inscriptionId: string;
   // Undefined on the deferred-content path: a provider that builds content
   // from the satoshi (buildContent) may not echo it back in the response.
-  content?: Buffer;
+  content?: Uint8Array;
   contentType: string;
   txid: string;
   vout: number;

--- a/packages/sdk/src/utils/credential-digest.ts
+++ b/packages/sdk/src/utils/credential-digest.ts
@@ -33,8 +33,8 @@ export async function computeCredentialDigest(
 
   const c14nProof = await canonicalizeDocument(proofInput);
   const c14nCred = await canonicalizeDocument(unsigned);
-  const hProof = sha256(Buffer.from(c14nProof, 'utf8'));
-  const hCred = sha256(Buffer.from(c14nCred, 'utf8'));
+  const hProof = sha256(new TextEncoder().encode(c14nProof));
+  const hCred = sha256(new TextEncoder().encode(c14nCred));
 
   const out = new Uint8Array(hProof.length + hCred.length);
   out.set(hProof, 0);

--- a/packages/sdk/src/vc/CredentialManager.ts
+++ b/packages/sdk/src/vc/CredentialManager.ts
@@ -445,9 +445,7 @@ export class CredentialManager {
     const signature = this.decodeMultibase(proofValue);
     if (!signature) return false;
 
-    const digest = Buffer.from(
-      await computeCredentialDigest(credential as unknown as Record<string, unknown>, proof as unknown as Record<string, unknown>)
-    );
+    const digest = await computeCredentialDigest(credential as unknown as Record<string, unknown>, proof as unknown as Record<string, unknown>);
     try {
       const resolvedKey = await this.resolveVerificationMethodMultibase(
         verificationMethod,
@@ -460,7 +458,7 @@ export class CredentialManager {
       // algorithm; selecting it from config.defaultKeyType made verification
       // fail whenever the verifier's config differed from the issuer's key.
       const signer = signerForKeyType(multikey.decodePublicKey(resolvedKey).type);
-      return await signer.verify(Buffer.from(digest), Buffer.from(signature), resolvedKey);
+      return await signer.verify(digest, signature, resolvedKey);
     } catch {
       return false;
     }
@@ -585,13 +583,11 @@ export class CredentialManager {
     privateKeyMultibase: string,
     proofBase: Proof
   ): Promise<string> {
-    const digest = Buffer.from(
-      await computeCredentialDigest(credential as unknown as Record<string, unknown>, proofBase as unknown as Record<string, unknown>)
-    );
+    const digest = await computeCredentialDigest(credential as unknown as Record<string, unknown>, proofBase as unknown as Record<string, unknown>);
     // Sign with the algorithm the private key actually is, not whatever
     // config.defaultKeyType happens to be on this instance.
     const signer = signerForKeyType(multikey.decodePrivateKey(privateKeyMultibase).type);
-    const sig = await signer.sign(Buffer.from(digest), privateKeyMultibase);
+    const sig = await signer.sign(digest, privateKeyMultibase);
     return encodeBase64UrlMultibase(sig);
   }
 
@@ -1062,7 +1058,7 @@ export class CredentialManager {
   async computeCredentialHash(credential: VerifiableCredential): Promise<string> {
     return this.tracked('credential.computeHash', async () => {
     const canonicalized = await canonicalizeDocument(credential);
-    const hash = sha256(Buffer.from(canonicalized, 'utf8'));
+    const hash = sha256(new TextEncoder().encode(canonicalized));
     return bytesToHex(hash);
     }); // end tracked
   }

--- a/packages/sdk/src/vc/cryptosuites/bbs.ts
+++ b/packages/sdk/src/vc/cryptosuites/bbs.ts
@@ -1,4 +1,5 @@
 import * as cbor from '../../utils/cbor.js';
+import { encodeBase64UrlMultibase, decodeBase64UrlMultibase } from '../../utils/encoding.js';
 
 /**
  * Minimal BBS utility methods ported from legacy for working with
@@ -12,17 +13,12 @@ import * as cbor from '../../utils/cbor.js';
  */
 export class BBSCryptosuiteUtils {
   private static encodeBase64urlNoPad(bytes: Uint8Array): string {
-    const b64 = Buffer.from(bytes).toString('base64');
-    const b64url = b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
-    return 'u' + b64url;
+    return encodeBase64UrlMultibase(bytes);
   }
 
   private static decodeBase64urlNoPad(s: string): Uint8Array {
     if (!s.startsWith('u')) throw new Error('Not a multibase base64url (u- prefixed) string');
-    const raw = s.slice(1);
-    const b64 = raw.replace(/-/g, '+').replace(/_/g, '/');
-    const pad = b64.length % 4 === 2 ? '==' : b64.length % 4 === 3 ? '=' : '';
-    return new Uint8Array(Buffer.from(b64 + pad, 'base64'));
+    return decodeBase64UrlMultibase(s);
   }
   private static compareBytes(a: Uint8Array, b: number[]): boolean {
     if (a.length !== b.length) return false;

--- a/packages/sdk/src/vc/cryptosuites/bbsCryptosuite.ts
+++ b/packages/sdk/src/vc/cryptosuites/bbsCryptosuite.ts
@@ -16,6 +16,7 @@ import { randomBytes } from '@noble/hashes/utils.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { BBSCryptosuiteUtils } from './bbs.js';
 import { multikey } from '../../crypto/Multikey.js';
+import { decodeBase64UrlMultibase } from '../../utils/encoding.js';
 import { canonize } from '../utils/jsonld.js';
 import type { DataIntegrityProof, VerificationResult } from './eddsa.js';
 import {
@@ -113,9 +114,7 @@ function resolveKey(key: Uint8Array | string | undefined, isPrivate: boolean): U
 /** Multibase base64url-no-pad decode (the 'u' prefix used by proof values). */
 function decodeMultibaseB64url(s: string): Uint8Array {
   if (!s || s[0] !== 'u') throw new Error('Proof value must be multibase-base64url-no-pad-encoded (start with "u")');
-  const raw = s.slice(1).replace(/-/g, '+').replace(/_/g, '/');
-  const pad = raw.length % 4 === 2 ? '==' : raw.length % 4 === 3 ? '=' : '';
-  return new Uint8Array(Buffer.from(raw + pad, 'base64'));
+  return decodeBase64UrlMultibase(s);
 }
 
 export class BBSCryptosuiteManager {

--- a/packages/sdk/tests/integration/CompleteLifecycle.e2e.test.ts
+++ b/packages/sdk/tests/integration/CompleteLifecycle.e2e.test.ts
@@ -250,7 +250,7 @@ describe('E2E Integration: Complete Lifecycle Flow', () => {
       // most-recent resource's bytes), and the btco DID document + resource
       // manifest ride in the inscription METADATA.
       expect(inscription?.contentType).toBe('image/png');
-      expect(inscription!.content!.toString()).toBe('mock-image-data');
+      expect(new TextDecoder().decode(inscription!.content)).toBe('mock-image-data');
       const inscribedDoc = (inscription!.metadata as { didDocument: { id: string; service: Array<{ type: string; serviceEndpoint: { resources: unknown[] } }> } }).didDocument;
       expect(inscribedDoc.id).toMatch(/^did:btco:/);
       const inscribedManifest = inscribedDoc.service.find((s) => s.type === 'OriginalsResourceManifest');

--- a/packages/sdk/tests/integration/LifecycleManager.test.ts
+++ b/packages/sdk/tests/integration/LifecycleManager.test.ts
@@ -2,7 +2,8 @@
 
 /** Inlined from LifecycleManager.btco.integration.part.ts */
 import { describe, test, expect } from 'bun:test';
-import { OriginalsSDK, OrdMockProvider } from '../../src';
+import { OriginalsSDK } from '../../src';
+import { OrdMockProvider } from '../../src/adapters/providers/OrdMockProvider';
 import { MockOrdinalsProvider } from '../mocks/adapters';
 import { MockKeyStore } from '../mocks/MockKeyStore';
 

--- a/packages/sdk/tests/setup.bun.ts
+++ b/packages/sdk/tests/setup.bun.ts
@@ -45,9 +45,10 @@ if (typeof globalThis.crypto === 'undefined') {
   globalThis.crypto = webcrypto as unknown as Crypto;
 }
 
-// Initialize noble crypto libraries (uses shared initialization module)
-// This ensures libraries are configured before any tests run
-import '../src/crypto/noble-init.js';
+// Initialize noble crypto libraries before any tests run. The module no longer
+// auto-inits at import time (sideEffects: false), so call it explicitly.
+import { initNobleCrypto } from '../src/crypto/noble-init.js';
+initNobleCrypto();
 
 // Global cleanup after each test
 afterEach(() => {

--- a/packages/sdk/tests/unit/adapters/OrdMockProvider.buildContent.test.ts
+++ b/packages/sdk/tests/unit/adapters/OrdMockProvider.buildContent.test.ts
@@ -14,7 +14,7 @@ describe('OrdMockProvider deferred content', () => {
     });
     expect(seenSat).toBe(result.satoshi);
     const stored = await provider.getInscriptionById(result.inscriptionId);
-    expect(JSON.parse(stored!.content.toString()).id).toBe(`did:btco:${result.satoshi}`);
+    expect(JSON.parse(new TextDecoder().decode(stored!.content)).id).toBe(`did:btco:${result.satoshi}`);
   });
 
   test('targetSatoshi reinscribes on the same sat (appends to sat history)', async () => {

--- a/packages/sdk/tests/unit/bitcoin/BitcoinManager.deferred.test.ts
+++ b/packages/sdk/tests/unit/bitcoin/BitcoinManager.deferred.test.ts
@@ -44,7 +44,7 @@ describe('BitcoinManager.inscribeData deferred content', () => {
       }),
       'image/png'
     );
-    expect(inscription.content?.toString()).toBe('media');
+    expect(new TextDecoder().decode(inscription.content)).toBe('media');
     expect((inscription.metadata as { didDocument: { id: string } }).didDocument.id)
       .toBe(`did:btco:reg:${inscription.satoshi}`);
   });

--- a/packages/sdk/tests/unit/bitcoin/OrdinalsClient.test.ts
+++ b/packages/sdk/tests/unit/bitcoin/OrdinalsClient.test.ts
@@ -280,7 +280,7 @@ describe('OrdinalsClient (real HTTP behavior with mocked fetch)', () => {
   test('resolveInscription returns mapped inscription with content bytes', async () => {
     const insc = await client.resolveInscription('insc-888');
     expect(insc).toEqual(expect.objectContaining({ inscriptionId: 'insc-888', txid: 'tx888', vout: 2 }));
-    expect(insc!.content).toBeInstanceOf(Buffer);
+    expect(insc!.content).toBeInstanceOf(Uint8Array);
     expect(insc!.content.length).toBe(2);
   });
 

--- a/packages/sdk/tests/unit/bitcoin/bitcoin-scenarios.test.ts
+++ b/packages/sdk/tests/unit/bitcoin/bitcoin-scenarios.test.ts
@@ -509,7 +509,7 @@ describe('BITCOIN-025: OrdNodeProvider resource resolution by satoshi', () => {
   // OrdNodeProvider is a stub (no real network). We verify the adapter wiring.
   // For a proper sat-resolution test using OrdMockProvider (an OrdinalsProvider)
   // we exercise getInscriptionsBySatoshi.
-  const { OrdMockProvider } = require('../../../src');
+  const { OrdMockProvider } = require('../../../src/adapters/providers/OrdMockProvider');
 
   test('OrdMockProvider resolves inscription by satoshi after creation', async () => {
     const provider = new OrdMockProvider();

--- a/packages/sdk/tests/unit/crypto/Signer.test.ts
+++ b/packages/sdk/tests/unit/crypto/Signer.test.ts
@@ -94,7 +94,7 @@ describe('Signer classes', () => {
       const pk = secp256k1.getPublicKey(sk);
       const signer = new ES256KSigner();
       const sig = await signer.sign(data, secpPrivMb(sk));
-      expect(Buffer.isBuffer(sig)).toBe(true);
+      expect(sig).toBeInstanceOf(Uint8Array);
       const ok = await signer.verify(data, sig, secpPubMb(pk));
       expect(ok).toBe(true);
     });
@@ -175,7 +175,7 @@ describe('Signer classes', () => {
       const pk = p256.getPublicKey(sk);
       const signer = new ES256Signer();
       const sig = await signer.sign(data, p256PrivMb(sk));
-      expect(Buffer.isBuffer(sig)).toBe(true);
+      expect(sig).toBeInstanceOf(Uint8Array);
       const ok = await signer.verify(data, sig, p256PubMb(pk));
       expect(ok).toBe(true);
     });
@@ -404,7 +404,7 @@ describe('ES256KSigner branch: sign returns direct Uint8Array', () => {
     const bytes = new Uint8Array(64).fill(5);
     const spy = spyOn(secp256k1, 'signAsync').mockResolvedValue(bytes as any);
     const sig = await signer.sign(Buffer.from('x'), secpPrivMb(sk));
-    expect(Buffer.isBuffer(sig)).toBe(true);
+    expect(sig).toBeInstanceOf(Uint8Array);
     expect(sig).toEqual(Buffer.from(bytes));
     spy.mockRestore();
   });

--- a/packages/sdk/tests/unit/lifecycle/LifecycleManager.celPersistence.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/LifecycleManager.celPersistence.test.ts
@@ -101,7 +101,7 @@ describe('CEL storage persistence (#Phase3 Task 3)', () => {
     const expectedKey = `cel/${celStoragePath(asset.id)}`;
     const write = puts.find(p => p.key === expectedKey);
     expect(write).toBeDefined();
-    const log = parseEventLogJson(write!.data.toString('utf8'));
+    const log = parseEventLogJson(new TextDecoder().decode(write!.data));
     expect(log.events[0].type).toBe('create');
     expect(write!.contentType).toBe('application/json');
   });


### PR DESCRIPTION
Phase 3 of [plan 033](https://github.com/onionoriginals/sdk/blob/main/plans/033-sdk-v3-roadmap.md), on top of Phases 0–2 (#464, #465, #466). Two commits, reviewable independently.

Phases 0–2 fixed correctness. This one fixes **shape**: the package was hostile to bundlers, and its export surface was missing exactly the toolkit a remote-custody integrator needs while exporting test mocks and generic infrastructure it doesn't.

---

## 043 — packaging and export surface

**`sideEffects: false`.** `index.ts` did `import './crypto/noble-init.js'` purely for its side effects, and no `sideEffects` field was declared — so a bundler had to retain the whole ~150-module graph (jsonld included) for a single type import. The auto-init is gone; `initNobleCrypto()` is now called explicitly by the only two modules that use *synchronous* noble APIs (`crypto/Signer.ts`, `did/KeyManager.ts`). Everything else is `*Async`-only and needs no init.

**Curated `exports`.** The map wildcarded 11 internal directories — making every internal file a permanent semver commitment — while omitting `adapters`, `events` and `kinds`. It is now five explicit entries: `.`, `./cel`, `./testing`, `./types`, `./package.json`. Exactly one deep import existed in the repo and was switched to the root export.

**Test doubles moved to `@originals/sdk/testing`.** `OrdMockProvider` and `FeeOracleMock` were production exports.

**The remote-signer toolkit is reachable from the root:** `Verifier`, `EdDSACryptosuiteManager`, `createDocumentLoader`, `currentControllerVm`. `retry` and `circuit-breaker` are dropped from the root — generic infrastructure with no business being public API, and no in-repo consumer imported them via the barrel.

## 044 — `Buffer` purged from public signatures

`Buffer` is a Node global; a browser consumer without a shim gets `ReferenceError`. It is replaced by `Uint8Array` across every public signature — `Signer` and its four subclasses (which both took *and returned* `Buffer`), `OrdinalsProvider`, `StorageAdapter`, `OrdinalsInscription.content`, `ResourceManager`, `KeyManager`, `estimateAppendCost` — plus runtime `Buffer.from` removed from the browser-guarded module graph. Node-only internals (PSBT/commit builders, the CLI, server providers) keep it deliberately.

This is not hypothetical: a `Buffer` bug shipped in Phase 1's `@originals/auth` work and was caught in review, in the one function specifically added for browser use.

---

## Deferred: the `@originals/cel` split

Not started, deliberately — and **the roadmap's premise for it needs correcting**, in the SDK's favour.

Plan 044 said the seam was "half-built". The agent that did this phase reported the opposite: that `/cel` is *not* Bitcoin-free because it re-exports `BtcoCelManager` and `BitcoinWitness`, which reach `BitcoinManager`. Both readings are wrong. Those are `import type` — erased at compile time. Walking the **built** graph:

```
modules in dist/cel/index.js graph: 38
bitcoin/ modules pulled:             0
heavy externals (jsonld/btc-signer/ordinals): none
```

`/cel` is already Bitcoin-free and browser-safe at runtime. No carving of `layers/`, `witnesses/`, `keyResolver` or `OriginalsCel` is needed, and the `/cel` public surface does not have to break.

What a split actually needs is **8 modules relocated** — `crypto/Multikey`, `crypto/signingInput`, and six `utils/*` — plus packaging mechanics: a new package, inverting the dependency so `@originals/sdk` depends on `@originals/cel`, and turbo/CI wiring. Meaningfully smaller than either estimate, and worth its own PR.

## Verification

Run the way CI runs it — four separate `bun test` invocations, not one:

- `@originals/sdk`: integration **171/0**, unit **3511/0**, security **174/0**, stress **18/0**; tsc 0
- `@originals/auth`: **246/0**
- `verify:browser`, `verify:esm`, lint, build — all green

## Reviewer notes

- **The `sideEffects: false` claim deserves scrutiny**, since a missing crypto init fails only at runtime. It holds: the four files calling *sync* `ed25519.sign`/`getPublicKey` import from `@noble/curves` (self-contained), while standalone `@noble/ed25519` users are either async-only or call `initNobleCrypto()` explicitly.
- `src/verify/UnifiedVerifier.ts` was left internal on purpose. Plan 043 listed a `verify` subpath, but that file is a self-declared unshipped spike; the real `vc/Verifier` is exported from the root instead.
- Six test files changed, each justified by the intentional byte-typed returns (`Buffer.isBuffer(sig)` → `instanceof Uint8Array`, `content.toString('utf8')` → `TextDecoder`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)