### PR TITLE
test(sdk): fix OrdMockProvider content assertions after Buffer→Uint8Array migration

### DIFF
--- a/.changeset/fix-ordmock-uint8array-tostring.md
+++ b/.changeset/fix-ordmock-uint8array-tostring.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix OrdMockProvider content assertions after Buffer→Uint8Array migration

--- a/packages/sdk/tests/mocks/adapters/OrdMockProvider.test.ts
+++ b/packages/sdk/tests/mocks/adapters/OrdMockProvider.test.ts
@@ -185,7 +185,7 @@ describe('OrdMockProvider', () => {
     expect(res.metadata).toEqual(metadata);
     const fetched = await prov.getInscriptionById(res.inscriptionId);
     expect(fetched?.metadata).toEqual(metadata);
-    expect(fetched?.content?.toString()).toBe('media-bytes');
+    expect(new TextDecoder().decode(fetched?.content)).toBe('media-bytes');
   });
 
   test('deferred buildContent may return { content, metadata }', async () => {
@@ -198,7 +198,7 @@ describe('OrdMockProvider', () => {
       })
     });
     const fetched = await prov.getInscriptionById(res.inscriptionId);
-    expect(fetched?.content?.toString()).toBe('deferred-media');
+    expect(new TextDecoder().decode(fetched?.content)).toBe('deferred-media');
     expect((fetched?.metadata as { didDocument: { id: string } }).didDocument.id)
       .toBe(`did:btco:reg:${res.satoshi}`);
   });


### PR DESCRIPTION
## What was red

2 tests in `packages/sdk/tests/mocks/adapters/OrdMockProvider.test.ts` were failing deterministically:

- `OrdMockProvider > static metadata round-trips through getInscriptionById`
- `OrdMockProvider > deferred buildContent may return { content, metadata }`

Both failed with:
```
Expected: "media-bytes"
Received: "109,101,100,105,97,45,98,121,116,101,115"
```

## Root cause

These tests were written in commit `b1c05f0` when `OrdMockProvider` stored `content` as `Buffer`. `Buffer.toString()` decodes bytes as UTF-8 text by default.

Commit `636417c` ("Buffer purged from public API") changed `OrdMockProvider.content` from `Buffer` to `Uint8Array` (correct — the class was moved to `@originals/cel`, which is browser-safe and cannot depend on Node's `Buffer`). But the two test assertions still called `.toString()` on the `Uint8Array`, which returns a comma-separated list of byte values (`"109,101,100,..."`) rather than the UTF-8 string — the wrong thing.

## Fix

Replace both `.toString()` calls with `new TextDecoder().decode()`, which correctly decodes a `Uint8Array` to a UTF-8 string and works in all environments (browser, Node, Bun).

The assertions still verify the same semantic invariant: that the content bytes round-trip through the mock store unchanged and are equal to the original string. Nothing was weakened.

## Green invariant output (post-fix)

```
bunx tsc --noEmit           → 0 errors
bun run build               → Tasks: 3 successful, 3 total
packages/cel:  bun test     → 876 pass, 0 fail (41 files)
packages/sdk:  bun test     → 3080 pass, 0 fail (223 files)
packages/auth: bun test     → 246 pass, 3 skip, 0 fail (13 files)
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCyaYeKbgp72oXgHRDrE5a)_