### PR TITLE
fix(landing): authenticate the bootstrap with Turnkey's attested stamp

### DIFF
--- a/.changeset/landing-attested-stamp-login.md
+++ b/.changeset/landing-attested-stamp-login.md
@@ -1,0 +1,29 @@
+---
+"@originals/landing": patch
+---
+
+**Fix: authenticate the signing bootstrap with Turnkey's attested stamp.**
+
+Signing failed on every real-network sign-in with:
+
+```
+Turnkey error 16: could not find public key in organization or its parent
+organization ... PUBLIC_KEY_NOT_FOUND
+```
+
+thrown at the request stamp, not the body. The bootstrap called the `otp_login`
+activity stamped with the browser's session key — a credential Turnkey has
+never seen, because logging in is what installs it. The request could not
+authenticate by construction.
+
+Turnkey's own SDK does not use that activity here. For a credential-less
+sub-org it configures an *attested* stamper from the verification token and
+calls `stamp_login`. The verification token is Turnkey's own signed artifact
+from verify-otp, so it authenticates a request from an org that holds no
+credential yet — which is precisely the moment this runs.
+
+The bootstrap now does the same: `X-Stamp-Attested` carrying the token, the
+bound public key, and a DER signature over the exact request body, exchanged at
+`/public/v1/submit/stamp_login`. Reproduced from `@turnkey/core` rather than
+depended on, since that package pulls ethers, viem and WalletConnect into a
+landing bundle.

--- a/apps/landing/DEPLOY.md
+++ b/apps/landing/DEPLOY.md
@@ -83,14 +83,15 @@ any of these is outstanding.
    sat→address only), so deposit polling costs no QuickNode quota and lives
    behind `BTC_INDEXER_API` instead.
 5. **One live Turnkey OTP verification.** Outstanding since PR #356. This
-   check earned its place: the login path was broken the entire time it went
-   unrun. Turnkey verifies OTP_LOGIN's `clientSignature` over a **raw**
-   IEEE-P1363 signature, every Turnkey stamper **defaults to DER**, and both
-   are plain hex strings — so no type, test, or build caught it and every live
-   sign-in ended in a failed signing bootstrap. Now pinned by
-   `OTP_LOGIN_SIGNATURE_FORMAT` and guarded before the network call, but the
-   only thing that proves the whole path works is running it against a real
-   org.
+   check earned its place twice over: the login path was broken the entire time
+   it went unrun, in two independent ways, and neither was reachable from any
+   test. It first sent a DER signature where OTP_LOGIN wants raw IEEE-P1363
+   (both are plain hex strings, so nothing local could tell them apart), and
+   underneath that it called the wrong activity entirely — an ordinary stamp on
+   `otp_login`, which Turnkey answers with `PUBLIC_KEY_NOT_FOUND` because the
+   credential being installed cannot already exist. It now runs STAMP_LOGIN
+   with the attested stamp, which is what `@turnkey/core` does. The only thing
+   that proves it works is running it against a real org.
 6. **One complete mainnet inscription by a human**, from a cold browser,
    before anyone else is invited.
 

--- a/apps/landing/src/auth/turnkey-browser-client.ts
+++ b/apps/landing/src/auth/turnkey-browser-client.ts
@@ -12,19 +12,16 @@
  */
 import { Turnkey, type TurnkeyIndexedDbClient } from '@turnkey/sdk-browser';
 import { SignatureFormat } from '@turnkey/sdk-types';
-import { OTP_LOGIN_SIGNATURE_FORMAT } from './turnkey-session';
 import type { SessionKeySigner, TurnkeyRevocationApi } from './turnkey-session';
 
 const TURNKEY_API_BASE_URL = 'https://api.turnkey.com';
 
 /**
- * Cross-check the contract stated in ./turnkey-session against Turnkey's own
- * enum. A renamed member stops resolving; a changed value fails this
- * assignment. Either way the typecheck breaks here instead of the signature
- * silently reverting to DER and signing failing in production again.
+ * Turnkey's attested stamp carries a DER signature (its own AttestedStamper
+ * passes SignatureFormat.Der). Stated explicitly rather than inherited: the
+ * default has been the wrong one before, and silence is how that happened.
  */
-const _rawIsStillRaw: typeof OTP_LOGIN_SIGNATURE_FORMAT = SignatureFormat.Raw;
-void _rawIsStillRaw;
+const STAMP_SIGNATURE_FORMAT = SignatureFormat.Der;
 
 /**
  * The session key plus the client that stamps with it. `signer` is the only
@@ -79,11 +76,9 @@ async function handleFor(subOrgId: string, opts: { reset: boolean }): Promise<Se
     client,
     signer: {
       publicKeyHex,
-      // The format is passed, never defaulted: the stamper's default is DER
-      // and Turnkey verifies OTP_LOGIN's clientSignature as raw IEEE-P1363,
-      // so omitting it produces a signature the API rejects. crypto.subtle
-      // hashes SHA-256 internally; the private key is never materialised.
-      sign: (message: string) => client.sign(message, SignatureFormat.Raw),
+      // crypto.subtle hashes SHA-256 internally; the private key is never
+      // materialised. The format is stated, never inherited.
+      signDer: (payload: string) => client.sign(payload, STAMP_SIGNATURE_FORMAT),
     },
     clear: () => client.clear(),
   };

--- a/apps/landing/src/auth/turnkey-session.test.ts
+++ b/apps/landing/src/auth/turnkey-session.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from 'bun:test';
 import {
-  otpLoginToSession,
-  OTP_LOGIN_SIGNATURE_FORMAT,
+  stampLoginToSession,
+  attestedStampValue,
   ensureBitcoinFundingAccount,
   type TurnkeyBitcoinClient,
   type TurnkeySessionApi,
@@ -81,7 +81,6 @@ import {
   clearSessionMeta,
   revokeSessionKey,
   restoreDecision,
-  loginClientSignatureMessage,
   decodeVerificationToken,
   type SigningSessionMeta,
   type SessionKeySigner,
@@ -189,70 +188,103 @@ describe('U1: signing capability survives a reload', () => {
   });
 });
 
-describe('U1: OTP_LOGIN runs off a non-extractable key', () => {
+describe('U1: STAMP_LOGIN authenticates with Turnkey\u2019s attested stamp', () => {
   const tokenId = 'tok-123';
   const sessionPublicKey = '02'.padEnd(66, 'b');
   const verificationToken = fakeVerificationToken({ id: tokenId, public_key: sessionPublicKey });
-
-  // A real raw P-256 signature: r‖s, 32 bytes each, hex — 128 chars. The old
-  // fixture returned 'deadbeef', which is why a DER-encoded signature (the
-  // stamper default, and the thing Turnkey actually rejects) passed this suite.
-  const rawSignature = 'ab'.repeat(64);
-  // What the stamper returns when the format is left to default: DER, 0x30 tag.
+  // The attested stamp carries a DER signature, per Turnkey's AttestedStamper.
   const derSignature = '3044' + 'cd'.repeat(68);
 
-  function signer(signature: string = rawSignature): SessionKeySigner & { signed: string[] } {
+  function signer(signature: string = derSignature): SessionKeySigner & { signed: string[] } {
     const signed: string[] = [];
     return {
       publicKeyHex: sessionPublicKey,
       signed,
-      // A non-extractable WebCrypto key can only be asked to sign a message;
+      // A non-extractable WebCrypto key can only be asked to sign a payload;
       // it can never hand over the private scalar. That is the whole point.
-      async sign(message: string) {
-        signed.push(message);
+      async signDer(payload: string) {
+        signed.push(payload);
         return signature;
       },
     };
+  }
+
+  function completed(session = 'session-jwt-xyz') {
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        activity: { status: 'ACTIVITY_STATUS_COMPLETED', result: { stampLoginResult: { session } } },
+      }),
+    } as unknown as Response;
   }
 
   test('decodeVerificationToken reads the bound public key and token id', () => {
     expect(decodeVerificationToken(verificationToken)).toEqual({ id: tokenId, public_key: sessionPublicKey });
   });
 
-  test('the login message is Turnkey’s USAGE_TYPE_LOGIN payload over tokenId + session public key', () => {
-    expect(loginClientSignatureMessage(tokenId, sessionPublicKey)).toBe(
-      JSON.stringify({ login: { publicKey: sessionPublicKey }, tokenId, type: 'USAGE_TYPE_LOGIN' })
+  // Turnkey verifies the stamp byte-for-byte, so base64url has to match
+  // @turnkey/encoding exactly: URL-safe alphabet AND stripped padding.
+  test('the stamp is base64url with padding stripped, and decodes to Turnkey\u2019s shape', () => {
+    const value = attestedStampValue({
+      verificationToken,
+      publicKey: sessionPublicKey,
+      signature: derSignature,
+    });
+    expect(value).not.toContain('=');
+    expect(value).not.toContain('+');
+    expect(value).not.toContain('/');
+    const decoded = JSON.parse(
+      atob(value.replace(/-/g, '+').replace(/_/g, '/').padEnd(Math.ceil(value.length / 4) * 4, '='))
     );
+    expect(decoded).toEqual({
+      publicKeyAttestation: verificationToken,
+      scheme: 'STAMP_ATTESTED_SCHEME_P256_VERIFICATION_TOKEN',
+      publicKey: sessionPublicKey,
+      signature: derSignature,
+    });
   });
 
-  test('otpLoginToSession signs with the injected key and sends the clientSignature object', async () => {
-    const calls: Array<Record<string, unknown>> = [];
-    const turnkey: TurnkeySessionApi = {
-      async otpLogin(params) {
-        calls.push(params as unknown as Record<string, unknown>);
-        return { session: 'session-jwt-xyz' };
-      },
-    };
+  test('the signed payload is byte-identical to the body sent', async () => {
+    let sentBody: string | undefined;
     const key = signer();
-    const t0 = 1_700_000_000_000;
-    const { session, meta } = await otpLoginToSession({
-      turnkey,
+    await stampLoginToSession({
       subOrgId: 'sub-1',
       verificationToken,
       signer: key,
+      now: () => 1_700_000_000_000,
+      fetchFn: (async (_url: string, init: RequestInit) => {
+        sentBody = init.body as string;
+        return completed();
+      }) as unknown as typeof fetch,
+    });
+    // Re-serialising between signing and sending would invalidate the stamp.
+    expect(key.signed).toHaveLength(1);
+    expect(sentBody).toBe(key.signed[0]);
+    expect(JSON.parse(sentBody!)).toEqual({
+      type: 'ACTIVITY_TYPE_STAMP_LOGIN',
+      timestampMs: '1700000000000',
+      organizationId: 'sub-1',
+      parameters: { publicKey: sessionPublicKey, expirationSeconds: String(SESSION_EXPIRATION_SECONDS) },
+    });
+  });
+
+  test('sends the attested stamp header and returns the session plus its expiry', async () => {
+    let headers: Record<string, string> | undefined;
+    const t0 = 1_700_000_000_000;
+    const { session, meta } = await stampLoginToSession({
+      subOrgId: 'sub-1',
+      verificationToken,
+      signer: signer(),
       now: () => t0,
+      fetchFn: (async (url: string, init: RequestInit) => {
+        expect(url).toContain('/public/v1/submit/stamp_login');
+        headers = init.headers as Record<string, string>;
+        return completed();
+      }) as unknown as typeof fetch,
     });
+    expect(headers?.['X-Stamp-Attested']).toBeTruthy();
     expect(session).toBe('session-jwt-xyz');
-    // The key signed the login message itself — no private scalar was read.
-    expect(key.signed).toEqual([loginClientSignatureMessage(tokenId, sessionPublicKey)]);
-    expect(calls[0].clientSignature).toEqual({
-      publicKey: sessionPublicKey,
-      scheme: 'CLIENT_SIGNATURE_SCHEME_API_P256',
-      message: loginClientSignatureMessage(tokenId, sessionPublicKey),
-      signature: rawSignature,
-    });
-    // Defaults to the extended window, and reports back when it dies.
-    expect(calls[0].expirationSeconds).toBe(String(SESSION_EXPIRATION_SECONDS));
     expect(meta).toEqual({
       subOrgId: 'sub-1',
       publicKey: sessionPublicKey,
@@ -260,42 +292,36 @@ describe('U1: OTP_LOGIN runs off a non-extractable key', () => {
     });
   });
 
-  // The live bug: every Turnkey stamper defaults to DER, Turnkey verifies
-  // OTP_LOGIN's clientSignature as raw IEEE-P1363, and nothing between the two
-  // is typed differently — both are plain hex strings. Only the API said no,
-  // and it said so as an opaque bootstrap failure.
-  test('OTP_LOGIN_SIGNATURE_FORMAT pins the encoding Turnkey verifies, not the stamper default', () => {
-    expect(OTP_LOGIN_SIGNATURE_FORMAT).toBe('raw');
+  // The failure that started this: Turnkey answered PUBLIC_KEY_NOT_FOUND and
+  // the only reason it was diagnosable is that its own words survived.
+  test('a rejection carries Turnkey\u2019s own message, not just a status code', async () => {
+    await expect(
+      stampLoginToSession({
+        subOrgId: 'sub-1',
+        verificationToken,
+        signer: signer(),
+        fetchFn: (async () => ({
+          ok: false,
+          status: 401,
+          json: async () => ({ message: 'could not find public key in organization' }),
+        })) as unknown as typeof fetch,
+      })
+    ).rejects.toThrow(/could not find public key/);
   });
 
-  test('a DER signature is refused here, naming DER, rather than by Turnkey', async () => {
-    // The fake SUCCEEDS on purpose. If the guard is ever removed, this test
-    // fails instead of passing on the fake's own error text.
-    let called = false;
-    const turnkey: TurnkeySessionApi = {
-      async otpLogin() {
-        called = true;
-        return { session: 'must-not-be-reached' };
-      },
-    };
+  test('an activity that did not complete is not mistaken for a session', async () => {
     await expect(
-      otpLoginToSession({ turnkey, subOrgId: 'sub-1', verificationToken, signer: signer(derSignature) })
-    ).rejects.toThrow(/that is DER, the stamper default/);
-    expect(called).toBe(false);
-  });
-
-  test('any non-raw signature length is refused before the network call', async () => {
-    let called = false;
-    const turnkey: TurnkeySessionApi = {
-      async otpLogin() {
-        called = true;
-        return { session: 's' };
-      },
-    };
-    await expect(
-      otpLoginToSession({ turnkey, subOrgId: 'sub-1', verificationToken, signer: signer('deadbeef') })
-    ).rejects.toThrow(/raw \(IEEE-P1363\)/);
-    expect(called).toBe(false);
+      stampLoginToSession({
+        subOrgId: 'sub-1',
+        verificationToken,
+        signer: signer(),
+        fetchFn: (async () => ({
+          ok: true,
+          status: 200,
+          json: async () => ({ activity: { status: 'ACTIVITY_STATUS_PENDING' } }),
+        })) as unknown as typeof fetch,
+      })
+    ).rejects.toThrow(/did not complete/);
   });
 });
 

--- a/apps/landing/src/auth/turnkey-session.ts
+++ b/apps/landing/src/auth/turnkey-session.ts
@@ -58,32 +58,15 @@ export interface SigningSessionMeta {
 export type SigningStatus = 'none' | 'active' | 'expired' | 'unavailable';
 
 /**
- * A handle to the session key. `sign` takes the message and returns a hex
- * signature; the caller can never obtain the private key, because a
+ * A handle to the session key. `signDer` takes the exact request body and
+ * returns a DER-encoded hex signature — the encoding Turnkey's attested stamp
+ * carries. The caller can never obtain the private key, because a
  * non-extractable CryptoKey has none to give.
  */
 export interface SessionKeySigner {
   /** Compressed P-256 public key hex. */
   publicKeyHex: string;
-  sign(message: string): Promise<string>;
-}
-
-export interface ClientSignature {
-  publicKey: string;
-  scheme: 'CLIENT_SIGNATURE_SCHEME_API_P256';
-  message: string;
-  signature: string;
-}
-
-/** The single OTP_LOGIN activity the session bootstrap needs. */
-export interface TurnkeySessionApi {
-  otpLogin(params: {
-    organizationId: string;
-    verificationToken: string;
-    publicKey: string;
-    clientSignature: ClientSignature;
-    expirationSeconds?: string;
-  }): Promise<{ session: string }>;
+  signDer(payload: string): Promise<string>;
 }
 
 /** The Bitcoin-signing + account surface the rest of Track B consumes. */
@@ -144,83 +127,156 @@ export function decodeVerificationToken(token: string): { id: string; public_key
 }
 
 /**
- * The signature encoding Turnkey verifies OTP_LOGIN's clientSignature in: RAW
- * IEEE-P1363 (r‖s), which `@turnkey/core` passes as `SignatureFormat.Raw`.
+ * Turnkey's ATTESTED stamp: how a request is authenticated for an org that
+ * holds no credential yet.
  *
- * Every Turnkey stamper DEFAULTS to DER instead, and DER is what the API
- * rejects — so this is passed explicitly at every call site and never left to
- * the default. Lives in this pure module, not the browser client, so the
- * contract is stated somewhere `bun test` can actually reach.
+ * This is the crux of the whole bootstrap. Straight after verify-otp the
+ * sub-org has NO registered key — the browser's key is exactly what login is
+ * about to install. So the request cannot be stamped the ordinary way: signing
+ * it with the browser key makes Turnkey answer
+ * `PUBLIC_KEY_NOT_FOUND` ("could not find public key in organization"), which
+ * is precisely what it did. The credential does not exist yet; that is the
+ * point of logging in.
+ *
+ * The attested stamp resolves the circularity by presenting the verification
+ * token — which Turnkey itself issued and signed at verify-otp — as the
+ * attestation, alongside a signature proving the caller holds the key that
+ * token was bound to.
+ *
+ * Mirrors `AttestedStamper` in @turnkey/core exactly, which is unpublished as
+ * a standalone package. Reproduced rather than depended on because
+ * @turnkey/core pulls ethers, viem and WalletConnect into a landing bundle.
  */
-export const OTP_LOGIN_SIGNATURE_FORMAT = 'raw';
+export const ATTESTED_STAMP_HEADER = 'X-Stamp-Attested';
+export const ATTESTED_SCHEME_VERIFICATION_TOKEN = 'STAMP_ATTESTED_SCHEME_P256_VERIFICATION_TOKEN';
+
+/** Turnkey's own endpoint and activity for exchanging that stamp for a session. */
+export const TURNKEY_API_BASE_URL = 'https://api.turnkey.com';
+export const STAMP_LOGIN_PATH = '/public/v1/submit/stamp_login';
+export const STAMP_LOGIN_ACTIVITY = 'ACTIVITY_TYPE_STAMP_LOGIN';
 
 /**
- * Raw P-256 is r‖s, 32 bytes each — exactly 128 hex chars. DER is
- * variable-length and starts with the 0x30 SEQUENCE tag.
+ * String → base64url. Mirrors `stringToBase64urlString` in @turnkey/encoding:
+ * `btoa` over the raw string, then URL-safe, then padding STRIPPED. Turnkey
+ * verifies the stamp byte-for-byte, so each of those three steps matters.
+ * `btoa` (not TextEncoder) is deliberate — it is what Turnkey calls, and the
+ * stamp JSON is ASCII, so the two agree.
  */
-const RAW_P256_SIGNATURE_HEX = /^[0-9a-f]{128}$/i;
+export function encodeBase64Url(input: string): string {
+  return btoa(input).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
 
-/**
- * The exact message Turnkey verifies for OTP_LOGIN's clientSignature — field
- * order included, since the signature is over this JSON string. Mirrors
- * `getClientSignatureMessageForLogin` in @turnkey/core.
- */
-export function loginClientSignatureMessage(tokenId: string, sessionPublicKey: string): string {
-  return JSON.stringify({ login: { publicKey: sessionPublicKey }, tokenId, type: 'USAGE_TYPE_LOGIN' });
+/** The `X-Stamp-Attested` header value for a request body. */
+export function attestedStampValue(opts: {
+  verificationToken: string;
+  publicKey: string;
+  signature: string;
+}): string {
+  // Field order is Turnkey's. The value is a JSON blob it parses, not a
+  // signature input, but keeping the order identical keeps the diff against
+  // their implementation readable.
+  return encodeBase64Url(
+    JSON.stringify({
+      publicKeyAttestation: opts.verificationToken,
+      scheme: ATTESTED_SCHEME_VERIFICATION_TOKEN,
+      publicKey: opts.publicKey,
+      signature: opts.signature,
+    })
+  );
 }
 
 /**
- * Run OTP_LOGIN: sign the login message with the browser's non-extractable
- * P-256 key and exchange it for a session credential valid for
- * `expirationSeconds`. Returns the metadata the reload path needs to know the
- * session is still alive — never the key.
- *
- * The message construction mirrors `getClientSignatureMessageForLogin` in
- * @turnkey/core exactly, field order included, and the signature is raw
- * IEEE-P1363 per OTP_LOGIN_SIGNATURE_FORMAT — the DER default was what made
- * every live attempt fail before it was pinned.
+ * The STAMP_LOGIN request body, as the exact string that is BOTH signed and
+ * sent. Re-serialising it after signing would risk a different byte sequence
+ * and an invalid stamp, so callers must send this string verbatim.
  */
-export async function otpLoginToSession(deps: {
-  turnkey: TurnkeySessionApi;
+export function stampLoginBody(opts: {
   subOrgId: string;
+  publicKey: string;
+  expirationSeconds: number;
+  timestampMs: number;
+}): string {
+  return JSON.stringify({
+    type: STAMP_LOGIN_ACTIVITY,
+    timestampMs: String(opts.timestampMs),
+    organizationId: opts.subOrgId,
+    parameters: {
+      publicKey: opts.publicKey,
+      expirationSeconds: String(opts.expirationSeconds),
+    },
+  });
+}
+
+/** What Turnkey answers with. Only the completed shape carries a session. */
+interface StampLoginResponse {
+  activity?: {
+    status?: string;
+    result?: { stampLoginResult?: { session?: string } };
+  };
+  message?: string;
+}
+
+/**
+ * Exchange the verification token for a signing session (STAMP_LOGIN).
+ *
+ * This is the flow @turnkey/core runs for a credential-less sub-org: configure
+ * an attested stamper from the verification token, then call stamp_login. It
+ * does NOT call the otp_login activity, and neither do we — an ordinary stamp
+ * there is unauthenticatable for the reason described above.
+ *
+ * Returns the metadata the reload path needs to know the session is alive —
+ * never the key.
+ */
+export async function stampLoginToSession(deps: {
   verificationToken: string;
+  subOrgId: string;
   signer: SessionKeySigner;
   expirationSeconds?: number;
   now?: () => number;
+  fetchFn?: typeof fetch;
+  apiBaseUrl?: string;
 }): Promise<{ session: string; meta: SigningSessionMeta }> {
-  const { id: tokenId, public_key: boundPublicKey } = decodeVerificationToken(deps.verificationToken);
-  const sessionPublicKey = boundPublicKey || deps.signer.publicKeyHex;
-  const message = loginClientSignatureMessage(tokenId, sessionPublicKey);
+  const { public_key: boundPublicKey } = decodeVerificationToken(deps.verificationToken);
+  // The token's bound key IS the browser's key (verify-otp bound it to exactly
+  // that), and it is the key the stamp attests to. Prefer the token's copy:
+  // Turnkey checks the stamp against the token, not against our belief.
+  const publicKey = boundPublicKey || deps.signer.publicKeyHex;
   const expirationSeconds = deps.expirationSeconds ?? SESSION_EXPIRATION_SECONDS;
-  const signature = await deps.signer.sign(message);
-  // Refuse a DER signature HERE, naming it. Every local type accepts one — the
-  // stamper returns a plain hex string either way — and only Turnkey rejects
-  // it, as an opaque bootstrap failure with no clue as to the cause.
-  if (!RAW_P256_SIGNATURE_HEX.test(signature)) {
-    const looksDer = signature.startsWith('30') ? ' — that is DER, the stamper default' : '';
-    throw new Error(
-      `OTP_LOGIN needs a raw (IEEE-P1363) P-256 signature; got ${signature.length} hex chars${looksDer}`
-    );
-  }
-  const clientSignature: ClientSignature = {
-    publicKey: sessionPublicKey,
-    scheme: 'CLIENT_SIGNATURE_SCHEME_API_P256',
-    message,
-    signature,
-  };
   const requestedAt = (deps.now ?? Date.now)();
-  const { session } = await deps.turnkey.otpLogin({
-    organizationId: deps.subOrgId,
-    verificationToken: deps.verificationToken,
-    publicKey: sessionPublicKey,
-    clientSignature,
-    expirationSeconds: String(expirationSeconds),
+
+  const body = stampLoginBody({
+    subOrgId: deps.subOrgId,
+    publicKey,
+    expirationSeconds,
+    timestampMs: requestedAt,
   });
+  const signature = await deps.signer.signDer(body);
+  const stamp = attestedStampValue({ verificationToken: deps.verificationToken, publicKey, signature });
+
+  const doFetch = deps.fetchFn ?? fetch;
+  const res = await doFetch(`${deps.apiBaseUrl ?? TURNKEY_API_BASE_URL}${STAMP_LOGIN_PATH}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', [ATTESTED_STAMP_HEADER]: stamp },
+    body,
+  });
+  const json = (await res.json().catch(() => ({}))) as StampLoginResponse;
+  if (!res.ok) {
+    // Carry Turnkey's own words. The previous failure was legible only because
+    // its message named the cause; a generic status code would not have been.
+    throw new Error(`STAMP_LOGIN failed (${res.status}): ${json.message ?? 'no message'}`);
+  }
+  const status = json.activity?.status;
+  if (status !== 'ACTIVITY_STATUS_COMPLETED') {
+    throw new Error(`STAMP_LOGIN did not complete: ${status ?? 'no activity status'}`);
+  }
+  const session = json.activity?.result?.stampLoginResult?.session;
+  if (!session) throw new Error('STAMP_LOGIN completed without returning a session');
+
   return {
     session,
     meta: {
       subOrgId: deps.subOrgId,
-      publicKey: sessionPublicKey,
+      publicKey,
       expiresAt: requestedAt + expirationSeconds * 1000,
     },
   };

--- a/apps/landing/src/auth/useAuth.tsx
+++ b/apps/landing/src/auth/useAuth.tsx
@@ -3,7 +3,7 @@ import * as api from './api';
 import type { AuthUser } from './api';
 import { createUserWebVHDid } from './webvh';
 import {
-  otpLoginToSession,
+  stampLoginToSession,
   ensureBitcoinFundingAccount,
   readSessionMeta,
   writeSessionMeta,
@@ -13,7 +13,6 @@ import {
   restoreDecision,
   type SigningStatus,
   type TurnkeyBitcoinClient,
-  type TurnkeySessionApi,
 } from './turnkey-session';
 import type { SessionKeyHandle } from './turnkey-browser-client';
 import { browserKeyStorage } from './browser-storage';
@@ -191,8 +190,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const bound = await openSessionKey(result.subOrgId);
       const signingClient = bound.client as unknown as TurnkeyBitcoinClient;
       step = 'otp-login';
-      const { meta } = await otpLoginToSession({
-        turnkey: signingClient as unknown as TurnkeySessionApi,
+      const { meta } = await stampLoginToSession({
         subOrgId: result.subOrgId,
         verificationToken: result.verificationToken,
         signer: bound.signer,


### PR DESCRIPTION
## What

Authenticates the signing bootstrap with Turnkey's **attested stamp** and `stamp_login`, replacing the `otp_login` call that could never have worked.

This is the actual cause of the live outage, confirmed from the error rather than inferred.

## Why

```
Turnkey error 16: could not find public key in organization or its parent organization
organizationId=00da079c-… publicKey=02a69fed…
turnkeyErrorCode: PUBLIC_KEY_NOT_FOUND
    at Z.request   ← the stamp, not the body
```

Raised at `request()`, which is **stamp verification** — the request never reached body validation.

The bootstrap called `otp_login` through the IndexedDb client, and that client stamps every request with the browser's session key. Turnkey has never seen that key. Registering it is *what logging in does*. So the request could not authenticate by construction: the credential it needs to prove itself with is the credential it is asking to create. No amount of fixing the body could have helped.

**Turnkey's own SDK never calls that activity here.** For a credential-less sub-org, `@turnkey/core`'s `loginWithOtp` does this:

```js
await this.overrideAttestedStamper({ verificationToken, publicKey: verificationPublicKey });
const loginRes = await this.httpClient.stampLogin({ publicKey: verificationPublicKey, ... }, StamperType.Attested);
```

The attested stamp resolves the circularity: it presents the **verification token** — Turnkey's own signed artifact from verify-otp — as the attestation, plus a signature proving the caller holds the key that token was bound to. That is exactly the credential-less moment this runs in.

## How

`X-Stamp-Attested: base64url({publicKeyAttestation, scheme, publicKey, signature})`, DER-signed over the exact body, POSTed to `/public/v1/submit/stamp_login`.

Reproduced from `@turnkey/core` rather than depended on: that package pulls **ethers, viem and WalletConnect**, which has no place in a landing bundle. The stamper it comes from is internal to core (`__stampers__/attested/base.js`), not separately published.

Details that had to be exact, each pinned by a test:

- **The body is signed and sent verbatim.** Re-serialising between signing and sending risks a different byte sequence and an invalid stamp, so `stampLoginBody()` returns the string and both paths use that one value.
- **base64url matches `@turnkey/encoding`**: `btoa`, URL-safe alphabet, padding **stripped**. Cross-checked against Node's independent `base64url` over every padding residue and the `+`/`/` cases.
- **The signature is DER**, per Turnkey's `AttestedStamper`, and is stated explicitly rather than inherited — inheriting a default is how #500 happened.
- **Turnkey's own error message survives** a rejection. The only reason this outage was diagnosable at all is that its words came through; a bare status code would have told us nothing.

Dead code from the old flow is removed rather than left behind: `otpLoginToSession`, `ClientSignature`, `TurnkeySessionApi`, and the OTP_LOGIN message builder.

**Relationship to #500.** That bug was real — `otp_login`'s `clientSignature` does want raw IEEE-P1363 and we sent DER — and the reasoning still holds for that activity. But the request never got as far as the body, so #500 corrected a path we no longer take. Superseded, not reverted.

Related: #494

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Test addition or improvement

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] I have updated JSDoc comments for any changed public APIs
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Testing

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing (describe steps)

Landing suite **710 pass / 0 fail**. Root and landing typechecks clean, lint clean, `vite build` clean.

The tests assert the properties Turnkey actually verifies — byte-identical signed-and-sent body, stamp encoding and decoded shape, header presence, error-message passthrough, and that a non-completed activity is not mistaken for a session — rather than restating the implementation.

**What is still unverified:** that a real sign-in completes. This was built from Turnkey's shipped SDK (`@turnkey/core@2.7.1`, `@turnkey/sdk-browser@7.0.0`, `@turnkey/indexed-db-stamper@1.3.2`, `@turnkey/encoding@0.6.0`), and the diagnosis is now grounded in the live error rather than inference — but `ensureBitcoinFundingAccount` still has never run live, and it is the next step after this one. #501's step labelling will name it if it fails.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
