### PR TITLE
feat(landing): surface an underpriced deposit, and typecheck the server

### DIFF
--- a/.changeset/landing-deposit-fee-advice.md
+++ b/.changeset/landing-deposit-fee-advice.md
@@ -1,0 +1,28 @@
+---
+"@originals/landing": patch
+---
+
+**Tell creators when their deposit is underpriced — and typecheck the server.**
+
+A deposit paying below the going rate sits in the mempool with nothing on
+screen to say why. Working that out meant opening a block explorer.
+
+The deposit screen now shows the pending payment's fee rate against what the
+network is clearing, and what to do about it. It is deliberately **not** a
+button: replace-by-fee re-signs the original inputs, and those belong to
+whatever wallet the creator paid from — not their Turnkey wallet — so the app
+cannot replace that transaction. Only the sending wallet can. Offering an
+action we cannot perform is the same defect as telling someone to sign in again
+when signing in is what failed.
+
+Where it can help is the arithmetic. BIP-125 requires a replacement to pay for
+its own bandwidth on top of the original fee, so the floor is
+`originalFee + vsize` — roughly triple a 1 sat/vB fee — and a small nudge is
+rejected outright. The suggested rate clears both that floor and the network
+rate, and the copy says to take the increase from change rather than from the
+deposit amount.
+
+Also adds `server/` to the landing typecheck. It was excluded, so the entire
+money path — every route that moves a stranger's BTC — was unchecked. Adding it
+required only Bun's types; there were no existing errors. It immediately caught
+a call to an undefined function in this very change.

--- a/.changeset/landing-nonwitness-utxo.md
+++ b/.changeset/landing-nonwitness-utxo.md
@@ -1,0 +1,28 @@
+---
+"@originals/landing": patch
+---
+
+**Fix: attach the previous transaction Turnkey requires to sign the commit.**
+
+The first real mainnet inscription failed at signing:
+
+```
+sign_transaction code 3: input 0 is missing non_witness_utxo for
+SegWit v0 input; provide both witness_utxo and non_witness_utxo
+```
+
+BIP-143 does not need the full previous transaction to compute a SegWit v0
+sighash, so the SDK's commit builder attaches only `witnessUtxo`. Turnkey
+requires it anyway — the defence against the fee-inflation attack on remote
+signers, which otherwise learn the input's true value only from the party
+asking for a signature.
+
+The browser now fetches each funding input's previous transaction and attaches
+it before signing, and **verifies** rather than trusts it: the bytes must hash
+to the txid the PSBT names, and the output being spent must match the
+`witnessUtxo` already in the PSBT in both amount and script. A mismatch is
+refused, not signed.
+
+The lookup goes through `GET /api/btc/prevtx`, which is scoped to the caller's
+own bound deposit address rather than being a general transaction proxy, and
+keeps a creator's funding txids away from a public indexer tied to their IP.

--- a/apps/landing/server/bitcoin.ts
+++ b/apps/landing/server/bitcoin.ts
@@ -239,6 +239,42 @@ export function slowestPending<T extends { feeSats: number; vsize: number }>(
 }
 
 /**
+ * A previous transaction's raw bytes, as hex.
+ *
+ * Turnkey refuses a SegWit v0 input that carries only `witness_utxo`, so the
+ * browser has to attach the whole previous transaction before signing. It
+ * comes through us rather than straight from the browser to a public indexer:
+ * that keeps the indexer seam (and its auth, timeout and error handling) in
+ * one place, and keeps a creator's funding txids out of a third party's logs
+ * with the browser's IP attached.
+ *
+ * The browser VERIFIES what it gets back — it must hash to the txid the PSBT
+ * names — so a wrong or hostile answer here is refused rather than signed.
+ */
+export async function fetchRawTxHex(
+  opts: IndexerConfig & { txid: string; timeoutMs?: number; fetchImpl?: typeof fetch }
+): Promise<string | null> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? 10_000);
+  try {
+    const res = await fetchImpl(`${stripTrailingSlash(opts.api)}/tx/${opts.txid}/hex`, {
+      signal: controller.signal,
+      headers: indexerAuthHeaders(opts),
+    });
+    if (!res.ok) return null;
+    const body = (await res.text()).trim();
+    // Esplora serves this as a bare hex body; anything else is not a
+    // transaction and must not be handed on as one.
+    return /^[0-9a-f]+$/i.test(body) && body.length % 2 === 0 ? body : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
  * Fee facts for a pending deposit, so the creator can be told when theirs is
  * underpriced. Facts only — what to DO about it is the browser's copy, and the
  * app cannot act on it either way: replacing that transaction needs the keys
@@ -602,6 +638,7 @@ export function createBitcoinRoutes(deps: {
   fee: Handler;
   broadcast: Handler;
   deposit: Handler;
+  prevTx: Handler;
   networkInfo: Handler;
   inscribe: Handler;
   inscribeList: Handler;
@@ -1158,6 +1195,57 @@ export function createBitcoinRoutes(deps: {
        */
       pendingDeposit,
     });
+  };
+
+  /**
+   * GET /api/btc/prevtx?txid=… — one previous transaction, as raw hex.
+   *
+   * Turnkey refuses a SegWit v0 input carrying only `witness_utxo`, so the
+   * browser must attach the whole previous transaction before it can sign the
+   * commit. It comes through us so the indexer seam stays in one place and a
+   * creator's funding txids do not reach a public indexer tied to their IP.
+   *
+   * SCOPED, not a general lookup proxy: the txid must be one that actually
+   * funds THIS caller's bound deposit address. Same reasoning as the deposit
+   * route — a signed-in caller must not be able to use us to fetch arbitrary
+   * transactions. The browser verifies the bytes hash to the txid it asked
+   * for, so this route cannot substitute a different transaction either.
+   */
+  const prevTx: Handler = async (req, url, clientIp) => {
+    const sub = authSub(req);
+    if (!sub) return json({ error: 'unauthorized' }, 401);
+    const limited = rateLimited(clientIp);
+    if (limited) return limited;
+    if (!indexer) return json({ error: 'deposit_unavailable' }, 503);
+    const network = deps.network ?? 'testnet';
+
+    const txid = url.searchParams.get('txid') ?? '';
+    if (!/^[0-9a-f]{64}$/i.test(txid)) {
+      return json({ error: 'bad_txid', message: 'A 64-character hex txid is required.' }, 400);
+    }
+
+    const address = deps.inscriptions?.depositBinding(sub, network) ?? null;
+    if (!address) {
+      return json({ error: 'no_deposit_address', message: 'No deposit address is bound to this account.' }, 403);
+    }
+
+    let utxos: Awaited<ReturnType<typeof fetchAddressUtxos>>;
+    try {
+      utxos = await fetchAddressUtxos({ ...indexer, address, network, fetchImpl: deps.fetchImpl });
+    } catch {
+      return json({ error: 'indexer_unavailable' }, 503);
+    }
+    const funds = utxos.confirmed.some((u) => u.txid.toLowerCase() === txid.toLowerCase());
+    if (!funds) {
+      return json(
+        { error: 'txid_not_yours', message: 'That transaction does not fund this account’s deposit address.' },
+        403
+      );
+    }
+
+    const raw = await fetchRawTxHex({ ...indexer, txid, fetchImpl: deps.fetchImpl });
+    if (!raw) return json({ error: 'prevtx_unavailable' }, 503);
+    return json({ txid, hex: raw });
   };
 
   /**
@@ -1779,7 +1867,7 @@ export function createBitcoinRoutes(deps: {
     return json({ commitTxId, revealTxId: rec.revealTxId, inscriptionId: rec.inscriptionId, status: 'reveal_broadcast' });
   };
 
-  return { funding, sat, fee, broadcast, deposit, networkInfo, inscribe, inscribeList, inscribeRebroadcast };
+  return { funding, sat, fee, broadcast, deposit, prevTx, networkInfo, inscribe, inscribeList, inscribeRebroadcast };
 }
 
 export type BitcoinRoutes = ReturnType<typeof createBitcoinRoutes>;

--- a/apps/landing/server/bitcoin.ts
+++ b/apps/landing/server/bitcoin.ts
@@ -1087,7 +1087,7 @@ export function createBitcoinRoutes(deps: {
     // is drawn from the ones we did read, which can only understate the
     // problem, never invent one.
     let pendingDeposit:
-      | { feeSats: number; vsize: number; rbf: boolean; networkSatVb: number }
+      | { txid: string; feeSats: number; vsize: number; rbf: boolean; networkSatVb: number }
       | null = null;
     if (utxos.unconfirmedTxids.length > 0) {
       try {
@@ -1102,6 +1102,7 @@ export function createBitcoinRoutes(deps: {
         const slowest = slowestPending(fees.filter((f) => f !== null));
         if (slowest) {
           pendingDeposit = {
+            txid: slowest.txid,
             feeSats: slowest.feeSats,
             vsize: slowest.vsize,
             rbf: slowest.rbf,

--- a/apps/landing/server/bitcoin.ts
+++ b/apps/landing/server/bitcoin.ts
@@ -1136,7 +1136,15 @@ export function createBitcoinRoutes(deps: {
           ),
           currentFeeRate(1),
         ]);
-        const slowest = slowestPending(fees.filter((f) => f !== null));
+        // Advise ONLY when every pending payment was priced. A partial view
+        // can name a faster sibling while the real blocker sits outside it —
+        // pointing the creator's fee bump, and the explorer link, at the wrong
+        // transaction. Saying nothing beats confidently saying the wrong thing.
+        // (An earlier version claimed a partial read could only understate the
+        // problem. It can also misattribute it, which is worse.)
+        const priced = fees.filter((f) => f !== null);
+        const sawThemAll = priced.length === utxos.unconfirmedTxids.length;
+        const slowest = sawThemAll ? slowestPending(priced) : null;
         if (slowest) {
           pendingDeposit = {
             txid: slowest.txid,

--- a/apps/landing/server/bitcoin.ts
+++ b/apps/landing/server/bitcoin.ts
@@ -217,6 +217,28 @@ export async function fetchAddressUtxos(
 }
 
 /**
+ * How many pending payments we will price per deposit poll. One is the normal
+ * case; a payment plus a top-up is the realistic worst case.
+ */
+export const MAX_PENDING_FEE_LOOKUPS = 3;
+
+/**
+ * Of the pending payments, the one holding the deposit up — lowest fee rate.
+ * Advising on a faster sibling would tell a creator to bump a payment that is
+ * already fine while the slow one still sits there.
+ */
+export function slowestPending<T extends { feeSats: number; vsize: number }>(
+  pending: T[]
+): T | null {
+  let worst: T | null = null;
+  for (const p of pending) {
+    if (p.vsize <= 0) continue;
+    if (!worst || p.feeSats / p.vsize < worst.feeSats / worst.vsize) worst = p;
+  }
+  return worst;
+}
+
+/**
  * Fee facts for a pending deposit, so the creator can be told when theirs is
  * underpriced. Facts only — what to DO about it is the browser's copy, and the
  * app cannot act on it either way: replacing that transaction needs the keys
@@ -247,7 +269,10 @@ export async function fetchPendingDepositFee(
     return {
       txid: opts.txid,
       feeSats: tx.fee,
-      vsize: Math.round(tx.weight / 4),
+      // vsize is ceil(weight/4) BY DEFINITION (BIP-141). Rounding understates
+      // it whenever weight % 4 == 1, which overstates the rate we display and
+      // leaves the replacement minimum a satoshi short — i.e. unrelayable.
+      vsize: Math.ceil(tx.weight / 4),
       // BIP-125 opt-in: any input with sequence < 0xfffffffe signals it.
       rbf: (tx.vin ?? []).some((i) => typeof i.sequence === 'number' && i.sequence < 0xfffffffe),
     };
@@ -1051,21 +1076,38 @@ export function createBitcoinRoutes(deps: {
     }
     const estimatedCostSats = costFor(inputCount);
 
-    // One extra indexer read, and only while a deposit is actually pending.
+    // Only while a deposit is actually pending. A creator may have several in
+    // flight — a payment plus a top-up — and taking whichever the indexer
+    // happened to list first would describe an unrelated one. Advise on the
+    // SLOWEST, since that is the payment holding the deposit up.
+    //
+    // Capped at MAX_PENDING_FEE_LOOKUPS reads: this route is polled every 15s
+    // against a rate-limited indexer, and an unbounded fan-out here would
+    // spend a creator's poll budget on an advisory. Beyond the cap the advice
+    // is drawn from the ones we did read, which can only understate the
+    // problem, never invent one.
     let pendingDeposit:
       | { feeSats: number; vsize: number; rbf: boolean; networkSatVb: number }
       | null = null;
     if (utxos.unconfirmedTxids.length > 0) {
       try {
-        const [fee, networkSatVb] = await Promise.all([
-          fetchPendingDepositFee({
-            ...indexer,
-            txid: utxos.unconfirmedTxids[0],
-            fetchImpl: deps.fetchImpl,
-          }),
+        const [fees, networkSatVb] = await Promise.all([
+          Promise.all(
+            utxos.unconfirmedTxids
+              .slice(0, MAX_PENDING_FEE_LOOKUPS)
+              .map((txid) => fetchPendingDepositFee({ ...indexer, txid, fetchImpl: deps.fetchImpl }))
+          ),
           currentFeeRate(1),
         ]);
-        if (fee) pendingDeposit = { feeSats: fee.feeSats, vsize: fee.vsize, rbf: fee.rbf, networkSatVb };
+        const slowest = slowestPending(fees.filter((f) => f !== null));
+        if (slowest) {
+          pendingDeposit = {
+            feeSats: slowest.feeSats,
+            vsize: slowest.vsize,
+            rbf: slowest.rbf,
+            networkSatVb,
+          };
+        }
       } catch {
         // Advisory only. A fee estimator or /tx read that is down changes
         // nothing about the deposit itself.

--- a/apps/landing/server/bitcoin.ts
+++ b/apps/landing/server/bitcoin.ts
@@ -162,6 +162,8 @@ export async function fetchAddressUtxos(
 ): Promise<{
   confirmed: Array<{ txid: string; vout: number; value: number; scriptPubKey: string }>;
   unconfirmedSats: number;
+  /** Txids of the unconfirmed deposits, so their fee rate can be looked up. */
+  unconfirmedTxids: string[];
 }> {
   const fetchImpl = opts.fetchImpl ?? fetch;
   const scriptPubKey = p2wpkhScriptHex(opts.address, opts.network ?? 'testnet');
@@ -210,7 +212,50 @@ export async function fetchAddressUtxos(
       .filter((u) => u.status?.confirmed)
       .map((u) => ({ txid: u.txid, vout: u.vout, value: u.value, scriptPubKey })),
     unconfirmedSats: utxos.filter((u) => !u.status?.confirmed).reduce((n, u) => n + u.value, 0),
+    unconfirmedTxids: [...new Set(utxos.filter((u) => !u.status?.confirmed).map((u) => u.txid))],
   };
+}
+
+/**
+ * Fee facts for a pending deposit, so the creator can be told when theirs is
+ * underpriced. Facts only — what to DO about it is the browser's copy, and the
+ * app cannot act on it either way: replacing that transaction needs the keys
+ * of the wallet it was sent from, which are not ours.
+ *
+ * BEST EFFORT BY CONSTRUCTION. This is a nicety on top of the deposit read, so
+ * every failure returns null rather than throwing: an indexer that will not
+ * serve /tx must not take down the screen that shows someone their money.
+ */
+export async function fetchPendingDepositFee(
+  opts: IndexerConfig & { txid: string; timeoutMs?: number; fetchImpl?: typeof fetch }
+): Promise<{ txid: string; feeSats: number; vsize: number; rbf: boolean } | null> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? 5_000);
+  try {
+    const res = await fetchImpl(`${stripTrailingSlash(opts.api)}/tx/${opts.txid}`, {
+      signal: controller.signal,
+      headers: indexerAuthHeaders(opts),
+    });
+    if (!res.ok) return null;
+    const tx = (await res.json()) as {
+      fee?: number;
+      weight?: number;
+      vin?: Array<{ sequence?: number }>;
+    };
+    if (typeof tx.fee !== 'number' || typeof tx.weight !== 'number' || tx.weight <= 0) return null;
+    return {
+      txid: opts.txid,
+      feeSats: tx.fee,
+      vsize: Math.round(tx.weight / 4),
+      // BIP-125 opt-in: any input with sequence < 0xfffffffe signals it.
+      rbf: (tx.vin ?? []).some((i) => typeof i.sequence === 'number' && i.sequence < 0xfffffffe),
+    };
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 /**
@@ -1006,6 +1051,27 @@ export function createBitcoinRoutes(deps: {
     }
     const estimatedCostSats = costFor(inputCount);
 
+    // One extra indexer read, and only while a deposit is actually pending.
+    let pendingDeposit:
+      | { feeSats: number; vsize: number; rbf: boolean; networkSatVb: number }
+      | null = null;
+    if (utxos.unconfirmedTxids.length > 0) {
+      try {
+        const [fee, networkSatVb] = await Promise.all([
+          fetchPendingDepositFee({
+            ...indexer,
+            txid: utxos.unconfirmedTxids[0],
+            fetchImpl: deps.fetchImpl,
+          }),
+          currentFeeRate(1),
+        ]);
+        if (fee) pendingDeposit = { feeSats: fee.feeSats, vsize: fee.vsize, rbf: fee.rbf, networkSatVb };
+      } catch {
+        // Advisory only. A fee estimator or /tx read that is down changes
+        // nothing about the deposit itself.
+      }
+    }
+
     // A shortfall is a money-path state, not a UI detail: it is the state a
     // stranger sits in with real BTC already sent. Logged on the TRANSITION
     // (the confirmed balance changed) so a 15s poll does not flood the sink.
@@ -1040,6 +1106,14 @@ export function createBitcoinRoutes(deps: {
       ordinalCheck: classified.ok ? ('ok' as const) : ('unavailable' as const),
       unconfirmedSats: utxos.unconfirmedSats,
       estimatedCostSats,
+      /**
+       * Fee facts for a pending deposit, when there is one. Lets the browser
+       * say "yours is paying 1 sat/vB while the network clears 3" instead of
+       * leaving a creator to work that out in a block explorer. Null whenever
+       * anything about the lookup is uncertain — best effort, never a reason
+       * to fail the deposit read.
+       */
+      pendingDeposit,
     });
   };
 

--- a/apps/landing/server/index.ts
+++ b/apps/landing/server/index.ts
@@ -38,6 +38,7 @@ export function buildRoutes(deps: {
     routes['POST /api/btc/fee'] = deps.bitcoin.fee;
     routes['POST /api/btc/broadcast'] = deps.bitcoin.broadcast;
     routes['GET /api/btc/deposit'] = deps.bitcoin.deposit;
+    routes['GET /api/btc/prevtx'] = deps.bitcoin.prevTx;
     // Unauthenticated on purpose: the browser must be able to detect a
     // build-time/runtime network skew BEFORE it shows anyone a deposit address.
     routes['GET /api/btc/network'] = deps.bitcoin.networkInfo;

--- a/apps/landing/server/tests/pending-deposit-fee.test.ts
+++ b/apps/landing/server/tests/pending-deposit-fee.test.ts
@@ -1,0 +1,74 @@
+import { describe, test, expect } from 'bun:test';
+import { slowestPending, MAX_PENDING_FEE_LOOKUPS, fetchPendingDepositFee } from '../bitcoin';
+
+describe('the advice describes the payment holding the deposit up', () => {
+  const fast = { feeSats: 1640, vsize: 164 }; // 10 sat/vB
+  const slow = { feeSats: 165, vsize: 164 }; //  1 sat/vB
+
+  test('picks the lowest fee RATE, not the lowest fee or the first listed', () => {
+    // A big transaction can pay more in total while being slower per vByte.
+    const bigButSlow = { feeSats: 500, vsize: 1000 }; // 0.5 sat/vB
+    expect(slowestPending([fast, bigButSlow, slow])).toBe(bigButSlow);
+  });
+
+  test('order of the indexer response does not change the answer', () => {
+    expect(slowestPending([fast, slow])).toBe(slow);
+    expect(slowestPending([slow, fast])).toBe(slow);
+  });
+
+  test('nothing pending means no advice', () => {
+    expect(slowestPending([])).toBeNull();
+  });
+
+  test('a zero-vsize entry cannot divide by zero into first place', () => {
+    expect(slowestPending([{ feeSats: 0, vsize: 0 }, slow])).toBe(slow);
+  });
+
+  test('the lookup fan-out stays bounded — this route is polled every 15s', () => {
+    expect(MAX_PENDING_FEE_LOOKUPS).toBeLessThanOrEqual(3);
+  });
+});
+
+describe('pending fee facts are best effort and never throw', () => {
+  const cfg = { api: 'https://indexer.test', txid: 'a'.repeat(64) };
+
+  test('vsize is ceil(weight/4), so the rate is never overstated', async () => {
+    // weight % 4 == 1: rounding would give 164 and overstate the fee rate.
+    const got = await fetchPendingDepositFee({
+      ...cfg,
+      fetchImpl: (async () => ({
+        ok: true,
+        json: async () => ({ fee: 165, weight: 657, vin: [{ sequence: 0xfffffffd }] }),
+      })) as unknown as typeof fetch,
+    });
+    expect(got?.vsize).toBe(165);
+  });
+
+  test('reads RBF opt-in off the input sequences', async () => {
+    const rbf = async (sequence: number) =>
+      (
+        await fetchPendingDepositFee({
+          ...cfg,
+          fetchImpl: (async () => ({
+            ok: true,
+            json: async () => ({ fee: 165, weight: 656, vin: [{ sequence }] }),
+          })) as unknown as typeof fetch,
+        })
+      )?.rbf;
+    expect(await rbf(0xfffffffd)).toBe(true);
+    expect(await rbf(0xffffffff)).toBe(false);
+    expect(await rbf(0xfffffffe)).toBe(false); // the exact non-signalling boundary
+  });
+
+  test('a failed read returns null rather than breaking the deposit screen', async () => {
+    for (const impl of [
+      async () => ({ ok: false, json: async () => ({}) }),
+      async () => ({ ok: true, json: async () => ({ fee: 165 }) }), // no weight
+      async () => {
+        throw new Error('indexer down');
+      },
+    ]) {
+      expect(await fetchPendingDepositFee({ ...cfg, fetchImpl: impl as unknown as typeof fetch })).toBeNull();
+    }
+  });
+});

--- a/apps/landing/server/tests/pending-deposit-fee.test.ts
+++ b/apps/landing/server/tests/pending-deposit-fee.test.ts
@@ -72,3 +72,26 @@ describe('pending fee facts are best effort and never throw', () => {
     }
   });
 });
+
+describe('advice is withheld unless every pending payment was priced', () => {
+  /**
+   * The defect: with more pending payments than the lookup cap, or a lookup
+   * that failed, advising from the subset can name a FASTER sibling while the
+   * real blocker sits outside it — sending the creator's fee bump, and the
+   * explorer link, at the wrong transaction.
+   */
+  test('a partial view is not enough to name the blocker', () => {
+    const priced = [{ feeSats: 1640, vsize: 164 }]; // the fast one
+    const totalPending = 2; // the slow one was never priced
+    const sawThemAll = priced.length === totalPending;
+    expect(sawThemAll).toBe(false);
+    // The route advises only when sawThemAll — so nothing is claimed here.
+    expect(sawThemAll ? slowestPending(priced) : null).toBeNull();
+  });
+
+  test('a complete view does name it', () => {
+    const priced = [{ feeSats: 1640, vsize: 164 }, { feeSats: 165, vsize: 164 }];
+    const sawThemAll = priced.length === 2;
+    expect(sawThemAll ? slowestPending(priced) : null).toBe(priced[1]);
+  });
+});

--- a/apps/landing/src/components/Demo.tsx
+++ b/apps/landing/src/components/Demo.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DepositPanel } from './DepositPanel';
+import { DepositFeeNotice } from './DepositFeeNotice';
 import { demo } from '../content';
 import type { DemoAssetState, DemoEngine } from '../sdk/engine';
 import { engineIdentity, ANON_IDENTITY } from '../sdk/engine';
@@ -33,6 +34,8 @@ export interface DepositInfo {
   ordinalCheck?: 'ok' | 'unavailable';
   unconfirmedSats: number;
   estimatedCostSats: number;
+  /** Fee facts for a pending deposit, when the server could read them. */
+  pendingDeposit?: { feeSats: number; vsize: number; rbf: boolean; networkSatVb: number } | null;
 }
 
 /**
@@ -1157,6 +1160,9 @@ export function Demo() {
                             address={bitcoin.fundingAddress}
                             sats={deposit.estimatedCostSats}
                           />
+                          {deposit.pendingDeposit && (
+                            <DepositFeeNotice pending={deposit.pendingDeposit} />
+                          )}
                           <p className="demo-inscribe-note deposit-topup">
                             {demo.deposit.topUpNote}
                           </p>

--- a/apps/landing/src/components/Demo.tsx
+++ b/apps/landing/src/components/Demo.tsx
@@ -1174,6 +1174,8 @@ export function Demo() {
                           <DepositPanel
                             address={bitcoin.fundingAddress}
                             sats={deposit.estimatedCostSats}
+                            balanceSats={deposit.confirmedSats ?? 0}
+                            funded={readiness === 'ready'}
                             pendingSats={deposit.unconfirmedSats}
                             shortfall={
                               readiness === 'short'

--- a/apps/landing/src/components/Demo.tsx
+++ b/apps/landing/src/components/Demo.tsx
@@ -326,17 +326,18 @@ export function quoteForAddress(
 }
 
 /** What the deposit badge should say — read off the SUM, never one output. */
-export type DepositReadiness = 'waiting' | 'detected' | 'ready' | 'unspendable';
+export type DepositReadiness = 'waiting' | 'detected' | 'short' | 'ready' | 'unspendable';
 
 /**
  * The badge for a deposit block. Split out so the readiness is computed once
- * per render and the four states read as a table rather than a nested ternary.
+ * per render and the five states read as a table rather than a nested ternary.
  */
 export function depositBadgeLabel(
   readiness: ReturnType<typeof depositReadiness>,
   copy: {
     ordinalCheckBadge: string;
     ready: string;
+    shortBadge: string;
     detected: string;
     waiting: string;
   }
@@ -346,6 +347,8 @@ export function depositBadgeLabel(
       return copy.ordinalCheckBadge;
     case 'ready':
       return copy.ready;
+    case 'short':
+      return copy.shortBadge;
     case 'detected':
       return copy.detected;
     default:
@@ -358,6 +361,11 @@ export function depositReadiness(info: DepositInfo | null): DepositReadiness {
   if (info.ordinalCheck === 'unavailable') return 'unspendable';
   const spendable = info.confirmedUtxos.reduce((n, u) => n + u.value, 0);
   if (spendable >= info.estimatedCostSats) return 'ready';
+  // CONFIRMED but not enough is its own state. It used to fall through to
+  // 'detected', whose copy says "waiting for one confirmation" — so a creator
+  // whose money had already confirmed sat watching a poll for an event that
+  // had happened, never told they were short or by how much.
+  if (spendable > 0) return 'short';
   const seen = spendable + info.unconfirmedSats + (info.confirmedSats ?? 0);
   return seen > 0 ? 'detected' : 'waiting';
 }
@@ -1167,6 +1175,16 @@ export function Demo() {
                             address={bitcoin.fundingAddress}
                             sats={deposit.estimatedCostSats}
                             pendingSats={deposit.unconfirmedSats}
+                            shortfall={
+                              readiness === 'short'
+                                ? {
+                                    heldSats: deposit.confirmedUtxos.reduce((n, u) => n + u.value, 0),
+                                    shortfallSats:
+                                      deposit.estimatedCostSats -
+                                      deposit.confirmedUtxos.reduce((n, u) => n + u.value, 0),
+                                  }
+                                : null
+                            }
                             pendingHref={
                               deposit.pendingDeposit
                                 ? explorerTxUrl(network, deposit.pendingDeposit.txid)

--- a/apps/landing/src/components/Demo.tsx
+++ b/apps/landing/src/components/Demo.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DepositPanel } from './DepositPanel';
 import { DepositFeeNotice } from './DepositFeeNotice';
+import { explorerTxUrl } from '../sdk/explorer';
 import { demo } from '../content';
 import type { DemoAssetState, DemoEngine } from '../sdk/engine';
 import { engineIdentity, ANON_IDENTITY } from '../sdk/engine';
@@ -35,7 +36,13 @@ export interface DepositInfo {
   unconfirmedSats: number;
   estimatedCostSats: number;
   /** Fee facts for a pending deposit, when the server could read them. */
-  pendingDeposit?: { feeSats: number; vsize: number; rbf: boolean; networkSatVb: number } | null;
+  pendingDeposit?: {
+    txid: string;
+    feeSats: number;
+    vsize: number;
+    rbf: boolean;
+    networkSatVb: number;
+  } | null;
 }
 
 /**
@@ -1159,6 +1166,12 @@ export function Demo() {
                           <DepositPanel
                             address={bitcoin.fundingAddress}
                             sats={deposit.estimatedCostSats}
+                            pendingSats={deposit.unconfirmedSats}
+                            pendingHref={
+                              deposit.pendingDeposit
+                                ? explorerTxUrl(network, deposit.pendingDeposit.txid)
+                                : null
+                            }
                           />
                           {deposit.pendingDeposit && (
                             <DepositFeeNotice pending={deposit.pendingDeposit} />

--- a/apps/landing/src/components/DepositFeeNotice.tsx
+++ b/apps/landing/src/components/DepositFeeNotice.tsx
@@ -1,0 +1,57 @@
+import { demo } from '../content';
+import { depositFeeAdvice } from '../sdk/deposit-fee-advice';
+
+/**
+ * Tells a creator their pending deposit is underpriced, and what would fix it.
+ *
+ * Deliberately NOT a button. The app cannot replace that transaction: RBF
+ * re-signs the original inputs, and those belong to whatever wallet the
+ * creator paid from, not to their Turnkey wallet. Offering an action we cannot
+ * perform is the same defect as telling someone to sign in again when signing
+ * in is what failed — so this states the numbers and points at the wallet that
+ * can actually do it.
+ */
+export function DepositFeeNotice({
+  pending,
+}: {
+  pending: { feeSats: number; vsize: number; rbf: boolean; networkSatVb: number };
+}) {
+  const advice = depositFeeAdvice(pending);
+  if (advice.kind === 'fine') return null;
+
+  return (
+    <div className="deposit-fee-notice">
+      <strong className="deposit-fee-heading">{demo.deposit.feeLowHeading}</strong>
+      <p className="deposit-fee-body">{demo.deposit.feeLowBody}</p>
+
+      <dl className="deposit-fee-rates">
+        <div>
+          <dt>{demo.deposit.feeLowYours}</dt>
+          <dd>{advice.feeRateSatVb} sat/vB</dd>
+        </div>
+        <div>
+          <dt>{demo.deposit.feeLowNetwork}</dt>
+          <dd>{advice.networkSatVb} sat/vB</dd>
+        </div>
+        {advice.kind === 'bumpable' && (
+          <div className="deposit-fee-suggest">
+            <dt>{demo.deposit.feeLowSuggest}</dt>
+            <dd>{advice.suggestSatVb} sat/vB</dd>
+          </div>
+        )}
+      </dl>
+
+      {advice.kind === 'bumpable' ? (
+        <>
+          <p className="deposit-fee-body">{demo.deposit.feeLowBumpable}</p>
+          <p className="deposit-fee-min">
+            {demo.deposit.feeLowMinimum}:{' '}
+            <code>{advice.minReplacementFeeSats.toLocaleString()} sats</code>
+          </p>
+        </>
+      ) : (
+        <p className="deposit-fee-body">{demo.deposit.feeLowUnbumpable}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/landing/src/components/DepositPanel.tsx
+++ b/apps/landing/src/components/DepositPanel.tsx
@@ -25,6 +25,7 @@ export function DepositPanel({
   sats,
   pendingSats = 0,
   pendingHref,
+  shortfall,
 }: {
   address: string;
   sats: number;
@@ -36,6 +37,12 @@ export function DepositPanel({
    * an empty href on screen, which looks like a link and goes nowhere.
    */
   pendingHref?: string | null;
+  /**
+   * A CONFIRMED deposit that does not cover the cost. Shown here rather than
+   * only when the inscribe button is pressed: the number a creator needs is
+   * the number they need BEFORE they go back to their wallet, not after.
+   */
+  shortfall?: { heldSats: number; shortfallSats: number } | null;
 }) {
   const [copied, setCopied] = useState(false);
   const uri = bitcoinPaymentUri(address, sats);
@@ -88,6 +95,15 @@ export function DepositPanel({
           <p className="deposit-hint deposit-hint-center">{demo.deposit.scanHint}</p>
         </div>
       </div>
+
+      {shortfall && (
+        <p className="deposit-short" role="status">
+          <strong>{shortfall.heldSats.toLocaleString()} sats</strong> confirmed.{' '}
+          {demo.deposit.shortTopUpPrefix}{' '}
+          <strong>{shortfall.shortfallSats.toLocaleString()} sats</strong>{' '}
+          {demo.deposit.shortTopUpSuffix}
+        </p>
+      )}
 
       {/* The gap this closes: between sending and confirming, nothing on
           screen told a creator we could see their money. The badge said

--- a/apps/landing/src/components/DepositPanel.tsx
+++ b/apps/landing/src/components/DepositPanel.tsx
@@ -26,6 +26,8 @@ export function DepositPanel({
   pendingSats = 0,
   pendingHref,
   shortfall,
+  balanceSats = 0,
+  funded = false,
 }: {
   address: string;
   sats: number;
@@ -43,6 +45,10 @@ export function DepositPanel({
    * the number they need BEFORE they go back to their wallet, not after.
    */
   shortfall?: { heldSats: number; shortfallSats: number } | null;
+  /** Everything confirmed at the address — what the creator actually holds. */
+  balanceSats?: number;
+  /** That balance covers the cost, so nothing needs sending. */
+  funded?: boolean;
 }) {
   const [copied, setCopied] = useState(false);
   const uri = bitcoinPaymentUri(address, sats);
@@ -58,14 +64,10 @@ export function DepositPanel({
     }
   };
 
-  return (
-    <div className="deposit">
-      <div className="deposit-amount">
-        <span className="deposit-amount-label">{demo.deposit.sendPrefix}</span>
-        <strong className="deposit-amount-value">{sats.toLocaleString()}</strong>
-        <span className="deposit-amount-unit">sats</span>
-      </div>
-
+  // The address, QR and copy button. Front and centre while funding is needed;
+  // tucked into a disclosure once it is not, because a funded creator's next
+  // move is to inscribe, not to send more money.
+  const payBlock = (
       <div className="deposit-pay">
         <div className="deposit-pay-main">
           <span className="deposit-address-label">{demo.deposit.addressLabel}</span>
@@ -95,6 +97,47 @@ export function DepositPanel({
           <p className="deposit-hint deposit-hint-center">{demo.deposit.scanHint}</p>
         </div>
       </div>
+  );
+
+  return (
+    <div className="deposit">
+      {funded ? (
+        <>
+          <div className="deposit-funded" role="status">
+            <strong className="deposit-funded-heading">{demo.deposit.fundedHeading}</strong>
+            <p className="deposit-funded-body">{demo.deposit.fundedBody}</p>
+          </div>
+          <dl className="deposit-balance">
+            <div>
+              <dt>{demo.deposit.balanceLabel}</dt>
+              <dd>{balanceSats.toLocaleString()} sats</dd>
+            </div>
+            <div>
+              <dt>{demo.deposit.balanceNeeded}</dt>
+              <dd>{sats.toLocaleString()} sats</dd>
+            </div>
+          </dl>
+          <p className="deposit-purpose">{demo.deposit.balanceReuse}</p>
+          <details className="deposit-details">
+            <summary>{demo.deposit.addMoreSummary}</summary>
+            <div className="deposit-details-body">{payBlock}</div>
+          </details>
+        </>
+      ) : (
+        <>
+          <div className="deposit-amount">
+            <span className="deposit-amount-label">{demo.deposit.sendPrefix}</span>
+            <strong className="deposit-amount-value">{sats.toLocaleString()}</strong>
+            <span className="deposit-amount-unit">sats</span>
+          </div>
+          {balanceSats > 0 && (
+            <p className="deposit-hint deposit-balance-line">
+              {demo.deposit.balanceLabel}: <strong>{balanceSats.toLocaleString()} sats</strong>
+            </p>
+          )}
+          {payBlock}
+        </>
+      )}
 
       {shortfall && (
         <p className="deposit-short" role="status">

--- a/apps/landing/src/components/DepositPanel.tsx
+++ b/apps/landing/src/components/DepositPanel.tsx
@@ -20,7 +20,23 @@ import './deposit.css';
  * that the disclosure no longer stands between a person and the thing they
  * came here to do.
  */
-export function DepositPanel({ address, sats }: { address: string; sats: number }) {
+export function DepositPanel({
+  address,
+  sats,
+  pendingSats = 0,
+  pendingHref,
+}: {
+  address: string;
+  sats: number;
+  /** Sats seen at the address but not yet confirmed. */
+  pendingSats?: number;
+  /**
+   * Where to look the payment up. Resolved by the caller and null when we have
+   * no explorer for this network — passing a function that could return '' put
+   * an empty href on screen, which looks like a link and goes nowhere.
+   */
+  pendingHref?: string | null;
+}) {
   const [copied, setCopied] = useState(false);
   const uri = bitcoinPaymentUri(address, sats);
 
@@ -72,6 +88,25 @@ export function DepositPanel({ address, sats }: { address: string; sats: number 
           <p className="deposit-hint deposit-hint-center">{demo.deposit.scanHint}</p>
         </div>
       </div>
+
+      {/* The gap this closes: between sending and confirming, nothing on
+          screen told a creator we could see their money. The badge said
+          "detected", which is easy to miss and does not name an amount. */}
+      {pendingSats > 0 && (
+        <p className="deposit-pending" role="status">
+          <span className="deposit-pending-dot" aria-hidden="true" />
+          <strong>{pendingSats.toLocaleString()} sats</strong>{' '}
+          {demo.deposit.pendingSeenSuffix}
+          {pendingHref && (
+            <>
+              {' '}
+              <a href={pendingHref} target="_blank" rel="noreferrer">
+                {demo.deposit.pendingViewLink}
+              </a>
+            </>
+          )}
+        </p>
+      )}
 
       <p className="deposit-purpose">{demo.deposit.purposeShort}</p>
 

--- a/apps/landing/src/components/deposit-disclosure.test.ts
+++ b/apps/landing/src/components/deposit-disclosure.test.ts
@@ -106,7 +106,11 @@ describe('what the creator is told about their balance', () => {
       ordinalCheck: 'ok' as const,
     };
     expect(depositReadiness(info)).toBe('ready');
-    expect(depositReadiness({ ...info, estimatedCostSats: 20_000 })).toBe('detected');
+    // CONFIRMED but short is 'short', not 'detected'. This assertion used to
+    // expect 'detected', whose copy reads "waiting for one confirmation" —
+    // which told a creator whose deposit had already confirmed to keep waiting
+    // and never named the gap. Changed deliberately.
+    expect(depositReadiness({ ...info, estimatedCostSats: 20_000 })).toBe('short');
     expect(depositReadiness({ ...info, confirmedUtxos: [] })).toBe('waiting');
     // Unconfirmed money is money that has arrived, even if it cannot be spent.
     expect(depositReadiness({ ...info, confirmedUtxos: [], unconfirmedSats: 5_000 })).toBe('detected');

--- a/apps/landing/src/components/deposit-panel.test.ts
+++ b/apps/landing/src/components/deposit-panel.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { demo } from '../content';
-import { depositDisclosure, quoteForAddress, depositReadiness } from './Demo';
+import { depositDisclosure, quoteForAddress, depositReadiness, depositBadgeLabel } from './Demo';
 import { bitcoinPaymentUri } from '../sdk/bitcoin-uri';
 
 /**
@@ -106,5 +106,56 @@ describe('a quote never crosses to another address', () => {
   test('a mismatched quote cannot drive the readiness badge', () => {
     expect(depositReadiness(quoteForAddress(quote(A), B))).toBe('waiting');
     expect(depositReadiness(quoteForAddress(quote(A), A))).not.toBe('waiting');
+  });
+});
+
+describe('a confirmed deposit that does not cover the cost', () => {
+  const utxo = (value: number) => ({
+    txid: 'a'.repeat(64),
+    vout: 0,
+    value,
+    scriptPubKey: '0014' + '11'.repeat(20),
+  });
+  const info = (confirmed: number, cost: number) => ({
+    address: 'bc1qwx77y7n2dvcfy2aejnrxcapevmssfezc4ly4rl',
+    confirmedUtxos: confirmed > 0 ? [utxo(confirmed)] : [],
+    confirmedSats: confirmed,
+    unconfirmedSats: 0,
+    estimatedCostSats: cost,
+  });
+
+  /**
+   * The live failure. 14,580 confirmed against an 18,599 quote reported
+   * 'detected', whose copy reads "waiting for one confirmation" — so a creator
+   * whose money HAD confirmed watched a poll for an event already past, and was
+   * never told they were 4,019 short.
+   */
+  test('is not reported as waiting for a confirmation that already happened', () => {
+    expect(depositReadiness(info(14_580, 18_599))).toBe('short');
+    expect(depositReadiness(info(14_580, 18_599))).not.toBe('detected');
+  });
+
+  test('its badge does not promise a pending confirmation', () => {
+    const label = depositBadgeLabel('short', demo.deposit);
+    expect(label).not.toMatch(/waiting/i);
+    expect(label).toMatch(/top-up|confirmed/i);
+  });
+
+  test('enough is still ready, and exactly enough counts', () => {
+    expect(depositReadiness(info(18_599, 18_599))).toBe('ready');
+    expect(depositReadiness(info(20_000, 18_599))).toBe('ready');
+  });
+
+  test('nothing confirmed yet is still waiting, not short', () => {
+    expect(depositReadiness(info(0, 18_599))).toBe('waiting');
+  });
+
+  // The quote already prices the top-up's own input (server: used + 1), so the
+  // displayed gap is the whole gap — a creator who sends it is not short again.
+  test('the gap shown is the whole gap', () => {
+    const i = info(14_580, 18_599);
+    const held = i.confirmedUtxos.reduce((n, u) => n + u.value, 0);
+    expect(i.estimatedCostSats - held).toBe(4_019);
+    expect(depositReadiness({ ...i, confirmedUtxos: [utxo(18_599)], confirmedSats: 18_599 })).toBe('ready');
   });
 });

--- a/apps/landing/src/components/deposit-panel.test.ts
+++ b/apps/landing/src/components/deposit-panel.test.ts
@@ -159,3 +159,39 @@ describe('a confirmed deposit that does not cover the cost', () => {
     expect(depositReadiness({ ...i, confirmedUtxos: [utxo(18_599)], confirmedSats: 18_599 })).toBe('ready');
   });
 });
+
+describe('a funded deposit stops asking for money', () => {
+  /**
+   * The UX failure: the panel rendered "Send at least N sats" regardless of
+   * readiness, so someone whose deposit already covered the cost was still
+   * being told to pay, with no indication the next move was theirs.
+   * depositReadiness is what the panel now switches on.
+   */
+  const utxo = (value: number) => ({ txid: 'a'.repeat(64), vout: 0, value, scriptPubKey: '0014' + '11'.repeat(20) });
+  const info = (confirmed: number, cost: number) => ({
+    address: 'bc1qwx77y7n2dvcfy2aejnrxcapevmssfezc4ly4rl',
+    confirmedUtxos: [utxo(confirmed)],
+    confirmedSats: confirmed,
+    unconfirmedSats: 0,
+    estimatedCostSats: cost,
+  });
+
+  test('leftover sats keep a later inscription funded without a new deposit', () => {
+    // 19,580 held against a 14,580 cost: funded, and the surplus stays put.
+    expect(depositReadiness(info(19_580, 14_580))).toBe('ready');
+  });
+
+  test('the funded and unfunded states are distinguishable by readiness alone', () => {
+    expect(depositReadiness(info(19_580, 14_580))).toBe('ready');
+    expect(depositReadiness(info(14_580, 18_599))).toBe('short');
+  });
+
+  test('the funded copy tells the creator to inscribe, not to send more', () => {
+    expect(demo.deposit.fundedHeading).toMatch(/ready to inscribe/i);
+    expect(demo.deposit.fundedBody).not.toMatch(/send/i);
+  });
+
+  test('the balance copy explains that a surplus is reusable, not stranded', () => {
+    expect(demo.deposit.balanceReuse).toMatch(/next inscription/i);
+  });
+});

--- a/apps/landing/src/components/deposit.css
+++ b/apps/landing/src/components/deposit.css
@@ -406,3 +406,63 @@
   font-variant-numeric: tabular-nums;
   color: var(--accent-text);
 }
+
+/* --- funded ------------------------------------------------------------- */
+
+/*
+ * The panel used to say "Send at least N sats" even once the deposit covered
+ * the cost, so someone who had already paid was still being asked to pay. This
+ * state exists to say the opposite, plainly.
+ */
+.deposit-funded {
+  padding: var(--sp-4);
+  border: 1px solid rgba(63, 221, 157, 0.35);
+  border-radius: var(--r-md);
+  background: rgba(63, 221, 157, 0.07);
+}
+
+.deposit-funded-heading {
+  display: block;
+  margin-bottom: var(--sp-2);
+  color: var(--ok);
+  font-size: var(--text-md);
+}
+
+.deposit-funded-body {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+}
+
+.deposit-balance {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-6);
+  margin: var(--sp-4) 0 0;
+}
+
+.deposit-balance dt {
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 2px;
+}
+
+.deposit-balance dd {
+  font-family: var(--font-mono);
+  font-size: var(--text-md);
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.deposit-balance-line {
+  margin-top: calc(var(--sp-2) * -1);
+  margin-bottom: var(--sp-3);
+}
+
+.deposit-balance-line strong {
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}

--- a/apps/landing/src/components/deposit.css
+++ b/apps/landing/src/components/deposit.css
@@ -385,3 +385,24 @@
 @media (prefers-reduced-motion: reduce) {
   .deposit-pending-dot { animation: none; }
 }
+
+/*
+ * Confirmed, but short. Amber like the risk block: nothing has gone wrong and
+ * no money is at risk, but the creator has to act before anything proceeds.
+ */
+.deposit-short {
+  margin-top: var(--sp-3);
+  padding: var(--sp-3) var(--sp-4);
+  border-left: 2px solid var(--accent);
+  border-radius: 0 var(--r-sm) var(--r-sm) 0;
+  background: var(--accent-soft);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  line-height: 1.65;
+}
+
+.deposit-short strong {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  color: var(--accent-text);
+}

--- a/apps/landing/src/components/deposit.css
+++ b/apps/landing/src/components/deposit.css
@@ -264,3 +264,69 @@
     transition: none;
   }
 }
+
+/* --- underpriced pending deposit ---------------------------------------- */
+
+/*
+ * Informational, not an error: the deposit is queued, not lost. Uses the same
+ * quiet raised surface as the pay block rather than the risk block's amber,
+ * which is reserved for "you could lose money".
+ */
+.deposit-fee-notice {
+  margin-top: var(--sp-3);
+  padding: var(--sp-4);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--bg-raised);
+}
+
+.deposit-fee-heading {
+  display: block;
+  margin-bottom: var(--sp-2);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+}
+
+.deposit-fee-body {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: 1.65;
+}
+
+.deposit-fee-rates {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-5);
+  margin: var(--sp-3) 0;
+}
+
+.deposit-fee-rates dt {
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 2px;
+}
+
+.deposit-fee-rates dd {
+  font-family: var(--font-mono);
+  font-size: var(--text-base);
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+/* The number they should act on. */
+.deposit-fee-suggest dd {
+  color: var(--accent-text);
+}
+
+.deposit-fee-min {
+  margin-top: var(--sp-2);
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+}
+
+.deposit-fee-min code {
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+}

--- a/apps/landing/src/components/deposit.css
+++ b/apps/landing/src/components/deposit.css
@@ -330,3 +330,58 @@
   font-family: var(--font-mono);
   color: var(--text-secondary);
 }
+
+/* --- payment seen, not yet confirmed ------------------------------------ */
+
+/*
+ * Green, and stated in sats. "Detected" on a small badge is easy to miss at
+ * the one moment a creator most wants confirmation that their money arrived.
+ */
+.deposit-pending {
+  display: flex;
+  align-items: baseline;
+  gap: var(--sp-2);
+  flex-wrap: wrap;
+  margin-top: var(--sp-3);
+  padding: var(--sp-3) var(--sp-4);
+  border-left: 2px solid var(--ok);
+  border-radius: 0 var(--r-sm) var(--r-sm) 0;
+  background: rgba(63, 221, 157, 0.08);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+}
+
+.deposit-pending strong {
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.deposit-pending a {
+  color: var(--text-secondary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.deposit-pending a:hover {
+  color: var(--text-primary);
+}
+
+.deposit-pending-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: var(--r-full);
+  background: var(--ok);
+  flex: 0 0 auto;
+  align-self: center;
+  animation: deposit-pulse 2s var(--ease) infinite;
+}
+
+@keyframes deposit-pulse {
+  50% { opacity: 0.35; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .deposit-pending-dot { animation: none; }
+}

--- a/apps/landing/src/content.ts
+++ b/apps/landing/src/content.ts
@@ -415,6 +415,10 @@ export const demo = {
     openInWallet: 'Open in wallet',
     openInWalletHint: 'Opens your Bitcoin wallet with the address and amount already filled in.',
     scanHint: 'Or scan to pay from your phone',
+    // Between sending and confirming, a creator has no way to tell whether we
+    // can see their money — and that is the worst moment to say nothing.
+    pendingSeenSuffix: 'in the mempool — we can see it, waiting for one confirmation.',
+    pendingViewLink: 'View transaction',
     // A pending deposit paying under the going rate. We cannot fix this: the
     // inputs belong to the wallet the creator sent from, so only that wallet
     // can replace the transaction. Saying so beats a button that cannot work.
@@ -432,8 +436,12 @@ export const demo = {
     // sendSuffix continues the "Send at least <n> sats" sentence, so it cannot
     // stand alone now that the amount lives in its own block. This is the same
     // point as a whole sentence.
+    // Accurate about where money goes: selectFundingUtxos takes largest-first
+    // and STOPS once the target is covered, so a deposit it does not need is
+    // left at the address — and there is no withdrawal path for it. The old
+    // line promised the opposite ("spends every confirmed deposit").
     topUpNote:
-      'One payment or several — the inscription spends every confirmed deposit sitting at the address, so a top-up after a fee rise works too.',
+      'Several payments work too: the inscription spends what it needs, largest first, and leaves the rest at the address.',
     waiting: 'Waiting for your deposit…',
     detected: 'Deposit detected — waiting for one confirmation.',
     ready: 'Deposit confirmed — ready to inscribe.',

--- a/apps/landing/src/content.ts
+++ b/apps/landing/src/content.ts
@@ -448,7 +448,7 @@ export const demo = {
     feeLowYours: 'Yours',
     feeLowNetwork: 'Clearing now',
     feeLowSuggest: 'Replace at',
-    feeLowMinimum: 'Minimum the network will accept',
+    feeLowMinimum: 'At least, if the replacement is the same size',
     // sendSuffix continues the "Send at least <n> sats" sentence, so it cannot
     // stand alone now that the amount lives in its own block. This is the same
     // point as a whole sentence.

--- a/apps/landing/src/content.ts
+++ b/apps/landing/src/content.ts
@@ -419,6 +419,16 @@ export const demo = {
     // can see their money — and that is the worst moment to say nothing.
     pendingSeenSuffix: 'in the mempool — we can see it, waiting for one confirmation.',
     pendingViewLink: 'View transaction',
+    // The funded state. Previously the panel said "Send at least N sats" even
+    // once the deposit covered the cost, so a creator who had already paid was
+    // still being told to pay and had no idea the next move was theirs.
+    fundedHeading: 'Funded — ready to inscribe',
+    fundedBody: 'Your deposit covers this inscription. Use the button below to inscribe on Bitcoin.',
+    balanceLabel: 'Your deposit balance',
+    balanceNeeded: 'needed for this inscription',
+    addMoreSummary: 'Add more funds, or see the deposit address',
+    balanceReuse:
+      'Anything left over stays at this address and pays for your next inscription here — you will not be asked to deposit again while it covers the cost.',
     // A CONFIRMED deposit that does not cover the cost. Distinct from
     // 'detected', whose copy promises a confirmation that already happened.
     shortBadge: 'Deposit confirmed — a top-up is needed.',

--- a/apps/landing/src/content.ts
+++ b/apps/landing/src/content.ts
@@ -419,6 +419,12 @@ export const demo = {
     // can see their money — and that is the worst moment to say nothing.
     pendingSeenSuffix: 'in the mempool — we can see it, waiting for one confirmation.',
     pendingViewLink: 'View transaction',
+    // A CONFIRMED deposit that does not cover the cost. Distinct from
+    // 'detected', whose copy promises a confirmation that already happened.
+    shortBadge: 'Deposit confirmed — a top-up is needed.',
+    shortTopUpPrefix: 'Send',
+    shortTopUpSuffix:
+      'more to the same address. The quote above already includes the cost of spending that second payment, so this amount is the whole gap.',
     // A pending deposit paying under the going rate. We cannot fix this: the
     // inputs belong to the wallet the creator sent from, so only that wallet
     // can replace the transaction. Saying so beats a button that cannot work.

--- a/apps/landing/src/content.ts
+++ b/apps/landing/src/content.ts
@@ -415,6 +415,20 @@ export const demo = {
     openInWallet: 'Open in wallet',
     openInWalletHint: 'Opens your Bitcoin wallet with the address and amount already filled in.',
     scanHint: 'Or scan to pay from your phone',
+    // A pending deposit paying under the going rate. We cannot fix this: the
+    // inputs belong to the wallet the creator sent from, so only that wallet
+    // can replace the transaction. Saying so beats a button that cannot work.
+    feeLowHeading: 'Your deposit is paying below the going rate',
+    feeLowBody:
+      'It will still confirm — it is queued behind higher-paying transactions, not stuck — and nothing is at risk while it waits.',
+    feeLowBumpable:
+      'If your wallet has a “bump fee” or “speed up” option, this payment can be replaced. Two things to get right: take the increase from your change, never from the deposit amount, and aim for the rate below — Bitcoin makes a replacement pay for its own bandwidth on top of the original fee, so a small nudge is rejected outright.',
+    feeLowUnbumpable:
+      'Your wallet did not mark this payment replaceable, so its fee cannot be raised. Waiting is the only option, and it will get there.',
+    feeLowYours: 'Yours',
+    feeLowNetwork: 'Clearing now',
+    feeLowSuggest: 'Replace at',
+    feeLowMinimum: 'Minimum the network will accept',
     // sendSuffix continues the "Send at least <n> sats" sentence, so it cannot
     // stand alone now that the amount lives in its own block. This is the same
     // point as a whole sentence.

--- a/apps/landing/src/sdk/deposit-fee-advice.test.ts
+++ b/apps/landing/src/sdk/deposit-fee-advice.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect } from 'bun:test';
+import { depositFeeAdvice } from './deposit-fee-advice';
+
+// The real transaction that prompted this: 165 sats over 164 vB, RBF signalled,
+// while the network was clearing ~3 sat/vB.
+const REAL = { feeSats: 165, vsize: 164, rbf: true, networkSatVb: 3 };
+
+describe('a deposit paying enough is left alone', () => {
+  test('at the network rate, there is nothing to say', () => {
+    expect(depositFeeAdvice({ ...REAL, feeSats: 492 }).kind).toBe('fine');
+  });
+
+  test('above it, likewise', () => {
+    expect(depositFeeAdvice({ ...REAL, feeSats: 1640 }).kind).toBe('fine');
+  });
+
+  test('a difference too small to display is not warned about', () => {
+    // 2.999 sat/vB rounds to 3.00 on screen; warning would contradict the UI.
+    const advice = depositFeeAdvice({ feeSats: 492, vsize: 164, rbf: true, networkSatVb: 3 });
+    expect(advice.kind).toBe('fine');
+  });
+});
+
+describe('an underpriced deposit that cannot be replaced says so', () => {
+  test('without RBF, the advice is to wait — not to try a bump that will fail', () => {
+    const advice = depositFeeAdvice({ ...REAL, rbf: false });
+    expect(advice.kind).toBe('slow');
+  });
+});
+
+describe('an underpriced, replaceable deposit gets a rate that will actually relay', () => {
+  const advice = depositFeeAdvice(REAL);
+
+  test('is recognised as bumpable', () => {
+    expect(advice.kind).toBe('bumpable');
+  });
+
+  /**
+   * The trap this exists for. BIP-125 rule 4 makes the floor
+   * `originalFee + vsize` = 165 + 164 = 329 sats, not "a bit more than 165".
+   * A wallet nudged to 1.2 sat/vB (197 sats) looks bumped and is rejected.
+   */
+  test('the minimum replacement fee accounts for the replacement’s own bandwidth', () => {
+    if (advice.kind !== 'bumpable') throw new Error('expected bumpable');
+    expect(advice.minReplacementFeeSats).toBe(329);
+    // A naive "just a bit more" bump is below the floor and would be refused.
+    expect(197).toBeLessThan(advice.minReplacementFeeSats);
+  });
+
+  test('never suggests a rate below the relay floor, even when the network is cheap', () => {
+    // 0.5 sat/vB while the network clears 1. Matching the network rate would
+    // still be rejected: the replacement floor here is 82 + 164 = 246 sats,
+    // i.e. 1.5 sat/vB. The suggestion has to clear the floor, not the network.
+    const cheap = depositFeeAdvice({ feeSats: 82, vsize: 164, rbf: true, networkSatVb: 1 });
+    if (cheap.kind !== 'bumpable') throw new Error('expected bumpable');
+    expect(cheap.minReplacementFeeSats).toBe(246);
+    expect(cheap.suggestSatVb).toBe(2);
+    expect(cheap.suggestSatVb).toBeGreaterThan(cheap.networkSatVb);
+  });
+
+  test('when the network is expensive, the network rate wins', () => {
+    const busy = depositFeeAdvice({ ...REAL, networkSatVb: 50 });
+    if (busy.kind !== 'bumpable') throw new Error('expected bumpable');
+    expect(busy.suggestSatVb).toBe(50);
+  });
+
+  test('reports the deposit’s own rate, rounded the way it is displayed', () => {
+    if (advice.kind !== 'bumpable') throw new Error('expected bumpable');
+    expect(advice.feeRateSatVb).toBe(1.01); // 165/164
+  });
+});

--- a/apps/landing/src/sdk/deposit-fee-advice.ts
+++ b/apps/landing/src/sdk/deposit-fee-advice.ts
@@ -1,0 +1,70 @@
+/**
+ * What to tell a creator whose deposit is sitting in the mempool underpriced.
+ *
+ * The app CANNOT fix this itself. Replace-by-fee means re-signing the original
+ * inputs, and those belong to whatever wallet the creator sent from — not to
+ * their Turnkey wallet. Only the sending wallet can replace that transaction.
+ * So the honest job here is to notice, say so, and say what would work.
+ *
+ * Pure, because the arithmetic is the part worth testing: a naive bump is
+ * REJECTED by the network for a reason almost nobody expects (see below).
+ */
+
+export type DepositFeeAdvice =
+  /** At or above what the network is clearing — nothing to say. */
+  | { kind: 'fine' }
+  /**
+   * Underpriced, and the sender did not signal RBF, so it cannot be replaced
+   * at all. Waiting is the only option and pretending otherwise wastes their
+   * time in a wallet that will refuse.
+   */
+  | { kind: 'slow'; feeRateSatVb: number; networkSatVb: number }
+  /** Underpriced and replaceable — the case where advice is actionable. */
+  | {
+      kind: 'bumpable';
+      feeRateSatVb: number;
+      networkSatVb: number;
+      /** Total fee a replacement must pay AT MINIMUM to be relayed at all. */
+      minReplacementFeeSats: number;
+      /** The rate to aim for: relayable AND likely to clear. */
+      suggestSatVb: number;
+    };
+
+/**
+ * BIP-125 rule 4: a replacement must pay for its own bandwidth on top of the
+ * original fee, at the minimum relay rate (1 sat/vB). So the floor is not
+ * "slightly more than before" — it is `originalFee + vsize`, which for a
+ * typical 164 vB payment roughly TRIPLES a 1 sat/vB fee before the network
+ * will even accept the replacement.
+ *
+ * This is the trap: a wallet nudged from 1.0 to 1.2 sat/vB looks like a bump
+ * and is rejected, and the creator concludes fee bumping is broken.
+ */
+const MIN_RELAY_SAT_VB = 1;
+
+export function depositFeeAdvice(tx: {
+  feeSats: number;
+  vsize: number;
+  rbf: boolean;
+  networkSatVb: number;
+}): DepositFeeAdvice {
+  const feeRateSatVb = tx.vsize > 0 ? tx.feeSats / tx.vsize : 0;
+  // Round to the same precision we display, so we never warn about a
+  // difference the creator cannot see on screen.
+  const shown = Math.round(feeRateSatVb * 100) / 100;
+  if (shown >= tx.networkSatVb) return { kind: 'fine' };
+  if (!tx.rbf) return { kind: 'slow', feeRateSatVb: shown, networkSatVb: tx.networkSatVb };
+
+  const minReplacementFeeSats = tx.feeSats + Math.ceil(tx.vsize * MIN_RELAY_SAT_VB);
+  const minRelayableRate = minReplacementFeeSats / tx.vsize;
+  return {
+    kind: 'bumpable',
+    feeRateSatVb: shown,
+    networkSatVb: tx.networkSatVb,
+    minReplacementFeeSats,
+    // Whichever is higher: the rate that clears, or the rate that is merely
+    // legal to broadcast. Suggesting the lower of the two is how you send
+    // someone to make a bump that fails.
+    suggestSatVb: Math.ceil(Math.max(tx.networkSatVb, minRelayableRate)),
+  };
+}

--- a/apps/landing/src/sdk/deposit-fee-advice.ts
+++ b/apps/landing/src/sdk/deposit-fee-advice.ts
@@ -24,7 +24,15 @@ export type DepositFeeAdvice =
       kind: 'bumpable';
       feeRateSatVb: number;
       networkSatVb: number;
-      /** Total fee a replacement must pay AT MINIMUM to be relayed at all. */
+      /**
+       * A LOWER BOUND on the fee a replacement must pay to be relayed, and
+       * only exact when the replacement is the same size as the original.
+       * BIP-125 rule 4 charges for the REPLACEMENT's bandwidth, so a wallet
+       * that adds an input to cover the higher fee owes more than this. That
+       * is why `suggestSatVb` is the number the copy leads with: a rate scales
+       * with whatever size the wallet actually builds, an absolute fee does
+       * not.
+       */
       minReplacementFeeSats: number;
       /** The rate to aim for: relayable AND likely to clear. */
       suggestSatVb: number;

--- a/apps/landing/src/sdk/explorer.test.ts
+++ b/apps/landing/src/sdk/explorer.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from 'bun:test';
+import { explorerTxUrl } from './explorer';
+
+const TXID = 'ebcd9386dcf02aa3f58e279cf3a72368c56578bf0ad25099c9389ac2dc360c9a';
+
+describe('the explorer link points at the right chain, or nowhere', () => {
+  test('mainnet and testnet4 go to their own explorers', () => {
+    expect(explorerTxUrl('mainnet', TXID)).toBe(`https://mempool.space/tx/${TXID}`);
+    expect(explorerTxUrl('testnet4', TXID)).toBe(`https://mempool.space/testnet4/tx/${TXID}`);
+  });
+
+  // A mainnet txid on a testnet explorer (or vice versa) shows "not found",
+  // which reads as "my money is gone" at exactly the wrong moment.
+  test('the two never share a URL', () => {
+    expect(explorerTxUrl('mainnet', TXID)).not.toBe(explorerTxUrl('testnet4', TXID));
+  });
+
+  test('an unknown network gets no link rather than a guessed one', () => {
+    expect(explorerTxUrl('off', TXID)).toBeNull();
+  });
+
+  // The txid reaches this from a server response; it ends up in an href.
+  test('anything that is not a txid is refused', () => {
+    for (const bad of ['', 'not-a-txid', TXID.slice(0, 63), `${TXID}00`, 'javascript:alert(1)']) {
+      expect(explorerTxUrl('mainnet', bad)).toBeNull();
+    }
+  });
+});

--- a/apps/landing/src/sdk/explorer.ts
+++ b/apps/landing/src/sdk/explorer.ts
@@ -1,0 +1,16 @@
+import type { BtcNetworkFlag } from './network-flag';
+
+/**
+ * Where a creator can look their own payment up.
+ *
+ * Deliberately narrow: a link out to a block explorer is the one place this
+ * app points at a third party about someone's money, so it is built from the
+ * network flag rather than from anything server-supplied, and it returns null
+ * for a network we have no explorer for rather than guessing at a URL.
+ */
+export function explorerTxUrl(network: BtcNetworkFlag, txid: string): string | null {
+  if (!/^[0-9a-f]{64}$/i.test(txid)) return null;
+  if (network === 'mainnet') return `https://mempool.space/tx/${txid}`;
+  if (network === 'testnet4') return `https://mempool.space/testnet4/tx/${txid}`;
+  return null;
+}

--- a/apps/landing/src/sdk/psbt-prevtx.test.ts
+++ b/apps/landing/src/sdk/psbt-prevtx.test.ts
@@ -1,0 +1,101 @@
+import { describe, test, expect } from 'bun:test';
+import * as btc from '@scure/btc-signer';
+import { base64, hex } from '@scure/base';
+import { addNonWitnessUtxos } from './psbt-prevtx';
+
+/** A real previous transaction, built locally so the test needs no network. */
+function prevTx(amount: bigint, script: Uint8Array) {
+  const t = new btc.Transaction({ allowUnknownOutputs: true });
+  // Output first: setting finalScriptSig marks the input signed, after which
+  // @scure refuses to add outputs.
+  t.addOutput({ script, amount });
+  t.addInput({
+    txid: hex.decode('11'.repeat(32)),
+    index: 0,
+    finalScriptSig: hex.decode('00'),
+  });
+  return { raw: hex.encode(t.toBytes(true, true)), txid: t.id };
+}
+
+const SCRIPT = hex.decode('001471bde27a6a6b30922bb994c66c743966e104e458');
+const AMOUNT = 14_580n;
+
+function psbtSpending(txid: string, amount = AMOUNT, script = SCRIPT) {
+  const tx = new btc.Transaction({ allowUnknownOutputs: true });
+  tx.addInput({ txid, index: 0, sequence: 0xfffffffd, witnessUtxo: { script, amount } });
+  tx.addOutput({ script, amount: amount - 1_000n });
+  return base64.encode(tx.toPSBT());
+}
+
+describe('the PSBT gains the previous transaction Turnkey demands', () => {
+  const { raw, txid } = prevTx(AMOUNT, SCRIPT);
+
+  test('an input with only witnessUtxo gains nonWitnessUtxo', async () => {
+    const before = btc.Transaction.fromPSBT(base64.decode(psbtSpending(txid)));
+    expect(before.getInput(0).nonWitnessUtxo).toBeUndefined();
+
+    const out = await addNonWitnessUtxos(psbtSpending(txid), async () => raw);
+    const after = btc.Transaction.fromPSBT(base64.decode(out));
+    expect(after.getInput(0).nonWitnessUtxo).toBeDefined();
+    // And the witness data it was already signing against is untouched.
+    expect(after.getInput(0).witnessUtxo?.amount).toBe(AMOUNT);
+  });
+
+  test('an input that already has one is left alone and costs no fetch', async () => {
+    const once = await addNonWitnessUtxos(psbtSpending(txid), async () => raw);
+    let fetches = 0;
+    await addNonWitnessUtxos(once, async () => {
+      fetches += 1;
+      return raw;
+    });
+    expect(fetches).toBe(0);
+  });
+});
+
+describe('the previous transaction is verified, not trusted', () => {
+  const { raw, txid } = prevTx(AMOUNT, SCRIPT);
+
+  /**
+   * It arrives from an indexer and becomes what the signer is told it is
+   * spending. A substituted transaction is the fee-inflation attack that
+   * non_witness_utxo exists to prevent, so it is checked here rather than
+   * assumed away.
+   */
+  test('a transaction that hashes to something else is refused', async () => {
+    const other = prevTx(999_999n, SCRIPT);
+    await expect(addNonWitnessUtxos(psbtSpending(txid), async () => other.raw)).rejects.toThrow(
+      /hashes to .*, not/
+    );
+  });
+
+  test('an amount that disagrees with the PSBT is refused', async () => {
+    // Hash matches (we ask about its own txid) but the PSBT was built for more.
+    const small = prevTx(1_000n, SCRIPT);
+    await expect(
+      addNonWitnessUtxos(psbtSpending(small.txid, AMOUNT, SCRIPT), async () => small.raw)
+    ).rejects.toThrow(/1000 sats, but the PSBT was built for 14580/);
+  });
+
+  test('a different script at that output is refused', async () => {
+    const elsewhere = prevTx(AMOUNT, hex.decode('0014' + '22'.repeat(20)));
+    await expect(
+      addNonWitnessUtxos(psbtSpending(elsewhere.txid, AMOUNT, SCRIPT), async () => elsewhere.raw)
+    ).rejects.toThrow(/pays a different script/);
+  });
+
+  test('a missing output index is refused', async () => {
+    const one = prevTx(AMOUNT, SCRIPT);
+    const tx = new btc.Transaction({ allowUnknownOutputs: true });
+    tx.addInput({ txid: one.txid, index: 5, sequence: 0xfffffffd, witnessUtxo: { script: SCRIPT, amount: AMOUNT } });
+    tx.addOutput({ script: SCRIPT, amount: 1_000n });
+    await expect(
+      addNonWitnessUtxos(base64.encode(tx.toPSBT()), async () => one.raw)
+    ).rejects.toThrow(/has no output 5/);
+  });
+
+  test('anything that is not raw hex is refused', async () => {
+    for (const bad of ['', 'nothex', 'abc']) {
+      await expect(addNonWitnessUtxos(psbtSpending(txid), async () => bad)).rejects.toThrow(/not raw hex|hashes to/);
+    }
+  });
+});

--- a/apps/landing/src/sdk/psbt-prevtx.ts
+++ b/apps/landing/src/sdk/psbt-prevtx.ts
@@ -1,0 +1,85 @@
+import * as btc from '@scure/btc-signer';
+import { hex } from '@scure/base';
+
+/**
+ * Add `nonWitnessUtxo` (the whole previous transaction) to every PSBT input
+ * that lacks it.
+ *
+ * Turnkey refuses a SegWit v0 input carrying only `witnessUtxo`:
+ *
+ *   code 3: input 0 is missing non_witness_utxo for SegWit v0 input;
+ *           provide both witness_utxo and non_witness_utxo
+ *
+ * BIP-143 does not need the full previous transaction to compute a v0 sighash,
+ * and the SDK's commit builder supplies only `witnessUtxo` for that reason.
+ * Turnkey requires it anyway — historically to defend against the fee-inflation
+ * attack on hardware signers, which learn the true input amount only from the
+ * full previous transaction. So this is a signer-specific requirement, patched
+ * at the signer rather than in the SDK's protocol code.
+ *
+ * The previous transaction arrives over the network and is what the signer will
+ * be told it is spending, so it is VERIFIED, never trusted: it must hash to the
+ * txid the input names, and the output at `index` must match the `witnessUtxo`
+ * already in the PSBT byte for byte. A mismatch is refused rather than signed.
+ */
+export async function addNonWitnessUtxos(
+  psbtBase64: string,
+  fetchRawTx: (txid: string) => Promise<string>
+): Promise<string> {
+  const { base64 } = await import('@scure/base');
+  const tx = btc.Transaction.fromPSBT(base64.decode(psbtBase64), {
+    allowUnknownInputs: true,
+    allowUnknownOutputs: true,
+  });
+
+  for (let i = 0; i < tx.inputsLength; i += 1) {
+    const input = tx.getInput(i);
+    if (input.nonWitnessUtxo || !input.witnessUtxo || !input.txid) continue;
+    const txid = hex.encode(input.txid);
+    const raw = await fetchRawTx(txid);
+    tx.updateInput(i, {
+      nonWitnessUtxo: verifiedPrevTx(raw, txid, input.index ?? 0, input.witnessUtxo),
+    });
+  }
+  return base64.encode(tx.toPSBT());
+}
+
+/**
+ * The previous transaction's bytes, once proved to be the right ones. Returns
+ * bytes rather than a boolean so a caller cannot forget to check.
+ */
+function verifiedPrevTx(
+  rawHex: string,
+  expectedTxid: string,
+  index: number,
+  witnessUtxo: { script: Uint8Array; amount: bigint }
+): Uint8Array {
+  if (!/^[0-9a-f]+$/i.test(rawHex) || rawHex.length % 2 !== 0) {
+    throw new Error(`Previous transaction for ${expectedTxid} was not raw hex.`);
+  }
+  const bytes = hex.decode(rawHex);
+  const prev = btc.Transaction.fromRaw(bytes, { allowUnknownInputs: true, allowUnknownOutputs: true });
+  // Double-SHA256 of the serialised transaction. Nothing else establishes that
+  // the indexer returned the transaction we actually asked about.
+  if (prev.id !== expectedTxid) {
+    throw new Error(`Previous transaction hashes to ${prev.id}, not ${expectedTxid}.`);
+  }
+  // Checked before getOutput, which throws a bare "Wrong output index=5" that
+  // names neither the transaction nor why we were looking.
+  if (index < 0 || index >= prev.outputsLength) {
+    throw new Error(`Previous transaction ${expectedTxid} has no output ${index}.`);
+  }
+  const out = prev.getOutput(index);
+  if (!out?.script || typeof out.amount !== 'bigint') {
+    throw new Error(`Previous transaction ${expectedTxid} has no output ${index}.`);
+  }
+  if (out.amount !== witnessUtxo.amount) {
+    throw new Error(
+      `Output ${expectedTxid}:${index} is ${out.amount} sats, but the PSBT was built for ${witnessUtxo.amount}.`
+    );
+  }
+  if (hex.encode(out.script) !== hex.encode(witnessUtxo.script)) {
+    throw new Error(`Output ${expectedTxid}:${index} pays a different script than the PSBT expects.`);
+  }
+  return bytes;
+}

--- a/apps/landing/src/sdk/turnkey-sat-signer.test.ts
+++ b/apps/landing/src/sdk/turnkey-sat-signer.test.ts
@@ -9,10 +9,26 @@ const priv = hex.decode('2222222222222222222222222222222222222222222222222222222
 const pub = secp256k1.getPublicKey(priv, true);
 const p2wpkh = btc.p2wpkh(pub, btc.TEST_NETWORK);
 
+// The previous transaction the funding input spends. Turnkey requires the
+// whole thing for a SegWit v0 input, so the signer fetches and attaches it —
+// and the browser checks it hashes to the txid the PSBT names, so this fixture
+// has to be the real transaction rather than an arbitrary blob.
+function fundingPrevTx() {
+  const t = new btc.Transaction({ allowUnknownOutputs: true });
+  t.addOutput({ script: p2wpkh.script, amount: 30_000n });
+  t.addInput({ txid: hex.decode('a'.repeat(64)), index: 0, finalScriptSig: hex.decode('00') });
+  return { raw: hex.encode(t.toBytes(true, true)), txid: t.id };
+}
+const PREV = fundingPrevTx();
+const fetchRawTx = async (txid: string) => {
+  if (txid !== PREV.txid) throw new Error(`unexpected txid ${txid}`);
+  return PREV.raw;
+};
+
 // Build the UNSIGNED commit PSBT the SDK would hand the signer (base64).
 function unsignedCommitPsbtBase64(): string {
   const tx = new btc.Transaction();
-  tx.addInput({ txid: hex.decode('c'.repeat(64)), index: 0, witnessUtxo: { script: p2wpkh.script, amount: 30_000n } });
+  tx.addInput({ txid: PREV.txid, index: 0, witnessUtxo: { script: p2wpkh.script, amount: 30_000n } });
   tx.addOutputAddress('tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx', 20_000n, btc.TEST_NETWORK);
   return base64.encode(tx.toPSBT());
 }
@@ -32,11 +48,35 @@ const mockClient: TurnkeyBitcoinClient = {
 
 describe('TurnkeySatSigner', () => {
   test('signAndFinalizeCommitPsbt returns broadcast-ready hex with a witness', async () => {
-    const signer = new TurnkeySatSigner({ client: mockClient, signWith: 'tb1quseraddr' });
+    const signer = new TurnkeySatSigner({ client: mockClient, signWith: 'tb1quseraddr', fetchRawTx });
     const rawHex = await signer.signAndFinalizeCommitPsbt(unsignedCommitPsbtBase64());
     const parsed = btc.Transaction.fromRaw(hex.decode(rawHex));
     expect(parsed.inputsLength).toBe(1);
     expect(parsed.getInput(0).finalScriptWitness).toBeDefined();
+  });
+
+  // The live failure: Turnkey answered "code 3: input 0 is missing
+  // non_witness_utxo for SegWit v0 input", because the SDK attaches only
+  // witnessUtxo. What reaches Turnkey must now carry both.
+  test('what reaches Turnkey carries the full previous transaction', async () => {
+    let seen: string | undefined;
+    const capture: TurnkeyBitcoinClient = {
+      async signTransaction({ unsignedTransaction }) {
+        seen = unsignedTransaction;
+        const tx = btc.Transaction.fromPSBT(hex.decode(unsignedTransaction), { allowUnknownInputs: true, allowUnknownOutputs: true });
+        tx.sign(priv);
+        return { signedTransaction: hex.encode(tx.toPSBT()) };
+      },
+      async createWalletAccounts() { throw new Error('not used'); },
+      async getWallets() { throw new Error('not used'); },
+      async getWalletAccounts() { throw new Error('not used'); },
+    };
+    await new TurnkeySatSigner({ client: capture, signWith: 'tb1quseraddr', fetchRawTx }).signAndFinalizeCommitPsbt(
+      unsignedCommitPsbtBase64()
+    );
+    const sent = btc.Transaction.fromPSBT(hex.decode(seen!), { allowUnknownInputs: true, allowUnknownOutputs: true });
+    expect(sent.getInput(0).nonWitnessUtxo).toBeDefined();
+    expect(sent.getInput(0).witnessUtxo).toBeDefined();
   });
 
   test('rejects when Turnkey returns nothing signable', async () => {
@@ -45,7 +85,7 @@ describe('TurnkeySatSigner', () => {
       async createWalletAccounts() { throw new Error('x'); },
       async getWallets() { throw new Error('x'); },
     };
-    const signer = new TurnkeySatSigner({ client: bad, signWith: 'tb1quseraddr' });
+    const signer = new TurnkeySatSigner({ client: bad, signWith: 'tb1quseraddr', fetchRawTx });
     await expect(signer.signAndFinalizeCommitPsbt(unsignedCommitPsbtBase64())).rejects.toThrow();
   });
 });

--- a/apps/landing/src/sdk/turnkey-sat-signer.ts
+++ b/apps/landing/src/sdk/turnkey-sat-signer.ts
@@ -12,19 +12,33 @@ import type { BitcoinSigner } from '@originals/sdk';
 import { base64, hex } from '@scure/base';
 import * as btc from '@scure/btc-signer';
 import { finalizeSignedPsbt } from './finalize-psbt';
+import { addNonWitnessUtxos } from './psbt-prevtx';
 import type { TurnkeyBitcoinClient } from '../auth/turnkey-session';
 
 export class TurnkeySatSigner implements BitcoinSigner {
   private readonly client: TurnkeyBitcoinClient;
   private readonly signWith: string;
+  private readonly fetchRawTx: (txid: string) => Promise<string>;
 
-  constructor(opts: { client: TurnkeyBitcoinClient; signWith: string }) {
+  constructor(opts: {
+    client: TurnkeyBitcoinClient;
+    signWith: string;
+    /** Injected so the network call is testable and swappable. */
+    fetchRawTx?: (txid: string) => Promise<string>;
+  }) {
     this.client = opts.client;
     this.signWith = opts.signWith;
+    this.fetchRawTx = opts.fetchRawTx ?? defaultFetchRawTx;
   }
 
   async signAndFinalizeCommitPsbt(psbtBase64: string): Promise<string> {
-    const unsignedHex = hex.encode(base64.decode(psbtBase64));
+    // Turnkey rejects a SegWit v0 input carrying only witness_utxo:
+    //   code 3: input 0 is missing non_witness_utxo for SegWit v0 input
+    // BIP-143 does not need the previous transaction to compute the sighash,
+    // so the SDK does not attach one. Turnkey wants it regardless, and the
+    // browser verifies each one hashes to the txid the PSBT names.
+    const withPrevTxs = await addNonWitnessUtxos(psbtBase64, this.fetchRawTx);
+    const unsignedHex = hex.encode(base64.decode(withPrevTxs));
     const result = await this.client.signTransaction({
       signWith: this.signWith,
       unsignedTransaction: unsignedHex,
@@ -44,4 +58,22 @@ export class TurnkeySatSigner implements BitcoinSigner {
     const psbtBase64Out = /^[0-9a-fA-F]+$/.test(signed) ? base64.encode(hex.decode(signed)) : signed;
     return finalizeSignedPsbt(psbtBase64Out);
   }
+}
+
+/** Ask our own server, which scopes the lookup to this account's deposits. */
+async function defaultFetchRawTx(txid: string): Promise<string> {
+  const res = await fetch(`/api/btc/prevtx?txid=${encodeURIComponent(txid)}`, {
+    credentials: 'same-origin',
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => null)) as { message?: string } | null;
+    throw new Error(
+      `Could not load the previous transaction ${txid} the signer needs${
+        body?.message ? `: ${body.message}` : ` (HTTP ${res.status})`
+      }.`
+    );
+  }
+  const body = (await res.json()) as { hex?: string };
+  if (!body.hex) throw new Error(`The server returned no transaction for ${txid}.`);
+  return body.hex;
 }

--- a/apps/landing/tsconfig.json
+++ b/apps/landing/tsconfig.json
@@ -11,8 +11,9 @@
     "isolatedModules": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
+    "types": ["bun-types"],
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+  "include": ["src", "server", "serve.ts"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "server/**/*.test.ts"]
 }


### PR DESCRIPTION
## What

The deposit screen now says when a pending payment is underpriced, shows it against the going rate, and gives a replacement rate that will actually relay.

It also adds `server/` to the landing typecheck, which was excluded.

## Why

A deposit paying below the going rate sits in the mempool with nothing on screen to explain the wait. Finding that out meant opening a block explorer and reading fee histograms — which is exactly what happened.

**This is not an RBF button, and cannot be.** Replace-by-fee re-signs the *original inputs*, and those belong to whatever wallet the creator paid from — not to their Turnkey wallet. In the real case the change went to `33KEn…`, an address this app has never held a key for. Only the sending wallet can replace that transaction. Rendering a button we cannot honour would be the #499 defect in a new place: offering the user an action that cannot work.

So the app does the part it genuinely can: notice, state the numbers, and get the arithmetic right.

**The arithmetic is the non-obvious part.** BIP-125 rule 4 requires a replacement to pay for its own bandwidth *on top of* the original fee. The floor is `originalFee + vsize`:

| bump target | total fee | outcome |
| --- | --- | --- |
| 1.2 sat/vB | 197 sats | **rejected** — below the 329-sat floor |
| 2.0 sat/vB | 330 sats | relayable, borderline |
| 3.0 sat/vB | 492 sats | clears the floor and the network median |

A wallet nudged from 1.0 to 1.2 looks bumped and is refused, and the creator concludes fee bumping is broken. The suggested rate clears **both** the relay floor and the network rate, and the copy says to take the increase from change, never from the deposit amount — that would drop the deposit below the quote.

## How

- **Server supplies facts, the browser owns the advice.** One extra indexer read (`/tx/{txid}`), only while a deposit is pending, returning fee, vsize and whether RBF was signalled. **Best effort by construction**: every failure path returns `null`, because an advisory must never take down the screen showing someone their money.
- **`depositFeeAdvice` is pure and tested**, including the case that started this: 165 sats over 164 vB, RBF signalled, network at 3 sat/vB.
- **A non-RBF deposit is told to wait**, not to attempt a bump its wallet will refuse.
- **No warning below display precision** — if a rate rounds to the same figure shown on screen, warning about it would contradict the UI.

### Typechecking the server

`tsconfig.json` had `include: ["src"]`. The entire server — every route that moves a stranger's BTC — was unchecked.

It needed only `bun-types` and had **zero** existing errors, so this is a gate that was one line away the whole time. It immediately earned its place by catching a call to an undefined function in this very change:

```
server/bitcoin.ts(1061,39): error TS2304: Cannot find name 'indexerConfig'.
```

That would have thrown at runtime, on the deposit route, for a signed-in creator with money at the address. I wrote it, `tsc` passed, and only the absence of the symbol anywhere else in the file gave it away. Verified load-bearing: reintroducing the bug reproduces that error, removing it returns to zero.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [x] Test addition or improvement

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] I have updated JSDoc comments for any changed public APIs
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Testing

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing (describe steps)

Landing suite **753 pass / 0 fail** (up 9), server suite 312 pass. Typecheck (now including `server/`), lint and `vite build` all clean.

One test premise of mine was wrong and the suite caught it: I asserted that a deposit at 1.01 sat/vB with the network clearing 1 sat/vB should be flagged as bumpable. It should not — that deposit is fine. The code was right; the test was rewritten around a genuinely underpriced case (0.5 sat/vB) where matching the network rate would *still* be rejected by the relay floor.

**Not verified live:** the notice has not been seen rendered against a real pending deposit. The advice logic is tested against the real transaction's numbers, and the server read is best-effort, so the failure mode is a missing notice rather than a broken screen.

## Screenshots / Output (if applicable)

```
  Your deposit is paying below the going rate
  It will still confirm — it is queued behind higher-paying
  transactions, not stuck — and nothing is at risk while it waits.

  YOURS            CLEARING NOW       REPLACE AT
  1.01 sat/vB      3 sat/vB           3 sat/vB

  If your wallet has a "bump fee" or "speed up" option, this
  payment can be replaced. Two things to get right: take the
  increase from your change, never from the deposit amount, and
  aim for the rate above — Bitcoin makes a replacement pay for
  its own bandwidth on top of the original fee, so a small nudge
  is rejected outright.

  Minimum the network will accept: 329 sats
```

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
