### PR TITLE
fix(landing): import OrdMockProvider from @originals/sdk/testing (deploy build is broken on main)

### DIFF
--- a/apps/landing/src/content.ts
+++ b/apps/landing/src/content.ts
@@ -360,9 +360,9 @@ export const developers = {
   quickstartLabel: 'Quickstart',
   quickstart: `import {
   OriginalsSDK,
-  OrdMockProvider,
   MemoryStorageAdapter
 } from '@originals/sdk';
+import { OrdMockProvider } from '@originals/sdk/testing';
 import { sha256 } from '@noble/hashes/sha2.js';
 
 // In-memory key store — swap for Turnkey, KMS, or your own

--- a/apps/landing/src/sdk/engine.ts
+++ b/apps/landing/src/sdk/engine.ts
@@ -17,9 +17,11 @@ import { short } from './format';
 export { short };
 import {
   OriginalsSDK,
-  OrdMockProvider,
   type OriginalsAsset
 } from '@originals/sdk';
+// Test doubles moved out of the root entry in plan 043 so they are not shipped
+// to production consumers.
+import { OrdMockProvider } from '@originals/sdk/testing';
 import { HttpHostingStorageAdapter } from './http-hosting-adapter';
 import { DurableHostingStorageAdapter } from './durable-hosting-adapter';
 import { HttpOrdinalsProvider } from './http-ordinals-provider';

--- a/apps/landing/src/sdk/verify-example.ts
+++ b/apps/landing/src/sdk/verify-example.ts
@@ -10,9 +10,9 @@
  * verification via the SDK — so the page never asks anyone to take its word.
  */
 import '../shims/buffer-global';
+import { OrdMockProvider } from '@originals/sdk/testing';
 import {
   OriginalsSDK,
-  OrdMockProvider,
   MemoryStorageAdapter,
   Ed25519Verifier,
   resolveDidCel


### PR DESCRIPTION
**Merge this first — `main` currently fails to deploy.**

## What broke

Plan 043 (#467) moved the test doubles off the SDK's root entry to `@originals/sdk/testing`. The landing app was only partly updated: `YourOriginals.tsx` and `make-example.ts` were fixed, but two files still import from the root, so the deploy build dies:

```
[MISSING_EXPORT] "OrdMockProvider" is not exported by "../../packages/sdk/dist/index.js"
  ╭─[ src/sdk/engine.ts:18:24 ]
  ╭─[ src/sdk/verify-example.ts:13:24 ]
```

Mine — I shipped it in #467.

## Why CI was green

Every build, test and lint job filters `./packages/*`. **`apps/landing` is never built in CI**, so a breaking change to the SDK's public entry can land fully green and fail only at deploy time. That is the same shape as the two gaps already in [plan 046](https://github.com/onionoriginals/sdk/blob/main/plans/046-ci-gaps.md) — CI not covering a thing that consumes the SDK — and I've noted it there as a fourth item to fix.

## The fix

`engine.ts` and `verify-example.ts` now import `OrdMockProvider` from `@originals/sdk/testing`.

Also fixed: the **quickstart sample rendered on the landing page itself** (`content.ts`) told readers to import `OrdMockProvider` from `@originals/sdk`. Not a build error — it's a template literal — but it would have taught every visitor an import that no longer resolves.

## Verification

Reproduced the deploy build locally, exactly as the failing job runs it:

```
bun run build && cd apps/landing && bunx vite build   → ✓ built
landing tests   151 pass / 0 fail
landing tsc     0 errors
```

(The remaining `INEFFECTIVE_DYNAMIC_IMPORT` warnings are pre-existing and unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)