### PR TITLE
fix(landing): name the failing bootstrap step, and report it at error level

### DIFF
--- a/.changeset/landing-localize-bootstrap-failure.md
+++ b/.changeset/landing-localize-bootstrap-failure.md
@@ -1,0 +1,21 @@
+---
+"@originals/landing": patch
+---
+
+**Fix: the signing bootstrap now says which step failed, at error level.**
+
+Three unrelated subsystems failed into one catch — the browser's IndexedDB key,
+Turnkey's OTP_LOGIN, and the Bitcoin funding account — and all three reported
+the same `console.warn`. Warn is hidden by the default "Errors" console filter,
+which is the filter in use when someone is debugging a broken page, so the one
+line explaining the failure was the one line they could not see.
+
+It now reports at error level and names the step and the origin (fresh sign-in
+vs. restore-on-reload), with the error object passed through unflattened so
+Turnkey's own fields stay inspectable.
+
+Also closes the last silent path: on a real-network build, a missing browser
+key or a missing `verificationToken` returned early with signing left at
+`'none'`, which renders "sign in again to get one" for a browser that just did
+— the same defect as the gate, one layer earlier, and reporting nothing at all.
+Both now report and set `unavailable`.

--- a/apps/landing/src/auth/bootstrap-report.test.ts
+++ b/apps/landing/src/auth/bootstrap-report.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  bootstrapFailureMessage,
+  reportBootstrapFailure,
+  type BootstrapStep,
+} from './bootstrap-report';
+
+const STEPS: BootstrapStep[] = ['open-session-key', 'otp-login', 'funding-account'];
+
+describe('the signing bootstrap says which step failed', () => {
+  test('every step produces a distinct, machine-greppable line', () => {
+    const lines = STEPS.map((s) => bootstrapFailureMessage('sign-in', s));
+    expect(new Set(lines).size).toBe(STEPS.length);
+    for (const step of STEPS) {
+      expect(bootstrapFailureMessage('sign-in', step)).toContain(`[step=${step}]`);
+    }
+  });
+
+  test('the origin is named, so a reload failure is not read as a sign-in failure', () => {
+    expect(bootstrapFailureMessage('reload', 'otp-login')).toContain('reload');
+    expect(bootstrapFailureMessage('sign-in', 'otp-login')).toContain('sign-in');
+  });
+
+  // The whole point of the change: console.warn is dropped by the default
+  // "Errors" filter, which is the filter in use when someone is debugging.
+  test('reports at error level, not warn, and passes the error through intact', () => {
+    const seen: unknown[][] = [];
+    const cause = new Error('Turnkey said no');
+    reportBootstrapFailure('sign-in', 'otp-login', cause, {
+      error: (...args: unknown[]) => seen.push(args),
+    } as unknown as Pick<Console, 'error'>);
+    expect(seen).toHaveLength(1);
+    expect(seen[0][0]).toContain('[step=otp-login]');
+    // Unflattened — an operator can expand it and read Turnkey's own fields.
+    expect(seen[0][1]).toBe(cause);
+  });
+});

--- a/apps/landing/src/auth/bootstrap-report.test.ts
+++ b/apps/landing/src/auth/bootstrap-report.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from 'bun:test';
 import {
   bootstrapFailureMessage,
   reportBootstrapFailure,
+  prerequisiteFailure,
   type BootstrapStep,
 } from './bootstrap-report';
 
@@ -33,5 +34,29 @@ describe('the signing bootstrap says which step failed', () => {
     expect(seen[0][0]).toContain('[step=otp-login]');
     // Unflattened — an operator can expand it and read Turnkey's own fields.
     expect(seen[0][1]).toBe(cause);
+  });
+});
+
+describe('a missing prerequisite is attributed to the step that actually failed', () => {
+  // The bug this exists to prevent: reporting a missing verificationToken as
+  // 'open-session-key' sends an operator to IndexedDB/WebCrypto when the
+  // browser key opened perfectly well and the OTP prerequisite is what broke.
+  test('a key that opened + no token is an otp-login failure, not a key failure', () => {
+    const failure = prerequisiteFailure({ sessionKey: true, verificationToken: false });
+    expect(failure?.step).toBe('otp-login');
+    expect(failure?.reason).toContain('verificationToken');
+  });
+
+  test('no browser key is a key failure, and takes precedence', () => {
+    expect(prerequisiteFailure({ sessionKey: false, verificationToken: false })?.step).toBe(
+      'open-session-key'
+    );
+    expect(prerequisiteFailure({ sessionKey: false, verificationToken: true })?.step).toBe(
+      'open-session-key'
+    );
+  });
+
+  test('both present is not a failure', () => {
+    expect(prerequisiteFailure({ sessionKey: true, verificationToken: true })).toBeNull();
   });
 });

--- a/apps/landing/src/auth/bootstrap-report.ts
+++ b/apps/landing/src/auth/bootstrap-report.ts
@@ -38,3 +38,31 @@ export function reportBootstrapFailure(
 ): void {
   sink.error(bootstrapFailureMessage(origin, step), err);
 }
+
+/**
+ * Which prerequisite is missing before OTP_LOGIN can even be attempted.
+ *
+ * The two are checked in order, because the step reported has to be the step
+ * that actually failed: a browser that opened its key fine but got no
+ * verification token failed at OTP_LOGIN's prerequisite, not at the key. This
+ * lives here, rather than as a ternary at the call site, so the mapping is
+ * testable — mislabelling the step defeats the entire point of naming it.
+ */
+export function prerequisiteFailure(have: {
+  sessionKey: boolean;
+  verificationToken: boolean;
+}): { step: BootstrapStep; reason: string } | null {
+  if (!have.sessionKey) {
+    return {
+      step: 'open-session-key',
+      reason: 'this browser could not open a signing key (IndexedDB or WebCrypto unavailable)',
+    };
+  }
+  if (!have.verificationToken) {
+    return {
+      step: 'otp-login',
+      reason: 'verify-otp returned no verificationToken, so OTP_LOGIN cannot run',
+    };
+  }
+  return null;
+}

--- a/apps/landing/src/auth/bootstrap-report.ts
+++ b/apps/landing/src/auth/bootstrap-report.ts
@@ -1,0 +1,40 @@
+/**
+ * Why the signing bootstrap failed, reported so an operator can act on it.
+ *
+ * Three unrelated subsystems fail into one catch — the browser's IndexedDB
+ * key, Turnkey's OTP_LOGIN, and the Bitcoin funding account — and the user
+ * sees the same sentence for all three. That is right for the user and useless
+ * for whoever has to fix it, so the log names the step.
+ *
+ * Reported at ERROR level on purpose. `console.warn` is hidden by the default
+ * "Errors" console filter, which is exactly the filter someone uses when they
+ * are looking at a broken page: the one line that explains the failure is the
+ * one line they cannot see.
+ */
+
+/** Where the bootstrap got to before it threw. */
+export type BootstrapStep = 'open-session-key' | 'otp-login' | 'funding-account';
+
+/** Which entry point ran it: a fresh sign-in, or restoring on page load. */
+export type BootstrapOrigin = 'sign-in' | 'reload';
+
+const WHAT_EACH_STEP_DOES: Record<BootstrapStep, string> = {
+  'open-session-key': "opening this browser's non-extractable signing key",
+  'otp-login': 'installing that key as a Turnkey session (OTP_LOGIN)',
+  'funding-account': 'deriving the Bitcoin funding account',
+};
+
+/** The operator-facing line. Names the step, so the next move is obvious. */
+export function bootstrapFailureMessage(origin: BootstrapOrigin, step: BootstrapStep): string {
+  return `[originals-demo] signing bootstrap failed during ${origin} while ${WHAT_EACH_STEP_DOES[step]} [step=${step}]`;
+}
+
+/** Report it. The error object is passed through unflattened so it stays inspectable. */
+export function reportBootstrapFailure(
+  origin: BootstrapOrigin,
+  step: BootstrapStep,
+  err: unknown,
+  sink: Pick<Console, 'error'> = console
+): void {
+  sink.error(bootstrapFailureMessage(origin, step), err);
+}

--- a/apps/landing/src/auth/useAuth.tsx
+++ b/apps/landing/src/auth/useAuth.tsx
@@ -19,7 +19,7 @@ import type { SessionKeyHandle } from './turnkey-browser-client';
 import { browserKeyStorage } from './browser-storage';
 import { endSigningSession, signOutIntent } from './sign-out';
 import { btcNetwork } from '../sdk/network-flag';
-import { reportBootstrapFailure, type BootstrapStep } from './bootstrap-report';
+import { reportBootstrapFailure, prerequisiteFailure, type BootstrapStep } from './bootstrap-report';
 
 export interface BitcoinSession {
   fundingAddress: string;
@@ -168,15 +168,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // the "sign in again to get one" copy for a browser that just did, and
     // reports nothing at all. Same defect as the gate, one layer earlier.
     if (!sessionKey || !result.verificationToken) {
-      reportBootstrapFailure(
-        'sign-in',
-        'open-session-key',
-        new Error(
-          sessionKey
-            ? 'verify-otp returned no verificationToken, so OTP_LOGIN cannot run'
-            : 'this browser could not open a signing key (IndexedDB or WebCrypto unavailable)'
-        )
-      );
+      const failure = prerequisiteFailure({
+        sessionKey: Boolean(sessionKey),
+        verificationToken: Boolean(result.verificationToken),
+      });
+      if (failure) reportBootstrapFailure('sign-in', failure.step, new Error(failure.reason));
       setBitcoin(null);
       setSigning('unavailable');
       setReauth({ active: false, fromSubOrgId: null });

--- a/apps/landing/src/auth/useAuth.tsx
+++ b/apps/landing/src/auth/useAuth.tsx
@@ -19,6 +19,7 @@ import type { SessionKeyHandle } from './turnkey-browser-client';
 import { browserKeyStorage } from './browser-storage';
 import { endSigningSession, signOutIntent } from './sign-out';
 import { btcNetwork } from '../sdk/network-flag';
+import { reportBootstrapFailure, type BootstrapStep } from './bootstrap-report';
 
 export interface BitcoinSession {
   fundingAddress: string;
@@ -82,6 +83,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setSigning(signingStatus(meta));
       return;
     }
+    let step: BootstrapStep = 'open-session-key';
     try {
       const { openSessionKey } = await import('./turnkey-browser-client');
       const handle = await openSessionKey(restored.subOrgId);
@@ -91,11 +93,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         return;
       }
       const signingClient = handle.client as unknown as TurnkeyBitcoinClient;
+      step = 'funding-account';
       const fundingAddress = await ensureBitcoinFundingAccount(signingClient, restored.subOrgId, network);
       setBitcoin({ fundingAddress, signingClient });
       setSigning('active');
     } catch (err) {
-      console.warn('[originals-demo] could not restore the signing session', err);
+      reportBootstrapFailure('reload', step, err);
       setBitcoin(null);
       setSigning('unavailable');
     }
@@ -154,12 +157,36 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     // Track B bootstrap: install the session key on the sub-org (OTP_LOGIN),
     // then build the signing client + ensure the network's funding account.
-    // Best-effort: a failure here must NOT block login — the demo falls back to
-    // the mock inscribe path. Only runs when the deploy enabled a real network.
-    if (network === 'off' || !result.verificationToken || !sessionKey) {
+    // Only runs when the deploy enabled a real network; on an 'off' build there
+    // is nothing to bootstrap and the demo runs the mock inscribe path.
+    if (network === 'off') {
       setReauth({ active: false, fromSubOrgId: null });
       return;
     }
+    // On a real-network build these two are FAILURES, not "no key yet". They
+    // used to return here silently, leaving signing at 'none' — which renders
+    // the "sign in again to get one" copy for a browser that just did, and
+    // reports nothing at all. Same defect as the gate, one layer earlier.
+    if (!sessionKey || !result.verificationToken) {
+      reportBootstrapFailure(
+        'sign-in',
+        'open-session-key',
+        new Error(
+          sessionKey
+            ? 'verify-otp returned no verificationToken, so OTP_LOGIN cannot run'
+            : 'this browser could not open a signing key (IndexedDB or WebCrypto unavailable)'
+        )
+      );
+      setBitcoin(null);
+      setSigning('unavailable');
+      setReauth({ active: false, fromSubOrgId: null });
+      return;
+    }
+    // Three different subsystems fail into the one catch below — the browser
+    // key, Turnkey's OTP_LOGIN, and the Bitcoin funding account. Without this
+    // label the report names none of them, and the whole surface reads as one
+    // opaque "signing is unavailable".
+    let step: BootstrapStep = 'open-session-key';
     try {
       // Re-open against the real sub-org: same IndexedDB key, but
       // signTransaction carries no organizationId of its own, so the client's
@@ -167,6 +194,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const { openSessionKey } = await import('./turnkey-browser-client');
       const bound = await openSessionKey(result.subOrgId);
       const signingClient = bound.client as unknown as TurnkeyBitcoinClient;
+      step = 'otp-login';
       const { meta } = await otpLoginToSession({
         turnkey: signingClient as unknown as TurnkeySessionApi,
         subOrgId: result.subOrgId,
@@ -175,6 +203,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       });
       const storage = browserKeyStorage();
       if (storage) writeSessionMeta(storage, meta);
+      step = 'funding-account';
       const fundingAddress = await ensureBitcoinFundingAccount(signingClient, result.subOrgId, network);
       setBitcoin({ fundingAddress, signingClient });
       setSigning('active');
@@ -182,7 +211,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // Non-fatal for sign-in itself, but on a real-network build the demo does
       // NOT fall back to mock — the inscribe step is gated. Mark it unavailable
       // so the UI says so instead of telling the user to sign in again.
-      console.warn('[originals-demo] bitcoin session bootstrap failed', err);
+      reportBootstrapFailure('sign-in', step, err);
       setBitcoin(null);
       setSigning('unavailable');
     } finally {


### PR DESCRIPTION
## What

The signing bootstrap now reports **which step** failed, at **error** level, and the last silent path is closed.

This is a prerequisite, not the cure. It does not fix signing — it makes the live failure diagnosable, which is what the next fix depends on.

## Why

Three unrelated subsystems fail into one `catch`:

1. `openSessionKey` — the browser's non-extractable IndexedDB key
2. `otpLoginToSession` — Turnkey's OTP_LOGIN
3. `ensureBitcoinFundingAccount` — deriving the BIP-84 Bitcoin account

All three logged the same `console.warn`, so the report distinguished none of them. And `console.warn` is dropped by the default **Errors** console filter — the filter someone is using when they are looking at a broken page. The one line explaining the outage was the one line they could not see.

That is not hypothetical. Diagnosing the current mainnet outage cost several round trips that this line would have ended immediately: with no step named, "signing is unavailable" is consistent with a browser-storage problem, a Turnkey API rejection, and a Bitcoin account-derivation failure at once.

It also closes the last silent path. On a real-network build:

```js
if (network === 'off' || !result.verificationToken || !sessionKey) return;  // signing stays 'none'
```

A missing browser key or a missing `verificationToken` are **failures** on such a build, not "no key yet" — but they left `signing` at `'none'`, which renders *"sign in again to get one"* for a browser that just did, and reported nothing at all. That is the same defect #499 fixed at the gate, one layer earlier.

## How

- `bootstrap-report.ts` is a **pure** module — the React provider only calls it, so the message builder is unit-testable. Same reason the format contract lives in `turnkey-session.ts`.
- Both entry points (fresh sign-in, restore-on-reload) tag their step and report the origin, so a reload failure is not misread as a sign-in failure.
- The error object is passed through **unflattened**, so Turnkey's own error fields stay inspectable rather than being stringified into a message.
- The two early-return conditions now report and set `unavailable` instead of returning silently.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Test addition or improvement

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] I have updated JSDoc comments for any changed public APIs
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Testing

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing (describe steps)

Landing suite **707 pass / 0 fail** (up 3). Typecheck and `vite build` clean.

Tests assert the properties that matter rather than the wording: every step yields a distinct, greppable `[step=…]` line; the origin is named; and the report goes to `error`, not `warn`, with the cause passed through by reference.

## Notes for the next fix

Two findings from reading Turnkey's shipped SDK while diagnosing this, recorded so they are not re-derived:

- **`@turnkey/core` never calls `otpLogin` directly.** Its `loginWithOtp` installs an *attested* stamper from the verification token and calls `stampLogin` instead:
  ```js
  await this.overrideAttestedStamper({ verificationToken, publicKey: verificationPublicKey });
  const loginRes = await this.httpClient.stampLogin({ publicKey: verificationPublicKey, ... }, StamperType.Attested);
  ```
- **We stamp OTP_LOGIN with the browser's key**, which Turnkey does not yet recognise — OTP_LOGIN is what registers it. The attested stamp exists for exactly this credential-less case, and is small and self-contained: `X-Stamp-Attested: base64url({publicKeyAttestation: <verificationToken>, scheme: "STAMP_ATTESTED_SCHEME_P256_VERIFICATION_TOKEN", publicKey, signature})`, DER-signed. Implementable without depending on `@turnkey/core`, which would pull ethers, viem and WalletConnect into a landing bundle.

That is the leading hypothesis, **not** a diagnosis: the funding-account step has never run live either, and until the log names a step, changing the login flow would be a guess. This PR is what turns that guess into a reading.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
