### PR TITLE
feat(landing): put paying first on the deposit screen, with a QR and copy

### DIFF
--- a/.changeset/landing-deposit-panel-redesign.md
+++ b/.changeset/landing-deposit-panel-redesign.md
@@ -1,0 +1,25 @@
+---
+"@originals/landing": patch
+---
+
+**Deposit screen: pay first, read second — plus a QR and a copy button.**
+
+The amount was stated, then five paragraphs of disclosure, then the address.
+Someone who had already decided to pay had to read ~250 words of terms to
+reach the string they needed — which is how a person learns to scroll past
+terms rather than read them.
+
+Now the action comes first: amount, address, copy button, and a scannable
+BIP-21 QR in one block. Below it, the substance of the two money risks (no
+withdraw or refund, no reversing a broadcast fee) in a form that needs no
+click. Below that, the full R27 text — complete and unedited — in a `<details>`
+on the same screen.
+
+Nothing was deleted and nothing moved off the page. A test asserts every line
+of the disclosure contract is still rendered, and that the short lines are
+additions rather than replacements.
+
+Also: the deposit address had no copy button, on the one screen in the app
+where a string has to be exact because real money depends on it, while three
+other screens had one. The `bitcoin:` link carries the address and the exact
+amount, so paying involves no transcription at all.

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -32,6 +32,7 @@
     "@turnkey/crypto": "^2.10.0",
     "@turnkey/sdk-browser": "^7.0.0",
     "didwebvh-ts": "^2.8.0",
+    "qrcode-generator": "2.0.4",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   },

--- a/apps/landing/src/components/Demo.tsx
+++ b/apps/landing/src/components/Demo.tsx
@@ -23,7 +23,7 @@ type Phase =
   | 'inscribed';
 
 /** GET /api/btc/deposit — the creator's own UTXOs + the estimated fee target. */
-interface DepositInfo {
+export interface DepositInfo {
   address: string;
   /** The ORDINAL-CHECKED spendable set — what an inscription may fund from. */
   confirmedUtxos: Array<{ txid: string; vout: number; value: number; scriptPubKey: string }>;
@@ -291,6 +291,28 @@ export function depositDisclosure(): string[] {
     demo.deposit.nonRefundable,
     demo.deposit.ifSomethingGoesWrong,
   ];
+}
+
+/**
+ * The quote to render, or nothing.
+ *
+ * A DepositInfo names the address it was fetched for, and a quote is only ever
+ * true of that address. `reset()` on an identity change clears the engine and
+ * the asset but not this, so a stale quote could pair the PREVIOUS account's
+ * balance with the NEW account's address — showing "ready to inscribe" to
+ * someone who has sent nothing, and, now that the two are fused into one
+ * BIP-21 URI, putting the old amount behind the new address in the wallet
+ * link and the QR.
+ *
+ * Matching on the address rather than clearing on identity also covers the
+ * window before the first fetch for a new address returns.
+ */
+export function quoteForAddress(
+  info: DepositInfo | null,
+  address: string | null | undefined
+): DepositInfo | null {
+  if (!info || !address) return null;
+  return info.address === address ? info : null;
 }
 
 /** What the deposit badge should say — read off the SUM, never one output. */
@@ -703,7 +725,7 @@ export function Demo() {
   // Creator-pays deposit state (mainnet): the user's own confirmed UTXOs at
   // their Turnkey-derived address, polled while the inscribe step is live so
   // "deposit detected → confirmed" updates without a reload.
-  const [deposit, setDeposit] = useState<DepositInfo | null>(null);
+  const [depositRaw, setDeposit] = useState<DepositInfo | null>(null);
   const [depositError, setDepositError] = useState<string | null>(null);
   // Mirror of depositError readable synchronously inside the inscribe click —
   // state set during that same await would still be stale there, and the
@@ -713,6 +735,8 @@ export function Demo() {
   // Which system is down, in badge form — see depositErrorCopy.
   const [depositBadge, setDepositBadge] = useState<string | null>(null);
   // Computed once per render: the badge below reads it four times.
+  // Never render a quote belonging to another address (see quoteForAddress).
+  const deposit = quoteForAddress(depositRaw, bitcoin?.fundingAddress);
   const readiness = depositReadiness(deposit);
   const fetchDeposit = useCallback(async (): Promise<DepositInfo | null> => {
     if (!bitcoin) return null;
@@ -815,6 +839,11 @@ export function Demo() {
     setTab('events');
     setCommitted(null);
     setUpdating(false);
+    // The previous identity's money view is not the new one's.
+    setDeposit(null);
+    setDepositError(null);
+    setDepositBadge(null);
+    depositErrorRef.current = null;
     setNonce(Math.floor(Math.random() * 1e9)); // fresh artwork for the next run
     // Next run gets a fresh engine — fresh keys, fresh DIDs, fresh publisher.
     // window.__originalsDemo keeps pointing at the old engine until the new

--- a/apps/landing/src/components/Demo.tsx
+++ b/apps/landing/src/components/Demo.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { DepositPanel } from './DepositPanel';
 import { demo } from '../content';
 import type { DemoAssetState, DemoEngine } from '../sdk/engine';
 import { engineIdentity, ANON_IDENTITY } from '../sdk/engine';
@@ -1117,24 +1118,20 @@ export function Demo() {
                             : depositBadgeLabel(readiness, demo.deposit)}
                         </span>
                       </div>
-                      {deposit && (
-                        <p className="demo-inscribe-note">
-                          {demo.deposit.sendPrefix}{' '}
-                          <code>{deposit.estimatedCostSats.toLocaleString()} sats</code>{' '}
-                          {demo.deposit.sendSuffix}
-                        </p>
-                      )}
-                      {/* R27: what the deposit is for, where the address came
-                          from, and what happens to a balance that is never
-                          spent — ABOVE the address, and in every state, so a
-                          top-up and a return visit read it too. */}
-                      {depositDisclosure().map((line) => (
-                        <p className="demo-inscribe-note" key={line}>{line}</p>
-                      ))}
+                      {/* R27 still renders in full and in every state — it
+                          moved INTO DepositPanel, below the address rather
+                          than between the amount and it. depositDisclosure()
+                          remains the contract for what must be present. */}
                       {deposit ? (
-                        <p className="demo-inscribe-note">
-                          {demo.deposit.addressLabel}: <code>{bitcoin.fundingAddress}</code>
-                        </p>
+                        <>
+                          <DepositPanel
+                            address={bitcoin.fundingAddress}
+                            sats={deposit.estimatedCostSats}
+                          />
+                          <p className="demo-inscribe-note deposit-topup">
+                            {demo.deposit.topUpNote}
+                          </p>
+                        </>
                       ) : depositError ? (
                         // The one fee source is down, so there is no honest
                         // amount to quote — say that, and show no address.

--- a/apps/landing/src/components/DepositPanel.tsx
+++ b/apps/landing/src/components/DepositPanel.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+import { demo } from '../content';
+import { bitcoinPaymentUri } from '../sdk/bitcoin-uri';
+import { DepositQr } from './DepositQr';
+import './deposit.css';
+
+/**
+ * The fund-your-inscription action.
+ *
+ * Ordering is the whole design. Previously the amount was stated, then five
+ * paragraphs of disclosure, then — finally — the address. Someone who has
+ * decided to pay had to read ~250 words of terms to reach the string they
+ * needed, which is how a person ends up scrolling past the terms rather than
+ * reading them.
+ *
+ * So: pay first, in one block — amount, address, copy, scan. Then the
+ * substance of the two money risks, unmissable and requiring no interaction.
+ * Then the full R27 text, complete and unedited, in a <details> on the same
+ * screen. Nothing was deleted and nothing moved off the page; what changed is
+ * that the disclosure no longer stands between a person and the thing they
+ * came here to do.
+ */
+export function DepositPanel({ address, sats }: { address: string; sats: number }) {
+  const [copied, setCopied] = useState(false);
+  const uri = bitcoinPaymentUri(address, sats);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(address);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard can be unavailable (permissions, insecure origin) — the
+      // address stays selectable, and the QR is a second way through.
+    }
+  };
+
+  return (
+    <div className="deposit">
+      <div className="deposit-amount">
+        <span className="deposit-amount-label">{demo.deposit.sendPrefix}</span>
+        <strong className="deposit-amount-value">{sats.toLocaleString()}</strong>
+        <span className="deposit-amount-unit">sats</span>
+      </div>
+
+      <div className="deposit-pay">
+        <div className="deposit-pay-main">
+          <span className="deposit-address-label">{demo.deposit.addressLabel}</span>
+          {/* Broken into a <code> that wraps on character boundaries: a bech32
+              address that overflows its box is one a person cannot read back
+              to check, which is exactly when they mistrust the screen. */}
+          <code className="deposit-address">{address}</code>
+          <div className="deposit-actions">
+            <button
+              type="button"
+              className="deposit-copy"
+              onClick={() => void copy()}
+              aria-label={demo.deposit.copyAddressAria}
+              data-copied={copied || undefined}
+            >
+              {copied ? demo.deposit.copiedAddress : demo.deposit.copyAddress}
+            </button>
+            <a className="deposit-wallet" href={uri}>
+              {demo.deposit.openInWallet}
+            </a>
+          </div>
+          <p className="deposit-hint">{demo.deposit.openInWalletHint}</p>
+        </div>
+
+        <div className="deposit-scan">
+          <DepositQr value={uri} />
+          <p className="deposit-hint deposit-hint-center">{demo.deposit.scanHint}</p>
+        </div>
+      </div>
+
+      <p className="deposit-purpose">{demo.deposit.purposeShort}</p>
+
+      {/* Not a <details>: the two money risks are the one thing that must not
+          need a click. */}
+      <p className="deposit-risk" role="note">{demo.deposit.riskSummary}</p>
+
+      <details className="deposit-details">
+        <summary>{demo.deposit.detailsSummary}</summary>
+        <div className="deposit-details-body">
+          <p>{demo.deposit.purpose}</p>
+          <p>{demo.deposit.addressOrigin}</p>
+          <p>{demo.deposit.unspentBalance}</p>
+          <p>{demo.deposit.nonRefundable}</p>
+          <p>{demo.deposit.ifSomethingGoesWrong}</p>
+        </div>
+      </details>
+    </div>
+  );
+}

--- a/apps/landing/src/components/DepositQr.tsx
+++ b/apps/landing/src/components/DepositQr.tsx
@@ -1,0 +1,39 @@
+import { useMemo } from 'react';
+import { qrPath } from '../sdk/qr-path';
+
+/**
+ * The deposit address as a scannable BIP-21 code.
+ *
+ * Rendered as inline SVG rather than a canvas or an image so it stays crisp at
+ * any size, needs no ref or effect, and carries no external request.
+ *
+ * Error correction is 'M'. 'L' would be denser but this code is pointed at by
+ * a phone camera, often at a screen with glare, and a misread is a payment to
+ * nowhere — though in practice a corrupted bech32 address fails its checksum
+ * in the wallet rather than sending anywhere.
+ */
+export function DepositQr({ value, size = 168 }: { value: string; size?: number }) {
+  const { path, count } = useMemo(() => qrPath(value), [value]);
+
+  // The quiet zone is part of the spec, not padding: scanners need it to find
+  // the code at all. Four modules on each side, inside the viewBox.
+  const quiet = 4;
+  const extent = count + quiet * 2;
+
+  return (
+    <svg
+      className="deposit-qr"
+      viewBox={`0 0 ${extent} ${extent}`}
+      width={size}
+      height={size}
+      role="img"
+      aria-label="Scan to pay this deposit address"
+      shapeRendering="crispEdges"
+    >
+      <rect width={extent} height={extent} fill="#ffffff" />
+      <g transform={`translate(${quiet} ${quiet})`} fill="#08090c">
+        <path d={path} />
+      </g>
+    </svg>
+  );
+}

--- a/apps/landing/src/components/deposit-panel.test.ts
+++ b/apps/landing/src/components/deposit-panel.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { demo } from '../content';
-import { depositDisclosure } from './Demo';
+import { depositDisclosure, quoteForAddress, depositReadiness } from './Demo';
 import { bitcoinPaymentUri } from '../sdk/bitcoin-uri';
 
 /**
@@ -67,5 +67,44 @@ describe('paying takes no transcription', () => {
   test('the QR encodes that same URI, not the bare address', () => {
     // Same helper feeds the link and the code, so they cannot drift apart.
     expect(bitcoinPaymentUri(address, 14_580)).toContain('amount=');
+  });
+});
+
+describe('a quote never crosses to another address', () => {
+  const A = 'bc1qwx77y7n2dvcfy2aejnrxcapevmssfezc4ly4rl';
+  const B = 'bc1qaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const quote = (address: string) => ({
+    address,
+    confirmedUtxos: [],
+    confirmedSats: 50_000,
+    unconfirmedSats: 0,
+    estimatedCostSats: 14_580,
+  });
+
+  test('a quote for the current address is used', () => {
+    expect(quoteForAddress(quote(A), A)).not.toBeNull();
+  });
+
+  /**
+   * The bug: reset() on an identity change clears the engine and the asset but
+   * not the quote, so the previous account's balance could be shown against
+   * the new account's address — "ready to inscribe" for someone who has sent
+   * nothing, and the old amount behind the new address in the wallet link.
+   */
+  test('a quote left over from another identity is not', () => {
+    expect(quoteForAddress(quote(A), B)).toBeNull();
+  });
+
+  test('nothing is rendered before an address is known', () => {
+    expect(quoteForAddress(quote(A), null)).toBeNull();
+    expect(quoteForAddress(quote(A), undefined)).toBeNull();
+    expect(quoteForAddress(null, A)).toBeNull();
+  });
+
+  // The readiness badge reads off the quote, so the guard has to sit upstream
+  // of it — otherwise the stale balance still turns the badge green.
+  test('a mismatched quote cannot drive the readiness badge', () => {
+    expect(depositReadiness(quoteForAddress(quote(A), B))).toBe('waiting');
+    expect(depositReadiness(quoteForAddress(quote(A), A))).not.toBe('waiting');
   });
 });

--- a/apps/landing/src/components/deposit-panel.test.ts
+++ b/apps/landing/src/components/deposit-panel.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect } from 'bun:test';
+import { demo } from '../content';
+import { depositDisclosure } from './Demo';
+import { bitcoinPaymentUri } from '../sdk/bitcoin-uri';
+
+/**
+ * The redesign moved the R27 disclosure from BETWEEN the amount and the
+ * address to BELOW both. The risk in any such move is that text quietly goes
+ * missing, so these assert the opposite: every original line is still on the
+ * screen, and the shortened lines add to them rather than replace them.
+ */
+describe('the deposit redesign keeps every word of the disclosure', () => {
+  const rendered = [
+    demo.deposit.purposeShort,
+    demo.deposit.riskSummary,
+    // What the <details> renders, in order.
+    demo.deposit.purpose,
+    demo.deposit.addressOrigin,
+    demo.deposit.unspentBalance,
+    demo.deposit.nonRefundable,
+    demo.deposit.ifSomethingGoesWrong,
+  ];
+
+  test('every line of the R27 contract is still rendered', () => {
+    for (const line of depositDisclosure()) {
+      expect(rendered).toContain(line);
+    }
+  });
+
+  test('the short lines are additions, not replacements', () => {
+    // If a summary were ever swapped IN for a full line, the count drops.
+    expect(rendered.length).toBe(depositDisclosure().length + 2);
+  });
+});
+
+describe('the two money risks do not require a click to see', () => {
+  const risk = demo.deposit.riskSummary;
+
+  test('names the absence of a withdrawal and of a refund', () => {
+    expect(/no withdraw/i.test(risk)).toBe(true);
+    expect(/refund/i.test(risk)).toBe(true);
+  });
+
+  test('names irreversibility, and does not exempt us from it', () => {
+    expect(/can.t be reversed|cannot be reversed/i.test(risk)).toBe(true);
+    expect(/us included|including us/i.test(risk)).toBe(true);
+  });
+
+  test('tells them to send the quoted amount, not a round number', () => {
+    expect(/round number/i.test(risk)).toBe(true);
+  });
+
+  // The summary must not promise a way out that the long-form line denies.
+  test('promises no refund path anywhere', () => {
+    expect(/we (?:can|will) (?:send|return|refund) it back/i.test(risk)).toBe(false);
+  });
+});
+
+describe('paying takes no transcription', () => {
+  const address = 'bc1qwx77y7n2dvcfy2aejnrxcapevmssfezc4ly4rl';
+
+  test('the wallet link carries both the address and the exact quoted amount', () => {
+    const uri = bitcoinPaymentUri(address, 14_580);
+    expect(uri).toBe(`bitcoin:${address}?amount=0.0001458`);
+  });
+
+  test('the QR encodes that same URI, not the bare address', () => {
+    // Same helper feeds the link and the code, so they cannot drift apart.
+    expect(bitcoinPaymentUri(address, 14_580)).toContain('amount=');
+  });
+});

--- a/apps/landing/src/components/deposit.css
+++ b/apps/landing/src/components/deposit.css
@@ -1,0 +1,266 @@
+/*
+ * The fund-your-inscription block.
+ *
+ * Hierarchy is deliberate and runs downward: amount, address, scan, purpose,
+ * risk, then the full terms. The amount and the address are the two things a
+ * person needs in hand, so they get the weight; everything after them is
+ * quieter without being hidden.
+ */
+
+.deposit {
+  margin-top: var(--sp-4);
+}
+
+/* --- amount ------------------------------------------------------------ */
+
+.deposit-amount {
+  display: flex;
+  align-items: baseline;
+  gap: var(--sp-2);
+  flex-wrap: wrap;
+  margin-bottom: var(--sp-3);
+}
+
+.deposit-amount-label {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+
+.deposit-amount-value {
+  font-family: var(--font-mono);
+  font-size: var(--text-lg);
+  font-weight: 600;
+  color: var(--accent-text);
+  /* Tabular figures: the number changes as fees move, and digits that shift
+     width make a re-render look like a different quote. */
+  font-variant-numeric: tabular-nums;
+}
+
+.deposit-amount-unit {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+
+/* --- pay: address + actions, with the code alongside ------------------- */
+
+.deposit-pay {
+  display: flex;
+  gap: var(--sp-5);
+  align-items: flex-start;
+  padding: var(--sp-4);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-md);
+  background: var(--bg-raised);
+}
+
+.deposit-pay-main {
+  flex: 1 1 auto;
+  min-width: 0; /* lets the address wrap instead of forcing the row wider */
+}
+
+.deposit-address-label {
+  display: block;
+  margin-bottom: var(--sp-2);
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.deposit-address {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  color: var(--text-primary);
+  /* A bech32 address has no spaces, so it must be allowed to break mid-token
+     or it overflows and becomes unreadable — and an address you cannot read
+     back is one you cannot check. */
+  overflow-wrap: anywhere;
+  word-break: break-all;
+  user-select: all;
+}
+
+.deposit-actions {
+  display: flex;
+  gap: var(--sp-2);
+  margin-top: var(--sp-3);
+  flex-wrap: wrap;
+}
+
+.deposit-copy,
+.deposit-wallet {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 14px;
+  border-radius: var(--r-sm);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: 550;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease),
+    border-color var(--dur-fast) var(--ease);
+}
+
+.deposit-copy {
+  border: 1px solid var(--border-strong);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-secondary);
+}
+
+.deposit-copy:hover {
+  background: rgba(255, 255, 255, 0.09);
+  color: var(--text-primary);
+}
+
+.deposit-copy[data-copied] {
+  color: var(--ok);
+  border-color: rgba(63, 221, 157, 0.4);
+}
+
+/* The primary action: it is the one that removes all transcription. */
+.deposit-wallet {
+  border: 1px solid transparent;
+  background: var(--accent-soft);
+  color: var(--accent-text);
+}
+
+.deposit-wallet:hover {
+  background: rgba(247, 147, 26, 0.22);
+}
+
+.deposit-hint {
+  margin-top: var(--sp-2);
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  line-height: 1.5;
+}
+
+.deposit-hint-center {
+  text-align: center;
+  max-width: 168px;
+}
+
+/* --- scan -------------------------------------------------------------- */
+
+.deposit-scan {
+  flex: 0 0 auto;
+}
+
+.deposit-qr {
+  display: block;
+  border-radius: var(--r-sm);
+  /* The code needs a light field to scan reliably; the ring keeps that white
+     square from reading as a hole punched in a dark panel. */
+  box-shadow: 0 0 0 1px var(--border-strong);
+}
+
+/* --- purpose, risk, terms ---------------------------------------------- */
+
+.deposit-purpose {
+  margin-top: var(--sp-4);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: 1.65;
+}
+
+/*
+ * The two money risks. Amber, not red: this is not an error and it is not a
+ * failure — it is a property of Bitcoin and of this service. Red here would
+ * cry wolf on the state that is actually wrong, and the deposit screen shows
+ * genuine errors in red just below.
+ */
+.deposit-risk {
+  margin-top: var(--sp-3);
+  padding: var(--sp-3) var(--sp-4);
+  border-left: 2px solid var(--accent);
+  border-radius: 0 var(--r-sm) var(--r-sm) 0;
+  background: var(--accent-soft);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  line-height: 1.65;
+}
+
+.deposit-details {
+  margin-top: var(--sp-3);
+}
+
+.deposit-details > summary {
+  cursor: pointer;
+  padding: var(--sp-2) 0;
+  color: var(--text-tertiary);
+  font-size: var(--text-sm);
+  list-style: none;
+  transition: color var(--dur-fast) var(--ease);
+}
+
+.deposit-details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.deposit-details > summary::before {
+  content: '›';
+  display: inline-block;
+  margin-right: var(--sp-2);
+  transition: transform var(--dur-fast) var(--ease);
+}
+
+.deposit-details[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.deposit-details > summary:hover {
+  color: var(--text-secondary);
+}
+
+.deposit-details-body {
+  padding: var(--sp-2) 0 0 var(--sp-4);
+  border-left: 1px solid var(--border);
+  margin-left: 3px;
+}
+
+.deposit-details-body p {
+  margin-bottom: var(--sp-3);
+  color: var(--text-tertiary);
+  font-size: var(--text-sm);
+  line-height: 1.65;
+}
+
+.deposit-details-body p:last-child {
+  margin-bottom: 0;
+}
+
+.deposit-topup {
+  margin-top: var(--sp-3);
+}
+
+/* --- narrow ------------------------------------------------------------ */
+
+@media (max-width: 560px) {
+  .deposit-pay {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  /* The code leads on a phone: the wallet is on the same device, so the
+     bitcoin: link is the likely path and the scan is the fallback. */
+  .deposit-scan {
+    order: -1;
+    align-self: center;
+  }
+
+  .deposit-hint-center {
+    max-width: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .deposit-copy,
+  .deposit-wallet,
+  .deposit-details > summary,
+  .deposit-details > summary::before {
+    transition: none;
+  }
+}

--- a/apps/landing/src/content.ts
+++ b/apps/landing/src/content.ts
@@ -399,6 +399,27 @@ export const demo = {
     sendPrefix: 'Send at least',
     sendSuffix: 'of BTC to your deposit address. One payment or several — the inscription spends every confirmed deposit sitting there, so a top-up after a fee rise works too. The change and the inscribed sat come back to the same address.',
     addressLabel: 'Your deposit address',
+    // The redesign (see DepositPanel): the action comes first and the full
+    // R27 text moves into an always-present <details> below it. These two
+    // lines are what stays visible without interaction — the purpose, and the
+    // SUBSTANCE of the two money risks. The long-form lines below are not
+    // replaced by them; they are still rendered, in full, on the same screen.
+    purposeShort:
+      'Covers the Bitcoin network fees for two transactions, plus the 546-sat output your inscription rides on. Change comes back to this address.',
+    riskSummary:
+      'There is no withdraw or refund. Anything you send that isn’t spent on an inscription stays at this address until you inscribe here again, and a broadcast fee can’t be reversed by anyone, us included. Send the amount above rather than a round number you’d want back.',
+    detailsSummary: 'How this works — the address, your key, and closing the tab',
+    copyAddress: 'Copy',
+    copiedAddress: 'Copied',
+    copyAddressAria: 'Copy your deposit address',
+    openInWallet: 'Open in wallet',
+    openInWalletHint: 'Opens your Bitcoin wallet with the address and amount already filled in.',
+    scanHint: 'Or scan to pay from your phone',
+    // sendSuffix continues the "Send at least <n> sats" sentence, so it cannot
+    // stand alone now that the amount lives in its own block. This is the same
+    // point as a whole sentence.
+    topUpNote:
+      'One payment or several — the inscription spends every confirmed deposit sitting at the address, so a top-up after a fee rise works too.',
     waiting: 'Waiting for your deposit…',
     detected: 'Deposit detected — waiting for one confirmation.',
     ready: 'Deposit confirmed — ready to inscribe.',

--- a/apps/landing/src/sdk/bitcoin-uri.test.ts
+++ b/apps/landing/src/sdk/bitcoin-uri.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect } from 'bun:test';
+import { satsToBtcAmount, bitcoinPaymentUri } from './bitcoin-uri';
+
+const ADDRESS = 'bc1qwx77y7n2dvcfy2aejnrxcapevmssfezc4ly4rl';
+
+describe('satoshis convert to BIP-21 BTC without touching a float', () => {
+  test.each([
+    [0, '0'],
+    [1, '0.00000001'],
+    [546, '0.00000546'],
+    [14_580, '0.0001458'],
+    [100_000_000, '1'],
+    [123_456_789, '1.23456789'],
+    [2_100_000_000_000_000, '21000000'],
+  ])('%i sats → %s BTC', (sats, expected) => {
+    expect(satsToBtcAmount(sats)).toBe(expected);
+  });
+
+  // The actual reason this is built from strings: not precision, but
+  // exponential notation. Small amounts serialise as '1e-8', which is not a
+  // BIP-21 amount at all. (Division is exact for 14,580 sats — the naive
+  // version is wrong for a different reason than it first appears.)
+  test('never emits exponential notation, which division does under 1e-6', () => {
+    expect(String(1 / 1e8)).toBe('1e-8');
+    expect(satsToBtcAmount(1)).toBe('0.00000001');
+    for (const sats of [1, 9, 99, 546, 999]) {
+      expect(satsToBtcAmount(sats)).not.toContain('e');
+    }
+  });
+
+  test('refuses anything that is not a whole, non-negative count of sats', () => {
+    expect(() => satsToBtcAmount(-1)).toThrow();
+    expect(() => satsToBtcAmount(1.5)).toThrow();
+    expect(() => satsToBtcAmount(NaN)).toThrow();
+  });
+});
+
+describe('the payment URI carries the address and the exact amount', () => {
+  test('is a BIP-21 URI a wallet opens prefilled', () => {
+    expect(bitcoinPaymentUri(ADDRESS, 14_580)).toBe(`bitcoin:${ADDRESS}?amount=0.0001458`);
+  });
+
+  test('omits the amount when there is no quote to state', () => {
+    expect(bitcoinPaymentUri(ADDRESS)).toBe(`bitcoin:${ADDRESS}`);
+  });
+
+  // Upper-casing shrinks the QR but mixed-case bech32 is invalid, and a
+  // wallet that rejects the address is worse than a slightly denser code.
+  test('preserves the address exactly as derived', () => {
+    expect(bitcoinPaymentUri(ADDRESS, 1)).toContain(ADDRESS);
+    expect(bitcoinPaymentUri(ADDRESS, 1)).not.toContain(ADDRESS.toUpperCase());
+  });
+
+  test('refuses to build a URI with no address', () => {
+    expect(() => bitcoinPaymentUri('', 1)).toThrow();
+  });
+});

--- a/apps/landing/src/sdk/bitcoin-uri.ts
+++ b/apps/landing/src/sdk/bitcoin-uri.ts
@@ -1,0 +1,41 @@
+/**
+ * BIP-21 payment URIs for the deposit address.
+ *
+ * The point is that nobody transcribes anything: the address and the exact
+ * amount travel together into the wallet. A deposit screen that makes someone
+ * retype a bech32 address and a sat figure by hand is the screen that produces
+ * a shortfall and a confused top-up.
+ */
+
+/**
+ * Satoshis → the decimal BTC string BIP-21 wants.
+ *
+ * Built by slicing an integer string, never by dividing. `String(sats / 1e8)`
+ * switches to exponential notation under 1e-6 — 1 sat serialises as `1e-8`,
+ * which is not a BIP-21 amount and which wallets reject. 99 of the first
+ * 300,000 sat values hit that. Integer arithmetic only, all the way to the
+ * string.
+ */
+export function satsToBtcAmount(sats: number): string {
+  if (!Number.isFinite(sats) || sats < 0 || !Number.isInteger(sats)) {
+    throw new Error(`Not a satoshi amount: ${sats}`);
+  }
+  const digits = String(sats).padStart(9, '0');
+  const whole = digits.slice(0, -8);
+  // BIP-21 permits trailing zeros but wallets display the trimmed form.
+  const fraction = digits.slice(-8).replace(/0+$/, '');
+  return fraction ? `${whole}.${fraction}` : whole;
+}
+
+/**
+ * `bitcoin:<address>?amount=<btc>` — the URI a wallet opens prefilled.
+ *
+ * The address is emitted verbatim, in the case we derived it. Bech32 is
+ * case-insensitive only when a string is uniformly cased, so "helpfully"
+ * upper-casing it to shrink the QR is a way to produce an address some
+ * wallets reject; the few bytes are not worth it.
+ */
+export function bitcoinPaymentUri(address: string, sats?: number): string {
+  if (!address) throw new Error('A payment URI needs an address');
+  return sats === undefined ? `bitcoin:${address}` : `bitcoin:${address}?amount=${satsToBtcAmount(sats)}`;
+}

--- a/apps/landing/src/sdk/qr-path.test.ts
+++ b/apps/landing/src/sdk/qr-path.test.ts
@@ -1,0 +1,34 @@
+import { describe, test, expect } from 'bun:test';
+import { qrPath } from './qr-path';
+import { bitcoinPaymentUri } from './bitcoin-uri';
+
+const URI = bitcoinPaymentUri('bc1qwx77y7n2dvcfy2aejnrxcapevmssfezc4ly4rl', 14_580);
+
+describe('the deposit QR is a well-formed code', () => {
+  test('picks a version whose module count is 4n+17, as the spec requires', () => {
+    const { count } = qrPath(URI);
+    expect((count - 17) % 4).toBe(0);
+    expect(count).toBeGreaterThanOrEqual(21); // version 1 floor
+    expect(count).toBeLessThanOrEqual(177); // version 40 ceiling
+  });
+
+  test('carries the three finder patterns a scanner locates the code by', () => {
+    const { path, count } = qrPath(URI);
+    const dark = (r: number, c: number) => path.includes(`M${c} ${r}h1v1h-1z`);
+    // Each finder is a 7x7 ring: dark corner, and a light gap at (1,1).
+    for (const [r, c] of [[0, 0], [0, count - 7], [count - 7, 0]] as const) {
+      expect(dark(r, c)).toBe(true);
+      expect(dark(r + 1, c + 1)).toBe(false);
+      expect(dark(r + 3, c + 3)).toBe(true); // solid 3x3 centre
+    }
+  });
+
+  test('is deterministic — the same URI always yields the same code', () => {
+    expect(qrPath(URI)).toEqual(qrPath(URI));
+  });
+
+  test('a different amount produces a different code', () => {
+    const other = bitcoinPaymentUri('bc1qwx77y7n2dvcfy2aejnrxcapevmssfezc4ly4rl', 20_000);
+    expect(qrPath(other).path).not.toBe(qrPath(URI).path);
+  });
+});

--- a/apps/landing/src/sdk/qr-path.ts
+++ b/apps/landing/src/sdk/qr-path.ts
@@ -1,0 +1,25 @@
+import qrcode from 'qrcode-generator';
+
+/**
+ * Encode a string as QR modules, flattened into one SVG path.
+ *
+ * Separate from the component so it can be tested without React or a DOM —
+ * this renders a payment address, so "does it encode what we think" is worth
+ * asserting rather than assuming.
+ *
+ * One path, not a rect per module: a version-5 code is 1,369 cells, and the
+ * deposit panel re-renders on every balance poll.
+ */
+export function qrPath(value: string): { path: string; count: number } {
+  const qr = qrcode(0, 'M'); // 0 = smallest version that fits; M = ~15% recovery
+  qr.addData(value);
+  qr.make();
+  const count = qr.getModuleCount();
+  let path = '';
+  for (let row = 0; row < count; row += 1) {
+    for (let col = 0; col < count; col += 1) {
+      if (qr.isDark(row, col)) path += `M${col} ${row}h1v1h-1z`;
+    }
+  }
+  return { path, count };
+}

--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
         "@turnkey/crypto": "^2.10.0",
         "@turnkey/sdk-browser": "^7.0.0",
         "didwebvh-ts": "^2.8.0",
+        "qrcode-generator": "2.0.4",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
       },
@@ -908,6 +909,8 @@
     "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
 
     "pvutils": ["pvutils@1.1.5", "", {}, "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="],
+
+    "qrcode-generator": ["qrcode-generator@2.0.4", "", {}, "sha512-mZSiP6RnbHl4xL2Ap5HfkjLnmxfKcPWpWe/c+5XxCuetEenqmNFf1FH/ftXPCtFG5/TDobjsjz6sSNL0Sr8Z9g=="],
 
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 


### PR DESCRIPTION
## What

The deposit screen now puts **paying** first: amount, address, copy button and a scannable BIP-21 QR in one block, with the disclosure below it rather than in front of it.

## Why

The old order was: amount → **five paragraphs of disclosure** → address.

Someone who had already decided to pay had to read roughly 250 words of terms to reach the one string they needed. That ordering does not get terms read. It teaches people that the text between them and the thing they came for is an obstacle, and they learn to scroll past it — including the two paragraphs that actually matter.

And the address had **no copy button**, on the one screen in the app where a string has to be exact because real money depends on it. `InstallCommand`, `IdentityPanel` and `OriginalDetail` all have one; the deposit address did not. A person was expected to transcribe `bc1qwx77y7n2dvcfy2aejnrxcapevmssfezc4ly4rl` and `14580` by hand, into a wallet, correctly.

## How

**Order.** Pay block → purpose → the two money risks → full terms in a `<details>`.

**Nothing was removed.** Every line of the R27 disclosure still renders on the same screen, unedited; it sits below the address instead of above it. The two new short lines are *additions*. A test asserts both — that each contract line is present, and that the rendered count is exactly the contract plus two, so a summary can never be silently swapped in for a full line.

**The risks need no click.** The no-withdraw / no-refund / not-reversible substance is rendered directly, not inside the `<details>`. Tests assert it names the missing withdrawal, the missing refund, irreversibility, that it does not exempt us from it, and that it never promises a refund path the long-form text denies.

**No transcription.** The `bitcoin:` URI carries the address and the exact quoted amount, so a wallet opens prefilled. The same URI feeds the link and the QR, so they cannot drift apart.

**Amount formatting is money-critical**, so it is built from integer strings and never by dividing. `String(sats / 1e8)` switches to exponential notation under 1e-6 — 1 sat serialises as `1e-8`, which is not a BIP-21 amount and which wallets reject. 99 of the first 300,000 sat values hit that.

> The first version of this claimed an IEEE-754 rounding error instead. Its own test disproved that — `14580 / 1e8` is exactly `0.0001458` — so I measured the real failure mode and the comment now states it. The string-building was right; my reason for it was not.

**QR.** `qrcode-generator` (no dependencies), rendered as inline SVG — crisp at any size, no external request, no canvas ref. Encoding is extracted into a pure module so it is testable without a DOM, and asserted on spec properties: a 4n+17 module count, and the three finder patterns a scanner locates the code by. One `<path>` for all modules, since a version-5 code is 1,369 cells and this re-renders on every balance poll.

**Design.** Uses the existing token system. Amber for the risk block rather than red — this is a property of Bitcoin, not an error, and the same panel shows genuine errors in red just below; red here would cry wolf. Tabular figures on the amount so a fee change does not make digits jump. The address wraps on character boundaries, because a bech32 string that overflows its box is one you cannot read back to check.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [x] Test addition or improvement

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] I have updated JSDoc comments for any changed public APIs
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Testing

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing (describe steps)

Landing suite **735 pass / 0 fail** (up 25). Typecheck, lint and `vite build` clean.

Verified beyond the suite:
- The QR was rendered to a terminal and inspected: version 5, 37 modules, three finder patterns and the alignment pattern all present and correctly placed.
- Every `className` in the new components resolves to a rule, so no element ships unstyled.
- Caught while wiring: `sendSuffix` begins mid-sentence (*"of BTC to your deposit address…"*) because it was written to continue "Send at least ⟨n⟩". Detached from the amount it read as a fragment, so the top-up point is now its own sentence.

**Not verified:** I have not looked at this in a browser. The structure, tokens and responsive rules are sound and the class check passes, but "make it look good" deserves your eyes on the rendered page — particularly the QR-beside-address balance at desktop width and the stacked order under 560px.

## Screenshots / Output (if applicable)

```
Fund your inscription                    [ Waiting for your deposit… ]

  Send at least  14,580  sats

  ┌──────────────────────────────────────────────────┬─────────────┐
  │ YOUR DEPOSIT ADDRESS                             │  ▄▄▄▄▄▄▄▄▄  │
  │ bc1qwx77y7n2dvcfy2aejnrxcapevmssfezc4ly4rl       │  █ ▄▄▄ █▀█  │
  │                                                  │  █ ███ █ ▄  │
  │ [ Copy ]  [ Open in wallet ]                     │  ▀▀▀▀▀▀▀▀▀  │
  │ Opens your Bitcoin wallet with the address and   │ Or scan to  │
  │ amount already filled in.                        │ pay from    │
  │                                                  │ your phone  │
  └──────────────────────────────────────────────────┴─────────────┘

  Covers the Bitcoin network fees for two transactions, plus the
  546-sat output your inscription rides on. Change comes back here.

  ┃ There is no withdraw or refund. Anything you send that isn't
  ┃ spent on an inscription stays at this address until you inscribe
  ┃ here again, and a broadcast fee can't be reversed by anyone, us
  ┃ included. Send the amount above rather than a round number.

  › How this works — the address, your key, and closing the tab
```

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
