### PR TITLE
docs(plans): record two more CI gaps; diagnose the intermittent test failure

### DIFF
--- a/plans/046-ci-gaps.md
+++ b/plans/046-ci-gaps.md
@@ -9,18 +9,23 @@
 
 - **Priority**: P2
 - **Effort**: S
-- **Risk**: LOW (item 1–2), MED (item 3 — surfaces 38 pre-existing errors)
+- **Risk**: LOW (items 1–2, 4), MED (item 3 — surfaces 38 pre-existing errors; item 5 — needs a real diagnosis, not a suppression)
 - **Category**: tech-debt / CI
 - **Found while**: executing plans 034–044 (run 3). Each gap is named by a bug it
   actually failed to catch, not by inspection.
 
 ## Why this matters
 
-Three gaps, each of which let something real through during run 3. None are
+Five gaps, each of which let something real through during run 3. None are
 hypothetical: for each, the bug shipped to a PR and was caught by a human or a
 review bot rather than by CI.
 
-### 1. `turbo run lint` does not depend on `^build`
+> **Item 1 is DONE** — fixed in the `@originals/cel` PR (#469), because that PR
+> made the gap fatal: the SDK depends on a workspace package for the first time,
+> so its own lint began failing in CI against unbuilt types. The remaining items
+> are still open.
+
+### 1. `turbo run lint` does not depend on `^build` — DONE (#469)
 
 `packages/auth` imports types from `@originals/sdk`, which resolve through
 `packages/sdk/dist`. The lint task has no `dependsOn: ["^build"]`, so during lint
@@ -82,6 +87,53 @@ and record the decision in the PR:
 **Do NOT** leave the glob unquoted to keep CI green. A lint job that silently
 skips two thirds of the source tree is worse than one that fails.
 
+### 4. `apps/landing` is never built in CI
+
+Every build, test and lint job filters `./packages/*`. The landing app consumes
+`@originals/sdk` but is not built, so a breaking change to the SDK's public
+entry lands fully green and fails only at deploy.
+
+**What it let through**: plan 043 moved `OrdMockProvider` to
+`@originals/sdk/testing`; two landing files kept importing it from the root and
+the deploy build died with `MISSING_EXPORT` (fixed in #470). A third instance the
+compiler could not catch — the quickstart sample *rendered on the landing page*
+— was teaching visitors the same dead import.
+
+**Fix**: add a CI job that runs `bun run build && cd apps/landing && bun run
+build` (plus `bun run typecheck`). It need not gate merges, but it must run.
+
+### 5. `bun run test` intermittently exits 1 with every suite reporting `0 fail`
+
+Seen on at least three PRs, including a **docs-only** one that could not possibly
+break tests. Signature, identical each time:
+
+- every suite prints `0 fail`, and no `(fail)` line appears anywhere in the log;
+- the run logs ~4128 passing tests — essentially the entire suite;
+- `@originals/sdk#test` nonetheless exits 1;
+- an unhandled `HTTP error! status: 404` from didwebvh-ts's
+  `fetchLogFromIdentifier` appears nearby;
+- **re-running the same commit passes.**
+
+**Diagnosis**: not a network dependency. `tests/setup.bun.ts` installs a `fetch`
+mock in `beforeEach` that returns 404 by design, to fail tests that forget to
+mock. So the 404 is the mock working. The problem is that the rejection escapes
+a test's lifecycle: some DID resolution is started but its promise is not
+awaited (or its rejection not caught), so it settles after the test finishes and
+Bun reports an unhandled rejection at exit — which is nondeterministic, hence
+the flake.
+
+**Fix**: find the floating promise rather than suppressing the symptom. Start by
+running with `DEBUG_FETCH=true` (the setup already logs unmocked fetch URLs) to
+identify which resolution is in flight, and check the deferred paths first —
+`LifecycleManager`'s `queueMicrotask` emit and anything calling `resolveDID`
+without `await`. Adding a global unhandled-rejection handler that fails the test
+run loudly, with the offending stack, would make the next occurrence
+self-diagnosing.
+
+**Do NOT** "fix" this by making the suite tolerate unhandled rejections. A
+provenance SDK swallowing a rejected promise is exactly the class of bug this
+repo spent run 3 eliminating.
+
 ## Done criteria
 
 1. `turbo.json`'s lint task depends on `^build`; deleting `dist` and running lint
@@ -89,7 +141,10 @@ skips two thirds of the source tree is worse than one that fails.
 2. The browser-safety gate covers `@originals/auth`'s browser-facing entries and
    fails on a `Buffer` reference in a guarded graph. Verify by temporarily
    reintroducing `Buffer.from` into `turnkeySignBytes` and confirming CI fails.
-3. `bun run lint` in both packages lints the entire `src` tree, and passes.
+3. `bun run lint` in every package lints the entire `src` tree, and passes.
+4. A CI job builds `apps/landing`, and fails if the SDK's public entry breaks it.
+5. `bun run test` exits 0 deterministically; the floating promise is identified
+   and awaited, not suppressed.
 
 ## STOP conditions
 


### PR DESCRIPTION
Docs only. Extends plan 046 with two gaps found while shipping the roadmap, and marks item 1 done.

**Item 1 (lint before build) — DONE**, fixed in #469. That PR made the gap fatal rather than latent: the SDK depends on a workspace package for the first time, so its own lint started failing in CI against unbuilt types.

**Item 4 — `apps/landing` is never built in CI.** Every job filters `./packages/*`. A breaking change to the SDK's public entry lands fully green and fails only at deploy — which is exactly what happened when plan 043 moved `OrdMockProvider` (fixed in #470). A third instance the compiler couldn't catch: the quickstart sample *rendered on the landing page* was teaching visitors the same dead import.

**Item 5 — the intermittent `Tests pass` failure, now diagnosed.** Seen on three PRs including a **docs-only** one that cannot possibly break tests. The signature is identical every time:

- every suite prints `0 fail`, no `(fail)` line anywhere in the log
- ~4128 passing tests logged — essentially the whole suite
- `@originals/sdk#test` still exits 1
- an unhandled `HTTP error! status: 404` from didwebvh-ts's `fetchLogFromIdentifier` nearby
- **re-running the same commit passes**

It is **not** a network dependency. `tests/setup.bun.ts` installs a `fetch` mock in `beforeEach` that returns 404 by design, to fail tests that forget to mock — so the 404 in the logs is the mock doing its job. The real problem is that the rejection escapes a test's lifecycle: a DID resolution is started and never awaited, settles after the test ends, and Bun reports an unhandled rejection at exit. Nondeterministic, hence the flake.

The plan records concrete next steps (`DEBUG_FETCH=true`, which the setup already supports; the deferred `queueMicrotask` emit path) and one instruction I'd want honoured: **do not suppress it.** An SDK that swallows a rejected promise is precisely the class of bug run 3 spent itself eliminating.