### PR TITLE
ci: gate apps/landing on every PR (plan 046 item 4)

### DIFF
--- a/.changeset/floppy-llamas-remain.md
+++ b/.changeset/floppy-llamas-remain.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI only: gate `apps/landing` (typecheck, tests, vite build) on every PR. No published package changes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,15 +98,6 @@ jobs:
       - name: Build
         run: bun run build
 
-      # apps/ is outside the ./packages/* filter every other job uses, so a
-      # breaking change to the SDK's public entry lands green and fails only at
-      # deploy — which is how #470 happened (plan 046, item 4). Runs on Bun and
-      # BEFORE the Node pin below: vite needs node:util's styleText, which
-      # Node 20.10 does not have. Build only, not typecheck — apps/landing does
-      # not declare @types/node, so its typecheck is separately fragile.
-      - name: Build the landing app against the built SDK
-        run: cd apps/landing && bun run build
-
       # The Bun test suite tolerates extensionless/attribute-less imports, so
       # importing the built dist under Node is the only gate that catches a
       # publish npm consumers cannot actually load.
@@ -124,9 +115,26 @@ jobs:
       - name: Verify browser-facing entry points have no eager Node builtins
         run: node scripts/check-browser-safety.mjs
 
-      # apps/ is outside the ./packages/* filter every other job uses, so a
-      # breaking change to the SDK's public entry lands green here and fails
-      # only at deploy — which is exactly how #470 happened (plan 046, item 4).
+  landing:
+    name: Landing app typechecks, tests and builds
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.22
+
+      - name: Install dependencies (bun)
+        run: bun install
+
+      # apps/ is outside the ./packages/* filter every other job uses, so SDK
+      # entry-point breakage lands green and fails at deploy (#470, plan 046 §4).
+      # Not landing:ci — that page-drive needs an API server + TURNKEY_* secrets.
+      - name: Typecheck, test and build the landing app against the built SDK
+        run: bun run landing:check
 
   changeset:
     name: Changeset present

--- a/apps/landing/src/content.quickstart.test.ts
+++ b/apps/landing/src/content.quickstart.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from 'bun:test';
+import { developers } from './content';
+
+/**
+ * The quickstart is a template literal, so nothing typechecks it. It shipped
+ * once telling every visitor to import OrdMockProvider from '@originals/sdk'
+ * after plan 043 moved it to '@originals/sdk/testing' (#470) — a dead import
+ * on the page teaching it. This resolves each specifier the snippet names and
+ * asserts the bindings it destructures actually exist.
+ */
+
+const IMPORT_RE = /import\s+(?:type\s+)?\{([^}]+)\}\s+from\s+'([^']+)';/g;
+
+function imports(source: string): Array<{ names: string[]; from: string }> {
+  return [...source.matchAll(IMPORT_RE)].map((m) => ({
+    names: m[1]
+      .split(',')
+      .map((n) => n.trim().replace(/^type\s+/, '').split(/\s+as\s+/)[0])
+      .filter(Boolean),
+    from: m[2]
+  }));
+}
+
+describe('the rendered quickstart snippet', () => {
+  const parsed = imports(developers.quickstart);
+
+  test('has imports to check', () => {
+    expect(parsed.length).toBeGreaterThan(0);
+  });
+
+  for (const { names, from } of parsed) {
+    test(`every binding it takes from '${from}' exists`, async () => {
+      const mod = (await import(from)) as Record<string, unknown>;
+      for (const name of names) expect(mod).toHaveProperty(name);
+    });
+  }
+});

--- a/apps/landing/src/content.quickstart.test.ts
+++ b/apps/landing/src/content.quickstart.test.ts
@@ -6,19 +6,35 @@ import { developers } from './content';
  * once telling every visitor to import OrdMockProvider from '@originals/sdk'
  * after plan 043 moved it to '@originals/sdk/testing' (#470) — a dead import
  * on the page teaching it. This resolves each specifier the snippet names and
- * asserts the bindings it destructures actually exist.
+ * asserts the bindings it destructures actually exist — and fails closed if the
+ * parser does not account for every import statement, so no form slips past.
  */
 
-const IMPORT_RE = /import\s+(?:type\s+)?\{([^}]+)\}\s+from\s+'([^']+)';/g;
+/** Any top-level import: default, namespace, named, side-effect; either quote, optional semicolon. */
+const IMPORT_RE = /^[ \t]*import\s+(?:type\s+)?(?:([\s\S]*?)\s+from\s+)?['"]([^'"]+)['"];?/gm;
+/** Same anchor, used to prove the parser saw every statement rather than skipping unknown forms. */
+const IMPORT_START_RE = /^[ \t]*import[\s'"]/gm;
 
-function imports(source: string): Array<{ names: string[]; from: string }> {
-  return [...source.matchAll(IMPORT_RE)].map((m) => ({
-    names: m[1]
-      .split(',')
-      .map((n) => n.trim().replace(/^type\s+/, '').split(/\s+as\s+/)[0])
-      .filter(Boolean),
-    from: m[2]
-  }));
+type ParsedImport = { names: string[]; from: string };
+
+/** Binding names to assert on the module namespace; `* as ns` binds the namespace itself, so it yields none. */
+function bindings(clause: string | undefined): string[] {
+  if (!clause) return [];
+  const named = clause.match(/\{([\s\S]*)\}/)?.[1];
+  const head = clause.replace(/\{[\s\S]*\}/, '').replace(/,\s*$/, '').trim();
+  const names: string[] = [];
+  if (head && !/^\*\s+as\s+/.test(head)) names.push('default');
+  if (named) {
+    for (const entry of named.split(',')) {
+      const name = entry.trim().replace(/^type\s+/, '').split(/\s+as\s+/)[0];
+      if (name) names.push(name);
+    }
+  }
+  return names;
+}
+
+function imports(source: string): ParsedImport[] {
+  return [...source.matchAll(IMPORT_RE)].map((m) => ({ names: bindings(m[1]), from: m[2] }));
 }
 
 describe('the rendered quickstart snippet', () => {
@@ -28,10 +44,35 @@ describe('the rendered quickstart snippet', () => {
     expect(parsed.length).toBeGreaterThan(0);
   });
 
+  test('parses every import statement in the snippet', () => {
+    expect(parsed.length).toBe(developers.quickstart.match(IMPORT_START_RE)?.length ?? 0);
+  });
+
   for (const { names, from } of parsed) {
     test(`every binding it takes from '${from}' exists`, async () => {
       const mod = (await import(from)) as Record<string, unknown>;
       for (const name of names) expect(mod).toHaveProperty(name);
     });
   }
+});
+
+describe('the quickstart import parser', () => {
+  // A form the parser misses is a dead import that ships unnoticed, so pin the forms.
+  test('covers default, namespace, double-quoted and semicolon-free imports', () => {
+    const source = [
+      `import Def from "a"`,
+      `import * as ns from 'b';`,
+      `import Def2, { x, y as z, type T } from 'c'`,
+      `import {\n  Multi,\n  Line\n} from "d";`,
+      `import 'e';`
+    ].join('\n');
+    expect(imports(source)).toEqual([
+      { names: ['default'], from: 'a' },
+      { names: [], from: 'b' },
+      { names: ['default', 'x', 'y', 'T'], from: 'c' },
+      { names: ['Multi', 'Line'], from: 'd' },
+      { names: [], from: 'e' }
+    ]);
+    expect(source.match(IMPORT_START_RE)?.length).toBe(5);
+  });
 });

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "turbo run build --filter='./packages/*'",
     "landing": "turbo run build --filter='./packages/*' && cd apps/landing && bunx vite build && bunx vite preview",
     "landing:ci": "bun apps/landing/scripts/ci.mjs",
+    "landing:check": "turbo run build --filter='./packages/*' && cd apps/landing && bun run typecheck && bun run typecheck:server && bun test && bun run build",
     "verify:esm": "node scripts/verify-esm.mjs",
     "verify:browser": "node scripts/check-browser-safety.mjs",
     "test": "turbo run test --filter='./packages/*'",

--- a/plans/046-ci-gaps.md
+++ b/plans/046-ci-gaps.md
@@ -87,6 +87,37 @@ and record the decision in the PR:
 **Do NOT** leave the glob unquoted to keep CI green. A lint job that silently
 skips two thirds of the source tree is worse than one that fails.
 
+### 4. `apps/landing` is never built in CI — FIXED
+
+Every job filters `./packages/*`, so the landing app was never typechecked,
+tested or built. A breaking change to the SDK's public entry landed fully green
+and failed only at deploy.
+
+**What it let through**: three times. (a) Plan 043 moved `OrdMockProvider` off
+the root entry; `engine.ts`/`verify-example.ts` kept importing it from
+`@originals/sdk` (#470). (b) The quickstart sample *rendered on the page* taught
+visitors the same dead import. (c) PR #455 shipped two silent-render bugs — the
+accent map and gloss keyed off `updateResource`, not a member of `EventType`,
+and the two migrate shapes differ (`targetDid` on webvh, `to` on btco) so a
+btco entry rendered with no identifier. #455 added tests pinning both, but those
+tests live in `apps/landing` and therefore never ran.
+
+**Fix**: a `landing` job running `bun run landing:check` — packages build, then
+`tsc` (client + server), the 194-test landing suite, and `vite build`. Replaces
+the build-only step previously bolted onto `esm-importable`.
+
+**Scope**: the headless page-drive (`bun run landing:ci`) stays OUT. It is red on
+unmodified `main` — it needs the standalone API server plus `TURNKEY_*` and
+`JWT_SECRET`, unavailable on fork PRs, and gates on zero console errors, which
+the auth 401s alone trip. A gate that is red on arrival gets disabled.
+
+**Verified red-then-green** by reintroducing each real regression: the dead
+`OrdMockProvider` import fails `tsc` (`TS2614`); the `updateResource` key fails
+`CEL entry glosses > no event type renders as its own bare name`; the dead
+import in the rendered snippet fails the new `content.quickstart.test.ts`, which
+resolves every specifier the snippet names. Runs in parallel with the existing
+jobs, ~1 min, so wall-clock CI time is unchanged.
+
 ### 5. A GC-sensitive stress test flaked under CI load — FIXED
 
 `Batch Operations Stress Tests > should not leak memory during repeated batch
@@ -130,6 +161,9 @@ while a GC sawtooth yields −67% and passes.
    fails on a `Buffer` reference in a guarded graph. Verify by temporarily
    reintroducing `Buffer.from` into `turnkeySignBytes` and confirming CI fails.
 3. `bun run lint` in both packages lints the entire `src` tree, and passes.
+4. CI typechecks, tests and builds `apps/landing` on every PR, and is green on
+   `main`. Verify by reintroducing the `OrdMockProvider` root import or the
+   `updateResource` key and confirming the job fails.
 
 ## STOP conditions
 

--- a/plans/046-ci-gaps.md
+++ b/plans/046-ci-gaps.md
@@ -116,7 +116,7 @@ the auth 401s alone trip. A gate that is red on arrival gets disabled.
 `CEL entry glosses > no event type renders as its own bare name`; the dead
 import in the rendered snippet fails the new `content.quickstart.test.ts`, which
 resolves every specifier the snippet names. Runs in parallel with the existing
-jobs, ~1 min, so wall-clock CI time is unchanged.
+jobs and finishes in ~25s, so wall-clock CI time is unchanged.
 
 ### 5. A GC-sensitive stress test flaked under CI load — FIXED
 

--- a/plans/046-ci-gaps.md
+++ b/plans/046-ci-gaps.md
@@ -103,7 +103,7 @@ btco entry rendered with no identifier. #455 added tests pinning both, but those
 tests live in `apps/landing` and therefore never ran.
 
 **Fix**: a `landing` job running `bun run landing:check` — packages build, then
-`tsc` (client + server), the 194-test landing suite, and `vite build`. Replaces
+`tsc` (client + server), the 196-test landing suite, and `vite build`. Replaces
 the build-only step previously bolted onto `esm-importable`.
 
 **Scope**: the headless page-drive (`bun run landing:ci`) stays OUT. It is red on
@@ -115,7 +115,8 @@ the auth 401s alone trip. A gate that is red on arrival gets disabled.
 `OrdMockProvider` import fails `tsc` (`TS2614`); the `updateResource` key fails
 `CEL entry glosses > no event type renders as its own bare name`; the dead
 import in the rendered snippet fails the new `content.quickstart.test.ts`, which
-resolves every specifier the snippet names. Runs in parallel with the existing
+resolves every specifier the snippet names and fails closed if its parser does
+not account for every import statement. Runs in parallel with the existing
 jobs and finishes in ~25s, so wall-clock CI time is unchanged.
 
 ### 5. A GC-sensitive stress test flaked under CI load — FIXED


### PR DESCRIPTION
Closes item 4 of `plans/046-ci-gaps.md`.

Every CI job filters `./packages/*`, so `apps/landing` was never typechecked, tested or built. A breaking change to the SDK's public entry lands fully green and fails only at deploy. That has now happened three times:

1. Plan 043 moved `OrdMockProvider` off the root entry; landing's `engine.ts`/`verify-example.ts` kept importing it from `@originals/sdk` (fixed in #470).
2. The quickstart sample **rendered on the landing page** taught every visitor the same dead import.
3. PR #455 shipped two silent-render bugs — the accent map and gloss keyed off `updateResource` (not a member of `EventType`), and the two migrate shapes differ (`targetDid` on webvh, `to` on btco) so a btco entry rendered with no identifier. #455 added `cel-chain-summary.test.ts` pinning both, but that test lives in `apps/landing` and therefore **never ran**.

## What the gate covers

A new `landing` job running `bun run landing:check` (a new root script, so CI and local are the same command — no drift):

| Step | Catches |
| --- | --- |
| `turbo run build --filter='./packages/*'` | landing bundles the SDK from `dist`, so this is the real consumer |
| `tsc --noEmit` (client) | dead/renamed imports from `@originals/sdk`, type drift |
| `tsc --noEmit -p tsconfig.server.json` | the same for `server/` |
| `bun test` (196 tests, 41 files) | the #455 render bugs, `verify-example`, the routes/store suites — none of which ran before |
| `vite build` | bundle-level `MISSING_EXPORT`, alias/shim breakage |

It replaces the build-only step previously bolted onto `esm-importable`.

## What it does NOT cover

- **The headless page-drive (`bun run landing:ci`) is out of scope.** It is red on unmodified `origin/main` — verified in this worktree at `1b8717ac` before any change. Two independent blockers, neither related to this work:
  - It requires the standalone API server (`server/index.ts` on :8787, which `vite preview` proxies `/api` to). Without it every request 502s and the smoke test dies at `HttpHostingStorageAdapter.put failed: 502`.
  - With the server up (dummy `JWT_SECRET` + `TURNKEY_*`), the lifecycle itself completes — `did:cel → did:webvh → did:btco`, real tx — but the gate fails anyway on unrelated console noise (`401 Unauthorized` from unauthenticated `/api/me`, `net::ERR_CONNECTION_CLOSED`). The `TURNKEY_*` secrets it would need are unavailable on fork PRs regardless.

  A gate that is red on arrival gets ignored or reverted, so it stays out. `landing:ci` remains the pre-deploy gate documented in `DEPLOY.md`.
- **Real-browser rendering is out.** Everything the page-drive would catch that the unit tests do not is CSS/layout, and the two #455 bugs are already covered by pure functions (`summarize`, `accentFor`) that the test suite pins directly.
- **The inscribe path** end-to-end against a real provider. `HttpOrdinalsProvider.createInscription` is unimplemented by design (construction/signing is local); the landing suite covers it with the mock.
- **Lint**: `apps/landing` has no `lint` script; not adding one here.

## Red-then-green evidence

Each of the three real regressions was reintroduced, the gate confirmed red, then reverted.

**(a) The dead `OrdMockProvider` import (#470)** — `engine.ts` back to importing it from `@originals/sdk`:

```
src/sdk/engine.ts(20,3): error TS2614: Module '"@originals/sdk"' has no exported
  member 'OrdMockProvider'. Did you mean to use 'import OrdMockProvider from
  "@originals/sdk"' instead?
error: script "typecheck" exited with code 1
error: script "landing:check" exited with code 1     # exit=1
```

**(b) The same dead import in the rendered quickstart** — this one had **no** coverage, so this PR adds `apps/landing/src/content.quickstart.test.ts`. The quickstart is a template literal, so nothing typechecks it; the test parses every import statement out of the rendered string (any clause form, either quote style, semicolon optional), resolves the module, and asserts every binding exists — and fails closed if its parser does not account for every statement, so no import form is silently skipped. Changing the snippet's `@originals/sdk/testing` back to `@originals/sdk`:

```
(fail) the rendered quickstart snippet > every binding it takes from '@originals/sdk' exists
error: expect(received).toHaveProperty(path)
Expected path: "OrdMockProvider"
```

**(c) The `updateResource` key (#455)** — `CelChain.tsx`'s accent map and gloss re-keyed to `updateResource`:

```
(fail) CEL entry glosses > no event type renders as its own bare name [0.73ms]
  expect(received).not.toBe(expected)
 1 fail
```

After reverting all three, `bun run landing:check` exits 0.

## CI time

**Wall-clock: unchanged.** The `landing` job runs in parallel with the seven existing jobs and **measured 21–25s on this PR's own CI runs** (second-fastest job; `Coverage` is 1m5s). `esm-importable` gets slightly *faster* — its landing build step moved out.

## Root checks

`bun run lint` (0 errors, 470 pre-existing warnings), `bun run typecheck`, `bun test` (all suites green).

## Changeset

Empty — repo infra plus one test file, no published package change. `.changeset/pre.json` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

