### PR TITLE
fix(ci): close the gaps that let three bugs reach main (plan 046)

### DIFF
--- a/.changeset/cli-display-untrusted-values.md
+++ b/.changeset/cli-display-untrusted-values.md
@@ -1,0 +1,7 @@
+---
+"@originals/sdk": patch
+---
+
+**`originals-cel inspect` no longer prints `[object Object]`.** CEL event data is arbitrary JSON written by whoever produced the log, so a field the CLI renders as a string — an asset `name`, a `layer`, a deactivation `reason` — can legitimately be an object. `String(value)` turned those into `[object Object]`, hiding the content at exactly the moment someone is inspecting a log to understand it. Non-primitives are now JSON-rendered. The `Unsupported proof type` error from the Data Integrity proof path had the same flaw and is fixed the same way.
+
+Found by quoting the `lint` script's glob: it was unquoted, so the shell expanded it to one directory level and `cel/cli`, `bitcoin/transactions`, `migration/*` and several other directories had never been linted at all.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,15 @@ jobs:
       - name: Build
         run: bun run build
 
+      # apps/ is outside the ./packages/* filter every other job uses, so a
+      # breaking change to the SDK's public entry lands green and fails only at
+      # deploy — which is how #470 happened (plan 046, item 4). Runs on Bun and
+      # BEFORE the Node pin below: vite needs node:util's styleText, which
+      # Node 20.10 does not have. Build only, not typecheck — apps/landing does
+      # not declare @types/node, so its typecheck is separately fragile.
+      - name: Build the landing app against the built SDK
+        run: cd apps/landing && bun run build
+
       # The Bun test suite tolerates extensionless/attribute-less imports, so
       # importing the built dist under Node is the only gate that catches a
       # publish npm consumers cannot actually load.
@@ -118,12 +127,6 @@ jobs:
       # apps/ is outside the ./packages/* filter every other job uses, so a
       # breaking change to the SDK's public entry lands green here and fails
       # only at deploy — which is exactly how #470 happened (plan 046, item 4).
-      # Deliberately the BUILD only. The landing app's `typecheck` needs
-      # @types/node, which it does not declare and which only resolves when
-      # hoisting happens to provide it — a pre-existing fragility, unrelated to
-      # what this gate is for. The build is what deploy runs and what broke.
-      - name: Build the landing app against the built SDK
-        run: cd apps/landing && bun run build
 
   changeset:
     name: Changeset present

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,8 +118,12 @@ jobs:
       # apps/ is outside the ./packages/* filter every other job uses, so a
       # breaking change to the SDK's public entry lands green here and fails
       # only at deploy — which is exactly how #470 happened (plan 046, item 4).
+      # Deliberately the BUILD only. The landing app's `typecheck` needs
+      # @types/node, which it does not declare and which only resolves when
+      # hoisting happens to provide it — a pre-existing fragility, unrelated to
+      # what this gate is for. The build is what deploy runs and what broke.
       - name: Build the landing app against the built SDK
-        run: cd apps/landing && bun run typecheck && bun run build
+        run: cd apps/landing && bun run build
 
   changeset:
     name: Changeset present

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,12 @@ jobs:
       - name: Verify browser-facing entry points have no eager Node builtins
         run: node scripts/check-browser-safety.mjs
 
+      # apps/ is outside the ./packages/* filter every other job uses, so a
+      # breaking change to the SDK's public entry lands green here and fails
+      # only at deploy — which is exactly how #470 happened (plan 046, item 4).
+      - name: Build the landing app against the built SDK
+        run: cd apps/landing && bun run typecheck && bun run build
+
   changeset:
     name: Changeset present
     # Only on PRs, and skip the "Version Packages" PR (which intentionally has no

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -38,8 +38,8 @@
   "scripts": {
     "build": "bunx tsc && bunx tsc-alias",
     "test": "bun test tests/",
-    "lint": "eslint src/**/*.ts",
-    "format": "prettier --write src/**/*.ts"
+    "lint": "eslint \"src/**/*.ts\"",
+    "format": "prettier --write \"src/**/*.ts\""
   },
   "keywords": [
     "originals",

--- a/packages/cel/eslint.config.js
+++ b/packages/cel/eslint.config.js
@@ -15,7 +15,7 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-unused-vars': [
         'error',
-        { argsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
       ],
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/no-unsafe-assignment': 'warn',

--- a/packages/cel/tests/setup.bun.ts
+++ b/packages/cel/tests/setup.bun.ts
@@ -60,8 +60,13 @@ afterEach(() => {
 process.on('unhandledRejection', (reason: unknown) => {
   const err = reason instanceof Error ? reason.stack : String(reason);
   console.error(
-    '\n=== UNHANDLED REJECTION (this is why the run exits non-zero) ===\n' +
+    '\n=== UNHANDLED REJECTION ===\n' +
       `${err}\n` +
       '=== A promise escaped a test lifecycle. Await it, or catch it. ===\n'
   );
+  // Registering a listener REPLACES the runtime's default handling, which is
+  // what would otherwise fail the process. Without this line the reporter would
+  // convert a red run into a green one — turning a diagnostic into exactly the
+  // false-green it was added to investigate. Force the failing status instead.
+  process.exitCode = 1;
 });

--- a/packages/cel/tests/setup.bun.ts
+++ b/packages/cel/tests/setup.bun.ts
@@ -47,3 +47,21 @@ afterEach(() => {
   console.debug = originalConsole.debug;
   console.warn = originalConsole.warn;
 });
+
+// An unhandled rejection makes `bun test` exit non-zero while every suite still
+// reports `0 fail` — the process dies after the summary, so CI shows a red X
+// with nothing to point at. That has now happened on three PRs, including a
+// docs-only one (plan 046, item 5).
+//
+// This does NOT swallow the rejection: it prints the stack and the test that
+// was running when it escaped, so the next occurrence identifies itself instead
+// of costing another investigation. A provenance SDK quietly discarding a
+// rejected promise is precisely the bug class this suite exists to catch.
+process.on('unhandledRejection', (reason: unknown) => {
+  const err = reason instanceof Error ? reason.stack : String(reason);
+  console.error(
+    '\n=== UNHANDLED REJECTION (this is why the run exits non-zero) ===\n' +
+      `${err}\n` +
+      '=== A promise escaped a test lifecycle. Await it, or catch it. ===\n'
+  );
+});

--- a/packages/sdk/eslint.config.js
+++ b/packages/sdk/eslint.config.js
@@ -15,7 +15,7 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-unused-vars': [
         'error',
-        { argsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
       ],
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/no-unsafe-assignment': 'warn',

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -46,8 +46,8 @@
     "test:ci": "bash -o pipefail -c 'bun test tests/integration tests/unit --coverage 2>&1 | bun run ../../scripts/check-coverage.ts'",
     "test:security": "bun test tests/security",
     "test:stress": "bun test tests/stress",
-    "lint": "eslint src/**/*.ts",
-    "format": "prettier --write src/**/*.ts"
+    "lint": "eslint \"src/**/*.ts\"",
+    "format": "prettier --write \"src/**/*.ts\""
   },
   "keywords": [
     "originals",

--- a/packages/sdk/src/bitcoin/providers/OrdNodeProvider.ts
+++ b/packages/sdk/src/bitcoin/providers/OrdNodeProvider.ts
@@ -60,12 +60,16 @@ export class OrdNodeProvider implements ResourceProvider {
     return Promise.reject(this.notImplemented('getMetadata', 'refusing to report missing metadata as if resolved.'));
   }
 
-  // eslint-disable-next-line require-yield
+  // Signature is the OrdinalsProvider contract; this provider refuses rather
+  // than crawl, so it neither yields nor awaits.
+  // eslint-disable-next-line require-yield, @typescript-eslint/require-await
   async *getAllResources(_options: ResourceCrawlOptions = {}): AsyncGenerator<LinkedResource[]> {
     throw this.notImplemented('getAllResources', 'refusing to report an empty resource set as if crawled.');
   }
 
-  // eslint-disable-next-line require-yield
+  // Signature is the OrdinalsProvider contract; this provider refuses rather
+  // than crawl, so it neither yields nor awaits.
+  // eslint-disable-next-line require-yield, @typescript-eslint/require-await
   async *getAllResourcesChronological(_options: ResourceCrawlOptions = {}): AsyncGenerator<LinkedResource[]> {
     throw this.notImplemented('getAllResourcesChronological', 'refusing to report an empty resource set as if crawled.');
   }

--- a/packages/sdk/src/bitcoin/transactions/commit.ts
+++ b/packages/sdk/src/bitcoin/transactions/commit.ts
@@ -200,7 +200,6 @@ export async function createRevealTransaction(
 
   const leafScript = inscriptionScript.script;
   const controlBlock = inscriptionScript.controlBlock;
-  const leafVersion = inscriptionScript.leafVersion ?? 0xc0;
 
   // Reveal fee from the real serialized leaf + control block (witness-discounted).
   const revealFee = Number(calculateFee(estimateRevealTxSize(leafScript.length, controlBlock.length), feeRate));

--- a/packages/sdk/src/cel/cli/create.ts
+++ b/packages/sdk/src/cel/cli/create.ts
@@ -88,7 +88,7 @@ async function generateKeyPair(): Promise<{ privateKey: string; publicKey: strin
   const publicKeyBytes = await (ed25519 as any).getPublicKeyAsync(privateKeyBytes);
   
   return {
-    privateKey: multikey.encodePrivateKey(privateKeyBytes as Uint8Array, 'Ed25519'),
+    privateKey: multikey.encodePrivateKey(privateKeyBytes, 'Ed25519'),
     publicKey: multikey.encodePublicKey(publicKeyBytes as Uint8Array, 'Ed25519'),
   };
 }
@@ -114,7 +114,7 @@ async function loadPrivateKey(keyPath: string): Promise<{ privateKey: string; pu
     } else {
       throw new Error('JSON key file must contain "privateKey" field');
     }
-  } catch (e) {
+  } catch (_e) {
     // Not JSON, treat as raw multibase key
     if (content.startsWith('z')) {
       privateKey = content;
@@ -289,9 +289,9 @@ export async function createCommand(flags: CreateFlags): Promise<CreateResult> {
   if (flags.output) {
     try {
       if (format === 'cbor') {
-        fs.writeFileSync(flags.output, output as Uint8Array);
+        fs.writeFileSync(flags.output, output);
       } else {
-        fs.writeFileSync(flags.output, output as string, 'utf-8');
+        fs.writeFileSync(flags.output, output, 'utf-8');
       }
     } catch (e) {
       return {
@@ -306,7 +306,7 @@ export async function createCommand(flags: CreateFlags): Promise<CreateResult> {
       const base64 = Buffer.from(output as Uint8Array).toString('base64');
       process.stdout.write(base64);
     } else {
-      process.stdout.write(output as string);
+      process.stdout.write(output);
     }
   }
   

--- a/packages/sdk/src/cel/cli/inspect.ts
+++ b/packages/sdk/src/cel/cli/inspect.ts
@@ -50,6 +50,24 @@ interface MigrationData {
 /**
  * Check if a proof is a WitnessProof (has witnessedAt field)
  */
+/**
+ * Renders an untrusted value for display. CEL event data is arbitrary JSON from
+ * whoever wrote the log, so a field the CLI expects to be a string can be an
+ * object — `String(obj)` would print "[object Object]" and hide it.
+ */
+function display(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value) ?? String(typeof value);
+  } catch {
+    return '[unserializable]';
+  }
+}
+
 function isWitnessProof(proof: DataIntegrityProof | WitnessProof): proof is WitnessProof {
   return 'witnessedAt' in proof && typeof (proof).witnessedAt === 'string';
 }
@@ -408,7 +426,7 @@ function outputInspection(log: EventLog, state: AssetState): void {
   if (state.deactivated) {
     console.log(`   Status: 🔒 DEACTIVATED`);
     if (state.metadata?.deactivationReason) {
-      console.log(`   Reason: ${String(state.metadata.deactivationReason)}`);
+      console.log(`   Reason: ${display(state.metadata.deactivationReason)}`);
     }
   } else {
     console.log(`   Status: ✅ ACTIVE`);
@@ -523,10 +541,10 @@ function outputInspection(log: EventLog, state: AssetState): void {
 
     // Event-specific details
     if (event.type === 'create') {
-      if (data.name) console.log(` ${connector}   Name: ${String(data.name)}`);
+      if (data.name) console.log(` ${connector}   Name: ${display(data.name)}`);
       if (data.did) console.log(` ${connector}   DID: ${formatDid(data.did as string)}`);
       if (data.controller) console.log(` ${connector}   Controller: ${formatDid(data.controller as string)}`);
-      if (data.layer) console.log(` ${connector}   Layer: ${String(data.layer)}`);
+      if (data.layer) console.log(` ${connector}   Layer: ${display(data.layer)}`);
       if (data.resources && Array.isArray(data.resources)) {
         console.log(` ${connector}   Resources: ${data.resources.length} file(s)`);
       }
@@ -546,7 +564,7 @@ function outputInspection(log: EventLog, state: AssetState): void {
     } else if (event.type === 'update') {
       // Show what changed
       const changes: string[] = [];
-      if (data.name) changes.push(`name → "${String(data.name)}"`);
+      if (data.name) changes.push(`name → "${display(data.name)}"`);
       if (data.resources) changes.push(`resources updated`);
       if (isMigrationEvent(event.data)) {
         const migrationData = event.data;
@@ -565,7 +583,7 @@ function outputInspection(log: EventLog, state: AssetState): void {
         }
       }
     } else if (event.type === 'deactivate') {
-      if (data.reason) console.log(` ${connector}   Reason: ${String(data.reason)}`);
+      if (data.reason) console.log(` ${connector}   Reason: ${display(data.reason)}`);
     }
     
     // Proof summary

--- a/packages/sdk/src/cel/cli/migrate.ts
+++ b/packages/sdk/src/cel/cli/migrate.ts
@@ -217,7 +217,7 @@ async function loadWalletKey(walletPath: string): Promise<{ privateKey: string; 
     } else {
       throw new Error('JSON wallet file must contain "privateKey" field');
     }
-  } catch (e) {
+  } catch (_e) {
     // Not JSON, treat as raw multibase key
     if (content.startsWith('z')) {
       privateKey = content;
@@ -413,7 +413,7 @@ export async function migrateCommand(flags: MigrateFlags): Promise<MigrateResult
     const ed25519 = await import('@noble/ed25519');
     const privateKeyBytes = ed25519.utils.randomSecretKey();
     const publicKeyBytes = await (ed25519 as any).getPublicKeyAsync(privateKeyBytes);
-    privateKey = multikey.encodePrivateKey(privateKeyBytes as Uint8Array, 'Ed25519');
+    privateKey = multikey.encodePrivateKey(privateKeyBytes, 'Ed25519');
     publicKey = multikey.encodePublicKey(publicKeyBytes as Uint8Array, 'Ed25519');
 
     // Never print the private key to a shared stream (stderr lands in shell
@@ -503,9 +503,9 @@ export async function migrateCommand(flags: MigrateFlags): Promise<MigrateResult
   if (flags.output) {
     try {
       if (format === 'cbor') {
-        fs.writeFileSync(flags.output, output as Uint8Array);
+        fs.writeFileSync(flags.output, output);
       } else {
-        fs.writeFileSync(flags.output, output as string, 'utf-8');
+        fs.writeFileSync(flags.output, output, 'utf-8');
       }
     } catch (e) {
       return {
@@ -520,7 +520,7 @@ export async function migrateCommand(flags: MigrateFlags): Promise<MigrateResult
       const base64 = Buffer.from(output as Uint8Array).toString('base64');
       process.stdout.write(base64);
     } else {
-      process.stdout.write(output as string);
+      process.stdout.write(output);
     }
   }
   

--- a/packages/sdk/src/kinds/validators/ModuleValidator.ts
+++ b/packages/sdk/src/kinds/validators/ModuleValidator.ts
@@ -104,7 +104,7 @@ export class ModuleValidator extends BaseKindValidator<OriginalKind.Module> {
             continue;
           } else if (typeof value === 'object' && value !== null) {
             // Conditional exports object
-            const exportObj = value as { import?: string; require?: string; types?: string };
+            const exportObj = value;
             if (!exportObj.import && !exportObj.require) {
               warnings.push(ValidationUtils.warning(
                 'INCOMPLETE_EXPORT',

--- a/packages/sdk/src/migration/MigrationManager.ts
+++ b/packages/sdk/src/migration/MigrationManager.ts
@@ -196,7 +196,7 @@ export class MigrationManager {
   private maybeRunStartupReclaim(): void {
     if (this.startupReclaimDone) return;
     this.startupReclaimDone = true;
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+     
     void this.checkpointManager.cleanupOldCheckpoints();
   }
 
@@ -297,7 +297,7 @@ export class MigrationManager {
       }
 
       // Step 1: Create migration state
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+       
       migrationState = await this.stateTracker.createMigration(options);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       const migrationId = migrationState.migrationId;
@@ -337,7 +337,7 @@ export class MigrationManager {
         progress: 20
       });
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       checkpoint = await this.checkpointManager.createCheckpoint(migrationId, options);
 
       // Persist checkpointId immediately so rollback can locate it
@@ -353,7 +353,7 @@ export class MigrationManager {
       // Step 4: Execute migration
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const migration = this.getMigrationOperation(options);
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
       const result = await migration.executeMigration(options, migrationId);
 
       // Step 5: Complete migration
@@ -418,7 +418,7 @@ export class MigrationManager {
         // (retryPendingDeletions + storage-truth enumeration sweep), so a
         // checkpoint stranded by a delete whose tombstone and pending-marker
         // writes both failed is reclaimed here too. Fire-and-forget; never throws.
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+         
         void this.checkpointManager.cleanupOldCheckpoints();
       }, 24 * 60 * 60 * 1000); // Sweep after 24 hours
       cleanupTimer.unref?.();
@@ -707,9 +707,9 @@ export class MigrationManager {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
         const rollbackResult = await this.rollbackManager.rollback(migrationId, checkpoint.checkpointId, { error, stateAtFailure });
         rollbackOutcome = rollbackResult;
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+         
         rollbackSuccess = rollbackResult.success;
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+         
         finalState = rollbackResult.restoredState;
 
         // Advance the tracked state to reflect the rollback outcome
@@ -727,7 +727,7 @@ export class MigrationManager {
         // machinery failure — only genuine QUARANTINED outcomes raise the
         // quarantine event.
         if (!rollbackSuccess && finalState === MigrationStateEnum.QUARANTINED) {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+           
           await this.emitEvent('migration:quarantine', {
             migrationId,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
@@ -746,7 +746,7 @@ export class MigrationManager {
         } catch (stateError) {
           console.error('Failed to update migration state after rollback failure:', stateError);
         }
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+         
         await this.emitEvent('migration:quarantine', {
           migrationId,
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
@@ -880,7 +880,7 @@ export class MigrationManager {
   /**
    * Emit event
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private async emitEvent(type: string, data: any): Promise<void> {
     try {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument

--- a/packages/sdk/src/migration/MigrationManager.ts
+++ b/packages/sdk/src/migration/MigrationManager.ts
@@ -196,7 +196,6 @@ export class MigrationManager {
   private maybeRunStartupReclaim(): void {
     if (this.startupReclaimDone) return;
     this.startupReclaimDone = true;
-     
     void this.checkpointManager.cleanupOldCheckpoints();
   }
 
@@ -297,7 +296,6 @@ export class MigrationManager {
       }
 
       // Step 1: Create migration state
-       
       migrationState = await this.stateTracker.createMigration(options);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       const migrationId = migrationState.migrationId;
@@ -418,7 +416,6 @@ export class MigrationManager {
         // (retryPendingDeletions + storage-truth enumeration sweep), so a
         // checkpoint stranded by a delete whose tombstone and pending-marker
         // writes both failed is reclaimed here too. Fire-and-forget; never throws.
-         
         void this.checkpointManager.cleanupOldCheckpoints();
       }, 24 * 60 * 60 * 1000); // Sweep after 24 hours
       cleanupTimer.unref?.();
@@ -707,9 +704,7 @@ export class MigrationManager {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
         const rollbackResult = await this.rollbackManager.rollback(migrationId, checkpoint.checkpointId, { error, stateAtFailure });
         rollbackOutcome = rollbackResult;
-         
         rollbackSuccess = rollbackResult.success;
-         
         finalState = rollbackResult.restoredState;
 
         // Advance the tracked state to reflect the rollback outcome
@@ -727,7 +722,6 @@ export class MigrationManager {
         // machinery failure — only genuine QUARANTINED outcomes raise the
         // quarantine event.
         if (!rollbackSuccess && finalState === MigrationStateEnum.QUARANTINED) {
-           
           await this.emitEvent('migration:quarantine', {
             migrationId,
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
@@ -746,7 +740,6 @@ export class MigrationManager {
         } catch (stateError) {
           console.error('Failed to update migration state after rollback failure:', stateError);
         }
-         
         await this.emitEvent('migration:quarantine', {
           migrationId,
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access

--- a/packages/sdk/src/migration/audit/AuditLogger.ts
+++ b/packages/sdk/src/migration/audit/AuditLogger.ts
@@ -149,7 +149,6 @@ export class AuditLogger implements IAuditLogger {
    * signature) used for both signing and verification.
    */
   private canonicalBytes(record: MigrationAuditRecord): Uint8Array {
-     
     const { signature: _signature, ...recordWithoutSig } = record as any;
     return Buffer.from(JSON.stringify(recordWithoutSig), 'utf8');
   }

--- a/packages/sdk/src/migration/audit/AuditLogger.ts
+++ b/packages/sdk/src/migration/audit/AuditLogger.ts
@@ -149,7 +149,7 @@ export class AuditLogger implements IAuditLogger {
    * signature) used for both signing and verification.
    */
   private canonicalBytes(record: MigrationAuditRecord): Uint8Array {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+     
     const { signature: _signature, ...recordWithoutSig } = record as any;
     return Buffer.from(JSON.stringify(recordWithoutSig), 'utf8');
   }
@@ -315,7 +315,7 @@ export class AuditLogger implements IAuditLogger {
               }
             }
           }
-        } catch (error) {
+        } catch (_error) {
           // Skip invalid audit records
         }
       }

--- a/packages/sdk/src/migration/checkpoint/CheckpointStorage.ts
+++ b/packages/sdk/src/migration/checkpoint/CheckpointStorage.ts
@@ -97,7 +97,7 @@ export class CheckpointStorage {
           this.checkpoints.set(checkpointId, checkpoint);
           return checkpoint;
         }
-      } catch (error) {
+      } catch (_error) {
         // Checkpoint not found in storage
       }
     }

--- a/packages/sdk/src/migration/rollback/RollbackManager.ts
+++ b/packages/sdk/src/migration/rollback/RollbackManager.ts
@@ -242,7 +242,7 @@ export class RollbackManager implements IRollbackManager {
       // Bitcoin transactions cannot be rolled back
       // But we can still restore the source DID to working state
       return true;
-    } catch (error) {
+    } catch (_error) {
       return false;
     }
   }

--- a/packages/sdk/src/vc/cryptosuites/bbs.ts
+++ b/packages/sdk/src/vc/cryptosuites/bbs.ts
@@ -102,7 +102,7 @@ export class BBSCryptosuiteUtils {
     // proofs use only the even tags 0x02/0x04/0x06/0x08.
     else throw new Error('Invalid BBS base proof header');
 
-    const components: any[] = cbor.decode(decoded.slice(3)) as any[];
+    const components: any[] = cbor.decode(decoded.slice(3));
     const base = {
       bbsSignature: components[0] as Uint8Array,
       bbsHeader: components[1] as Uint8Array,
@@ -230,7 +230,7 @@ export class BBSCryptosuiteUtils {
     else if (this.compareBytes(header, [0xd9, 0x5d, 0x07])) featureOption = 'pseudonym';
     else throw new Error('Invalid BBS derived proof header');
 
-    const components: any[] = cbor.decode(decoded.slice(3)) as any[];
+    const components: any[] = cbor.decode(decoded.slice(3));
     const decompressedLabelMap = this.decompressLabelMap(components[1]);
     const result: any = {
       bbsProof: components[0],

--- a/packages/sdk/src/vc/proofs/data-integrity.ts
+++ b/packages/sdk/src/vc/proofs/data-integrity.ts
@@ -30,7 +30,9 @@ export class DataIntegrityProofManager {
     // the actual proof's declared type.)
     const declaredType = (options as { type?: unknown }).type;
     if (declaredType !== undefined && declaredType !== 'DataIntegrityProof') {
-      throw new Error(`Unsupported proof type: ${String(declaredType)}`);
+      throw new Error(
+        `Unsupported proof type: ${typeof declaredType === 'string' ? declaredType : JSON.stringify(declaredType)}`
+      );
     }
     const opts: ProofOptions = { ...options, type: 'DataIntegrityProof' };
     // Route bbs-2023 through the BBS backend so createProof is symmetric with

--- a/packages/sdk/src/vc/utils/jsonld.ts
+++ b/packages/sdk/src/vc/utils/jsonld.ts
@@ -14,7 +14,7 @@ export async function canonize(input: any, { documentLoader }: any): Promise<str
 }
 
 export async function canonizeProof(proof: any, { documentLoader }: any): Promise<string> {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+   
   const { jws: _jws, signatureValue: _signatureValue, proofValue: _proofValue, ...rest } = proof;
   return await canonize(rest, { documentLoader });
 }

--- a/packages/sdk/src/vc/utils/jsonld.ts
+++ b/packages/sdk/src/vc/utils/jsonld.ts
@@ -14,7 +14,6 @@ export async function canonize(input: any, { documentLoader }: any): Promise<str
 }
 
 export async function canonizeProof(proof: any, { documentLoader }: any): Promise<string> {
-   
   const { jws: _jws, signatureValue: _signatureValue, proofValue: _proofValue, ...rest } = proof;
   return await canonize(rest, { documentLoader });
 }

--- a/packages/sdk/src/vc/utils/selective-disclosure.ts
+++ b/packages/sdk/src/vc/utils/selective-disclosure.ts
@@ -496,10 +496,11 @@ export const canonicalizeAndGroup = async (
     await skolemizeCompactJsonLd(document, CUSTOM_URN_SCHEME, options);
   const deskolemizedNQuads = await toDeskolemizedNQuads(skolemizedCompactDocument, options);
 
-  let { nquads, labelMap } =
+  // Only labelMap is reassigned below; nquads is not.
+  const { nquads, labelMap: canonicalLabelMap } =
     await labelReplacementCanonicalizeNQuads(labelMapFactoryFunction, deskolemizedNQuads, options);
 
-  labelMap = stripBlankNodePrefixes(labelMap);
+  const labelMap = stripBlankNodePrefixes(canonicalLabelMap);
   const selections = new Map<string, SelectionResult>();
   for (const [name, pointers] of Object.entries(groupDefinitions)) {
     selections.set(name, await selectCanonicalNQuads(

--- a/packages/sdk/tests/setup.bun.ts
+++ b/packages/sdk/tests/setup.bun.ts
@@ -80,8 +80,13 @@ afterEach(() => {
 process.on('unhandledRejection', (reason: unknown) => {
   const err = reason instanceof Error ? reason.stack : String(reason);
   originalConsole.error(
-    '\n=== UNHANDLED REJECTION (this is why the run exits non-zero) ===\n' +
+    '\n=== UNHANDLED REJECTION ===\n' +
       `${err}\n` +
       '=== A promise escaped a test lifecycle. Await it, or catch it. ===\n'
   );
+  // Registering a listener REPLACES the runtime's default handling, which is
+  // what would otherwise fail the process. Without this line the reporter would
+  // convert a red run into a green one — turning a diagnostic into exactly the
+  // false-green it was added to investigate. Force the failing status instead.
+  process.exitCode = 1;
 });

--- a/packages/sdk/tests/setup.bun.ts
+++ b/packages/sdk/tests/setup.bun.ts
@@ -68,3 +68,20 @@ afterEach(() => {
   verificationMethodRegistry.clear();
 });
 
+// An unhandled rejection makes `bun test` exit non-zero while every suite still
+// reports `0 fail` — the process dies after the summary, so CI shows a red X
+// with nothing to point at. That has now happened on three PRs, including a
+// docs-only one (plan 046, item 5).
+//
+// This does NOT swallow the rejection: it prints the stack and the test that
+// was running when it escaped, so the next occurrence identifies itself instead
+// of costing another investigation. A provenance SDK quietly discarding a
+// rejected promise is precisely the bug class this suite exists to catch.
+process.on('unhandledRejection', (reason: unknown) => {
+  const err = reason instanceof Error ? reason.stack : String(reason);
+  originalConsole.error(
+    '\n=== UNHANDLED REJECTION (this is why the run exits non-zero) ===\n' +
+      `${err}\n` +
+      '=== A promise escaped a test lifecycle. Await it, or catch it. ===\n'
+  );
+});

--- a/packages/sdk/tests/stress/batch-operations-stress.test.ts
+++ b/packages/sdk/tests/stress/batch-operations-stress.test.ts
@@ -392,33 +392,41 @@ describe('Batch Operations Stress Tests', () => {
 
   describe('6. Memory and Resource Tests', () => {
     it('should not leak memory during repeated batch operations', async () => {
-      // When this test runs after the integration/unit/security suites the heap
-      // can be ~80MB from accumulated allocations. Bun's GC is incremental:
-      // Bun.gc(false) advances one GC cycle but cannot force a synchronous
-      // full-heap collection. The deferred major collection can fire at any point
-      // during the measured window, causing a dramatic heap drop (80 → 14MB)
-      // that makes Math.abs(growth) far exceed 50% as a false positive.
+      // What this asserts: repeated batches must not grow RETAINED memory
+      // without bound. Everything below exists to make "retained" measurable.
       //
-      // Fix (supersedes the warmup-only approach from #425): reset the
-      // measurement window whenever a major GC event is detected (>30% heap drop
-      // between consecutive iterations), so the 10 comparison readings all come
-      // from the same post-GC stable phase. A real unbounded leak grows
-      // monotonically, never triggers the reset, and still fails the assertion.
+      // `process.memoryUsage().heapUsed` is not a usable signal in Bun on its
+      // own — it lags reality badly. Holding 300k live Uint8Arrays reports
+      // ~0.2MB, and the same measurement after a synchronous collection reports
+      // ~38MB. Readings taken without forcing collection are therefore noise,
+      // not measurements.
+      //
+      // The previous version called `Bun.gc(false)`, the INCREMENTAL collector,
+      // which cannot force a full collection. Major GCs then fired at arbitrary
+      // points, producing 80MB → 14MB cliffs mid-window, and the test coped by
+      // discarding the window on any >30% drop and restarting — needing 10
+      // consecutive GC-free readings. Under CI memory pressure those resets fire
+      // repeatedly, the run exhausts its 100-iteration cap, and the test throws
+      // "Memory window never stabilised". That is a flake, not a leak, and it
+      // failed unrelated PRs.
+      //
+      // `Bun.gc(true)` runs a SYNCHRONOUS full collection, so every reading is
+      // taken from a settled heap. Collection stops being a random event to
+      // detect and becomes a step in the measurement, which removes the reset
+      // machinery, the iteration cap and the throw path entirely.
       const measuredIterations = 10;
       const batchSize = 100;
-      const GC_DROP_THRESHOLD = 0.30; // 30%+ drop → major GC event
 
-      // Bun.gc() advances the incremental GC; helps but cannot guarantee full
-      // collection. We rely on the reset logic below to handle stragglers.
+      /** Synchronous full collection — see above; `false` here would not settle the heap. */
       const forceGC = () => {
         if (typeof Bun !== 'undefined' && typeof Bun.gc === 'function') {
-          Bun.gc(false);
+          Bun.gc(true);
         } else if (typeof global.gc === 'function') {
           global.gc();
         }
       };
 
-      // 5 un-measured warmup iterations to warm the JIT before measuring.
+      // Warm the JIT so early iterations are not measured against cold code.
       for (let i = 0; i < 5; i++) {
         await sdk.lifecycle.batchCreateAssets(createTestResourcesList(batchSize), {
           maxConcurrent: 5
@@ -426,58 +434,37 @@ describe('Batch Operations Stress Tests', () => {
         forceGC();
       }
 
-      // Collect measuredIterations readings. If a major GC fires mid-window
-      // (detected as a >30% drop from the previous reading), discard accumulated
-      // readings and start over — the post-GC phase is the stable baseline we
-      // actually want to measure.
-      let memoryReadings: number[] = [];
-      let prevMem = process.memoryUsage().heapUsed / 1024 / 1024;
-
-      // Hard cap on total iterations so a pathological GC storm (window resets on
-      // every iteration under heavy memory pressure) fails fast with a clear
-      // message instead of silently running into the 180s test timeout.
-      let totalIterations = 0;
-      const maxTotalIterations = measuredIterations * 10;
-
-      while (memoryReadings.length < measuredIterations) {
-        if (++totalIterations > maxTotalIterations) {
-          throw new Error(
-            `[STRESS] Memory window never stabilised: GC drops kept resetting it after ` +
-              `${maxTotalIterations} iterations (needed ${measuredIterations} consecutive clean readings). ` +
-              `Likely a very memory-pressured agent, not a leak — re-run or raise maxTotalIterations.`
-          );
-        }
+      // Every reading is post-collection, so the series is directly comparable
+      // and the loop runs a fixed number of times.
+      const memoryReadings: number[] = [];
+      for (let i = 0; i < measuredIterations; i++) {
         await sdk.lifecycle.batchCreateAssets(createTestResourcesList(batchSize), {
           maxConcurrent: 5
         });
         forceGC();
-
         const memUsage = process.memoryUsage().heapUsed / 1024 / 1024; // MB
-        const drop = (prevMem - memUsage) / Math.max(prevMem, 1);
-
-        if (drop > GC_DROP_THRESHOLD) {
-          // Major GC fired — discard the pre-GC readings and restart the window.
-          console.log(
-            `[STRESS] GC drop detected (${(drop * 100).toFixed(0)}%) at iteration ${totalIterations}, resetting window`
-          );
-          memoryReadings = [];
-        } else {
-          memoryReadings.push(memUsage);
-        }
-        prevMem = memUsage;
-        console.log(`[STRESS] reading ${memoryReadings.length}/${measuredIterations}: ${memUsage.toFixed(2)}MB`);
+        memoryReadings.push(memUsage);
+        console.log(`[STRESS] reading ${i + 1}/${measuredIterations}: ${memUsage.toFixed(2)}MB`);
       }
 
-      // Compare first half vs second half: a real unbounded leak shows the
-      // second half steadily above the first.
+      // Compare halves by MEDIAN rather than mean: a leak shifts the whole
+      // distribution, while one unusually large iteration shifts only the mean.
+      const median = (xs: number[]) => {
+        const sorted = [...xs].sort((a, b) => a - b);
+        const mid = Math.floor(sorted.length / 2);
+        return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+      };
       const half = Math.floor(measuredIterations / 2);
-      const firstHalf = memoryReadings.slice(0, half).reduce((a, b) => a + b) / half;
-      const secondHalf = memoryReadings.slice(half).reduce((a, b) => a + b) / (measuredIterations - half);
+      const firstHalf = median(memoryReadings.slice(0, half));
+      const secondHalf = median(memoryReadings.slice(half));
       const growth = ((secondHalf - firstHalf) / firstHalf) * 100;
 
-      console.log(`[STRESS] Memory growth: ${growth.toFixed(2)}%`);
-      // A memory leak manifests as POSITIVE growth. GC-driven shrinkage between
-      // halves is normal and not a leak, so we only check the positive direction.
+      console.log(
+        `[STRESS] Retained memory: ${firstHalf.toFixed(2)}MB -> ${secondHalf.toFixed(2)}MB ` +
+          `(${growth.toFixed(2)}%)`
+      );
+      // A leak manifests as POSITIVE growth. Shrinkage is not a leak, so only
+      // the positive direction is asserted.
       expect(growth).toBeLessThan(50); // Memory shouldn't grow > 50%
     }, 180000);
 

--- a/plans/046-ci-gaps.md
+++ b/plans/046-ci-gaps.md
@@ -16,7 +16,7 @@
 
 ## Why this matters
 
-Three gaps, each of which let something real through during run 3. None are
+Four gaps, each of which let something real through during run 3. None are
 hypothetical: for each, the bug shipped to a PR and was caught by a human or a
 review bot rather than by CI.
 
@@ -86,6 +86,41 @@ and record the decision in the PR:
 
 **Do NOT** leave the glob unquoted to keep CI green. A lint job that silently
 skips two thirds of the source tree is worse than one that fails.
+
+### 5. A GC-sensitive stress test flaked under CI load — FIXED
+
+`Batch Operations Stress Tests > should not leak memory during repeated batch
+operations` failed intermittently with `[STRESS] Memory window never stabilised`,
+taking ~43s to do so, on PRs that could not possibly have caused it.
+
+**Root cause**: `process.memoryUsage().heapUsed` is not a usable signal in Bun
+without forcing collection first — holding 300k live `Uint8Array`s reports
+~0.2MB, and the same measurement after a synchronous collection reports ~38MB.
+The test called `Bun.gc(false)`, the INCREMENTAL collector, which cannot force a
+full collection, so major GCs fired at arbitrary points and produced 80MB → 14MB
+cliffs mid-window. It coped by discarding the measurement window on any >30%
+drop and restarting, requiring 10 consecutive GC-free readings; under CI memory
+pressure the resets fire repeatedly and the run exhausts its iteration cap.
+
+**Fix**: `Bun.gc(true)` performs a synchronous full collection, so every reading
+comes from a settled heap. Collection stops being a random event to detect and
+becomes a step in the measurement, which removed the reset machinery, the
+iteration cap and the throw path. Halves are now compared by median rather than
+mean, so one unusually large iteration cannot move the result. Verified the
+detection still works: a steadily rising series yields 100% growth and fails,
+while a GC sawtooth yields −67% and passes.
+
+> **This was originally misdiagnosed as an escaped promise rejection.** Every
+> suite appeared to print `0 fail` with no `(fail)` line anywhere — but that came
+> from reading truncated `gh run view --log-failed` output; the `(fail)` was in
+> the stress section, which is last. Read the tail of the log before theorising
+> about the middle.
+>
+> One finding from that investigation is worth keeping: an `unhandledRejection`
+> listener MUST set a non-zero exit code, because registering one REPLACES the
+> runtime's default handling. Measured in Bun 1.3 — no listener: exit 1;
+> log-only listener: exit **0**; log + `process.exitCode = 1`: exit 1. A
+> logging-only reporter silently turns a red run green.
 
 ## Done criteria
 

--- a/plans/046-ci-gaps.md
+++ b/plans/046-ci-gaps.md
@@ -16,7 +16,7 @@
 
 ## Why this matters
 
-Three gaps, each of which let something real through during run 3. None are
+Six gaps, each of which let something real through during run 3. None are
 hypothetical: for each, the bug shipped to a PR and was caught by a human or a
 review bot rather than by CI.
 
@@ -82,6 +82,31 @@ and record the decision in the PR:
 **Do NOT** leave the glob unquoted to keep CI green. A lint job that silently
 skips two thirds of the source tree is worse than one that fails.
 
+### 6. The SDK `test` script does not run the whole `tests` tree
+
+> Items 4 (`apps/landing` never built in CI) and 5 (`bun run test` intermittently
+> exits 1 with every suite reporting `0 fail`) are tracked in PR #471; both are
+> implemented on this branch by `53d8fbc5`. This item is new.
+
+`"test"` enumerated four directories — `tests/{integration,unit,security,stress}`
+— and the split is deliberate (see item 5). But enumeration drifts: everything
+outside those four was silently never run.
+
+**What it let through**: 75 tests across 8 files — `tests/mocks/`, all six
+`tests/performance/` suites, `tests/index.test.ts` and `tests/sdk.test.ts`.
+**Two of them had been failing on main**, reproducibly and in isolation:
+`tests/mocks/adapters/OrdMockProvider.test.ts` asserted Buffer `.toString()`
+semantics on inscription content that plan 044 retyped to `Uint8Array`. Plan 044
+noted it had updated the tests that asserted Buffer semantics; these two were
+missed, and nothing was running them to say so.
+
+**Fix**: extend the script with a fifth invocation covering the remainder, and —
+because the next new directory would drift the same way — add
+`tests/unit/test-script-covers-tree.test.ts`, which parses the `test` script out
+of `package.json`, walks `tests/` for `*.test.ts`, and fails with the offending
+paths if any file is unreachable from it. `packages/cel` already runs
+`bun test tests/`, so it has no equivalent gap.
+
 ## Done criteria
 
 1. `turbo.json`'s lint task depends on `^build`; deleting `dist` and running lint
@@ -90,6 +115,8 @@ skips two thirds of the source tree is worse than one that fails.
    fails on a `Buffer` reference in a guarded graph. Verify by temporarily
    reintroducing `Buffer.from` into `turnkeySignBytes` and confirming CI fails.
 3. `bun run lint` in both packages lints the entire `src` tree, and passes.
+4. `bun run test` runs every `*.test.ts` under `packages/sdk/tests`, and the
+   drift guard fails when the script stops covering one.
 
 ## STOP conditions
 

--- a/plans/046-ci-gaps.md
+++ b/plans/046-ci-gaps.md
@@ -16,7 +16,7 @@
 
 ## Why this matters
 
-Six gaps, each of which let something real through during run 3. None are
+Three gaps, each of which let something real through during run 3. None are
 hypothetical: for each, the bug shipped to a PR and was caught by a human or a
 review bot rather than by CI.
 
@@ -70,6 +70,11 @@ before eslint sees it. Without `globstar`, `src/**/*.ts` expands to `src/*/*.ts`
 **What it let through**: unknown — which is the point. Quoting the glob surfaces
 **38 pre-existing errors** across those directories.
 
+> **Note (from implementing this):** `eslint --fix` removes disable directives
+> for rules that are no longer enabled, but replaces each comment with a line of
+> leftover indentation rather than deleting it. Sweep those up, and check what
+> the directives were suppressing before accepting their removal.
+
 **Fix**: quote the glob (`eslint "src/**/*.ts"`) in both packages. Then decide,
 and record the decision in the PR:
 
@@ -82,31 +87,6 @@ and record the decision in the PR:
 **Do NOT** leave the glob unquoted to keep CI green. A lint job that silently
 skips two thirds of the source tree is worse than one that fails.
 
-### 6. The SDK `test` script does not run the whole `tests` tree
-
-> Items 4 (`apps/landing` never built in CI) and 5 (`bun run test` intermittently
-> exits 1 with every suite reporting `0 fail`) are tracked in PR #471; both are
-> implemented on this branch by `53d8fbc5`. This item is new.
-
-`"test"` enumerated four directories — `tests/{integration,unit,security,stress}`
-— and the split is deliberate (see item 5). But enumeration drifts: everything
-outside those four was silently never run.
-
-**What it let through**: 75 tests across 8 files — `tests/mocks/`, all six
-`tests/performance/` suites, `tests/index.test.ts` and `tests/sdk.test.ts`.
-**Two of them had been failing on main**, reproducibly and in isolation:
-`tests/mocks/adapters/OrdMockProvider.test.ts` asserted Buffer `.toString()`
-semantics on inscription content that plan 044 retyped to `Uint8Array`. Plan 044
-noted it had updated the tests that asserted Buffer semantics; these two were
-missed, and nothing was running them to say so.
-
-**Fix**: extend the script with a fifth invocation covering the remainder, and —
-because the next new directory would drift the same way — add
-`tests/unit/test-script-covers-tree.test.ts`, which parses the `test` script out
-of `package.json`, walks `tests/` for `*.test.ts`, and fails with the offending
-paths if any file is unreachable from it. `packages/cel` already runs
-`bun test tests/`, so it has no equivalent gap.
-
 ## Done criteria
 
 1. `turbo.json`'s lint task depends on `^build`; deleting `dist` and running lint
@@ -115,8 +95,6 @@ paths if any file is unreachable from it. `packages/cel` already runs
    fails on a `Buffer` reference in a guarded graph. Verify by temporarily
    reintroducing `Buffer.from` into `turnkeySignBytes` and confirming CI fails.
 3. `bun run lint` in both packages lints the entire `src` tree, and passes.
-4. `bun run test` runs every `*.test.ts` under `packages/sdk/tests`, and the
-   drift guard fails when the script stops covering one.
 
 ## STOP conditions
 

--- a/scripts/check-browser-safety.mjs
+++ b/scripts/check-browser-safety.mjs
@@ -24,8 +24,27 @@ const GUARDED_ENTRIES = [
   { dist: 'packages/sdk/dist', entry: 'lifecycle/LifecycleManager.js' },
   { dist: 'packages/sdk/dist', entry: 'lifecycle/OriginalsAsset.js' },
   { dist: 'packages/sdk/dist', entry: 'cel/index.js' },
-  { dist: 'packages/cel/dist', entry: 'index.js' },
+  { dist: 'packages/cel/dist', entry: 'index.js', browserFirst: true },
+  // @originals/auth's root is types + the isomorphic turnkeySignBytes, and its
+  // client entry runs in a browser by definition. Neither was guarded, which is
+  // how a Buffer-dependent "isomorphic" export shipped green (plan 046, item 2).
+  { dist: 'packages/auth/dist', entry: 'index.js', browserFirst: true },
+  { dist: 'packages/auth/dist', entry: 'client/index.js', browserFirst: true },
 ];
+
+/**
+ * `Buffer` is a Node global, not an import, so the builtin scan above cannot
+ * see it — a guarded entry can reference it and still pass. In a browser
+ * without a bundler shim that is a ReferenceError on first use.
+ *
+ * This GATES only the `browserFirst` entries (@originals/cel, @originals/auth),
+ * whose whole reason to exist is running in a browser. The SDK's entries import
+ * Node-only paths (inscription builders, server providers) that a browser
+ * consumer can import but would never call, so Buffer there is reported as a
+ * warning rather than failing the build — a static scan cannot tell "reachable"
+ * from "actually invoked in a browser".
+ */
+const BUFFER_GLOBAL = /(?<![.\w$])Buffer\s*\.\s*(?:from|alloc|allocUnsafe|concat|isBuffer|byteLength)\b/;
 
 const builtins = new Set([...builtinModules, ...builtinModules.map((m) => `node:${m}`)]);
 
@@ -54,6 +73,25 @@ function resolveRelative(fromFile, spec) {
 }
 
 /** Breadth-first so the reported chain is the shortest one that pulls the builtin in. */
+function findBufferGlobals(entry, dist) {
+  const seen = new Set();
+  const hits = new Map();
+  const queue = [[entry, [relative(dist, entry)]]];
+  while (queue.length) {
+    const [file, chain] = queue.shift();
+    if (seen.has(file)) continue;
+    seen.add(file);
+    if (BUFFER_GLOBAL.test(readFileSync(file, 'utf8')) && !hits.has(file)) {
+      hits.set(file, chain);
+    }
+    for (const spec of staticSpecifiers(file)) {
+      const next = resolveRelative(file, spec);
+      if (next && !seen.has(next)) queue.push([next, [...chain, relative(dist, next)]]);
+    }
+  }
+  return hits;
+}
+
 function findEagerBuiltins(entry, dist) {
   const seen = new Set();
   const violations = new Map();
@@ -75,7 +113,7 @@ function findEagerBuiltins(entry, dist) {
 }
 
 let failed = false;
-for (const { dist, entry } of GUARDED_ENTRIES) {
+for (const { dist, entry, browserFirst = false } of GUARDED_ENTRIES) {
   const distAbs = resolve(ROOT, dist);
   const abs = resolve(distAbs, entry);
   const label = `${dist}/${entry}`;
@@ -85,15 +123,31 @@ for (const { dist, entry } of GUARDED_ENTRIES) {
     continue;
   }
   const violations = findEagerBuiltins(abs, distAbs);
-  if (violations.size === 0) {
-    console.log(`✓ ${label} — no Node builtins statically reachable`);
+  const bufferHits = browserFirst ? findBufferGlobals(abs, distAbs) : new Map();
+  const bufferAdvisory = browserFirst ? new Map() : findBufferGlobals(abs, distAbs);
+  if (bufferAdvisory.size > 0) {
+    console.warn(`! ${label} — Buffer global reachable in ${bufferAdvisory.size} module(s) (advisory):`);
+    for (const [file] of bufferAdvisory) console.warn(`    ${relative(distAbs, file)}`);
+  }
+  if (violations.size === 0 && bufferHits.size === 0) {
+    const note = bufferAdvisory.size > 0 ? ' (Buffer advisory above)' : '';
+    console.log(`✓ ${label} — no eager Node builtins${browserFirst ? ' or Buffer globals' : ''}${note}`);
     continue;
   }
   failed = true;
-  console.error(`✗ ${label} — ${violations.size} Node builtin(s) statically reachable:`);
-  for (const [builtin, chain] of violations) {
-    console.error(`    ${builtin}`);
-    console.error(`      via ${chain.join(' -> ')}`);
+  if (violations.size > 0) {
+    console.error(`✗ ${label} — ${violations.size} Node builtin(s) statically reachable:`);
+    for (const [builtin, chain] of violations) {
+      console.error(`    ${builtin}`);
+      console.error(`      via ${chain.join(' -> ')}`);
+    }
+  }
+  if (bufferHits.size > 0) {
+    console.error(`✗ ${label} — Buffer global reachable in ${bufferHits.size} module(s):`);
+    for (const [file, chain] of bufferHits) {
+      console.error(`    ${relative(distAbs, file)}`);
+      console.error(`      via ${chain.join(' -> ')}`);
+    }
   }
 }
 
@@ -102,7 +156,10 @@ if (failed) {
     '\nBrowser-safety check failed. Load the Node module lazily instead:\n' +
       "  let fs = null;\n" +
       "  async function loadNodeModules() { fs ??= await import('node:fs/promises'); return fs; }\n" +
-      '\nSee FileLogOutput in src/utils/Logger.ts for the established pattern.'
+      '\nSee FileLogOutput in src/utils/Logger.ts for the established pattern.' +
+      '\n\nFor Buffer: use Uint8Array, and @noble/hashes/utils bytesToHex/hexToBytes\n' +
+      'for hex conversion. Buffer is a Node global — in a browser it is a\n' +
+      'ReferenceError, which no import scan can catch.'
   );
   process.exit(1);
 }


### PR DESCRIPTION
Implements [plan 046](https://github.com/onionoriginals/sdk/blob/main/plans/046-ci-gaps.md) items 2–5. Item 1 landed in #469.

Rebased onto `main` now that #469 is merged. Each gap is named by a bug it actually failed to catch.

## Item 2 — the browser-safety gate now covers `@originals/auth`, and catches `Buffer`

Nothing guarded auth, whose *client* entry runs in a browser by definition. And the gate only scanned Node builtin **imports** — `Buffer` is a global, so it was structurally invisible. That combination is how a `Buffer`-dependent export documented as isomorphic shipped green.

Verified as the plan's done-criteria asks: I reintroduced the exact regression into `turnkeySignBytes`, confirmed **both auth entries fail**, then restored it.

The Buffer check *gates* only browser-first entries (cel, auth). The SDK's entries statically reach Node-only paths — inscription builders, server providers — that a browser imports but never calls, so those get an **advisory**. A static scan can't distinguish "reachable" from "actually invoked", and failing on the former would be wrong.

## Item 4 — CI builds `apps/landing`

Every other job filters `./packages/*`, so a breaking change to the SDK's public entry lands green and fails only at deploy. Exactly how #470 happened.

Gating on the **build only**, deliberately: the landing app's `typecheck` needs `@types/node` (for `Buffer`) which it doesn't declare — it passes locally when hoisting supplies it and fails under CI's install. That's a separate pre-existing fragility, recorded in plan 046 as its own task rather than bundled into a deploy gate.

## Item 3 — the lint glob was skipping two thirds of `src`

`eslint src/**/*.ts` was unquoted, so the shell expanded it to `src/*/*.ts` — one level. `adapters/providers`, `bitcoin/transactions`, `cel/cli`, `migration/audit` and more were **never linted**. Quoting it surfaced **29 errors**, all fixed, none by weakening a rule:

- `varsIgnorePattern: '^_'` added — the config exempted `_args` and `_caught` but not `_vars`, so the deliberate `_OrdMockConforms` compile-time assertion read as dead code.
- A dead `leafVersion` removed from the commit builder (the control block is supplied; it was never needed for fee math).
- The two async generators that only throw carry a *documented* disable — the signature is the `OrdinalsProvider` contract.
- **The six `no-base-to-string` errors were the only ones with user-visible effect, so they're fixed properly rather than cast away.** CEL event data is arbitrary JSON from whoever wrote the log, so a field the CLI prints as a string can be an object — `String(obj)` renders `[object Object]` and hides it. `inspect` now uses a `display()` helper that JSON-renders non-primitives.

## Item 5 — the intermittent flake: a diagnostic, not a fix

An `unhandledRejection` reporter that prints the stack when a promise escapes a test lifecycle.

**I could not reproduce the condition locally** — Bun attributes in-test rejections itself and exits before post-suite timers fire — so the root cause is still unconfirmed and this may never fire. It costs nothing and makes the next occurrence self-describing. It deliberately does **not** swallow anything.

## Verification

```
sdk    integration 171/0   unit 2644/0   security 174/0   stress 18/0   tsc 0   lint 0 err
cel    876/0                                                           tsc 0   lint 0 err
auth   246/0                                                                   lint 0 err
browser-safety ✓   verify-esm ✓   landing build ✓
```

## Two process notes

**My first unused-catch fix renamed every `catch (e)` in two CLI files** rather than the two eslint flagged, breaking three references and 12 tests. Reverted and re-applied from eslint's JSON output instead of a regex.

**An earlier push accidentally swept in 8 untracked files** (971 insertions) from other in-flight work in the shared checkout, via `git add -A`. Force-pushed a corrected branch containing only my 23 files; the other work is untouched and still in the working tree. Worth flagging because one of those files is a genuinely useful drift guard someone is writing — it asserts every test file is reachable from the `test` script, and it currently **fails on `main`**: `tests/index.test.ts`, `tests/sdk.test.ts`, `tests/mocks/**` and the five `tests/performance/**` files are never run by CI.