### PR TITLE
fix(landing): stop calling a commit-only broadcast an inscription

### DIFF
--- a/.changeset/landing-commit-only-not-inscribed.md
+++ b/.changeset/landing-commit-only-not-inscribed.md
@@ -1,0 +1,18 @@
+---
+"@originals/landing": patch
+---
+
+**Fix: a commit-only broadcast is no longer reported as an inscription.**
+
+On the first real mainnet inscription the site said "inscribed" and offered an
+explorer link to a reveal txid that returned 404.
+
+The server had answered `status: 'commit_broadcast'` — the commit was on the
+network, the reveal had not propagated, and the recovery sweep still owed the
+creator an inscription. The server distinguishes the two outcomes and the
+provider types them, but the SDK discards `submitInscription`'s return value,
+so nothing downstream could tell them apart and every 200 rendered as done.
+
+The provider now records what the submit achieved and the demo says it plainly:
+the commit is on the network, the reveal follows automatically once it
+confirms, nothing is stuck and nothing more is owed.

--- a/apps/landing/src/components/Demo.tsx
+++ b/apps/landing/src/components/Demo.tsx
@@ -325,6 +325,18 @@ export function quoteForAddress(
   return info.address === address ? info : null;
 }
 
+/**
+ * Whether the pair actually reached the network, or only the commit did.
+ *
+ * The server distinguishes these; the SDK discards the distinction (it does
+ * not capture submitInscription's return), so the browser reads it back off
+ * the provider. Calling a commit-only outcome "inscribed" tells a creator
+ * their inscription exists when it does not yet.
+ */
+export function inscribeIsComplete(status: string | null | undefined): boolean {
+  return status === 'reveal_broadcast';
+}
+
 /** What the deposit badge should say — read off the SUM, never one output. */
 export type DepositReadiness = 'waiting' | 'detected' | 'short' | 'ready' | 'unspendable';
 
@@ -744,6 +756,8 @@ export function Demo() {
   // their Turnkey-derived address, polled while the inscribe step is live so
   // "deposit detected → confirmed" updates without a reload.
   const [depositRaw, setDeposit] = useState<DepositInfo | null>(null);
+  // True when the submit reached the server but only the COMMIT propagated.
+  const [commitOnly, setCommitOnly] = useState(false);
   const [depositError, setDepositError] = useState<string | null>(null);
   // Mirror of depositError readable synchronously inside the inscribe click —
   // state set during that same await would still be stale there, and the
@@ -792,6 +806,7 @@ export function Demo() {
 
   const inscribe = () =>
     run('published', 'inscribing', 'inscribed', async (engine) => {
+      setCommitOnly(false);
       // Mock path (no real network enabled): unchanged bare inscribe.
       if (!real) return engine.inscribe();
       // Never build a real-BTC transaction against a server on another chain.
@@ -822,13 +837,18 @@ export function Demo() {
             depositShortfallMessage(selection.totalSats, selection.shortfallSats)
           );
         }
-        return engine.inscribe({
+        const state = await engine.inscribe({
           funding: {
             fundingUtxos: selection.selected,
             changeAddress: bitcoin.fundingAddress,
             signingClient: bitcoin.signingClient,
           },
         });
+        // The server distinguishes commit-only from a complete pair; the SDK
+        // discards submitInscription's return, so read it off the provider.
+        const submitted = (engine.ordinalsProvider as { lastSubmit?: { status?: string } }).lastSubmit;
+        setCommitOnly(!inscribeIsComplete(submitted?.status));
+        return state;
       }
       // testnet4: ask the server faucet to fund the user's address, then
       // inscribe with the user's Turnkey key. 507 surfaces a friendly message.
@@ -1277,6 +1297,15 @@ export function Demo() {
 
                 {phase === 'inscribed' && asset && (
                   <div className="demo-done" data-sim={inscribeView.simulated ? '' : undefined}>
+                    {/* Commit-only is not "inscribed": the reveal carries
+                        the inscription, and until it propagates there is
+                        nothing on chain to point at. */}
+                    {commitOnly && (
+                      <div className="deposit-funded" role="status">
+                        <strong className="deposit-funded-heading">{demo.deposit.commitOnlyHeading}</strong>
+                        <p className="deposit-funded-body">{demo.deposit.commitOnlyBody}</p>
+                      </div>
+                    )}
                     <p>
                       <strong>{done.lead}</strong> {done.beforeSatoshi}{' '}
                       <code>{asset.inscription?.satoshi}</code> {done.beforeTx}{' '}

--- a/apps/landing/src/components/Demo.tsx
+++ b/apps/landing/src/components/Demo.tsx
@@ -338,20 +338,36 @@ export function inscribeIsComplete(status: string | null | undefined): boolean {
 }
 
 /**
- * What the completion panel may show, given what actually reached the network.
+ * What actually reached the network, as far as the browser can know.
+ *
+ * `not-observed` is NOT the same as "we do not know whether it worked": the
+ * mock tier and the testnet4 faucet path do not go through the submit seam at
+ * all, so a successful inscribe there IS complete and there is no status to
+ * read. Collapsing the two into a single nullable status told mock users that
+ * a nonexistent funding transaction was on the network.
+ */
+export type SubmitOutcome =
+  | { kind: 'not-observed' }
+  | { kind: 'submitted'; status: string | null };
+
+/**
+ * What the completion panel may show.
  *
  * A decision rather than a JSX condition, because the first attempt at this
  * fix added a pending notice and left the completion sentence and the reveal
  * explorer link rendering underneath it — so the page both denied and claimed
- * completion, and still linked to a transaction that 404s. A condition spread
- * across three places in a large component is one nothing can test; this can
- * be, and is.
+ * completion, and still linked to a transaction that 404s.
+ *
+ * Fail-closed applies only where the status is observable: on the submit path
+ * a missing or unrecognised status means the reveal is not known to have
+ * landed, so nothing is claimed.
  */
-export function inscribeDoneView(status: string | null | undefined): {
+export function inscribeDoneView(outcome: SubmitOutcome): {
   claimComplete: boolean;
   showExplorerLink: boolean;
 } {
-  const complete = inscribeIsComplete(status);
+  const complete =
+    outcome.kind === 'not-observed' ? true : inscribeIsComplete(outcome.status);
   return { claimComplete: complete, showExplorerLink: complete };
 }
 
@@ -775,7 +791,7 @@ export function Demo() {
   // "deposit detected → confirmed" updates without a reload.
   const [depositRaw, setDeposit] = useState<DepositInfo | null>(null);
   // True when the submit reached the server but only the COMMIT propagated.
-  const [submitStatus, setSubmitStatus] = useState<string | null>(null);
+  const [submitOutcome, setSubmitOutcome] = useState<SubmitOutcome>({ kind: 'not-observed' });
   const [depositError, setDepositError] = useState<string | null>(null);
   // Mirror of depositError readable synchronously inside the inscribe click —
   // state set during that same await would still be stale there, and the
@@ -824,7 +840,7 @@ export function Demo() {
 
   const inscribe = () =>
     run('published', 'inscribing', 'inscribed', async (engine) => {
-      setSubmitStatus(null);
+      setSubmitOutcome({ kind: 'not-observed' });
       // Mock path (no real network enabled): unchanged bare inscribe.
       if (!real) return engine.inscribe();
       // Never build a real-BTC transaction against a server on another chain.
@@ -865,7 +881,7 @@ export function Demo() {
         // The server distinguishes commit-only from a complete pair; the SDK
         // discards submitInscription's return, so read it off the provider.
         const submitted = (engine.ordinalsProvider as { lastSubmit?: { status?: string } }).lastSubmit;
-        setSubmitStatus(submitted?.status ?? null);
+        setSubmitOutcome({ kind: 'submitted', status: submitted?.status ?? null });
         return state;
       }
       // testnet4: ask the server faucet to fund the user's address, then
@@ -932,7 +948,7 @@ export function Demo() {
   }, [identity, reauth.active, reauthIdentity]);
 
   // One decision, used by all three parts of the completion panel.
-  const doneView = inscribeDoneView(submitStatus);
+  const doneView = inscribeDoneView(submitOutcome);
   const step = phaseToStep[phase];
   const busy =
     phase === 'creating' || phase === 'publishing' || phase === 'inscribing' || updating;

--- a/apps/landing/src/components/Demo.tsx
+++ b/apps/landing/src/components/Demo.tsx
@@ -337,6 +337,24 @@ export function inscribeIsComplete(status: string | null | undefined): boolean {
   return status === 'reveal_broadcast';
 }
 
+/**
+ * What the completion panel may show, given what actually reached the network.
+ *
+ * A decision rather than a JSX condition, because the first attempt at this
+ * fix added a pending notice and left the completion sentence and the reveal
+ * explorer link rendering underneath it — so the page both denied and claimed
+ * completion, and still linked to a transaction that 404s. A condition spread
+ * across three places in a large component is one nothing can test; this can
+ * be, and is.
+ */
+export function inscribeDoneView(status: string | null | undefined): {
+  claimComplete: boolean;
+  showExplorerLink: boolean;
+} {
+  const complete = inscribeIsComplete(status);
+  return { claimComplete: complete, showExplorerLink: complete };
+}
+
 /** What the deposit badge should say — read off the SUM, never one output. */
 export type DepositReadiness = 'waiting' | 'detected' | 'short' | 'ready' | 'unspendable';
 
@@ -757,7 +775,7 @@ export function Demo() {
   // "deposit detected → confirmed" updates without a reload.
   const [depositRaw, setDeposit] = useState<DepositInfo | null>(null);
   // True when the submit reached the server but only the COMMIT propagated.
-  const [commitOnly, setCommitOnly] = useState(false);
+  const [submitStatus, setSubmitStatus] = useState<string | null>(null);
   const [depositError, setDepositError] = useState<string | null>(null);
   // Mirror of depositError readable synchronously inside the inscribe click —
   // state set during that same await would still be stale there, and the
@@ -806,7 +824,7 @@ export function Demo() {
 
   const inscribe = () =>
     run('published', 'inscribing', 'inscribed', async (engine) => {
-      setCommitOnly(false);
+      setSubmitStatus(null);
       // Mock path (no real network enabled): unchanged bare inscribe.
       if (!real) return engine.inscribe();
       // Never build a real-BTC transaction against a server on another chain.
@@ -847,7 +865,7 @@ export function Demo() {
         // The server distinguishes commit-only from a complete pair; the SDK
         // discards submitInscription's return, so read it off the provider.
         const submitted = (engine.ordinalsProvider as { lastSubmit?: { status?: string } }).lastSubmit;
-        setCommitOnly(!inscribeIsComplete(submitted?.status));
+        setSubmitStatus(submitted?.status ?? null);
         return state;
       }
       // testnet4: ask the server faucet to fund the user's address, then
@@ -913,6 +931,8 @@ export function Demo() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [identity, reauth.active, reauthIdentity]);
 
+  // One decision, used by all three parts of the completion panel.
+  const doneView = inscribeDoneView(submitStatus);
   const step = phaseToStep[phase];
   const busy =
     phase === 'creating' || phase === 'publishing' || phase === 'inscribing' || updating;
@@ -1300,29 +1320,43 @@ export function Demo() {
                     {/* Commit-only is not "inscribed": the reveal carries
                         the inscription, and until it propagates there is
                         nothing on chain to point at. */}
-                    {commitOnly && (
+                    {!doneView.claimComplete && (
                       <div className="deposit-funded" role="status">
                         <strong className="deposit-funded-heading">{demo.deposit.commitOnlyHeading}</strong>
                         <p className="deposit-funded-body">{demo.deposit.commitOnlyBody}</p>
                       </div>
                     )}
-                    <p>
-                      <strong>{done.lead}</strong> {done.beforeSatoshi}{' '}
-                      <code>{asset.inscription?.satoshi}</code> {done.beforeTx}{' '}
-                      <code>{asset.inscription?.txid}</code>. {done.after}
-                    </p>
-                    {/* The engine withholds the explorer URL in the simulated
-                        tier (U2); the label goes with it, so no completion
-                        screen can offer a link to a transaction that isn't. */}
-                    {asset.inscription?.explorerUrl && done.explorerLabel && (
-                      <a
-                        className="demo-explorer-link"
-                        href={asset.inscription.explorerUrl}
-                        target="_blank"
-                        rel="noreferrer"
-                      >
-                        {done.explorerLabel}
-                      </a>
+                    {/* Both the completion sentence and the explorer link are
+                        withheld while only the commit has landed. Rendering
+                        them under the pending notice is what let the page go
+                        on claiming completion — and link to a reveal txid that
+                        404s — while saying above that it had not finished. */}
+                    {!doneView.claimComplete ? (
+                      <p className="demo-inscribe-note">
+                        {demo.deposit.commitOnlySatPrefix}{' '}
+                        <code>{asset.inscription?.satoshi}</code>.
+                      </p>
+                    ) : (
+                      <>
+                        <p>
+                          <strong>{done.lead}</strong> {done.beforeSatoshi}{' '}
+                          <code>{asset.inscription?.satoshi}</code> {done.beforeTx}{' '}
+                          <code>{asset.inscription?.txid}</code>. {done.after}
+                        </p>
+                        {/* The engine withholds the explorer URL in the simulated
+                            tier (U2); the label goes with it, so no completion
+                            screen can offer a link to a transaction that isn't. */}
+                        {doneView.showExplorerLink && asset.inscription?.explorerUrl && done.explorerLabel && (
+                          <a
+                            className="demo-explorer-link"
+                            href={asset.inscription.explorerUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            {done.explorerLabel}
+                          </a>
+                        )}
+                      </>
                     )}
                     <button type="button" className="demo-reset" onClick={reset}>
                       {demo.reset}

--- a/apps/landing/src/components/deposit-panel.test.ts
+++ b/apps/landing/src/components/deposit-panel.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { demo } from '../content';
-import { depositDisclosure, quoteForAddress, depositReadiness, depositBadgeLabel } from './Demo';
+import { depositDisclosure, quoteForAddress, depositReadiness, depositBadgeLabel, inscribeIsComplete } from './Demo';
 import { bitcoinPaymentUri } from '../sdk/bitcoin-uri';
 
 /**
@@ -193,5 +193,33 @@ describe('a funded deposit stops asking for money', () => {
 
   test('the balance copy explains that a surplus is reusable, not stranded', () => {
     expect(demo.deposit.balanceReuse).toMatch(/next inscription/i);
+  });
+});
+
+describe('a commit-only broadcast is not an inscription', () => {
+  /**
+   * Hit live: the site said "inscribed" and the reveal txid 404'd. The server
+   * had returned status 'commit_broadcast' — the commit was on the network,
+   * the reveal had not propagated, and the recovery sweep still owed the
+   * creator an inscription. The SDK discards submitInscription's return, so
+   * every 200 read as done.
+   */
+  test('only a broadcast reveal counts as complete', () => {
+    expect(inscribeIsComplete('reveal_broadcast')).toBe(true);
+    expect(inscribeIsComplete('commit_broadcast')).toBe(false);
+  });
+
+  test('an absent or unknown status is not treated as complete', () => {
+    expect(inscribeIsComplete(null)).toBe(false);
+    expect(inscribeIsComplete(undefined)).toBe(false);
+    expect(inscribeIsComplete('signed')).toBe(false);
+    expect(inscribeIsComplete('')).toBe(false);
+  });
+
+  test('the commit-only copy does not claim the inscription exists', () => {
+    expect(demo.deposit.commitOnlyHeading).not.toMatch(/inscribed/i);
+    expect(demo.deposit.commitOnlyBody).toMatch(/not propagated|has not propagated/i);
+    // And it must not imply the creator owes another action.
+    expect(demo.deposit.commitOnlyBody).toMatch(/automatically/i);
   });
 });

--- a/apps/landing/src/components/deposit-panel.test.ts
+++ b/apps/landing/src/components/deposit-panel.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { demo } from '../content';
-import { depositDisclosure, quoteForAddress, depositReadiness, depositBadgeLabel, inscribeIsComplete, inscribeDoneView } from './Demo';
+import { depositDisclosure, quoteForAddress, depositReadiness, depositBadgeLabel, inscribeIsComplete, inscribeDoneView, type SubmitOutcome } from './Demo';
 import { bitcoinPaymentUri } from '../sdk/bitcoin-uri';
 
 /**
@@ -231,30 +231,51 @@ describe('the completion panel shows nothing it cannot back up', () => {
    * The page denied and claimed completion at once, and still offered a link
    * to a transaction that 404s. Caught in review; this is the guard.
    */
+  const submitted = (status: string | null): SubmitOutcome => ({ kind: 'submitted', status });
+
   test('a commit-only broadcast claims nothing and links nowhere', () => {
-    const view = inscribeDoneView('commit_broadcast');
+    const view = inscribeDoneView(submitted('commit_broadcast'));
     expect(view.claimComplete).toBe(false);
     expect(view.showExplorerLink).toBe(false);
   });
 
   test('a broadcast reveal claims completion and may link to it', () => {
-    const view = inscribeDoneView('reveal_broadcast');
+    const view = inscribeDoneView(submitted('reveal_broadcast'));
     expect(view.claimComplete).toBe(true);
     expect(view.showExplorerLink).toBe(true);
   });
 
-  test('an unknown status claims nothing — fail closed', () => {
-    for (const s of [null, undefined, '', 'signed', 'confirmed']) {
-      expect(inscribeDoneView(s).claimComplete).toBe(false);
-      expect(inscribeDoneView(s).showExplorerLink).toBe(false);
+  test('on the submit path an unknown status claims nothing — fail closed', () => {
+    for (const s of [null, '', 'signed', 'confirmed']) {
+      expect(inscribeDoneView(submitted(s)).claimComplete).toBe(false);
+      expect(inscribeDoneView(submitted(s)).showExplorerLink).toBe(false);
     }
+  });
+
+  /**
+   * The regression the fail-closed default caused: the mock tier and the
+   * testnet4 faucet path never touch the submit seam, so there is no status to
+   * read and a successful inscribe there IS complete. Treating that silence as
+   * "unknown" told mock users a nonexistent transaction was on the network.
+   */
+  test('a path with no submit seam is complete, not pending', () => {
+    const view = inscribeDoneView({ kind: 'not-observed' });
+    expect(view.claimComplete).toBe(true);
+    expect(view.showExplorerLink).toBe(true);
   });
 
   // The link and the claim move together: a page that links to a reveal it
   // will not vouch for is the defect this exists to prevent.
   test('the claim and the link are never out of step', () => {
-    for (const s of ['commit_broadcast', 'reveal_broadcast', null, 'nonsense']) {
-      const v = inscribeDoneView(s);
+    const cases: SubmitOutcome[] = [
+      { kind: 'not-observed' },
+      submitted('commit_broadcast'),
+      submitted('reveal_broadcast'),
+      submitted(null),
+      submitted('nonsense'),
+    ];
+    for (const c of cases) {
+      const v = inscribeDoneView(c);
       expect(v.claimComplete).toBe(v.showExplorerLink);
     }
   });

--- a/apps/landing/src/components/deposit-panel.test.ts
+++ b/apps/landing/src/components/deposit-panel.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { demo } from '../content';
-import { depositDisclosure, quoteForAddress, depositReadiness, depositBadgeLabel, inscribeIsComplete } from './Demo';
+import { depositDisclosure, quoteForAddress, depositReadiness, depositBadgeLabel, inscribeIsComplete, inscribeDoneView } from './Demo';
 import { bitcoinPaymentUri } from '../sdk/bitcoin-uri';
 
 /**
@@ -221,5 +221,41 @@ describe('a commit-only broadcast is not an inscription', () => {
     expect(demo.deposit.commitOnlyBody).toMatch(/not propagated|has not propagated/i);
     // And it must not imply the creator owes another action.
     expect(demo.deposit.commitOnlyBody).toMatch(/automatically/i);
+  });
+});
+
+describe('the completion panel shows nothing it cannot back up', () => {
+  /**
+   * The first attempt at the commit-only fix added a pending notice but left
+   * the completion sentence and the reveal explorer link rendering below it.
+   * The page denied and claimed completion at once, and still offered a link
+   * to a transaction that 404s. Caught in review; this is the guard.
+   */
+  test('a commit-only broadcast claims nothing and links nowhere', () => {
+    const view = inscribeDoneView('commit_broadcast');
+    expect(view.claimComplete).toBe(false);
+    expect(view.showExplorerLink).toBe(false);
+  });
+
+  test('a broadcast reveal claims completion and may link to it', () => {
+    const view = inscribeDoneView('reveal_broadcast');
+    expect(view.claimComplete).toBe(true);
+    expect(view.showExplorerLink).toBe(true);
+  });
+
+  test('an unknown status claims nothing — fail closed', () => {
+    for (const s of [null, undefined, '', 'signed', 'confirmed']) {
+      expect(inscribeDoneView(s).claimComplete).toBe(false);
+      expect(inscribeDoneView(s).showExplorerLink).toBe(false);
+    }
+  });
+
+  // The link and the claim move together: a page that links to a reveal it
+  // will not vouch for is the defect this exists to prevent.
+  test('the claim and the link are never out of step', () => {
+    for (const s of ['commit_broadcast', 'reveal_broadcast', null, 'nonsense']) {
+      const v = inscribeDoneView(s);
+      expect(v.claimComplete).toBe(v.showExplorerLink);
+    }
   });
 });

--- a/apps/landing/src/content.ts
+++ b/apps/landing/src/content.ts
@@ -427,6 +427,12 @@ export const demo = {
     balanceLabel: 'Your deposit balance',
     balanceNeeded: 'needed for this inscription',
     addMoreSummary: 'Add more funds, or see the deposit address',
+    // The commit landed but the reveal did not propagate. The inscription is
+    // NOT on chain yet, and saying "inscribed" here is the same dishonesty as
+    // telling someone to sign in again when signing in is what failed.
+    commitOnlyHeading: 'Commit broadcast — the inscription finishes shortly',
+    commitOnlyBody:
+      'Your funding transaction is on the network. The second transaction, the one that carries the inscription, has not propagated yet — this is expected while the first is still unconfirmed. It is signed and saved on our side and goes out automatically once the first confirms. Nothing is stuck and nothing more is owed; your Your Originals page shows it through to done.',
     balanceReuse:
       'Anything left over stays at this address and pays for your next inscription here — you will not be asked to deposit again while it covers the cost.',
     // A CONFIRMED deposit that does not cover the cost. Distinct from

--- a/apps/landing/src/content.ts
+++ b/apps/landing/src/content.ts
@@ -431,6 +431,9 @@ export const demo = {
     // NOT on chain yet, and saying "inscribed" here is the same dishonesty as
     // telling someone to sign in again when signing in is what failed.
     commitOnlyHeading: 'Commit broadcast — the inscription finishes shortly',
+    // The sat is decided by the commit's first input, so it IS known already;
+    // the inscription that will ride on it is not on chain yet.
+    commitOnlySatPrefix: 'It will land on satoshi',
     commitOnlyBody:
       'Your funding transaction is on the network. The second transaction, the one that carries the inscription, has not propagated yet — this is expected while the first is still unconfirmed. It is signed and saved on our side and goes out automatically once the first confirms. Nothing is stuck and nothing more is owed; your Your Originals page shows it through to done.',
     balanceReuse:

--- a/apps/landing/src/sdk/http-ordinals-provider.ts
+++ b/apps/landing/src/sdk/http-ordinals-provider.ts
@@ -67,8 +67,23 @@ export class HttpOrdinalsProvider implements OrdinalsProvider {
     fundingUtxo?: { txid: string; vout: number; value: number; scriptPubKey?: string };
     changeAddress: string;
   }): Promise<{ commitTxId: string; revealTxId: string; status: 'commit_broadcast' | 'reveal_broadcast' }> {
-    return this.post('/api/btc/inscribe', params);
+    const result = await this.post<{
+      commitTxId: string;
+      revealTxId: string;
+      status: 'commit_broadcast' | 'reveal_broadcast';
+    }>('/api/btc/inscribe', params);
+    // The SDK discards this return value, so the status would otherwise never
+    // reach the UI and every 200 would read as "inscribed" — including the
+    // commit-only outcome, where the reveal has NOT landed and the recovery
+    // sweep still owes the creator an inscription. Kept here so the caller can
+    // read what actually happened.
+    this.lastSubmit = result;
+    return result;
   }
+
+  /** What the last submitInscription actually achieved. Null before any. */
+  lastSubmit: { commitTxId: string; revealTxId: string; status: 'commit_broadcast' | 'reveal_broadcast' } | null =
+    null;
 
   // --- Not implemented (the sat-selected inscribe path never calls these). ---
   getInscriptionById(): Promise<never> {


### PR DESCRIPTION
## What

A commit-only broadcast no longer renders as "inscribed".

## Why

Hit on the **first real mainnet inscription**. The site said inscribed and linked to a reveal txid that 404s:

```
8ad88c2ab862cb311da677e56ba5aea2edbfab459650decaad3406cf1081360b  → not found
```

The commit was fine — on the network, spending the identity UTXO, change returned. What had not happened was the reveal, the transaction that actually carries the inscription. The server knew: it answered `status: 'commit_broadcast'`, persisted the reveal hex, and left the recovery sweep to finish once the commit confirms.

That distinction never reached the UI, because the SDK drops it:

```ts
await provider.submitInscription({...});   // typed return value, discarded
```

`HttpOrdinalsProvider.submitInscription` is declared `Promise<{…; status: 'commit_broadcast' | 'reveal_broadcast' }>`, so the type was right all the way to the seam — and then thrown away. Every 200 read as done, and a creator was pointed at a transaction that did not exist.

## How

The provider records what the submit achieved; the demo reads it back and renders the honest state: the commit is on the network, the reveal follows automatically, nothing is stuck and nothing more is owed by the creator.

`inscribeIsComplete` is a pure function and fails closed — only `reveal_broadcast` counts, so an absent, empty or unknown status is never treated as done.

**This is a landing-side read-back, not the real fix.** The SDK is the layer that discards the value; threading it through `inscribeOnSat`'s return is better and belongs in a separate SDK change, alongside the `prevTxHex` support the same flow needed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Test addition or improvement

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] I have updated JSDoc comments for any changed public APIs
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Testing

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing (describe steps)

Landing suite **787 pass / 0 fail**. Typecheck (including `server/`), lint and `vite build` clean.

Verified against the live incident: commit `b15bceae…` broadcast and confirming, reveal `8ad88c2a…` 404 — exactly the state that rendered as "inscribed".

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)