### PR TITLE
fix(landing): look up the funding account with getWalletAccounts

### DIFF
--- a/.changeset/landing-funding-account-lookup.md
+++ b/.changeset/landing-funding-account-lookup.md
@@ -1,0 +1,27 @@
+---
+"@originals/landing": patch
+---
+
+**Fix: the Bitcoin funding account is found instead of re-created every sign-in.**
+
+Every sign-in after the first failed with:
+
+```
+create_wallet_account {"code":6,"message":"path already exists in wallet account …"}
+```
+
+`ensureBitcoinFundingAccount` looked for the existing account by reading
+`wallet.accounts` off `getWallets`. Turnkey's `v1Wallet` has no `accounts`
+field — it returns wallet metadata only, and accounts come from
+`getWalletAccounts`. So the lookup was always `undefined`, the account was
+never found, and the first sign-in created it while every later one tried to
+create the same BIP-32 path again.
+
+The path is fixed, so re-reading returns the same address a previous session
+created — which matters, because a creator may already have BTC sitting at it.
+
+Also made genuinely idempotent rather than only claiming to be: if creation
+reports the path already exists, that is itself proof the account is there, so
+it re-reads and returns it rather than failing a sign-in over an account that
+already works. And the network-prefix check now covers a re-read account, not
+just a freshly created one.

--- a/apps/landing/src/auth/turnkey-session.test.ts
+++ b/apps/landing/src/auth/turnkey-session.test.ts
@@ -4,68 +4,7 @@ import {
   attestedStampValue,
   ensureBitcoinFundingAccount,
   type TurnkeyBitcoinClient,
-  type TurnkeySessionApi,
 } from './turnkey-session';
-
-describe('turnkey-session helpers', () => {
-  test('ensureBitcoinFundingAccount adds a testnet P2WPKH account and returns its tb1 address (idempotent)', async () => {
-    let existing: Array<{ address: string; path: string }> = [];
-    const client: TurnkeyBitcoinClient = {
-      async getWallets() {
-        return { wallets: [{ walletId: 'w1', accounts: existing }] };
-      },
-      async createWalletAccounts(params) {
-        const address = 'tb1qexampleuseraddr000000000000000000000000';
-        existing = [{ address, path: params.accounts[0].path }];
-        return { addresses: [address] };
-      },
-      async signTransaction() {
-        throw new Error('not used here');
-      },
-    };
-    const addr = await ensureBitcoinFundingAccount(client, 'sub-1');
-    expect(addr.startsWith('tb1q')).toBe(true);
-    // Second call must NOT create a duplicate account — returns the cached one.
-    const addr2 = await ensureBitcoinFundingAccount(client, 'sub-1');
-    expect(addr2).toBe(addr);
-  });
-
-  test('ensureBitcoinFundingAccount(mainnet) uses the mainnet path/format and expects bc1', async () => {
-    const created: Array<{ path: string; addressFormat: string }> = [];
-    const client: TurnkeyBitcoinClient = {
-      async getWallets() {
-        return { wallets: [{ walletId: 'w1', accounts: [] }] };
-      },
-      async createWalletAccounts(params) {
-        created.push(params.accounts[0]);
-        return { addresses: ['bc1qexampleuseraddr000000000000000000000000'] };
-      },
-      async signTransaction() {
-        throw new Error('not used here');
-      },
-    };
-    const addr = await ensureBitcoinFundingAccount(client, 'sub-1', 'mainnet');
-    expect(addr.startsWith('bc1')).toBe(true);
-    // BIP-84 mainnet coin type 0' — a DIFFERENT account than the testnet path.
-    expect(created[0].path).toBe("m/84'/0'/0'/0/0");
-    expect(created[0].addressFormat).toBe('ADDRESS_FORMAT_BITCOIN_MAINNET_P2WPKH');
-  });
-
-  test('ensureBitcoinFundingAccount(mainnet) rejects a tb1 address from Turnkey', async () => {
-    const client: TurnkeyBitcoinClient = {
-      async getWallets() {
-        return { wallets: [{ walletId: 'w1', accounts: [] }] };
-      },
-      async createWalletAccounts() {
-        return { addresses: ['tb1qwrongnetworkaddr00000000000000000000000'] };
-      },
-      async signTransaction() {
-        throw new Error('not used here');
-      },
-    };
-    await expect(ensureBitcoinFundingAccount(client, 'sub-1', 'mainnet')).rejects.toThrow('unexpected funding address');
-  });
-});
 
 /**
  * U1 — the two defects the plan calls out, each proved before it is fixed:
@@ -110,6 +49,127 @@ function fakeVerificationToken(payload: { id: string; public_key: string }): str
 }
 
 const MINUTES = 60_000;
+
+describe('the Bitcoin funding account is found, not re-created', () => {
+  /**
+   * Models the REAL Turnkey API: getWallets returns wallet metadata with no
+   * accounts field, and accounts come from getWalletAccounts.
+   *
+   * The previous fake returned `accounts` from getWallets — a field
+   * `v1Wallet` does not have. That one invented field is why the suite showed
+   * this function as idempotent while every live sign-in after the first
+   * failed with "code 6: path already exists in wallet account".
+   */
+  function client(opts: {
+    accounts?: Array<{ address: string; path: string }>;
+    createAddress?: string;
+    createThrows?: Error;
+    onCreate?: (path: string, addressFormat: string) => void;
+  }) {
+    const accounts = [...(opts.accounts ?? [])];
+    let creates = 0;
+    const api: TurnkeyBitcoinClient = {
+      async getWallets() {
+        return { wallets: [{ walletId: 'w1' }] };
+      },
+      async getWalletAccounts() {
+        return { accounts };
+      },
+      async createWalletAccounts(params) {
+        creates += 1;
+        opts.onCreate?.(params.accounts[0].path, params.accounts[0].addressFormat);
+        if (opts.createThrows) throw opts.createThrows;
+        const address = opts.createAddress ?? 'tb1qexampleuseraddr000000000000000000000000';
+        accounts.push({ address, path: params.accounts[0].path });
+        return { addresses: [address] };
+      },
+      async signTransaction() {
+        throw new Error('not used here');
+      },
+    };
+    return { api, creates: () => creates };
+  }
+
+  test('creates the account when the path is absent, and returns its address', async () => {
+    const { api, creates } = client({});
+    expect(await ensureBitcoinFundingAccount(api, 'sub-1')).toStartWith('tb1q');
+    expect(creates()).toBe(1);
+  });
+
+  // The live failure: a second sign-in must find the account, not re-create it.
+  test('a second call finds the existing account and never calls create again', async () => {
+    const { api, creates } = client({});
+    const first = await ensureBitcoinFundingAccount(api, 'sub-1');
+    const second = await ensureBitcoinFundingAccount(api, 'sub-1');
+    expect(second).toBe(first);
+    expect(creates()).toBe(1);
+  });
+
+  test('an account created by an earlier session is reused, so funds stay reachable', async () => {
+    const address = 'tb1qalreadytherefrombefore00000000000000000';
+    const { api, creates } = client({ accounts: [{ address, path: "m/84'/1'/0'/0/0" }] });
+    expect(await ensureBitcoinFundingAccount(api, 'sub-1')).toBe(address);
+    expect(creates()).toBe(0);
+  });
+
+  test('mainnet uses its own path and format, and is not satisfied by the testnet account', async () => {
+    const seen: Array<[string, string]> = [];
+    const { api } = client({
+      accounts: [{ address: 'tb1qtestnetaccount0000000000000000000000000', path: "m/84'/1'/0'/0/0" }],
+      createAddress: 'bc1qexampleuseraddr000000000000000000000000',
+      onCreate: (path, fmt) => seen.push([path, fmt]),
+    });
+    expect(await ensureBitcoinFundingAccount(api, 'sub-1', 'mainnet')).toStartWith('bc1q');
+    expect(seen).toEqual([["m/84'/0'/0'/0/0", 'ADDRESS_FORMAT_BITCOIN_MAINNET_P2WPKH']]);
+  });
+
+  // Turnkey saying the path exists is proof the account is there. Failing the
+  // sign-in over it would block a user out of an account that already works.
+  test('recovers when create reports the path already exists', async () => {
+    const address = 'tb1qracedaccount000000000000000000000000000';
+    const accounts: Array<{ address: string; path: string }> = [];
+    const api: TurnkeyBitcoinClient = {
+      async getWallets() {
+        return { wallets: [{ walletId: 'w1' }] };
+      },
+      async getWalletAccounts() {
+        // Empty on the first read, populated by the time we re-read.
+        const snapshot = [...accounts];
+        accounts.push({ address, path: "m/84'/1'/0'/0/0" });
+        return { accounts: snapshot };
+      },
+      async createWalletAccounts() {
+        throw new Error('path already exists in wallet account 0728c0a2-a504-44f2-ba5c-79d3db14f0c4');
+      },
+      async signTransaction() {
+        throw new Error('not used here');
+      },
+    };
+    expect(await ensureBitcoinFundingAccount(api, 'sub-1')).toBe(address);
+  });
+
+  test('an unrelated create failure is not swallowed', async () => {
+    const { api } = client({ createThrows: new Error('insufficient permissions') });
+    await expect(ensureBitcoinFundingAccount(api, 'sub-1')).rejects.toThrow('insufficient permissions');
+  });
+
+  test('rejects a testnet address returned for the mainnet path', async () => {
+    const { api } = client({ createAddress: 'tb1qwrongnetwork00000000000000000000000000' });
+    await expect(ensureBitcoinFundingAccount(api, 'sub-1', 'mainnet')).rejects.toThrow(
+      'unexpected funding address'
+    );
+  });
+
+  // The prefix check used to run only on a freshly created address.
+  test('rejects a wrong-network address even when it comes from an existing account', async () => {
+    const { api } = client({
+      accounts: [{ address: 'tb1qwrongnetwork00000000000000000000000000', path: "m/84'/0'/0'/0/0" }],
+    });
+    await expect(ensureBitcoinFundingAccount(api, 'sub-1', 'mainnet')).rejects.toThrow(
+      'unexpected funding address'
+    );
+  });
+});
 
 describe('U1: session lifetime survives a Bitcoin confirmation wait', () => {
   test('the configured expiry is far longer than the 15-minute Turnkey default', () => {

--- a/apps/landing/src/auth/turnkey-session.ts
+++ b/apps/landing/src/auth/turnkey-session.ts
@@ -86,8 +86,17 @@ export interface TurnkeyBitcoinClient {
       addressFormat: 'ADDRESS_FORMAT_BITCOIN_TESTNET_P2WPKH' | 'ADDRESS_FORMAT_BITCOIN_MAINNET_P2WPKH';
     }>;
   }): Promise<{ addresses: string[] }>;
+  /**
+   * Wallet METADATA only. Turnkey's `v1Wallet` carries no accounts — listing
+   * them is a separate call, and assuming otherwise is what made the funding
+   * account re-create itself on every sign-in.
+   */
   getWallets(params: { organizationId: string }): Promise<{
-    wallets: Array<{ walletId: string; accounts?: Array<{ address: string; path?: string }> }>;
+    wallets: Array<{ walletId: string }>;
+  }>;
+  /** The accounts themselves. `walletId` is optional; omitted = the whole org. */
+  getWalletAccounts(params: { organizationId: string; walletId?: string }): Promise<{
+    accounts: Array<{ address: string; path: string; addressFormat?: string }>;
   }>;
 }
 
@@ -376,9 +385,18 @@ export async function revokeSessionKey(
 
 /**
  * Ensure the user's wallet has a P2WPKH account for the given network and
- * return its bech32 address (tb1… on testnet4, bc1… on mainnet). Idempotent:
- * if the path already exists, the cached address wins — re-creating would
- * waste an activity and could error on a duplicate path.
+ * return its bech32 address (tb1… on testnet4, bc1… on mainnet).
+ *
+ * Genuinely idempotent, which it previously only claimed to be. The lookup
+ * used to read `wallet.accounts` off `getWallets`, and Turnkey's `v1Wallet`
+ * has no such field — so it was always undefined, the account was never found,
+ * and every sign-in after the first tried to create a path that already
+ * existed and failed with `code 6: path already exists in wallet account`.
+ * Accounts come from `getWalletAccounts`.
+ *
+ * The address is derived from a fixed BIP-32 path, so re-reading an existing
+ * account always yields the same address a previous run created — which
+ * matters, because a creator may already have BTC sitting at it.
  */
 export async function ensureBitcoinFundingAccount(
   client: TurnkeyBitcoinClient,
@@ -386,26 +404,56 @@ export async function ensureBitcoinFundingAccount(
   network: FundingNetwork = 'testnet4'
 ): Promise<string> {
   const account = P2WPKH_ACCOUNTS[network];
+
+  const findExisting = async (): Promise<string | undefined> => {
+    const { accounts } = await client.getWalletAccounts({ organizationId: subOrgId });
+    return accounts?.find((a) => a.path === account.path)?.address;
+  };
+
+  const already = await findExisting();
+  if (already) return verifyFundingAddress(already, account.prefix);
+
   const { wallets } = await client.getWallets({ organizationId: subOrgId });
   const wallet = wallets[0];
   if (!wallet) throw new Error('No Turnkey wallet found for the sub-organization.');
-  const existing = wallet.accounts?.find((a) => a.path === account.path);
-  if (existing?.address) return existing.address;
-  const { addresses } = await client.createWalletAccounts({
-    walletId: wallet.walletId,
-    organizationId: subOrgId,
-    accounts: [
-      {
-        curve: 'CURVE_SECP256K1',
-        pathFormat: 'PATH_FORMAT_BIP32',
-        path: account.path,
-        addressFormat: account.addressFormat,
-      },
-    ],
-  });
-  const address = addresses[0];
-  if (!address || !address.startsWith(account.prefix)) {
+
+  let addresses: string[];
+  try {
+    ({ addresses } = await client.createWalletAccounts({
+      walletId: wallet.walletId,
+      organizationId: subOrgId,
+      accounts: [
+        {
+          curve: 'CURVE_SECP256K1',
+          pathFormat: 'PATH_FORMAT_BIP32',
+          path: account.path,
+          addressFormat: account.addressFormat,
+        },
+      ],
+    }));
+  } catch (err) {
+    // Belt and braces: the read above should have found it, but a paginated
+    // or eventually-consistent listing could miss one. Turnkey telling us the
+    // path exists is itself proof the account is there, so re-read rather than
+    // surfacing a failure for a thing that already succeeded.
+    if (!/already exists/i.test(String((err as Error)?.message ?? err))) throw err;
+    const recovered = await findExisting();
+    if (!recovered) throw err;
+    return verifyFundingAddress(recovered, account.prefix);
+  }
+
+  return verifyFundingAddress(addresses[0], account.prefix);
+}
+
+/**
+ * A mainnet path must not hand back a testnet address, or vice versa. Applied
+ * to a re-read account as well as a freshly created one: this is the last
+ * checkpoint before a stranger is told where to send BTC.
+ */
+function verifyFundingAddress(address: string | undefined, prefix: string): string {
+  if (!address || !address.startsWith(prefix)) {
     throw new Error(`Turnkey returned an unexpected funding address: ${String(address)}`);
   }
   return address;
 }
+


### PR DESCRIPTION
## What

`ensureBitcoinFundingAccount` now finds the existing account with `getWalletAccounts` instead of re-creating it on every sign-in.

## Why

```
create_wallet_account {"code":6,"message":"path already exists in wallet account 0728c0a2-…"}
```

The lookup read `wallet.accounts` off `getWallets`:

```ts
const existing = wallet.accounts?.find((a) => a.path === account.path);
```

Turnkey's `v1Wallet` has **no `accounts` field**. `getWallets` returns wallet metadata — `walletId`, `walletName`, `createdAt`, `updatedAt`, `exported`, `imported` — and nothing else. Accounts come from a separate `getWalletAccounts` call.

So `existing` was **always** `undefined`. The first sign-in created the account and succeeded; every sign-in after it tried to create the same BIP-32 path again and failed. That is exactly the observed behaviour — this account was created during the first successful sign-in after #502, and the next one broke.

**The suite reported this function as idempotent the whole time.** Its fake returned an `accounts` array from `getWallets`:

```ts
async getWallets() {
  return { wallets: [{ walletId: 'w1', accounts: existing }] };   // a field the API does not have
}
```

One invented field, and a test named "(idempotent)" that asserted the second call reuses the first — against a shape the real API cannot produce. Same failure mode as the `'deadbeef'` signature fixture in #500 and the `wallet.accounts` optional in our own interface that permitted it.

## How

- Look up via `getWalletAccounts({ organizationId })`. `walletId` is optional there, so the lookup no longer assumes `wallets[0]` either.
- `wallet.accounts` is **removed from our `TurnkeyBitcoinClient` interface**, so the type system stops permitting the mistake rather than merely not catching it.
- **Idempotent in fact, not just in the docstring**: if creation reports the path already exists, that is itself proof the account is there — re-read and return it instead of failing a sign-in over an account that already works. An unrelated create failure still propagates.
- The network-prefix check (`bc1` vs `tb1`) now guards a **re-read** address too, not only a freshly created one. It is the last checkpoint before a stranger is told where to send BTC.

The BIP-32 path is fixed, so re-reading returns the same address an earlier session created. That matters: a creator may already have BTC sitting at it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Test addition or improvement

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] I have updated JSDoc comments for any changed public APIs
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Testing

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing (describe steps)

Landing suite **744 pass / 0 fail** (739 + 5). Typecheck, lint and `vite build` clean.

The fakes now model the real API: `getWallets` returns `{ walletId }` only, and accounts come from `getWalletAccounts`. Verified the tests catch the actual bug — restoring the old `getWallets`-based lookup fails three, including the one that reproduces the live failure:

```
(fail) a second call finds the existing account and never calls create again
(fail) an account created by an earlier session is reused, so funds stay reachable
(fail) recovers when create reports the path already exists
```

**Disclosed:** rewriting the fixtures initially deleted two unrelated `describe` blocks — *session lifetime survives a Bitcoin confirmation wait* and *signing capability survives a reload*, 9 tests. The suite still went green at 735, which is what surfaced it: 739 was the count before. Both are restored and the total reconciles exactly.

**Not verified live:** that a sign-in now completes. Diagnosed from Turnkey's shipped API types (`@turnkey/sdk-browser@7.0.0`) plus the error, not a live round trip.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
