### PR TITLE
fix(landing): two verification bugs on signed-in Originals

### DIFF
--- a/.changeset/landing-cel-copy-host-key.md
+++ b/.changeset/landing-cel-copy-host-key.md
@@ -1,0 +1,9 @@
+---
+"@originals/landing": patch
+---
+
+Let the SDK's layer-agnostic CEL copy through the durable host-key guard, so `did:cel` resolves from storage for signed-in users.
+
+`LifecycleManager.persistCelArtifacts` writes two copies after genesis and after every append: the webvh-hosted `<host>/<path>/cel.json`, and `cel/<did:cel digest>.json` — the conventional key `DIDManager.resolveDID`'s `did:cel` branch reads back. `isWebvhArtifactKey` only recognised `…/did.jsonl`, `…/cel.json` and `…/resources/<multibase>`, so the second key was rejected as `forbidden_path` (403), swallowed as a `cel:host-failed` warning. On the durable path that copy never landed and `did:cel` never resolved from storage. (The anonymous ephemeral host has no key guard, so only signed-in users were affected.)
+
+The allowance is tight: exactly two segments, the first literally `cel`, the second `u<base64url>.json`. `serve()` keys on `${url.host}${url.pathname}`, so this key is only reachable as host `cel` plus `/<digest>.json` — it cannot name a path on the app's own origin, which is the static-asset shadowing the guard exists to prevent.

--- a/.changeset/landing-inscribed-verification.md
+++ b/.changeset/landing-inscribed-verification.md
@@ -1,0 +1,9 @@
+---
+"@originals/landing": patch
+---
+
+Fix `/me/<did>` verification going red on every Original that was inscribed on Bitcoin.
+
+`verifyOriginal` resolved the CEL through `resolveDidCel` with no `ordinalsProvider`. Inscribing appends a `migrate`/`btco` event carrying a `bitcoin-ordinals-2024` witness proof, which `verifyEventLog` fails closed on without one — so the check reported `CEL event chain did not verify` and the page showed "Verification incomplete", even though nothing was wrong with the chain. No provider can fix this in the browser: this origin proxies `/api/btc/sat|fee|broadcast`, not inscription lookups, so `HttpOrdinalsProvider.getInscriptionById` rejects by design.
+
+The check now verifies the chain with `verifyEventLog` directly, and when the *only* failures are anchor lookups on events **after** the `did:webvh` migrate, it re-verifies the log up to that migrate — which is exactly the claim the page makes (genesis → this `did:webvh`) — and says how much it proved: `2 of 4 signed events verified → did:cel:… · the Bitcoin anchor needs an on-chain lookup this page can't make`. A tampered genesis, a bad signature, or an error on an earlier event still fails the check. A CEL whose migrate targets a different DID is now called out separately rather than being conflated with "could not be fetched".

--- a/apps/landing/server/originals-routes.ts
+++ b/apps/landing/server/originals-routes.ts
@@ -23,23 +23,35 @@ const HOST_PREFIX = '/api/originals/host/';
 // users hit.
 const MAX_UPLOAD_BYTES = 8 * 1024 * 1024;
 
+/** A content digest suffix — multibase base64url, always 'u'-prefixed. */
+const DIGEST_MULTIBASE = /^u[A-Za-z0-9_-]+$/;
+/** The CEL copy's filename: the did:cel digest plus `.json`. */
+const CEL_COPY_FILE = /^u[A-Za-z0-9_-]+\.json$/;
+
 /**
- * A host key must name a did:webvh hosting artifact: `<segs…>/did.jsonl`,
- * `<segs…>/cel.json`, or `<segs…>/resources/<multibase>`. This confines every
- * authed PUT to the shapes the SDK actually publishes and — crucially — makes
- * it impossible to plant bytes at a path that would SHADOW the app's own static
- * assets (`index.html`, `assets/app-*.js`). `buildFetch` runs `originals.serve`
- * before the SPA/static fallback, so an unconfined key like
- * `<host>/assets/app-abc.js` would otherwise be served (as a forced download,
- * via untrustedHeaders) to every visitor, breaking the page. Cross-user
- * OVERWRITE of a claimed key is separately blocked by the store's owner sidecar.
+ * A host key must name an artifact the SDK actually publishes: `<segs…>/did.jsonl`,
+ * `<segs…>/cel.json`, `<segs…>/resources/<multibase>`, or the layer-agnostic CEL
+ * copy `cel/<multibase>.json`. This confines every authed PUT to those shapes
+ * and — crucially — makes it impossible to plant bytes at a path that would
+ * SHADOW the app's own static assets (`index.html`, `assets/app-*.js`).
+ * `buildFetch` runs `originals.serve` before the SPA/static fallback, so an
+ * unconfined key like `<host>/assets/app-abc.js` would otherwise be served (as a
+ * forced download, via untrustedHeaders) to every visitor, breaking the page.
+ * Cross-user OVERWRITE of a claimed key is separately blocked by the store's
+ * owner sidecar.
  */
 function isWebvhArtifactKey(key: string): boolean {
   const segs = key.split('/');
   const last = segs[segs.length - 1];
   if (last === 'did.jsonl' || last === 'cel.json') return true;
+  // The SDK's layer-agnostic CEL copy, `cel/<did:cel digest>.json`
+  // (LifecycleManager.persistCelArtifacts) — the conventional key
+  // DIDManager.resolveDID's did:cel branch reads back. Exactly two segments and
+  // a content-derived digest, so `serve` can only ever reach it as host `cel`
+  // plus `/<digest>.json`: it cannot name a path on the app's own origin.
+  if (segs.length === 2 && segs[0] === 'cel' && CEL_COPY_FILE.test(last)) return true;
   // Published resource: `…/resources/<base64url-multibase>` (multibase 'u' prefix).
-  return segs[segs.length - 2] === 'resources' && /^u[A-Za-z0-9_-]+$/.test(last);
+  return segs[segs.length - 2] === 'resources' && DIGEST_MULTIBASE.test(last);
 }
 
 /** The caller's per-user namespace slug — mirrors userWebvhSlug in src/auth/webvh.ts. */

--- a/apps/landing/server/tests/originals-routes.test.ts
+++ b/apps/landing/server/tests/originals-routes.test.ts
@@ -73,9 +73,16 @@ describe('originals routes — auth gating', () => {
     expect((await shadow('magby.originals.build/index.html')).status).toBe(403);
     // A bare 'resources/<name>' whose name isn't a multibase is refused too.
     expect((await shadow('magby.originals.build/assets/resources/evil.js')).status).toBe(403);
+    // A 'cel/…' key that isn't the content-digest copy is refused.
+    expect((await shadow('cel/index.html')).status).toBe(403);
+    expect((await shadow('cel/evil.json')).status).toBe(403); // no 'u' multibase prefix
+    expect((await shadow('cel/uAbc.json/../../index.html')).status).toBe(403);
+    expect((await shadow('magby.originals.build/cel/uAbc.json')).status).toBe(403); // 2 segments only
     // But real did:webvh artifacts are allowed.
     expect((await shadow('magby.originals.build/user-sub-1/did.jsonl')).status).toBe(200);
     expect((await shadow('magby.originals.build/ueibabc/resources/uJZtLeUr')).status).toBe(200);
+    // …as is the SDK's layer-agnostic CEL copy (persistCelArtifacts).
+    expect((await shadow('cel/uEiCGpqek6fgu3Ut-2k4Pj8KTiobAgA6PiAHuJ-Fw0dcGDA.json')).status).toBe(200);
   });
 
   test('rejects an oversized upload by Content-Length (413)', async () => {

--- a/apps/landing/src/sdk/engine.durable-publish.test.ts
+++ b/apps/landing/src/sdk/engine.durable-publish.test.ts
@@ -63,4 +63,36 @@ describe('authed durable publish', () => {
     const served = store.serve(new URL(state.webvhLogUrl!.replace('https://', 'http://')));
     expect(served).not.toBeNull();
   });
+
+  // The SDK persists a layer-agnostic copy of the CEL at `cel/<did:cel digest>.json`
+  // — the key DIDManager.resolveDID's did:cel branch reads back. The host-key
+  // guard used to reject that shape (403 → a swallowed cel:host-failed warning),
+  // so the copy never landed on the durable path.
+  test('the layer-agnostic CEL copy lands and is refreshed after the migrate append', async () => {
+    const engine = new DemoEngine({ authed: true, subOrgId: 'sub-1' });
+    const sdk = (engine as unknown as {
+      sdk: {
+        lifecycle: { on(t: string, h: (e: unknown) => void): void };
+        did: { resolveDID(did: string, o?: { skipCache?: boolean }): Promise<unknown> };
+      };
+    }).sdk;
+    const hostFailures: unknown[] = [];
+    sdk.lifecycle.on('cel:host-failed', (e) => hostFailures.push(e));
+
+    await engine.create('Copied Piece', 'Artwork', '<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+    await engine.publish();
+
+    const didCel = engine.asset!.id;
+    expect(didCel.startsWith('did:cel:')).toBe(true);
+    const res = store.read('sub-1', `cel/${didCel.slice('did:cel:'.length)}.json`);
+    expect(res.status).toBe(200);
+    // Refreshed AFTER the migrate append, not frozen at genesis.
+    expect((JSON.parse(await res.text()) as { events: unknown[] }).events.length).toBe(2);
+    expect(hostFailures).toEqual([]);
+
+    // The point of the copy: did:cel now resolves from storage (network read,
+    // not the in-memory cache) via DIDManager's did:cel branch.
+    const resolved = (await sdk.did.resolveDID(didCel, { skipCache: true })) as { id?: string } | null;
+    expect(resolved?.id).toBe(didCel);
+  });
 });

--- a/apps/landing/src/sdk/verify-original.test.ts
+++ b/apps/landing/src/sdk/verify-original.test.ts
@@ -1,0 +1,142 @@
+/**
+ * verifyOriginal against artifacts from a REAL publish (DemoEngine → durable
+ * store), so the checks are exercised on the exact bytes the detail page fetches.
+ *
+ * The inscribed case is the regression: a btco-anchored log carries a
+ * `bitcoin-ordinals-2024` witness proof that fails closed without an ordinals
+ * lookup, which used to turn the CEL check red on every asset taken through the
+ * demo's third step.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { signToken, getAuthCookieConfig } from '@originals/auth/server';
+import { DemoEngine } from './engine';
+import { verifyOriginal } from './verify-original';
+import { createOriginalsStore } from '../../server/originals-store';
+import { createOriginalsRoutes } from '../../server/originals-routes';
+import { createWebvhHostStore } from '../../server/webvh-host';
+import { buildFetch } from '../../server/app';
+import {
+  webvhArtifacts,
+  celResources,
+  parseDidLog,
+  digestMultibaseSha256Hex,
+  sha256HexToResourceMultibase,
+  type CelLog
+} from '../pages/original-detail-data';
+
+const JWT = 'test-secret-at-least-32-chars-long!!';
+const HOST = 'demo.test';
+const SVG = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="8" height="8"/></svg>';
+
+function installServerFetch(store: ReturnType<typeof createOriginalsStore>) {
+  const originals = createOriginalsRoutes({ jwtSecret: JWT, store });
+  const apiRoutes = {
+    'POST /api/originals': originals.record,
+    'GET /api/originals': originals.list
+  } as Record<string, (req: Request, url: URL) => Response | Promise<Response>>;
+  const fetchFn = buildFetch({ apiRoutes, hostStore: createWebvhHostStore(), distDir: '/nonexistent/', originals });
+  const cookie = getAuthCookieConfig(signToken('sub-1', 's@b.com', undefined, { secret: JWT }));
+  const cookieHeader = `${cookie.name}=${cookie.value}`;
+  const real = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(typeof input === 'string' ? input : input.toString(), `http://${HOST}`);
+    const headers = new Headers(init?.headers as HeadersInit);
+    headers.set('cookie', cookieHeader); // the browser would attach the auth cookie
+    return fetchFn(new Request(url, { ...init, headers }));
+  }) as unknown as typeof fetch;
+  return () => { globalThis.fetch = real; };
+}
+
+/** Fetch back exactly what the detail page fetches, then verify it. */
+async function verifyPublished(store: ReturnType<typeof createOriginalsStore>, did: string) {
+  const arts = webvhArtifacts(did)!;
+  const logEntries = parseDidLog(await store.serve(new URL(arts.logUrl))!.text());
+  const celLog = JSON.parse(await store.serve(new URL(arts.celUrl))!.text()) as CelLog;
+  const artwork = celResources(celLog).find((r) => r.mediaType === 'image/svg+xml')!;
+  const declaredHash = digestMultibaseSha256Hex(artwork.digestMultibase!)!;
+  const served = store.serve(new URL(arts.resourceUrl(sha256HexToResourceMultibase(declaredHash)!)))!;
+  const resourceBytes = new Uint8Array(await served.arrayBuffer());
+  const checks = await verifyOriginal({ did, logEntries, celLog, resourceBytes, declaredHash });
+  return { checks, celLog };
+}
+
+describe('verifyOriginal on a real published Original', () => {
+  let restore: () => void;
+  let store: ReturnType<typeof createOriginalsStore>;
+
+  beforeEach(() => {
+    (import.meta as unknown as { env: Record<string, string> }).env ??= {};
+    (import.meta as unknown as { env: Record<string, string> }).env.VITE_WEBVH_HOST = HOST;
+    store = createOriginalsStore({ dataDir: mkdtempSync(join(tmpdir(), 'verify-original-')) });
+    restore = installServerFetch(store);
+  });
+  afterEach(() => restore());
+
+  test('a published (not inscribed) asset passes all three checks', async () => {
+    const engine = new DemoEngine({ authed: true, subOrgId: 'sub-1' });
+    await engine.create('Published Piece', 'Artwork', SVG);
+    const { webvhDid } = await engine.publish();
+
+    const { checks } = await verifyPublished(store, webvhDid!);
+    expect(checks.map((c) => c.id)).toEqual(['hash', 'log', 'cel']);
+    expect(checks.every((c) => c.ok)).toBe(true);
+    expect(checks.find((c) => c.id === 'cel')!.detail).toContain('2 signed events verified');
+  });
+
+  test('an INSCRIBED asset still verifies, scoped to the events the browser can check', async () => {
+    const engine = new DemoEngine({ authed: true, subOrgId: 'sub-1' });
+    await engine.create('Inscribed Piece', 'Artwork', SVG);
+    const { webvhDid } = await engine.publish();
+    await engine.inscribe();
+
+    const { checks, celLog } = await verifyPublished(store, webvhDid!);
+    // The inscribe step really did extend the log past the web publication.
+    expect(celLog.events.length).toBeGreaterThan(2);
+    expect(checks.every((c) => c.ok)).toBe(true);
+    const cel = checks.find((c) => c.id === 'cel')!;
+    expect(cel.detail).toContain(`2 of ${celLog.events.length} signed events verified`);
+    expect(cel.detail).toContain('Bitcoin anchor');
+  });
+
+  test('a tampered genesis event fails the CEL check', async () => {
+    const engine = new DemoEngine({ authed: true, subOrgId: 'sub-1' });
+    await engine.create('Tampered Piece', 'Artwork', SVG);
+    const { webvhDid } = await engine.publish();
+
+    const arts = webvhArtifacts(webvhDid!)!;
+    const celLog = JSON.parse(await store.serve(new URL(arts.celUrl))!.text()) as CelLog;
+    celLog.events[0].data!.name = 'not-what-was-signed';
+
+    const checks = await verifyOriginal({
+      did: webvhDid!,
+      logEntries: parseDidLog(await store.serve(new URL(arts.logUrl))!.text()),
+      celLog,
+      resourceBytes: null,
+      declaredHash: null
+    });
+    expect(checks.find((c) => c.id === 'cel')!.ok).toBe(false);
+  });
+
+  test('a CEL log whose migrate targets another DID fails the CEL check', async () => {
+    const engine = new DemoEngine({ authed: true, subOrgId: 'sub-1' });
+    await engine.create('Mismatched Piece', 'Artwork', SVG);
+    const { webvhDid } = await engine.publish();
+
+    const arts = webvhArtifacts(webvhDid!)!;
+    const celLog = JSON.parse(await store.serve(new URL(arts.celUrl))!.text()) as CelLog;
+
+    const checks = await verifyOriginal({
+      did: 'did:webvh:QmSomeoneElse:demo.test:other',
+      logEntries: parseDidLog(await store.serve(new URL(arts.logUrl))!.text()),
+      celLog,
+      resourceBytes: null,
+      declaredHash: null
+    });
+    const cel = checks.find((c) => c.id === 'cel')!;
+    expect(cel.ok).toBe(false);
+    expect(cel.detail).toBe('CEL log does not bind to this DID');
+  });
+});

--- a/apps/landing/src/sdk/verify-original.ts
+++ b/apps/landing/src/sdk/verify-original.ts
@@ -4,12 +4,13 @@
  * Mirrors verify-example.ts, but runs against the artifacts the Original
  * actually hosts at this origin (fetched by the detail page): the resource
  * bytes are re-hashed, the did:webvh log's SCID + Ed25519 proof chain is
- * re-verified via didwebvh-ts, and the CEL event log's whole signed chain is
- * re-verified via the SDK — binding it to this DID through the migrate event.
- * Nothing is taken on faith from the server; the checks are the proof.
+ * re-verified via didwebvh-ts, and the CEL event log's signed chain is
+ * re-verified via the SDK up to the web publication — binding it to this DID
+ * through the migrate event. Nothing is taken on faith from the server; the
+ * checks are the proof, and each one reports exactly what it proved.
  */
 import '../shims/buffer-global';
-import { Ed25519Verifier, resolveDidCel } from '@originals/sdk';
+import { Ed25519Verifier, verifyEventLog } from '@originals/sdk';
 import { resolveDIDFromLog } from 'didwebvh-ts';
 import { sha256 } from '@noble/hashes/sha2.js';
 import type { CelLog } from '../pages/original-detail-data';
@@ -24,6 +25,28 @@ const toHex = (bytes: Uint8Array) =>
   Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
 
 const short = (did: string) => (did.length > 42 ? `${did.slice(0, 36)}…` : did);
+
+/**
+ * True when every verification error is "this event's Bitcoin anchor needs an
+ * on-chain lookup" AND belongs to an event AFTER `upTo` (the web publication).
+ * Once an asset is inscribed, its btco events carry a `bitcoin-ordinals-2024`
+ * witness proof that verifyEventLog fails closed on without an ordinalsProvider
+ * — and the browser has none (this origin proxies fee/broadcast, not inscription
+ * lookups). Those errors say "not checkable here", not "the chain is broken", so
+ * they must not condemn the genesis → did:webvh chain the page actually claims.
+ * Errors on earlier events, or of any other kind, fail the check as before.
+ */
+function onlyUncheckableAnchorErrors(errors: string[], upTo: number): boolean {
+  if (errors.length === 0) return false;
+  return errors.every((err) => {
+    const idx = Number(/^Event (\d+)/.exec(err)?.[1]);
+    return (
+      Number.isInteger(idx) &&
+      idx > upTo &&
+      /ordinalsProvider|ordinals provider/.test(err)
+    );
+  });
+}
 
 export async function verifyOriginal(input: {
   /** The Original's did:webvh identifier. */
@@ -72,23 +95,42 @@ export async function verifyOriginal(input: {
   }
   checks.push({ id: 'log', ok: logOk, detail: logDetail });
 
-  // 3 · Provenance: re-derive the did:cel genesis identity from the CEL log —
-  //     resolveDidCel verifies the WHOLE signed event chain and binds the DID
-  //     to it (null otherwise) — and confirm its migrate event targets this
-  //     did:webvh, chaining genesis → published identity.
+  // 3 · Provenance: re-verify the CEL's whole signed event chain against the
+  //     did:cel its genesis event derives (expectedDid — so a doctored log
+  //     fails closed) and confirm its migrate event targets this did:webvh,
+  //     chaining genesis → published identity.
+  //
+  //     An INSCRIBED asset's log continues past that migrate with Bitcoin-
+  //     anchored events whose witness proofs need an on-chain lookup the
+  //     browser can't make. Verifying only up to the web publication — the
+  //     exact claim this page makes — keeps those assets honest-green with a
+  //     detail that says how much was checked, instead of reporting the whole
+  //     chain broken (which is what it did before, on every inscribed asset).
+  const events = input.celLog?.events ?? [];
+  const migrateIdx = events.findIndex((e) => e.type === 'migrate' && e.data?.layer === 'webvh');
+  const migrate = migrateIdx >= 0 ? events[migrateIdx] : undefined;
+  const celDid = migrate?.data?.sourceDid;
   let celOk = false;
   let celDetail = 'CEL log could not be fetched';
-  const migrate = input.celLog?.events?.find(
-    (e) => e.type === 'migrate' && e.data?.layer === 'webvh'
-  );
-  const celDid = migrate?.data?.sourceDid;
   if (input.celLog && celDid) {
+    celDetail = 'CEL event chain did not verify';
     try {
-      const celDoc = await resolveDidCel(celDid, input.celLog as never);
-      celOk = !!celDoc && migrate?.data?.targetDid === input.did;
-      celDetail = celOk
-        ? `${input.celLog.events.length} signed events verified → ${short(celDid)}`
-        : 'CEL event chain did not verify';
+      if (migrate?.data?.targetDid !== input.did) {
+        celDetail = 'CEL log does not bind to this DID';
+      } else {
+        const full = await verifyEventLog(input.celLog as never, { expectedDid: celDid } as never);
+        if (full.verified) {
+          celOk = true;
+          celDetail = `${events.length} signed events verified → ${short(celDid)}`;
+        } else if (onlyUncheckableAnchorErrors(full.errors ?? [], migrateIdx)) {
+          const head = { ...input.celLog, events: events.slice(0, migrateIdx + 1) };
+          const prefix = await verifyEventLog(head as never, { expectedDid: celDid } as never);
+          celOk = prefix.verified;
+          celDetail = celOk
+            ? `${migrateIdx + 1} of ${events.length} signed events verified → ${short(celDid)} · the Bitcoin anchor needs an on-chain lookup this page can't make`
+            : 'CEL event chain did not verify';
+        }
+      }
     } catch (err) {
       console.error('[originals-sdk] original CEL verification failed', err);
       celDetail = 'CEL event chain did not verify';


### PR DESCRIPTION
Two independent bugs found while chasing a report that "the landing page verification fails on new assets". Neither is that report's cause — that one is still open, see the bottom — but both are real and reproduced end-to-end.

## 1 · `/me/<did>` went red on every inscribed Original

`verifyOriginal` resolved the CEL through `resolveDidCel` with no `ordinalsProvider`. Inscribing appends a `migrate`/`btco` event carrying a `bitcoin-ordinals-2024` witness proof, and `verifyEventLog` fails that closed:

```
Event 2, Proof 1: bitcoin witness proof cannot be verified without an
ordinalsProvider (required for btco anchoring)
```

So a perfectly good chain reported `CEL event chain did not verify` and the page showed "Verification incomplete". The shipped example stayed green only because it is create + publish, never inscribed.

**No provider can fix this in the browser.** This origin proxies `/api/btc/sat|fee|broadcast` — there is no inscription-lookup route — and `HttpOrdinalsProvider.getInscriptionById` / `getInscriptionsBySatoshi` reject by design. On the mock path the inscription doesn't exist anywhere at all.

So the check now verifies what the browser can actually prove. It calls `verifyEventLog` directly; when the *only* failures are anchor lookups on events **after** the `did:webvh` migrate, it re-verifies the log up to that migrate — which is exactly the claim this page makes, genesis → this `did:webvh` — and reports how much it proved:

> `2 of 4 signed events verified → did:cel:… · the Bitcoin anchor needs an on-chain lookup this page can't make`

A tampered genesis, a bad signature, or an error on an earlier event still fails the check. A CEL whose migrate targets a different DID is now reported as such instead of being conflated with "could not be fetched".

## 2 · The SDK's layer-agnostic CEL copy never landed for signed-in users

`LifecycleManager.persistCelArtifacts` writes two copies after genesis and after every append: the webvh-hosted `<host>/<path>/cel.json`, and `cel/<did:cel digest>.json` — the conventional key `DIDManager.resolveDID`'s `did:cel` branch reads back (`readStoredCelLog`). `isWebvhArtifactKey` only recognised `…/did.jsonl`, `…/cel.json` and `…/resources/<multibase>`, so the second key was `forbidden_path` (403) on every durable publish, swallowed as a `cel:host-failed` warning:

```
WARN [SDK:Events] CEL hosting failed {"target":"cel-copy",
  "error":"DurableHostingStorageAdapter.put failed: 403 for cel/uEiC….json"}
```

The copy never landed and `did:cel` never resolved from storage. The anonymous ephemeral host has no key guard, so only signed-in users were affected.

The allowance is deliberately tight: exactly two segments, first literally `cel`, second `u<base64url>.json`. `serve()` keys on `${url.host}${url.pathname}`, so this key is only reachable as host `cel` plus `/<digest>.json` — it cannot name a path on the app's own origin, which is the static-asset shadowing the guard exists to prevent. The digest is content-derived, so cross-user collision isn't possible either, and the store's owner sidecar still blocks overwrites.

## Tests

New `apps/landing/src/sdk/verify-original.test.ts` drives a real publish through `DemoEngine` → `DurableHostingStorageAdapter` → the originals store, then verifies the bytes the detail page actually fetches:

- published-only → all three green, `2 signed events verified`
- **inscribed** → green, scoped detail (the regression)
- tampered genesis → red
- migrate targeting another DID → red, with its own message

`server/tests/originals-routes.test.ts` gains guard cases: the CEL-copy key is accepted; `cel/index.html`, `cel/evil.json` (no `u` prefix), a traversal attempt, and a host-prefixed `…/cel/uAbc.json` all still 403.

`src/sdk/engine.durable-publish.test.ts` proves the round trip: after a real authed publish the copy lands, holds **2** events (so it was refreshed after the migrate append, not frozen at genesis), no `cel:host-failed` fires, and `sdk.did.resolveDID(didCel, { skipCache: true })` resolves the `did:cel` from storage.

201 landing tests pass, 0 fail; app and server typechecks clean.

## Still open

The original report — verification failing on an Original that was **never inscribed** — is not explained by either fix. I could not reproduce it: single publish, second asset in the same engine, second asset in a fresh engine, and `VITE_BTC_TESTNET=1` all verify green. Diagnosing it needs the failing DID so its public artifacts can be pulled from the live origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
