### PR TITLE
fix(landing): stop telling users to sign in again when signing in is what failed

### DIFF
--- a/.changeset/landing-signing-unavailable-gate.md
+++ b/.changeset/landing-signing-unavailable-gate.md
@@ -1,0 +1,18 @@
+---
+"@originals/landing": patch
+---
+
+**Fix: a failed signing bootstrap no longer tells the user to sign in again.**
+
+A signed-in browser with no signing client fell through to one message — "sign
+in again to get one" — whether it had never minted a key or had just tried and
+failed. In the second case that instruction is unactionable: signing in is
+exactly what failed, so following it loops.
+
+`SigningStatus` gains `'unavailable'`, set by both catch paths that mean "we
+tried and could not" (restore-on-reload and the post-OTP bootstrap). It renders
+its own message — signing is down on our end, re-authenticating will not fix
+it, the Original and any deposited BTC are untouched — and deliberately offers
+no re-auth button, since offering the action that just failed is the defect.
+
+`'none'` and `'expired'` are unchanged: there, signing in again is the remedy.

--- a/apps/landing/src/auth/turnkey-session.ts
+++ b/apps/landing/src/auth/turnkey-session.ts
@@ -48,7 +48,14 @@ export interface SigningSessionMeta {
   expiresAt: number;
 }
 
-export type SigningStatus = 'none' | 'active' | 'expired';
+/**
+ * 'none' — this browser holds no session key yet; signing in mints one.
+ * 'expired' — it had one and the window closed; signing in refreshes it.
+ * 'unavailable' — the bootstrap itself FAILED. Signing in again is what just
+ *   failed, so telling the user to repeat it sends them round a loop that
+ *   cannot terminate. Kept distinct for that reason alone.
+ */
+export type SigningStatus = 'none' | 'active' | 'expired' | 'unavailable';
 
 /**
  * A handle to the session key. `sign` takes the message and returns a hex

--- a/apps/landing/src/auth/useAuth.tsx
+++ b/apps/landing/src/auth/useAuth.tsx
@@ -97,7 +97,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     } catch (err) {
       console.warn('[originals-demo] could not restore the signing session', err);
       setBitcoin(null);
-      setSigning('none');
+      setSigning('unavailable');
     }
   }, []);
 
@@ -179,10 +179,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setBitcoin({ fundingAddress, signingClient });
       setSigning('active');
     } catch (err) {
-      // Non-fatal: log for the console-visible demo narrative; UI stays on mock.
-      console.warn('[originals-demo] bitcoin session bootstrap failed; inscribe stays on mock', err);
+      // Non-fatal for sign-in itself, but on a real-network build the demo does
+      // NOT fall back to mock — the inscribe step is gated. Mark it unavailable
+      // so the UI says so instead of telling the user to sign in again.
+      console.warn('[originals-demo] bitcoin session bootstrap failed', err);
       setBitcoin(null);
-      setSigning('none');
+      setSigning('unavailable');
     } finally {
       setReauth({ active: false, fromSubOrgId: null });
     }

--- a/apps/landing/src/components/Demo.tsx
+++ b/apps/landing/src/components/Demo.tsx
@@ -81,7 +81,7 @@ export function networkSkewDetected(
  * again at the inscribe click — so an expired session is a UI state rather than
  * a raw Turnkey error arriving after the money moved.
  */
-export type SigningGate = 'ok' | 'sign-in' | 'reauth';
+export type SigningGate = 'ok' | 'sign-in' | 'reauth' | 'unavailable';
 
 export function signingGate(opts: {
   authenticated: boolean;
@@ -89,7 +89,10 @@ export function signingGate(opts: {
   status: SigningStatus;
 }): SigningGate {
   if (!opts.authenticated) return 'sign-in';
-  return opts.hasSigningClient && opts.status === 'active' ? 'ok' : 'reauth';
+  if (opts.hasSigningClient && opts.status === 'active') return 'ok';
+  // A failed bootstrap is NOT "no key yet" — see SigningStatus. Re-signing-in
+  // is the thing that failed, so it gets its own gate and its own copy.
+  return opts.status === 'unavailable' ? 'unavailable' : 'reauth';
 }
 
 /**
@@ -103,6 +106,7 @@ export function signingGateMessage(
   status: SigningStatus = 'expired'
 ): string | null {
   if (gate === 'ok') return null;
+  if (gate === 'unavailable') return demo.session.unavailableBody;
   if (gate === 'reauth') return status === 'expired' ? demo.session.expiredBody : demo.session.missingBody;
   return network === 'mainnet' ? demo.deposit.signInPrompt : demo.testnet4.signInPrompt;
 }
@@ -1144,6 +1148,16 @@ export function Demo() {
                       {deposit?.ordinalCheck === 'unavailable' && (
                         <p className="demo-error" role="alert">{demo.deposit.ordinalCheckUnavailable}</p>
                       )}
+                    </div>
+                  ) : gate === 'unavailable' ? (
+                    // No re-auth CTA here on purpose: signing in is what
+                    // failed, so offering it again is a loop, not a remedy.
+                    <div className="demo-deposit">
+                      <div className="demo-deposit-head">
+                        <strong>{demo.session.unavailableHeading}</strong>
+                      </div>
+                      <p className="demo-error" role="alert">{signingGateMessage(gate, network, signing)}</p>
+                      <p className="demo-inscribe-note">{demo.session.preserved}</p>
                     </div>
                   ) : gate === 'reauth' ? (
                     <div className="demo-deposit">

--- a/apps/landing/src/components/demo-session-gate.test.ts
+++ b/apps/landing/src/components/demo-session-gate.test.ts
@@ -114,3 +114,35 @@ describe('the Sign out button cannot fire mid signing-session refresh', () => {
     expect(button).toContain('nav.signOutBlocked');
   });
 });
+
+/**
+ * A signing bootstrap that FAILED is not the same state as a browser that
+ * simply has no key yet. Telling someone to "sign in again to get one" when
+ * the last sign-in is exactly what failed sends them round a loop that cannot
+ * terminate — and does it on the surface where their money is.
+ */
+describe('signingGate: a failed bootstrap is its own state', () => {
+  const base = { authenticated: true, hasSigningClient: false as boolean };
+
+  test('a bootstrap that failed does not read as "no key yet"', () => {
+    expect(signingGate({ ...base, status: 'unavailable' })).toBe('unavailable');
+    expect(signingGate({ ...base, status: 'none' })).toBe('reauth');
+  });
+
+  test('its copy does not tell the user to sign in again', () => {
+    const msg = signingGateMessage('unavailable', 'mainnet', 'unavailable');
+    expect(msg).toBeTruthy();
+    expect(msg!.toLowerCase()).not.toContain('sign in again');
+    expect(msg).not.toBe(demo.session.missingBody);
+    expect(msg).not.toBe(demo.session.expiredBody);
+  });
+
+  test('it still says the money is safe, like every other blocked state', () => {
+    const msg = signingGateMessage('unavailable', 'mainnet', 'unavailable')!;
+    expect(msg.toLowerCase()).toMatch(/deposit|btc|bitcoin/);
+  });
+
+  test('an anonymous visitor is still asked to sign in, whatever the status', () => {
+    expect(signingGate({ ...base, authenticated: false, status: 'unavailable' })).toBe('sign-in');
+  });
+});

--- a/apps/landing/src/content.ts
+++ b/apps/landing/src/content.ts
@@ -376,6 +376,12 @@ export const demo = {
       'Your browser’s signing key has expired, so nothing can be signed right now. Sign in again to get a fresh one — your Original, and any BTC already sitting at your deposit address, are untouched and waiting.',
     missingBody:
       'You’re signed in, but this browser has no signing key for your account — sign in again to get one. Nothing is lost: your Original is still real and resolvable, and any BTC at your deposit address is still yours.',
+    // Deliberately does NOT offer "sign in again": this state is reached
+    // because signing in is what failed. Promising a retry that cannot work is
+    // the failure mode this string exists to avoid.
+    unavailableHeading: 'Signing is unavailable right now',
+    unavailableBody:
+      'Signing isn’t working on this site right now, so inscribing is paused — this is on our end, not something you can fix by signing in again. Nothing is lost: your Original is still real and resolvable, and any BTC at your deposit address stays yours, at your own address, under your own key.',
     reauthCta: 'Sign in again to keep going',
     reauthPending: 'Waiting for you to sign back in…',
     preserved: 'Your Original is held right where you left it — signing back in picks up from here.',


### PR DESCRIPTION
## What

A signing session that failed to bootstrap is now its own state, with its own message. It no longer tells the user to "sign in again" when signing in is exactly what failed.

## Why

Hit on the live deploy, not in a test.

`signingGate` took only `authenticated`, `hasSigningClient`, and `status`. Any signed-in user without a signing client fell to `reauth`, which renders:

> You're signed in, but this browser has no signing key for your account — **sign in again to get one.**

That is correct when the browser genuinely has no key yet. It is wrong, and unactionable, when the bootstrap itself failed — because signing in again is the thing that just failed. The user loops, and does it on the surface where their deposit is.

Both catch paths that mean "we tried and could not" — restore-on-reload and the post-OTP bootstrap — set `signing` to `'none'`, which is indistinguishable from "never had one." That collapse is the bug.

Related: #494

## How

`SigningStatus` gains `'unavailable'` and `SigningGate` gains a matching gate. The two catch paths set it instead of `'none'`. `signingGate` routes it before falling through to `reauth`.

The new state renders a named alert saying signing is down on our end, that re-signing-in will not fix it, and that the Original and any deposited BTC are untouched at the user's own address under their own key. **It deliberately renders no re-auth button** — offering the action that just failed is the defect, not the wording.

`'none'` and `'expired'` are unchanged: for those, signing in again really is the remedy.

**Why the tests missed it.** `signingGate` is a pure function and was tested with hand-built inputs — never with the state a real failed bootstrap produces. Same shape as the FR1 finding in #498: a green pure-function test guarding a path the real wiring does not reach. The new tests assert the copy does *not* contain "sign in again" and is not either of the other two strings, which is the property that actually matters here.

Also corrects a stale comment claiming the UI "stays on mock" after a failed bootstrap — on a real-network build it does not; the inscribe step is gated.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test addition or improvement

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] I have updated JSDoc comments for any changed public APIs
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Testing

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing (describe steps)

Landing suite **701 pass / 0 fail** (up 4). Both typechecks clean, `vite build` clean.

Red observed before implementing: `expect(signingGate({authenticated: true, hasSigningClient: false, status: 'unavailable'})).toBe('unavailable')` returned `"reauth"` — the collapse this PR fixes.

**This does not fix the underlying failure.** The live deploy is fully configured for mainnet (`/api/btc/network` returns `{"network":"mainnet","faucet":false}`) and `otpLoginToSession` is still failing against Turnkey — the path #498's own checklist flagged as never exercised live. This PR makes the resulting message honest; it does not make signing work. That diagnosis is ongoing, and #494 is a live suspect for the cause.

## Screenshots / Output (if applicable)

<!-- Copy-only change to a blocked-state panel; no new visual surface. -->

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
