### PR TITLE
fix(release): unblock the 3.0 prerelease — pre.json claimed all 12 changesets were already shipped

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -7,18 +7,5 @@
     "@originals/cel": "0.1.0",
     "@originals/sdk": "2.1.0"
   },
-  "changesets": [
-    "bbs-selective-disclosure-fail-closed",
-    "buffer-purged-from-public-api",
-    "cel-cryptosuite-rename-and-bind",
-    "cel-package-extraction",
-    "cli-display-untrusted-values",
-    "custody-required-defaults-flip",
-    "example-credential-reverify",
-    "fail-loud-signing-phase-0",
-    "fix-gzip-bomb-timing-flake",
-    "fix-ordmock-uint8array-tostring",
-    "packaging-curated-exports",
-    "remote-custody-signer-core"
-  ]
+  "changesets": []
 }

--- a/.changeset/prerelease-unblock.md
+++ b/.changeset/prerelease-unblock.md
@@ -1,0 +1,5 @@
+---
+---
+
+Release plumbing only — corrects the hand-written `pre.json` that made the
+prerelease version job a no-op. No package code changes.


### PR DESCRIPTION
## The prerelease is currently a silent no-op

`Release` has been green on every push since #476, and producing nothing. The version job's actual output:

```
All changesets are empty; not creating PR
```

### Why

`pre.json`'s `changesets` array is changesets' record of which changesets have **already shipped in a previous prerelease** — it's how the final release aggregates a changelog across several `-next.N` bumps. `changeset pre enter` writes it as `[]`.

#476 hand-wrote `pre.json` (the commit adds it whole; `changeset version` was never run — no `package.json` was touched). The array was populated with all 12 pending changesets, which tells changesets they're already out. So there is nothing left to version, the job no-ops, and the workflow reports success.

Nothing has been published to npm, so the correct value is `[]`.

### The second half of the problem

PR #459 "Version Packages" was computed at `2026-08-16T06:01:21Z`. Pre mode landed at `06:24`. It predates it — `git merge-base --is-ancestor` confirms — so that branch carries **no `pre.json`** and bumps to plain:

| package | #459 says | should be |
|---|---|---|
| `@originals/sdk` | `3.0.0` | `3.0.0-next.0` |
| `@originals/auth` | `3.0.0` | `3.0.0-next.0` |
| `@originals/cel` | `0.2.0` | `0.2.0-next.0` |

Merging #459 as it stands would burn the real `3.0.0` version number on what was meant to be a prerelease. **Do not merge it until it re-renders with `-next.0`.**

Once this lands, the version job runs against a correct `pre.json` and force-pushes `changeset-release/main`, updating #459 in place with the right versions. Then merging #459 triggers the publish job, which is gated behind the `npm-publish` environment's required reviewer.

### Note carried over from #476, still true

`changeset publish` sends a package with no prior regular release to `latest` regardless of pre mode — so `@originals/cel@0.2.0-next.0` will land on `latest`. For a package with no released version that's the only way it's installable. `@originals/sdk` and `@originals/auth` both have 2.x on `latest` and are unaffected.

### Changes

- `.changeset/pre.json` — `changesets: [...12]` → `changesets: []`
- `.changeset/prerelease-unblock.md` — empty changeset to satisfy the `Changeset present` gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
