### PR TITLE
fix(release): make the Version PR the single approval surface for publishing

### DIFF
--- a/.changeset/release-single-pr-approval.md
+++ b/.changeset/release-single-pr-approval.md
@@ -1,0 +1,7 @@
+---
+---
+
+Release plumbing and docs only — the Version Packages PR is now the single
+approval surface for a release (publish no longer waits on a second approval in
+the Actions UI), and it carries a generated publish plan. No package code
+changes.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,10 @@ permissions:
   id-token: write       # npm provenance
 
 jobs:
-  # Gate 1 — maintain the "Version Packages" PR. While changesets are pending on
-  # main this job opens/updates that PR (versions + CHANGELOGs). Merging the PR is
-  # the human approval that a release should happen. No publishing happens here.
+  # Maintain the "Version Packages" PR. While changesets are pending on main this
+  # job opens/updates that PR (versions + CHANGELOGs) and comments the publish
+  # plan on it. That PR is the SINGLE approval surface for a release: merging it
+  # publishes. No publishing happens here.
   version:
     name: Version (open release PR)
     runs-on: ubuntu-latest
@@ -46,17 +47,41 @@ jobs:
         uses: changesets/action@v1
         with:
           version: bun run version
-          # No publish here — publishing is the separately-gated job below.
+          # No publish here — the publish job below runs once this PR merges.
           publish: ""
         env:
           GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN || secrets.GITHUB_TOKEN }}
 
+      # Merging the Version PR IS the release approval, so the PR must state what
+      # merging does. changesets' own body lists changelogs but never the target
+      # versions' dist-tags — and the surprising one (a brand-new package skipping
+      # `next` for `latest`) is invisible without this.
+      - name: Comment the publish plan on the Version PR
+        if: steps.changesets.outputs.hasChangesets == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CHANGESETS_TOKEN || secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          git fetch origin changeset-release/main
+          node scripts/publish-plan.mjs origin/changeset-release/main > /tmp/plan.md
+          pr=$(gh pr list --head changeset-release/main --state open --json number --jq '.[0].number // empty')
+          if [ -z "$pr" ]; then echo "no open Version PR — nothing to comment on"; exit 0; fi
+          # Upsert by marker so repeated pushes edit one comment instead of piling up.
+          id=$(gh api "repos/$REPO/issues/$pr/comments" --paginate \
+                 --jq 'map(select(.body | startswith("<!-- publish-plan -->"))) | .[0].id // empty')
+          if [ -n "$id" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$id" -F body=@/tmp/plan.md >/dev/null
+          else
+            gh api -X POST "repos/$REPO/issues/$pr/comments" -F body=@/tmp/plan.md >/dev/null
+          fi
+
   # Decide whether there is actually a new version to publish. `hasChangesets ==
   # false` is true both after the Version PR merges (a real release) AND on any
   # changeset-less push to main (docs/CI, or the first push after enabling this
-  # workflow). Without this guard the env-gated publish job below would prompt a
-  # reviewer for those no-op pushes too. We only proceed when a package's local
-  # version is not yet on the registry — i.e. a genuine pending release.
+  # workflow). We only proceed when a package's local version is not yet on the
+  # registry — i.e. a genuine pending release. This is what keeps "merge the
+  # Version PR" the only trigger: an ordinary push to main never reaches publish.
   check-publish:
     name: Check for unpublished versions
     needs: version
@@ -100,16 +125,19 @@ jobs:
           done
           echo "should=$should" >> "$GITHUB_OUTPUT"
 
-  # Gate 2 — publish. Runs only for a genuine pending release (Version PR merged
-  # and a version is not yet on npm). The `npm-publish` Environment carries a
-  # required reviewer, so a human must approve in the GitHub UI before anything
-  # reaches npm, and we refuse to publish a build that fails the Node-ESM check.
+  # Publish. Runs only for a genuine pending release (Version PR merged and a
+  # version is not yet on npm).
+  #
+  # Deliberately NOT bound to the `npm-publish` Environment. That environment's
+  # required reviewer was a SECOND approval for a decision already made by
+  # merging the Version PR — invisible from the PR, so a merged release would sit
+  # unpublished with nothing on the PR saying so. The PR is the gate now; the
+  # automated gates below (Node-ESM + browser-safety) still block a bad build.
   publish:
     name: Publish to npm
     needs: [version, check-publish]
     if: needs.check-publish.outputs.shouldPublish == 'true'
     runs-on: ubuntu-latest
-    environment: npm-publish
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,45 @@
+# Releasing
+
+One PR, one approval. Merging the **Version Packages** PR publishes to npm. There
+is no second approval and no reason to open the Actions tab.
+
+## The flow
+
+1. **Land changes with a changeset.** Every PR that changes a published package
+   adds one (`bun run changeset`). Repo-infra and docs PRs add an empty one
+   (`bun run changeset --empty`) to satisfy the `Changeset present` gate.
+2. **The bot maintains a Version Packages PR.** While changesets are pending on
+   `main`, the `Release` workflow keeps `changeset-release/main` open with the
+   version bumps and CHANGELOGs, and comments a **publish plan** on it — every
+   package, its old and new version, and the dist-tag it will land on.
+3. **Merge that PR to release.** The workflow builds, runs the Node-ESM and
+   browser-safety gates, then publishes, pushes git tags, and creates GitHub
+   Releases. A failed gate blocks the publish.
+
+Read the publish plan before merging. npm publishes are effectively permanent —
+unpublish is limited to 72 hours and breaks anyone who already installed.
+
+## Prerelease mode
+
+`.changeset/pre.json` puts the repo in prerelease mode; versions become
+`X.Y.Z-next.N` and publish under the `next` dist-tag, leaving `latest` where it
+is.
+
+- Enter with `bunx changeset pre enter next`, exit with `bunx changeset pre exit`.
+  **Never hand-edit `pre.json`.** Its `changesets` array records which changesets
+  have already shipped in a prerelease; writing pending ones into it tells
+  changesets they are already out, and the version job silently no-ops with
+  `All changesets are empty; not creating PR`.
+- A package with **no prior normal release** publishes to `latest` even in
+  prerelease mode. That is `changeset publish`'s behaviour for a first publish —
+  it is the only way a brand-new package is installable at all. The publish plan
+  flags this explicitly.
+- A brand-new package's packument can 404 for a few minutes after its first
+  publish while the registry propagates, even though the tarball is already
+  live. Re-check before assuming the publish failed.
+
+## Credentials
+
+Publishing uses the repo secret `NPM_TOKEN`. See
+[RELEASE_TOKEN_ROTATION.md](./RELEASE_TOKEN_ROTATION.md) for rotation steps and
+the status of the OIDC trusted-publishing migration.

--- a/scripts/publish-plan.mjs
+++ b/scripts/publish-plan.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * Render the publish plan for a pending "Version Packages" PR as markdown.
+ *
+ * The Version PR is the single approval surface for a release: merging it
+ * publishes. So it has to state plainly what merging will DO — every package,
+ * its old and new version, and the dist-tag it lands on. That last column is
+ * the one that surprises: `changeset publish` sends a package with no prior
+ * NORMAL release to `latest` even in prerelease mode, so a brand-new package
+ * skips `next` entirely.
+ *
+ * Usage: node scripts/publish-plan.mjs <git-ref>   (e.g. origin/changeset-release/main)
+ */
+import { execFileSync } from 'node:child_process';
+
+const ref = process.argv[2];
+if (!ref) {
+  console.error('usage: publish-plan.mjs <git-ref>');
+  process.exit(2);
+}
+
+const git = (...args) => execFileSync('git', args, { encoding: 'utf8' });
+
+/** Read a file out of the ref, or null when it isn't there. */
+function show(path) {
+  try {
+    // stderr silenced: a missing path is an expected answer here, not a failure.
+    return execFileSync('git', ['show', `${ref}:${path}`], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    });
+  } catch {
+    return null;
+  }
+}
+
+/** Published versions from the registry; [] when the package is brand new. */
+function publishedVersions(name) {
+  try {
+    const out = execFileSync('npm', ['view', name, 'versions', '--json'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    });
+    const parsed = JSON.parse(out);
+    return Array.isArray(parsed) ? parsed : [parsed];
+  } catch {
+    return []; // 404 (never published) or a registry blip — treated the same downstream
+  }
+}
+
+const isPrerelease = (v) => /-/.test(v);
+
+// Package manifests live one level under packages/ and apps/.
+const manifests = git('ls-tree', '-r', '--name-only', ref, '--', 'packages', 'apps')
+  .split('\n')
+  .filter((p) => /^(packages|apps)\/[^/]+\/package\.json$/.test(p));
+
+const preRaw = show('.changeset/pre.json');
+const pre = preRaw ? JSON.parse(preRaw) : null;
+
+const rows = [];
+for (const path of manifests) {
+  const raw = show(path);
+  if (!raw) continue;
+  const pkg = JSON.parse(raw);
+  if (pkg.private || !pkg.name || !pkg.version) continue;
+
+  const published = publishedVersions(pkg.name);
+  if (published.includes(pkg.version)) continue; // already on the registry — publish skips it
+
+  // changesets' own rule: pre mode uses its tag, EXCEPT for a package with no
+  // prior normal release, which goes to `latest` regardless.
+  const hadNormalRelease = published.some((v) => !isPrerelease(v));
+  const tag = pre && hadNormalRelease ? pre.tag : 'latest';
+
+  rows.push({
+    name: pkg.name,
+    from: published.length ? published[published.length - 1] : '—',
+    to: pkg.version,
+    tag,
+    brandNew: published.length === 0
+  });
+}
+
+const out = ['<!-- publish-plan -->', '## What merging this PR publishes', ''];
+
+if (rows.length === 0) {
+  out.push('Nothing — every version in this PR is already on the registry.');
+} else {
+  out.push('| package | from | to | dist-tag |');
+  out.push('|---|---|---|---|');
+  for (const r of rows) {
+    out.push(`| \`${r.name}\` | ${r.from} | **${r.to}** | \`${r.tag}\` |`);
+  }
+  out.push('');
+  if (pre) {
+    out.push(`Prerelease mode is **on** (tag \`${pre.tag}\`).`);
+    const promoted = rows.filter((r) => r.tag === 'latest');
+    if (promoted.length) {
+      const names = promoted.map((r) => `\`${r.name}\``).join(', ');
+      out.push(
+        `> ⚠️ ${names} ${promoted.length === 1 ? 'has' : 'have'} no prior normal release, ` +
+          `so ${promoted.length === 1 ? 'it lands' : 'they land'} on \`latest\` rather than \`${pre.tag}\` — ` +
+          'that is `changeset publish`\'s behaviour for a first publish, not a misconfiguration.'
+      );
+    }
+  } else {
+    out.push('Prerelease mode is **off** — these are normal `latest` releases.');
+  }
+  out.push('');
+  out.push(
+    'Merging publishes immediately: no second approval, no Actions tab. ' +
+      'npm publishes are effectively permanent (unpublish is limited to 72h and breaks installs), so check the versions above before merging.'
+  );
+}
+
+console.log(out.join('\n'));


### PR DESCRIPTION
## One PR, one approval

Releasing took **two** human approvals for one decision: merge the Version Packages PR, then approve the `npm-publish` environment in the Actions UI. The workflow's own comment already called merging *"the human approval that a release should happen"* — the second gate was redundant, and invisible from the PR. That is exactly how today's release ended up merged-but-unpublished with nothing on the PR saying so.

### 1. Drop the second gate

`environment: npm-publish` comes off the publish job. `NPM_TOKEN` is a repo-level secret, so nothing else depended on that binding. The automated gates — Node-ESM importability and browser safety — still run and still block a bad build.

Done in the workflow rather than in repo settings so the change is visible in this diff and revertible by revert.

### 2. Put the publish plan on the PR

changesets' PR body lists changelogs but never the target **dist-tags** — and that is the part that surprises. New `scripts/publish-plan.mjs` renders a table onto the Version PR, upserted by an HTML marker so repeated pushes edit one comment instead of piling up.

Run against the stale #459 that nearly got merged as a plain `3.0.0`:

| package | from | to | dist-tag |
|---|---|---|---|
| `@originals/auth` | 3.0.0-next.0 | **3.0.0** | `latest` |
| `@originals/cel` | 0.2.0-next.0 | **0.2.0** | `latest` |
| `@originals/sdk` | 3.0.0-next.0 | **3.0.0** | `latest` |

> Prerelease mode is **off** — these are normal `latest` releases.

The trap, stated on the PR, before the click. Against the version that actually shipped, it prints `Nothing — every version in this PR is already on the registry.`

It also flags the case that bit us: a package with no prior normal release publishes to `latest` even in prerelease mode, because that is `changeset publish`'s behaviour for a first publish.

### 3. Document it

`docs/RELEASING.md` — the flow in three steps, plus the two prerelease traps hit this week:

- **Never hand-edit `pre.json`.** Its `changesets` array records what has already shipped in a prerelease; writing pending ones into it tells changesets they are already out, and the version job silently no-ops with `All changesets are empty; not creating PR` while the workflow reports success (#477).
- A brand-new package's **packument 404s for a few minutes** after its first publish while the tarball is already live. Re-check before assuming failure — `@originals/cel@0.2.0-next.0` did exactly this today and resolved on its own.

## Verification

- Workflow YAML parses; `jobs.publish` no longer binds an environment; the new step is present in the `version` job.
- `publish-plan.mjs` exercised against two real refs: `d949ab29` (pending, unpublished → the table above) and `31621dd1` (already published → the empty-plan path).

## Follow-up

The `npm-publish` environment still exists in repo settings with its now-unused reviewer rule. Worth deleting so it cannot be silently re-bound later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
