### PR TITLE
fix(landing): sign OTP_LOGIN raw, not DER, so signing works at all

### DIFF
--- a/.changeset/landing-otp-login-raw-signature.md
+++ b/.changeset/landing-otp-login-raw-signature.md
@@ -1,0 +1,22 @@
+---
+"@originals/landing": patch
+---
+
+**Fix: OTP_LOGIN sent a DER signature where Turnkey verifies raw IEEE-P1363.**
+
+Signing never worked on a real network build. Turnkey verifies OTP_LOGIN's
+`clientSignature` over a raw (IEEE-P1363) P-256 signature — `@turnkey/core`
+passes `SignatureFormat.Raw` explicitly — but every Turnkey stamper defaults to
+DER, and the browser client called `sign(message)` with no format. Turnkey
+rejected the signature, the session bootstrap threw, and the user was left
+signed in but unable to inscribe.
+
+Nothing local could catch it: both encodings are plain hex strings, so the
+types, the build, and the test suite all passed. The suite's fake signer
+returned `'deadbeef'`, which is neither shape.
+
+The encoding is now pinned by `OTP_LOGIN_SIGNATURE_FORMAT` and passed
+explicitly, and `otpLoginToSession` refuses a non-raw signature before the
+network call, naming DER when it sees it — so a regression fails locally with
+its cause in the message rather than as an opaque bootstrap failure in
+production.

--- a/apps/landing/DEPLOY.md
+++ b/apps/landing/DEPLOY.md
@@ -82,10 +82,15 @@ any of these is outstanding.
    blocked at the edge, and the Ordinals add-on maps outpoint→address and
    sat→address only), so deposit polling costs no QuickNode quota and lives
    behind `BTC_INDEXER_API` instead.
-5. **One live Turnkey OTP verification.** Still outstanding from PR #356, and
-   now more important: the OTP login client signature was corrected in this
-   branch after being found unacceptable to Turnkey's API, so the login path
-   has almost certainly never completed end to end against a real org.
+5. **One live Turnkey OTP verification.** Outstanding since PR #356. This
+   check earned its place: the login path was broken the entire time it went
+   unrun. Turnkey verifies OTP_LOGIN's `clientSignature` over a **raw**
+   IEEE-P1363 signature, every Turnkey stamper **defaults to DER**, and both
+   are plain hex strings — so no type, test, or build caught it and every live
+   sign-in ended in a failed signing bootstrap. Now pinned by
+   `OTP_LOGIN_SIGNATURE_FORMAT` and guarded before the network call, but the
+   only thing that proves the whole path works is running it against a real
+   org.
 6. **One complete mainnet inscription by a human**, from a cold browser,
    before anyone else is invited.
 

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -36,6 +36,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
+    "@turnkey/sdk-types": "1.2.0",
     "@turnkey/sdk-server": "^7.0.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/apps/landing/src/auth/turnkey-browser-client.ts
+++ b/apps/landing/src/auth/turnkey-browser-client.ts
@@ -11,9 +11,13 @@
  * generated, stored, or sent anywhere.
  */
 import { Turnkey, type TurnkeyIndexedDbClient } from '@turnkey/sdk-browser';
+import { OTP_LOGIN_SIGNATURE_FORMAT } from './turnkey-session';
 import type { SessionKeySigner, TurnkeyRevocationApi } from './turnkey-session';
 
 const TURNKEY_API_BASE_URL = 'https://api.turnkey.com';
+
+/** The stamper's own format parameter, so a Turnkey rename fails typecheck here. */
+type SignFormat = Parameters<TurnkeyIndexedDbClient['sign']>[1];
 
 /**
  * The session key plus the client that stamps with it. `signer` is the only
@@ -68,9 +72,12 @@ async function handleFor(subOrgId: string, opts: { reset: boolean }): Promise<Se
     client,
     signer: {
       publicKeyHex,
-      // crypto.subtle.sign hashes SHA-256 internally and Turnkey's stamper
-      // re-encodes IEEE-P1363 → DER; the private key is never materialised.
-      sign: (message: string) => client.sign(message),
+      // The format is passed, never defaulted: the stamper's default is DER
+      // and Turnkey verifies OTP_LOGIN's clientSignature as raw IEEE-P1363,
+      // so omitting it produces a signature the API rejects. crypto.subtle
+      // hashes SHA-256 internally; the private key is never materialised.
+      sign: (message: string) =>
+        client.sign(message, OTP_LOGIN_SIGNATURE_FORMAT as SignFormat),
     },
     clear: () => client.clear(),
   };

--- a/apps/landing/src/auth/turnkey-browser-client.ts
+++ b/apps/landing/src/auth/turnkey-browser-client.ts
@@ -11,13 +11,20 @@
  * generated, stored, or sent anywhere.
  */
 import { Turnkey, type TurnkeyIndexedDbClient } from '@turnkey/sdk-browser';
+import { SignatureFormat } from '@turnkey/sdk-types';
 import { OTP_LOGIN_SIGNATURE_FORMAT } from './turnkey-session';
 import type { SessionKeySigner, TurnkeyRevocationApi } from './turnkey-session';
 
 const TURNKEY_API_BASE_URL = 'https://api.turnkey.com';
 
-/** The stamper's own format parameter, so a Turnkey rename fails typecheck here. */
-type SignFormat = Parameters<TurnkeyIndexedDbClient['sign']>[1];
+/**
+ * Cross-check the contract stated in ./turnkey-session against Turnkey's own
+ * enum. A renamed member stops resolving; a changed value fails this
+ * assignment. Either way the typecheck breaks here instead of the signature
+ * silently reverting to DER and signing failing in production again.
+ */
+const _rawIsStillRaw: typeof OTP_LOGIN_SIGNATURE_FORMAT = SignatureFormat.Raw;
+void _rawIsStillRaw;
 
 /**
  * The session key plus the client that stamps with it. `signer` is the only
@@ -76,8 +83,7 @@ async function handleFor(subOrgId: string, opts: { reset: boolean }): Promise<Se
       // and Turnkey verifies OTP_LOGIN's clientSignature as raw IEEE-P1363,
       // so omitting it produces a signature the API rejects. crypto.subtle
       // hashes SHA-256 internally; the private key is never materialised.
-      sign: (message: string) =>
-        client.sign(message, OTP_LOGIN_SIGNATURE_FORMAT as SignFormat),
+      sign: (message: string) => client.sign(message, SignatureFormat.Raw),
     },
     clear: () => client.clear(),
   };

--- a/apps/landing/src/auth/turnkey-session.test.ts
+++ b/apps/landing/src/auth/turnkey-session.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from 'bun:test';
 import {
   otpLoginToSession,
+  OTP_LOGIN_SIGNATURE_FORMAT,
   ensureBitcoinFundingAccount,
   type TurnkeyBitcoinClient,
   type TurnkeySessionApi,
@@ -193,7 +194,14 @@ describe('U1: OTP_LOGIN runs off a non-extractable key', () => {
   const sessionPublicKey = '02'.padEnd(66, 'b');
   const verificationToken = fakeVerificationToken({ id: tokenId, public_key: sessionPublicKey });
 
-  function signer(): SessionKeySigner & { signed: string[] } {
+  // A real raw P-256 signature: r‖s, 32 bytes each, hex — 128 chars. The old
+  // fixture returned 'deadbeef', which is why a DER-encoded signature (the
+  // stamper default, and the thing Turnkey actually rejects) passed this suite.
+  const rawSignature = 'ab'.repeat(64);
+  // What the stamper returns when the format is left to default: DER, 0x30 tag.
+  const derSignature = '3044' + 'cd'.repeat(68);
+
+  function signer(signature: string = rawSignature): SessionKeySigner & { signed: string[] } {
     const signed: string[] = [];
     return {
       publicKeyHex: sessionPublicKey,
@@ -202,7 +210,7 @@ describe('U1: OTP_LOGIN runs off a non-extractable key', () => {
       // it can never hand over the private scalar. That is the whole point.
       async sign(message: string) {
         signed.push(message);
-        return 'deadbeef';
+        return signature;
       },
     };
   }
@@ -241,7 +249,7 @@ describe('U1: OTP_LOGIN runs off a non-extractable key', () => {
       publicKey: sessionPublicKey,
       scheme: 'CLIENT_SIGNATURE_SCHEME_API_P256',
       message: loginClientSignatureMessage(tokenId, sessionPublicKey),
-      signature: 'deadbeef',
+      signature: rawSignature,
     });
     // Defaults to the extended window, and reports back when it dies.
     expect(calls[0].expirationSeconds).toBe(String(SESSION_EXPIRATION_SECONDS));
@@ -250,6 +258,44 @@ describe('U1: OTP_LOGIN runs off a non-extractable key', () => {
       publicKey: sessionPublicKey,
       expiresAt: t0 + SESSION_EXPIRATION_SECONDS * 1000,
     });
+  });
+
+  // The live bug: every Turnkey stamper defaults to DER, Turnkey verifies
+  // OTP_LOGIN's clientSignature as raw IEEE-P1363, and nothing between the two
+  // is typed differently — both are plain hex strings. Only the API said no,
+  // and it said so as an opaque bootstrap failure.
+  test('OTP_LOGIN_SIGNATURE_FORMAT pins the encoding Turnkey verifies, not the stamper default', () => {
+    expect(OTP_LOGIN_SIGNATURE_FORMAT).toBe('raw');
+  });
+
+  test('a DER signature is refused here, naming DER, rather than by Turnkey', async () => {
+    // The fake SUCCEEDS on purpose. If the guard is ever removed, this test
+    // fails instead of passing on the fake's own error text.
+    let called = false;
+    const turnkey: TurnkeySessionApi = {
+      async otpLogin() {
+        called = true;
+        return { session: 'must-not-be-reached' };
+      },
+    };
+    await expect(
+      otpLoginToSession({ turnkey, subOrgId: 'sub-1', verificationToken, signer: signer(derSignature) })
+    ).rejects.toThrow(/that is DER, the stamper default/);
+    expect(called).toBe(false);
+  });
+
+  test('any non-raw signature length is refused before the network call', async () => {
+    let called = false;
+    const turnkey: TurnkeySessionApi = {
+      async otpLogin() {
+        called = true;
+        return { session: 's' };
+      },
+    };
+    await expect(
+      otpLoginToSession({ turnkey, subOrgId: 'sub-1', verificationToken, signer: signer('deadbeef') })
+    ).rejects.toThrow(/raw \(IEEE-P1363\)/);
+    expect(called).toBe(false);
   });
 });
 

--- a/apps/landing/src/auth/turnkey-session.ts
+++ b/apps/landing/src/auth/turnkey-session.ts
@@ -144,6 +144,23 @@ export function decodeVerificationToken(token: string): { id: string; public_key
 }
 
 /**
+ * The signature encoding Turnkey verifies OTP_LOGIN's clientSignature in: RAW
+ * IEEE-P1363 (r‖s), which `@turnkey/core` passes as `SignatureFormat.Raw`.
+ *
+ * Every Turnkey stamper DEFAULTS to DER instead, and DER is what the API
+ * rejects — so this is passed explicitly at every call site and never left to
+ * the default. Lives in this pure module, not the browser client, so the
+ * contract is stated somewhere `bun test` can actually reach.
+ */
+export const OTP_LOGIN_SIGNATURE_FORMAT = 'raw';
+
+/**
+ * Raw P-256 is r‖s, 32 bytes each — exactly 128 hex chars. DER is
+ * variable-length and starts with the 0x30 SEQUENCE tag.
+ */
+const RAW_P256_SIGNATURE_HEX = /^[0-9a-f]{128}$/i;
+
+/**
  * The exact message Turnkey verifies for OTP_LOGIN's clientSignature — field
  * order included, since the signature is over this JSON string. Mirrors
  * `getClientSignatureMessageForLogin` in @turnkey/core.
@@ -158,9 +175,10 @@ export function loginClientSignatureMessage(tokenId: string, sessionPublicKey: s
  * `expirationSeconds`. Returns the metadata the reload path needs to know the
  * session is still alive — never the key.
  *
- * NOTE: the message construction is taken from Turnkey's own SDK, but has not
- * been exercised against the live API from here; it stays a manual-smoke
- * verification point.
+ * The message construction mirrors `getClientSignatureMessageForLogin` in
+ * @turnkey/core exactly, field order included, and the signature is raw
+ * IEEE-P1363 per OTP_LOGIN_SIGNATURE_FORMAT — the DER default was what made
+ * every live attempt fail before it was pinned.
  */
 export async function otpLoginToSession(deps: {
   turnkey: TurnkeySessionApi;
@@ -174,11 +192,21 @@ export async function otpLoginToSession(deps: {
   const sessionPublicKey = boundPublicKey || deps.signer.publicKeyHex;
   const message = loginClientSignatureMessage(tokenId, sessionPublicKey);
   const expirationSeconds = deps.expirationSeconds ?? SESSION_EXPIRATION_SECONDS;
+  const signature = await deps.signer.sign(message);
+  // Refuse a DER signature HERE, naming it. Every local type accepts one — the
+  // stamper returns a plain hex string either way — and only Turnkey rejects
+  // it, as an opaque bootstrap failure with no clue as to the cause.
+  if (!RAW_P256_SIGNATURE_HEX.test(signature)) {
+    const looksDer = signature.startsWith('30') ? ' — that is DER, the stamper default' : '';
+    throw new Error(
+      `OTP_LOGIN needs a raw (IEEE-P1363) P-256 signature; got ${signature.length} hex chars${looksDer}`
+    );
+  }
   const clientSignature: ClientSignature = {
     publicKey: sessionPublicKey,
     scheme: 'CLIENT_SIGNATURE_SCHEME_API_P256',
     message,
-    signature: await deps.signer.sign(message),
+    signature,
   };
   const requestedAt = (deps.now ?? Date.now)();
   const { session } = await deps.turnkey.otpLogin({

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
     },
     "apps/landing": {
       "name": "@originals/landing",
-      "version": "0.1.2",
+      "version": "0.1.3-next.2",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",
@@ -33,6 +33,7 @@
       },
       "devDependencies": {
         "@turnkey/sdk-server": "^7.0.0",
+        "@turnkey/sdk-types": "1.2.0",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.3",
@@ -46,11 +47,11 @@
     },
     "packages/auth": {
       "name": "@originals/auth",
-      "version": "2.0.0",
+      "version": "3.0.0-next.0",
       "dependencies": {
         "@noble/ed25519": "^3.1.0",
         "@noble/hashes": "^2.0.1",
-        "@originals/sdk": "^2.0.0",
+        "@originals/sdk": "^3.0.0-next.0",
         "@turnkey/crypto": "^2.10.0",
         "@turnkey/sdk-server": "^7.0.0",
         "jsonwebtoken": "^9.0.2",
@@ -77,7 +78,7 @@
     },
     "packages/cel": {
       "name": "@originals/cel",
-      "version": "0.1.0",
+      "version": "0.2.0-next.1",
       "dependencies": {
         "@aviarytech/did-peer": "^1.1.2",
         "@noble/curves": "^2.2.0",
@@ -101,7 +102,7 @@
     },
     "packages/sdk": {
       "name": "@originals/sdk",
-      "version": "2.1.0",
+      "version": "3.0.0-next.1",
       "bin": {
         "originals-cel": "./dist/cel/cli/index.js",
       },
@@ -112,7 +113,7 @@
         "@noble/ed25519": "^3.1.0",
         "@noble/hashes": "^2.0.1",
         "@noble/secp256k1": "^3.1.0",
-        "@originals/cel": "^0.1.0",
+        "@originals/cel": "^0.2.0-next.1",
         "@scure/base": "^2.2.0",
         "@scure/btc-signer": "^2.2.0",
         "b58": "^4.0.3",


### PR DESCRIPTION
## What

`otpLoginToSession` now signs OTP_LOGIN's `clientSignature` as **raw IEEE-P1363**, not DER. This is the reason signing has never worked on the live mainnet build.

## Why

Turnkey verifies OTP_LOGIN's `clientSignature` over a raw (IEEE-P1363) P-256 signature. Its own SDK does this explicitly — `@turnkey/core`'s `signWithApiKey`:

```js
return await this.apiKeyStamper.sign(message, apiKeyStamper.SignatureFormat.Raw);
```

Every Turnkey stamper defaults to the *other* encoding. `@turnkey/indexed-db-stamper`:

```js
async sign(payload, format = SignatureFormat.Der) { ... }
```

We called `client.sign(message)` with no format. So every live sign-in sent a DER signature where Turnkey expects raw, Turnkey rejected it, `otpLogin` threw, and the bootstrap landed in the `unavailable` state added by #499 — signed in, deposit address intact, unable to inscribe.

**Nothing local could catch this.** Both encodings are plain hex strings off the same `sign()` call, so the types, the build, and all 701 tests passed while the path was completely broken. The suite's fake signer returned `'deadbeef'` — 8 hex chars, neither a raw signature (128) nor DER. A fixture that models neither real value is what let a green suite guard a path that had never once worked. Same failure mode as the FR1 finding in #498 and the gate collapse in #499: a green pure-function test over inputs the real wiring never produces.

This is the cause of the symptom #499 made honest. #499 fixed the message; this fixes the thing.

Related: #494

## How

- `OTP_LOGIN_SIGNATURE_FORMAT = 'raw'` lives in the **pure** `turnkey-session.ts`, not the browser client, so the contract sits somewhere `bun test` can reach — the browser client can't be imported under the test runner, which is why the constant was previously nowhere at all.
- The browser client passes Turnkey's own `SignatureFormat.Raw` and never inherits the default, with a cross-check binding that enum to the contract stated in `turnkey-session`. A renamed member stops resolving; a changed value fails the assignment — so drift breaks the typecheck instead of silently reverting to DER. Verified by drifting the constant to `'der'`: `error TS2322: Type 'SignatureFormat.Raw' is not assignable to type '"der"'`.
  - **Corrected during review.** The first version of this used `'raw' as Parameters<TurnkeyIndexedDbClient['sign']>[1]` and this section claimed that made a rename fail the typecheck. It did not — an `as` assertion silences the check rather than performing it, so the drift this binding exists to catch would have passed. Caught by review; `@turnkey/sdk-types` is now pinned to `1.2.0`, the exact version `@turnkey/sdk-browser` already depends on.
- `otpLoginToSession` refuses a non-raw signature **before** the network call and names DER when it sees the `0x30` tag. A regression now fails locally with its cause in the message, rather than in production as an opaque bootstrap failure.
- The corrected message construction from #498 was verified against `getClientSignatureMessageForLogin` in `@turnkey/core` and matches exactly, field order included. The message was never the problem; the encoding was. The stale "not exercised against the live API" note is updated to say so.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Test addition or improvement

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] I have updated JSDoc comments for any changed public APIs
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Testing

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing (describe steps)

Landing suite **704 pass / 0 fail** (up 3). Root and landing typechecks clean; `vite build` clean.

Both new guard tests were verified to go **red** with the guard disabled and green with it. The first attempt at the DER test was a false positive — it passed with the guard disabled because the fake's own error message contained "DER" and satisfied the regex. It now asserts against the guard's exact wording and that `otpLogin` is never reached, and fails correctly when the guard is removed.

The existing `deadbeef` fixture was replaced with a real 128-hex-char raw signature; the DER fixture carries a genuine `0x30` SEQUENCE tag.

**What is still unverified:** that a real sign-in now completes. This was diagnosed by reading Turnkey's shipped SDK — `@turnkey/core@2.7.1` from the registry and the installed `@turnkey/sdk-browser@7.0.0` / `@turnkey/indexed-db-stamper@1.3.2` — not by a live OTP round trip. The encoding mismatch is certain; whether anything *else* also fails downstream (`ensureBitcoinFundingAccount` creating a BIP-84 mainnet account has likewise never run live) is not established. DEPLOY.md item 5 is updated to say exactly this.

## Screenshots / Output (if applicable)

Ground truth, `@turnkey/core@2.7.1` — what Turnkey signs:

```js
// utils.js — getClientSignatureMessageForLogin
const payload = { login: usage, tokenId: decoded.id, type: "USAGE_TYPE_LOGIN" };
// core.js — signWithApiKey
return await this.apiKeyStamper.sign(message, apiKeyStamper.SignatureFormat.Raw);
```

`@turnkey/indexed-db-stamper@1.3.2` — what we were sending:

```js
async sign(payload, format = sdkTypes.SignatureFormat.Der) {
  ...
  case Raw: return uint8ArrayToHexString(signatureIeee1363);   // 128 hex chars
  case Der: return uint8ArrayToHexString(convertEcdsaIeee1363ToDer(...)); // 0x30…
}
```

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
