### PR TITLE
docs(plans): mark the v3 roadmap complete; record two corrections + plan 046

### DIFF
--- a/plans/033-sdk-v3-roadmap.md
+++ b/plans/033-sdk-v3-roadmap.md
@@ -9,7 +9,7 @@
 ## Status
 
 - **Priority**: P0 (the SDK's recommended path is unusable for remote custody)
-- **Effort**: XL (spans 2.1 → 3.0)
+- **Effort**: XL (one 3.0.0 release; see Sequencing)
 - **Risk**: HIGH (breaking API + a cryptosuite relabel)
 - **Category**: architecture / correctness / DX
 
@@ -148,7 +148,7 @@ provenance event has failed, and should say so.
 
 ## Work items
 
-### Phase 0 — stop the bleeding (2.1, additive, no API break)
+### Phase 0 — stop the bleeding (additive, no API break)
 
 **Status: DONE** (2026-08-13). tsc 0; 3795 tests pass / 0 fail across unit,
 integration, security and stress; `verify:browser` and `verify:esm` gates green.
@@ -175,7 +175,7 @@ also failing to LOAD (silently reducing the suite) — fixed, which is why the
 count rose from 3587 to 3795.
 
 Phase 0 converts the four worst silent failures into loud ones.
-Ship as 2.1 before starting phase 1.
+Landed before phase 1, as its own PR (#464).
 
 ### Phase 1 — the signer core (additive)
 
@@ -249,12 +249,20 @@ package. Two copies of `multikey` or `StructuredError` in one tree breaks
 
 ## Sequencing and compatibility
 
-- **2.1** = phase 0. No API change; four silent failures become throws. Some
-  consumers' currently-"working" code will start failing — that is the point, and
-  the release notes must say so plainly.
-- **2.2** = phase 1. Purely additive; the old paths still work with deprecation
-  warnings. Publish a migration guide here, not at 3.0.
-- **3.0** = phases 2–4. One breaking release, one migration.
+**Superseded — everything ships as one 3.0.0.** The staged plan below assumed a
+migration window that stopped existing the moment phase 0 shipped with a `major`
+changeset: the next publish is 3.0.0 regardless of what later phases declare.
+The maintainer's decision was that nothing releases until every phase is merged,
+so consumers get a single migration rather than three, and the migration guide
+belongs with the 3.0.0 release notes.
+
+What still holds from the original plan is the *warning*: consumers' currently
+"working" code will start failing, because in every case it was producing
+artifacts that could not verify. The release notes must say so plainly.
+
+~~- **2.1** = phase 0. No API change; four silent failures become throws.~~
+~~- **2.2** = phase 1. Purely additive; old paths work with deprecation warnings.~~
+~~- **3.0** = phases 2–4. One breaking release, one migration.~~
 
 ## Done criteria for the roadmap
 

--- a/plans/033-sdk-v3-roadmap.md
+++ b/plans/033-sdk-v3-roadmap.md
@@ -177,39 +177,75 @@ count rose from 3587 to 3795.
 Phase 0 converts the four worst silent failures into loud ones.
 Ship as 2.1 before starting phase 1.
 
-### Phase 1 — the signer core (2.2, additive)
+### Phase 1 — the signer core (additive)
+
+**Status: DONE** — merged in #465 (`ed327d9b`), together with plan 045 pulled
+forward from Phase 4.
 
 | # | Item | Effort |
 |---|---|---|
-| 039 | `OriginalsSigner` + `signingInput` namespace + the five adapters. Every internal signing path routed through them (`celSignerFromKeyPair`, `createKeyStoreCelSigner`, `WebVHManager`, `Issuer`, `MultiSigManager`, `witnessEvent`). `signer` accepted on `OriginalsConfig` and on `createAsset`/`publishToWeb`/`inscribeOnBitcoin`/`rotateBtcoKeys`/`authorizeSigner`/`addResourceVersion`. `ExternalSigner`/`CelSigner`/`KeyStore`-as-signer marked `@deprecated`. | L |
-| 040 | **`assertSignerConformance(signer)` + `MockRemoteSigner`.** A published conformance harness any custody backend can run, plus an in-repo signer that implements **only** `signBytes` — no key export, no `sign()`. Rule: every documented end-to-end flow gets a test that runs it under `MockRemoteSigner`. | M |
+| 039 | ✅ `OriginalsSigner` + `signingInput` namespace + the five adapters. Every internal signing path routed through them (`celSignerFromKeyPair`, `createKeyStoreCelSigner`, `WebVHManager`, `Issuer`, `MultiSigManager`, `witnessEvent`). `signer` accepted on `OriginalsConfig` and on `createAsset`/`publishToWeb`/`inscribeOnBitcoin`/`rotateBtcoKeys`/`authorizeSigner`/`addResourceVersion`. `ExternalSigner`/`CelSigner`/`KeyStore`-as-signer marked `@deprecated`. | L |
+| 040 | ✅ **`assertSignerConformance(signer)` + `MockRemoteSigner`.** A published conformance harness any custody backend can run, plus an in-repo signer that implements **only** `signBytes` — no key export, no `sign()`. Rule: every documented end-to-end flow gets a test that runs it under `MockRemoteSigner`. | M |
 
 **040 is the durable fix.** The reason this class of bug shipped is that no test in
 76k lines of test code exercises a non-exporting custody backend, so every
 remote-custody path could rot undetected. The interface redesign fixes today's bug;
 the conformance harness is what stops the next one.
 
-### Phase 2 — 3.0, defaults flip
+### Phase 2 — defaults flip
+
+**Status: DONE** — merged in #466 (`ae9f8cb8`).
 
 | # | Item | Effort |
 |---|---|---|
-| 041 | Remove `ExternalSigner`/`CelSigner` from public API (adapters remain). `createAsset` requires custody. `onAppendFailure` defaults to `'throw'`. `KeyStore` documented as persistence-only. | M |
-| 042 | **CEL cryptosuite: rename *and* bind the proof configuration**, in one breaking change. Emit a bespoke id (`originals-cel-ed25519-jcs-v1`); the verifier dispatches on the label and keeps a legacy read path for `eddsa-jcs-2022` logs forever. Two notes that make this cheaper than it looks: (a) because the proof config is currently excluded from the preimage, relabelling alone does not invalidate a single existing signature; (b) binding the config closes a real gap — `created` and `proofPurpose` are presently unattested. Do both at once or pay the migration twice. | M |
+| 041 | ✅ Remove `ExternalSigner`/`CelSigner` from public API (adapters remain). `createAsset` requires custody. `onAppendFailure` defaults to `'throw'`. `KeyStore` documented as persistence-only. | M |
+| 042 | ✅ **CEL cryptosuite: rename *and* bind the proof configuration**, in one breaking change. Emit a bespoke id (`originals-cel-ed25519-jcs-v1`); the verifier dispatches on the label and keeps a legacy read path for `eddsa-jcs-2022` logs forever. Two notes that make this cheaper than it looks: (a) because the proof config is currently excluded from the preimage, relabelling alone does not invalidate a single existing signature; (b) binding the config closes a real gap — `created` and `proofPurpose` are presently unattested. Do both at once or pay the migration twice. | M |
 
-### Phase 3 — packaging (3.0)
+### Phase 3 — packaging
+
+**Status: DONE for 043 and 044's Buffer purge** — merged in #467 (`636417c4`).
+The `@originals/cel` split (044 item 6) is the roadmap's last open item; see the
+scope correction below.
 
 | # | Item | Effort |
 |---|---|---|
-| 043 | Remove the side-effect import from `index.ts` (make `noble-init` explicit at point of use), set `"sideEffects": false`. Replace the 11 `/*` wildcards with a curated subpath list; add the missing `verify`, and move `OrdMockProvider`/`FeeOracleMock` to `@originals/sdk/testing`; drop `retry`/`circuit-breaker` from root. Add the missing remote-signer toolkit to root: `signingInput`, `canonicalizeEvent`, `currentControllerVm`, `createDocumentLoader`, `Verifier`, `EdDSACryptosuiteManager`. | M |
-| 044 | **Purge `Buffer` from public signatures** → `Uint8Array` (51 dist files; `crypto/Signer.ts` first, it's root-exported). Then split `@originals/cel` — zero Bitcoin, zero `jsonld`, browser-safe. The `/cel` entry and `scripts/check-browser-safety.mjs` gate already exist, so the seam is half-built. | L |
+| 043 | ✅ Remove the side-effect import from `index.ts` (make `noble-init` explicit at point of use), set `"sideEffects": false`. Replace the 11 `/*` wildcards with a curated subpath list; add the missing `verify`, and move `OrdMockProvider`/`FeeOracleMock` to `@originals/sdk/testing`; drop `retry`/`circuit-breaker` from root. Add the missing remote-signer toolkit to root: `signingInput`, `canonicalizeEvent`, `currentControllerVm`, `createDocumentLoader`, `Verifier`, `EdDSACryptosuiteManager`. | M |
+| 044 | ✅ (Buffer purge; split deferred) **Purge `Buffer` from public signatures** → `Uint8Array` (51 dist files; `crypto/Signer.ts` first, it's root-exported). Then split `@originals/cel` — zero Bitcoin, zero `jsonld`, browser-safe. The `/cel` entry and `scripts/check-browser-safety.mjs` gate already exist, so the seam is half-built. | L |
 
 ### Phase 4 — `@originals/auth`
 
+**Status: DONE** — pulled forward into Phase 1 and merged in #465, because
+without it Phase 1 shipped an interface no signer the project ships could
+satisfy.
+
 | # | Item | Effort |
 |---|---|---|
-| 045 | Root exports types only (`export * from './types.js'`) — server stays behind `/server`. Extract one `turnkeySignBytes()` primitive; both Turnkey signers become thin `OriginalsSigner` wrappers over it, deleting the "kept in sync by comment" duplication. Move `turnkeyAddressToMultikey` upstream into the SDK (Turnkey Ed25519 accounts are `ADDRESS_FORMAT_SOLANA`, so the address is base58 of the raw key — **not** a Multikey, and consumers keep re-deriving this wrong). | M |
+| 045 | ✅ Root exports types only (`export * from './types.js'`) — server stays behind `/server`. Extract one `turnkeySignBytes()` primitive; both Turnkey signers become thin `OriginalsSigner` wrappers over it, deleting the "kept in sync by comment" duplication. Move `turnkeyAddressToMultikey` upstream into the SDK (Turnkey Ed25519 accounts are `ADDRESS_FORMAT_SOLANA`, so the address is base58 of the raw key — **not** a Multikey, and consumers keep re-deriving this wrong). | M |
 
 ---
+
+### Correction: the `@originals/cel` split is smaller than this plan assumed
+
+Plan 044 called the seam "half-built", and the agent that executed Phase 3
+reported the opposite — that `/cel` is not Bitcoin-free because it re-exports
+`BtcoCelManager` and `BitcoinWitness`, which reach `BitcoinManager`. **Both are
+wrong.** Those are `import type`, erased at compile time. Walking the BUILT
+graph of `dist/cel/index.js`:
+
+```
+modules in graph: 38
+bitcoin/ modules pulled: 0
+heavy externals (jsonld / btc-signer / micro-ordinals): none
+```
+
+`/cel` is already Bitcoin-free and browser-safe at runtime. Nothing needs
+carving out of the barrel and the `/cel` surface need not break. The real job is
+relocating **8 modules** — `crypto/Multikey`, `crypto/signingInput`, and six
+`utils/*` — plus packaging mechanics (new package, invert the dependency, turbo
+and CI wiring). The one hazard is duplication: `Multikey` and `telemetry` are
+used well outside the CEL graph, so the SDK must import them FROM the new
+package. Two copies of `multikey` or `StructuredError` in one tree breaks
+`instanceof` checks.
 
 ## Sequencing and compatibility
 

--- a/plans/046-ci-gaps.md
+++ b/plans/046-ci-gaps.md
@@ -1,0 +1,98 @@
+# Plan 046: close the CI gaps that let two shipped bugs through
+
+> **Executor instructions**: Small, self-contained, repo-infra only — no `src/`
+> changes except where a lint fix is genuinely required. Read the whole plan
+> first; item 3 will surface pre-existing errors and needs a decision before you
+> start fixing them.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW (item 1–2), MED (item 3 — surfaces 38 pre-existing errors)
+- **Category**: tech-debt / CI
+- **Found while**: executing plans 034–044 (run 3). Each gap is named by a bug it
+  actually failed to catch, not by inspection.
+
+## Why this matters
+
+Three gaps, each of which let something real through during run 3. None are
+hypothetical: for each, the bug shipped to a PR and was caught by a human or a
+review bot rather than by CI.
+
+### 1. `turbo run lint` does not depend on `^build`
+
+`packages/auth` imports types from `@originals/sdk`, which resolve through
+`packages/sdk/dist`. The lint task has no `dependsOn: ["^build"]`, so during lint
+those types are unresolved and typescript-eslint reports every value flowing from
+them as `any`/`error`-typed.
+
+**What it let through**: while implementing plan 045 the defensive narrowing in
+`turnkey-signer.ts` was removed (it looked redundant — locally, with `dist` built,
+it *is* redundant). CI lint then failed with two `no-unsafe-argument` errors that
+made no sense locally. The original author had written that narrowing precisely
+because lint runs without a build; the reason was invisible.
+
+**Fix**: add `"dependsOn": ["^build"]` to the `lint` task in `turbo.json`. Then
+the defensive `unknown` + `instanceof Uint8Array` narrowing in both Turnkey
+signers can be simplified back, with a comment saying why it is no longer needed.
+
+**Verify**: delete `packages/sdk/dist`, run `bun run lint` from the repo root, and
+confirm it builds first and reports 0 errors.
+
+### 2. `check-browser-safety.mjs` only guards the SDK
+
+The script guards `index.js`, `lifecycle/LifecycleManager.js`,
+`lifecycle/OriginalsAsset.js` and `cel/index.js` — all in `packages/sdk`. Nothing
+guards `@originals/auth`, whose *client* entry runs in a browser by definition.
+
+**What it let through**: plan 045 added `turnkeySignBytes` as a root export of
+`@originals/auth`, documented as isomorphic, using `Buffer` for both hex encode
+and decode. In a browser without a shim that throws `ReferenceError` on every
+call — in exactly the environment the export was added for. CI was green;
+Greptile caught it.
+
+**Fix**: extend the guarded-entry list to `packages/auth`'s root and `/client`
+entries. Note the script currently checks only for eager **Node builtins**; a
+`Buffer` global reference is not an import, so also fail on a bare `Buffer`
+identifier in a guarded graph (or assert against a `globalThis.Buffer`-free
+evaluation, which is what the regression test in
+`packages/auth/tests/turnkey-signbytes.test.ts` does).
+
+### 3. The SDK lint script silently under-scans
+
+`"lint": "eslint src/**/*.ts"` is **unquoted**, so the shell expands the glob
+before eslint sees it. Without `globstar`, `src/**/*.ts` expands to `src/*/*.ts`
+— exactly one directory level. Files at `src/*.ts` and `src/*/*/*.ts` (all of
+`cel/algorithms/`, `cel/cli/`, `cel/layers/`, `bitcoin/transactions/`,
+`migration/*/`, `vc/cryptosuites/`, …) are **never linted**.
+
+**What it let through**: unknown — which is the point. Quoting the glob surfaces
+**38 pre-existing errors** across those directories.
+
+**Fix**: quote the glob (`eslint "src/**/*.ts"`) in both packages. Then decide,
+and record the decision in the PR:
+
+- fix all 38 (most are `no-unnecessary-type-assertion` and unused caught errors —
+  mechanical), or
+- quote the glob and add targeted `eslint-disable` comments with reasons, or
+- quote it and downgrade the specific rules to warnings for the newly-covered
+  directories, with a follow-up issue.
+
+**Do NOT** leave the glob unquoted to keep CI green. A lint job that silently
+skips two thirds of the source tree is worse than one that fails.
+
+## Done criteria
+
+1. `turbo.json`'s lint task depends on `^build`; deleting `dist` and running lint
+   from the root passes.
+2. The browser-safety gate covers `@originals/auth`'s browser-facing entries and
+   fails on a `Buffer` reference in a guarded graph. Verify by temporarily
+   reintroducing `Buffer.from` into `turnkeySignBytes` and confirming CI fails.
+3. `bun run lint` in both packages lints the entire `src` tree, and passes.
+
+## STOP conditions
+
+- If item 3's 38 errors turn out to include anything that looks like a real
+  defect rather than a style violation, stop and report it separately — that is
+  a finding, not cleanup.

--- a/plans/README.md
+++ b/plans/README.md
@@ -29,8 +29,12 @@ and `publishToWeb` silently drops the CEL `migrate` event when it can't sign.
 
 | Plan | Title | Priority | Effort | Risk | Depends on | Status |
 |------|-------|----------|--------|------|------------|--------|
-| 033 | SDK v3 roadmap — signer abstraction, fail-loud, packaging (spawns 034–045) | P0 | XL | HIGH | — | IN PROGRESS (Phase 0 = 034–038 DONE) |
-| 034–038 | Phase 0 — stop the bleeding (seal-time self-verify, suite whitelist, external-signer credentials, required DIDManager, published-README de-rot) | P0 | M | MED | — | DONE (tsc 0; 3795 pass / 0 fail; browser+esm gates green; not yet pushed) |
+| 033 | SDK v3 roadmap — signer abstraction, fail-loud, packaging (spawns 034–045) | P0 | XL | HIGH | — | DONE except the `@originals/cel` split (044 item 6) |
+| 034–038 | Phase 0 — stop the bleeding | P0 | M | MED | — | DONE (merged, PR #464 `0d241bcb`) |
+| 039–040, 045 | Phase 1 — signer core, conformance harness, Turnkey signBytes | P0 | L | MED | 034–038 | DONE (merged, PR #465 `ed327d9b`) |
+| 041–042 | Phase 2 — custody required, appends throw, cryptosuite renamed + bound | P0 | L | HIGH | 039 | DONE (merged, PR #466 `ae9f8cb8`) |
+| 043–044 | Phase 3 — packaging, curated exports, Buffer purge | P1 | M | MED | 039 | DONE (merged, PR #467 `636417c4`); split deferred |
+| 046 | CI gaps that let two shipped bugs through | P2 | S | LOW | — | TODO (not started) |
 
 ### Run 2
 


### PR DESCRIPTION
Docs only — no source changes. Safe to merge independently of the `@originals/cel` split.

## Roadmap status

Phases 0–3 are merged (#464, #465, #466, #467) and the phase sections are marked accordingly. **Phase 4 was already done**: plan 045 (`@originals/auth` Turnkey `signBytes`) got pulled forward into Phase 1 and merged with it, because without it Phase 1 shipped an interface no signer this project ships could satisfy.

The only roadmap item still open is the `@originals/cel` split (044 item 6).

## Two corrections, both from measurement

**The split is smaller than anyone estimated.** Plan 044 called the seam "half-built"; the agent that deferred it in Phase 3 reported the opposite — that `/cel` isn't Bitcoin-free because it re-exports `BtcoCelManager` and `BitcoinWitness`, which reach `BitcoinManager`. Both readings are wrong: those are `import type`, erased at compile time. Walking the **built** graph:

```
modules in dist/cel/index.js graph: 38
bitcoin/ modules pulled:             0
heavy externals (jsonld / btc-signer / micro-ordinals): none
```

Nothing needs carving out of the barrel and the `/cel` surface needn't break. The job is relocating 8 modules (`crypto/Multikey`, `crypto/signingInput`, six `utils/*`) plus packaging mechanics. The one hazard is duplication — `Multikey` and `telemetry` are used well outside the CEL graph, so the SDK must import them *from* the new package; two copies of `multikey` or `StructuredError` in one tree breaks `instanceof` checks.

**The 2.1 / 2.2 / 3.0 sequence is superseded.** It assumed a migration window that stopped existing the moment Phase 0 shipped with a `major` changeset — the next publish is 3.0.0 regardless. Per the maintainer's decision, nothing releases until every phase merges, so all phases land as one 3.0.0 and consumers get a single migration instead of three.

## New: plan 046 — CI gaps

Three gaps found during run 3, each **named by a bug it actually failed to catch** rather than by inspection:

1. **`turbo run lint` doesn't depend on `^build`** — so `@originals/auth` lints against unresolved `@originals/sdk` types. This is why both Turnkey signers narrow their preimage defensively; removing that narrowing (it looks redundant locally) turned two warnings into CI errors with no local reproduction.
2. **`check-browser-safety.mjs` only guards the SDK** — nothing guards `@originals/auth`, whose client entry is a browser by definition. That's how a `Buffer`-dependent export documented as isomorphic shipped green and had to be caught in review.
3. **The lint glob is unquoted** — `eslint src/**/*.ts` expands to `src/*/*.ts`, one directory level, so `cel/algorithms/`, `cel/cli/`, `bitcoin/transactions/`, `vc/cryptosuites/` and more are **never linted**. Quoting it surfaces 38 pre-existing errors; the plan lays out the options and explicitly forbids leaving it unquoted to keep CI green.

I have not implemented 046 — it's repo infrastructure rather than roadmap work, and item 3 needs a decision on those 38 errors.

## Verification

No code changed. For the record, merged `main` was verified end-to-end after all four PRs landed (the squash-merged combination had never been run as a whole), CI-style with separate suite invocations:

```
sdk   integration 171/0   unit 3511/0   security 174/0   stress 18/0   tsc 0
auth  246/0
build, verify:browser, verify:esm, lint — green
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)