### PR TITLE
feat(sdk): optional prevTxHex, and report how far broadcasting got

### DIFF
--- a/.changeset/sdk-signer-dx.md
+++ b/.changeset/sdk-signer-dx.md
@@ -1,0 +1,28 @@
+---
+"@originals/sdk": minor
+---
+
+**Two signer-facing improvements, both from the first real mainnet inscription.**
+
+**`Utxo.prevTxHex` (optional).** BIP-143 computes a SegWit v0 sighash from
+`witnessUtxo` alone, so the commit builder never attached the previous
+transaction. Some signers require it regardless — Turnkey answers
+`code 3: input N is missing non_witness_utxo for SegWit v0 input`, and hardware
+wallets have long demanded it as their only defence against being lied to about
+an input's value. Supply `prevTxHex` on a funding UTXO and the commit builder
+attaches `nonWitnessUtxo`; omit it and nothing changes.
+
+It is verified, not trusted: the bytes must hash to the UTXO's `txid`, and the
+output at `vout` must match its value and `scriptPubKey`. An unchecked
+`nonWitnessUtxo` is exactly what the fee-inflation attack substitutes, so a
+mismatch throws rather than being signed.
+
+**`InscribeOnSatResult.broadcast`.** `submitInscription` already returned
+`'commit_broadcast' | 'reveal_broadcast'`, and `inscribeOnSat` discarded it —
+so callers could not tell a completed pair from a commit-only broadcast where
+the reveal is persisted for rebroadcast. Both are successes, but only one means
+the inscription exists; a UI built on the missing distinction announced an
+inscription and linked to a reveal txid that returned 404.
+
+A provider that reports no status is treated as complete, which is what it has
+always meant, so existing implementations are unaffected.

--- a/packages/sdk/src/bitcoin/inscribe-on-sat.ts
+++ b/packages/sdk/src/bitcoin/inscribe-on-sat.ts
@@ -28,6 +28,23 @@ export interface InscribeOnSatResult {
   inscriptionId: string;
   commitTxId: string;
   revealTxId: string;
+  /**
+   * How far broadcasting actually got.
+   *
+   * `'reveal_broadcast'` — both transactions reached the network; the
+   * inscription exists.
+   * `'commit_broadcast'` — the commit is on the network and the reveal is
+   * persisted by the provider for rebroadcast. STILL A SUCCESS: it completes
+   * without the caller re-signing anything, usually once the commit confirms.
+   * But the inscription does NOT exist yet, so a caller must not announce one
+   * or link to `revealTxId` — that transaction is not findable.
+   *
+   * This used to be dropped: `submitInscription` returns it, the value was not
+   * captured, and callers had no way to tell the two apart. A UI built on that
+   * told a creator their inscription was done and linked to a reveal txid that
+   * 404'd.
+   */
+  broadcast: 'commit_broadcast' | 'reveal_broadcast';
 }
 
 /**
@@ -159,9 +176,10 @@ export async function inscribeOnSat(params: InscribeOnSatParams): Promise<Inscri
   // commit and reveal can never strand the committed funds (the reveal is
   // rebroadcast from the persisted copy). Otherwise fall back to the two
   // sequential broadcasts with in-memory recovery data.
+  let broadcast: InscribeOnSatResult['broadcast'] = 'reveal_broadcast';
   if (typeof provider.submitInscription === 'function') {
     try {
-      await provider.submitInscription({
+      const submitted = await provider.submitInscription({
         signedCommitHex: signedCommit,
         revealTxHex: reveal.revealTxHex,
         fundingUtxos,
@@ -170,6 +188,9 @@ export async function inscribeOnSat(params: InscribeOnSatParams): Promise<Inscri
         fundingUtxo: identityUtxo,
         changeAddress
       });
+      // An implementation predating this field reports nothing; treat that as
+      // the complete case it has always meant, rather than inventing doubt.
+      if (submitted?.status === 'commit_broadcast') broadcast = 'commit_broadcast';
     } catch (e) {
       // Ambiguous by construction: the submit may have failed before anything
       // was persisted/broadcast (nothing spent) or after (server-side recovery
@@ -199,5 +220,5 @@ export async function inscribeOnSat(params: InscribeOnSatParams): Promise<Inscri
     }
   }
 
-  return { satoshi, inscriptionId: reveal.inscriptionId, commitTxId, revealTxId: reveal.revealTxId };
+  return { satoshi, inscriptionId: reveal.inscriptionId, commitTxId, revealTxId: reveal.revealTxId, broadcast };
 }

--- a/packages/sdk/src/bitcoin/transactions/commit.ts
+++ b/packages/sdk/src/bitcoin/transactions/commit.ts
@@ -297,6 +297,44 @@ export async function createRevealTransaction(
  * @param changeOutputVBytes - Size of one change output, per the change address's script class
  * @returns Estimated transaction size in virtual bytes
  */
+/**
+ * The bytes of `utxo.prevTxHex`, once proved to be the transaction this UTXO
+ * says it is.
+ *
+ * A `nonWitnessUtxo` is what a signer reads to learn an input's true value, so
+ * an unverified one is precisely what the fee-inflation attack substitutes:
+ * hand a signer a transaction claiming a larger input and it approves a fee
+ * far bigger than the user agreed to. Returns bytes rather than a boolean so a
+ * caller cannot forget to check the result.
+ */
+function verifiedPrevTx(utxo: Utxo): Uint8Array {
+  const raw = utxo.prevTxHex as string;
+  if (!/^[0-9a-fA-F]+$/.test(raw) || raw.length % 2 !== 0) {
+    throw new Error(`prevTxHex for ${utxo.txid}:${utxo.vout} is not raw transaction hex.`);
+  }
+  const bytes = Uint8Array.from(Buffer.from(raw, 'hex'));
+  const prev = btc.Transaction.fromRaw(bytes, { allowUnknownInputs: true, allowUnknownOutputs: true });
+  if (prev.id !== utxo.txid) {
+    throw new Error(`prevTxHex hashes to ${prev.id}, not ${utxo.txid}.`);
+  }
+  if (utxo.vout < 0 || utxo.vout >= prev.outputsLength) {
+    throw new Error(`prevTxHex for ${utxo.txid} has no output ${utxo.vout}.`);
+  }
+  const out = prev.getOutput(utxo.vout);
+  if (!out?.script || typeof out.amount !== 'bigint') {
+    throw new Error(`prevTxHex output ${utxo.txid}:${utxo.vout} is unreadable.`);
+  }
+  if (out.amount !== BigInt(utxo.value)) {
+    throw new Error(
+      `prevTxHex says ${utxo.txid}:${utxo.vout} is ${out.amount} sats, but the UTXO says ${utxo.value}.`
+    );
+  }
+  if (Buffer.from(out.script).toString('hex') !== String(utxo.scriptPubKey).toLowerCase()) {
+    throw new Error(`prevTxHex output ${utxo.txid}:${utxo.vout} pays a different script than the UTXO.`);
+  }
+  return bytes;
+}
+
 function estimateCommitTxSize(inputs: Utxo[], outputCount: number, changeOutputVBytes: number): number {
   // Transaction overhead
   const overhead = 10.5;
@@ -729,7 +767,12 @@ export async function createCommitTransaction(
       witnessUtxo: {
         script: Buffer.from(utxo.scriptPubKey, 'hex'),
         amount: BigInt(utxo.value)
-      }
+      },
+      // Optional, and only when the caller supplied it (see Utxo.prevTxHex).
+      // Some signers refuse a SegWit v0 input carrying witnessUtxo alone —
+      // Turnkey answers "code 3: input N is missing non_witness_utxo". It is
+      // VERIFIED before being attached; see verifiedPrevTx.
+      ...(utxo.prevTxHex ? { nonWitnessUtxo: verifiedPrevTx(utxo) } : {})
     });
   }
 

--- a/packages/sdk/src/bitcoin/transactions/commit.ts
+++ b/packages/sdk/src/bitcoin/transactions/commit.ts
@@ -8,6 +8,7 @@
  */
 
 import * as btc from '@scure/btc-signer';
+import { StructuredError } from '@originals/cel';
 import * as ordinals from 'micro-ordinals';
 import { schnorr } from '@noble/curves/secp256k1.js';
 import { Utxo, ResourceUtxo } from '../../types/bitcoin.js';
@@ -308,29 +309,36 @@ export async function createRevealTransaction(
  * caller cannot forget to check the result.
  */
 function verifiedPrevTx(utxo: Utxo): Uint8Array {
+  const at = `${utxo.txid}:${utxo.vout}`;
   const raw = utxo.prevTxHex as string;
   if (!/^[0-9a-fA-F]+$/.test(raw) || raw.length % 2 !== 0) {
-    throw new Error(`prevTxHex for ${utxo.txid}:${utxo.vout} is not raw transaction hex.`);
+    throw new StructuredError('INVALID_PREV_TX', `prevTxHex for ${at} is not raw transaction hex.`, { outpoint: at });
   }
   const bytes = Uint8Array.from(Buffer.from(raw, 'hex'));
   const prev = btc.Transaction.fromRaw(bytes, { allowUnknownInputs: true, allowUnknownOutputs: true });
   if (prev.id !== utxo.txid) {
-    throw new Error(`prevTxHex hashes to ${prev.id}, not ${utxo.txid}.`);
+    throw new StructuredError('INVALID_PREV_TX', `prevTxHex hashes to ${prev.id}, not ${utxo.txid}.`, {
+      outpoint: at, hashedTo: prev.id
+    });
   }
   if (utxo.vout < 0 || utxo.vout >= prev.outputsLength) {
-    throw new Error(`prevTxHex for ${utxo.txid} has no output ${utxo.vout}.`);
+    throw new StructuredError('INVALID_PREV_TX', `prevTxHex for ${utxo.txid} has no output ${utxo.vout}.`, { outpoint: at });
   }
   const out = prev.getOutput(utxo.vout);
   if (!out?.script || typeof out.amount !== 'bigint') {
-    throw new Error(`prevTxHex output ${utxo.txid}:${utxo.vout} is unreadable.`);
+    throw new StructuredError('INVALID_PREV_TX', `prevTxHex output ${at} is unreadable.`, { outpoint: at });
   }
   if (out.amount !== BigInt(utxo.value)) {
-    throw new Error(
-      `prevTxHex says ${utxo.txid}:${utxo.vout} is ${out.amount} sats, but the UTXO says ${utxo.value}.`
+    throw new StructuredError(
+      'INVALID_PREV_TX',
+      `prevTxHex says ${at} is ${out.amount} sats, but the UTXO says ${utxo.value}.`,
+      { outpoint: at, prevTxSats: String(out.amount), utxoSats: utxo.value }
     );
   }
   if (Buffer.from(out.script).toString('hex') !== String(utxo.scriptPubKey).toLowerCase()) {
-    throw new Error(`prevTxHex output ${utxo.txid}:${utxo.vout} pays a different script than the UTXO.`);
+    throw new StructuredError('INVALID_PREV_TX', `prevTxHex output ${at} pays a different script than the UTXO.`, {
+      outpoint: at
+    });
   }
   return bytes;
 }
@@ -772,7 +780,10 @@ export async function createCommitTransaction(
       // Some signers refuse a SegWit v0 input carrying witnessUtxo alone —
       // Turnkey answers "code 3: input N is missing non_witness_utxo". It is
       // VERIFIED before being attached; see verifiedPrevTx.
-      ...(utxo.prevTxHex ? { nonWitnessUtxo: verifiedPrevTx(utxo) } : {})
+      // `!== undefined`, not truthiness: prevTxHex: '' is a SUPPLIED value —
+      // a fetch that returned nothing — and skipping it silently produces a
+      // misleading signer-side error later instead of a clear one here.
+      ...(utxo.prevTxHex !== undefined ? { nonWitnessUtxo: verifiedPrevTx(utxo) } : {})
     });
   }
 

--- a/packages/sdk/src/bitcoin/transactions/commit.ts
+++ b/packages/sdk/src/bitcoin/transactions/commit.ts
@@ -315,7 +315,20 @@ function verifiedPrevTx(utxo: Utxo): Uint8Array {
     throw new StructuredError('INVALID_PREV_TX', `prevTxHex for ${at} is not raw transaction hex.`, { outpoint: at });
   }
   const bytes = Uint8Array.from(Buffer.from(raw, 'hex'));
-  const prev = btc.Transaction.fromRaw(bytes, { allowUnknownInputs: true, allowUnknownOutputs: true });
+  // Even-length hex can still be anything. Left unguarded, @scure's parser
+  // error ("Reader(inputs/arrayLen): readByte: Unexpected end of buffer")
+  // escapes with no code, so a consumer cannot classify the very failure this
+  // function exists to report.
+  let prev: btc.Transaction;
+  try {
+    prev = btc.Transaction.fromRaw(bytes, { allowUnknownInputs: true, allowUnknownOutputs: true });
+  } catch (e) {
+    throw new StructuredError(
+      'INVALID_PREV_TX',
+      `prevTxHex for ${at} is not a decodable Bitcoin transaction: ${e instanceof Error ? e.message : String(e)}`,
+      { outpoint: at }
+    );
+  }
   if (prev.id !== utxo.txid) {
     throw new StructuredError('INVALID_PREV_TX', `prevTxHex hashes to ${prev.id}, not ${utxo.txid}.`, {
       outpoint: at, hashedTo: prev.id

--- a/packages/sdk/src/types/bitcoin.ts
+++ b/packages/sdk/src/types/bitcoin.ts
@@ -41,6 +41,21 @@ export interface Utxo {
   vout: number;
   value: number; // satoshis
   scriptPubKey?: string;
+  /**
+   * The whole previous transaction, hex, OPTIONAL.
+   *
+   * BIP-143 computes a SegWit v0 sighash from `witnessUtxo` alone, so the
+   * commit PSBT does not need this and most callers will not supply it. Some
+   * signers require it regardless — Turnkey answers
+   * `code 3: input N is missing non_witness_utxo for SegWit v0 input`, and
+   * hardware wallets have historically demanded it too, as their only defence
+   * against being lied to about an input's value (the fee-inflation attack).
+   *
+   * Supply it and the commit builder attaches `nonWitnessUtxo`, after checking
+   * it hashes to `txid` and that output `vout` matches this UTXO. Omit it and
+   * nothing changes.
+   */
+  prevTxHex?: string;
   address?: string;
   inscriptions?: string[]; // inscription ids located on this outpoint
   locked?: boolean; // if true, cannot be spent due to wallet locks

--- a/packages/sdk/tests/unit/bitcoin/inscribeOnSat.test.ts
+++ b/packages/sdk/tests/unit/bitcoin/inscribeOnSat.test.ts
@@ -335,3 +335,52 @@ describe('inscribeOnSat — multi-input funding', () => {
       .rejects.toMatchObject({ code: 'INVALID_INPUT' });
   });
 });
+
+/**
+ * `broadcast` — how far broadcasting actually got.
+ *
+ * From the first real mainnet inscription: the provider reported
+ * `status: 'commit_broadcast'` (commit on-chain, reveal persisted for
+ * rebroadcast), the SDK discarded submitInscription's return value, and the
+ * caller had no way to tell that from a completed pair. A UI built on that
+ * announced an inscription and linked to a reveal txid that 404'd.
+ */
+describe('inscribeOnSat reports how far broadcasting got', () => {
+  it('reports reveal_broadcast when both transactions reached the network', async () => {
+    const provider = providerDouble({
+      submitInscription: async () => ({ commitTxId: 'a', revealTxId: 'b', status: 'reveal_broadcast' })
+    });
+    const res = await inscribeOnSat({ ...baseParams(), satSigner: signer, provider });
+    expect(res.broadcast).toBe('reveal_broadcast');
+  });
+
+  it('reports commit_broadcast when only the commit did — the case that used to be invisible', async () => {
+    const provider = providerDouble({
+      submitInscription: async () => ({ commitTxId: 'a', revealTxId: 'b', status: 'commit_broadcast' })
+    });
+    const res = await inscribeOnSat({ ...baseParams(), satSigner: signer, provider });
+    expect(res.broadcast).toBe('commit_broadcast');
+    // Still a success: the reveal completes without the caller re-signing.
+    expect(res.revealTxId).toBeTruthy();
+    expect(res.inscriptionId).toBeTruthy();
+  });
+
+  it('treats a provider that reports no status as complete, not as doubt', async () => {
+    // Pre-dates the field. It has always meant "both broadcast", so inventing
+    // uncertainty here would regress every existing implementation.
+    const provider = providerDouble({
+      submitInscription: async () => ({ commitTxId: 'a', revealTxId: 'b' })
+    });
+    const res = await inscribeOnSat({ ...baseParams(), satSigner: signer, provider });
+    expect(res.broadcast).toBe('reveal_broadcast');
+  });
+
+  it('reports reveal_broadcast on the two-broadcast fallback path', async () => {
+    // No submitInscription seam: both broadcasts must have succeeded to get
+    // here at all, since a failed reveal throws REVEAL_BROADCAST_FAILED.
+    const provider = providerDouble();
+    delete (provider as any).submitInscription;
+    const res = await inscribeOnSat({ ...baseParams(), satSigner: signer, provider });
+    expect(res.broadcast).toBe('reveal_broadcast');
+  });
+});

--- a/packages/sdk/tests/unit/bitcoin/transactions/prev-tx-hex.test.ts
+++ b/packages/sdk/tests/unit/bitcoin/transactions/prev-tx-hex.test.ts
@@ -1,0 +1,93 @@
+/**
+ * `Utxo.prevTxHex` — the optional whole previous transaction some signers
+ * demand for a SegWit v0 input.
+ *
+ * From the first real mainnet inscription: Turnkey answered
+ *   code 3: input 0 is missing non_witness_utxo for SegWit v0 input
+ * because the commit builder attaches only `witnessUtxo`. BIP-143 does not
+ * need more, so the default is unchanged; supplying prevTxHex opts in.
+ */
+import { describe, it, expect } from 'bun:test';
+import * as btc from '@scure/btc-signer';
+import { createCommitTransaction } from '../../../../src/bitcoin/transactions/commit.js';
+import type { Utxo } from '../../../../src/types/bitcoin.js';
+
+const changeAddress = 'bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080';
+const SCRIPT_HEX = '0014' + 'b'.repeat(40);
+const VALUE = 100_000;
+
+/** A genuine previous transaction paying VALUE to SCRIPT_HEX at vout 0. */
+function prevTx(amount = BigInt(VALUE), scriptHex = SCRIPT_HEX) {
+  const t = new btc.Transaction({ allowUnknownOutputs: true });
+  t.addOutput({ script: Uint8Array.from(Buffer.from(scriptHex, 'hex')), amount });
+  t.addInput({
+    txid: Uint8Array.from(Buffer.from('11'.repeat(32), 'hex')),
+    index: 0,
+    finalScriptSig: Uint8Array.from([0])
+  });
+  return { hex: Buffer.from(t.toBytes(true, true)).toString('hex'), txid: t.id };
+}
+
+const build = (utxo: Utxo) =>
+  createCommitTransaction({
+    content: Buffer.from('hello'),
+    contentType: 'text/plain',
+    utxos: [utxo],
+    changeAddress,
+    feeRate: 2,
+    network: 'regtest'
+  });
+
+describe('prevTxHex is optional and off by default', () => {
+  it('a UTXO without it produces the same witness-only input as before', async () => {
+    const p = prevTx();
+    const commit = await build({ txid: p.txid, vout: 0, value: VALUE, scriptPubKey: SCRIPT_HEX });
+    expect(commit.commitPsbt.getInput(0).witnessUtxo).toBeDefined();
+    expect(commit.commitPsbt.getInput(0).nonWitnessUtxo).toBeUndefined();
+  });
+
+  it('supplying it attaches the whole previous transaction alongside witnessUtxo', async () => {
+    const p = prevTx();
+    const commit = await build({
+      txid: p.txid, vout: 0, value: VALUE, scriptPubKey: SCRIPT_HEX, prevTxHex: p.hex
+    });
+    expect(commit.commitPsbt.getInput(0).nonWitnessUtxo).toBeDefined();
+    expect(commit.commitPsbt.getInput(0).witnessUtxo).toBeDefined();
+  });
+});
+
+describe('a supplied prevTxHex is verified, never trusted', () => {
+  /**
+   * `nonWitnessUtxo` is how a signer learns an input's true value, so an
+   * unchecked one IS the fee-inflation attack: substitute a transaction
+   * claiming a larger input and the signer approves a far larger fee.
+   */
+  it('refuses a transaction that hashes to a different txid', async () => {
+    const real = prevTx();
+    const other = prevTx(BigInt(999_999));
+    await expect(
+      build({ txid: real.txid, vout: 0, value: VALUE, scriptPubKey: SCRIPT_HEX, prevTxHex: other.hex })
+    ).rejects.toThrow(/hashes to/);
+  });
+
+  it('refuses a value that disagrees with the UTXO', async () => {
+    const p = prevTx();
+    await expect(
+      build({ txid: p.txid, vout: 0, value: VALUE + 1, scriptPubKey: SCRIPT_HEX, prevTxHex: p.hex })
+    ).rejects.toThrow(/sats, but the UTXO says/);
+  });
+
+  it('refuses an output index the previous transaction does not have', async () => {
+    const p = prevTx();
+    await expect(
+      build({ txid: p.txid, vout: 7, value: VALUE, scriptPubKey: SCRIPT_HEX, prevTxHex: p.hex })
+    ).rejects.toThrow(/has no output 7/);
+  });
+
+  it('refuses anything that is not raw transaction hex', async () => {
+    const p = prevTx();
+    await expect(
+      build({ txid: p.txid, vout: 0, value: VALUE, scriptPubKey: SCRIPT_HEX, prevTxHex: 'nothex' })
+    ).rejects.toThrow(/not raw transaction hex/);
+  });
+});

--- a/packages/sdk/tests/unit/bitcoin/transactions/prev-tx-hex.test.ts
+++ b/packages/sdk/tests/unit/bitcoin/transactions/prev-tx-hex.test.ts
@@ -104,6 +104,22 @@ describe('a supplied prevTxHex is verified, never trusted', () => {
     ).rejects.toThrow(/not raw transaction hex/);
   });
 
+  /**
+   * Even-length hex that is not a transaction. The parser throws a
+   * dependency-specific error with no code; unguarded, it would escape and
+   * defeat the stable code this function promises.
+   */
+  it('refuses undecodable hex with the same stable code, not a parser error', async () => {
+    const p = prevTx();
+    try {
+      await build({ txid: p.txid, vout: 0, value: VALUE, scriptPubKey: SCRIPT_HEX, prevTxHex: 'deadbeef' });
+      throw new Error('expected a rejection');
+    } catch (e) {
+      expect((e as { code?: string }).code).toBe('INVALID_PREV_TX');
+      expect((e as Error).message).toMatch(/not a decodable Bitcoin transaction/);
+    }
+  });
+
   /** Consumers classify by code, not by parsing message text (CLAUDE.md). */
   it('reports a stable error code, not a bare Error', async () => {
     const p = prevTx();

--- a/packages/sdk/tests/unit/bitcoin/transactions/prev-tx-hex.test.ts
+++ b/packages/sdk/tests/unit/bitcoin/transactions/prev-tx-hex.test.ts
@@ -90,4 +90,28 @@ describe('a supplied prevTxHex is verified, never trusted', () => {
       build({ txid: p.txid, vout: 0, value: VALUE, scriptPubKey: SCRIPT_HEX, prevTxHex: 'nothex' })
     ).rejects.toThrow(/not raw transaction hex/);
   });
+
+  /**
+   * An empty string is a SUPPLIED value — a fetch that came back with nothing —
+   * not an absent one. Truthiness treated it as absent, so the input silently
+   * lost its nonWitnessUtxo and the signer failed later with its own, less
+   * useful error.
+   */
+  it('refuses an empty prevTxHex rather than silently skipping it', async () => {
+    const p = prevTx();
+    await expect(
+      build({ txid: p.txid, vout: 0, value: VALUE, scriptPubKey: SCRIPT_HEX, prevTxHex: '' })
+    ).rejects.toThrow(/not raw transaction hex/);
+  });
+
+  /** Consumers classify by code, not by parsing message text (CLAUDE.md). */
+  it('reports a stable error code, not a bare Error', async () => {
+    const p = prevTx();
+    try {
+      await build({ txid: p.txid, vout: 0, value: VALUE + 1, scriptPubKey: SCRIPT_HEX, prevTxHex: p.hex });
+      throw new Error('expected a rejection');
+    } catch (e) {
+      expect((e as { code?: string }).code).toBe('INVALID_PREV_TX');
+    }
+  });
 });


### PR DESCRIPTION
## What

Two additive SDK changes, both earned by the first real mainnet inscription:

- **`Utxo.prevTxHex`** (optional) — attach the previous transaction for signers that require it, verified before use.
- **`InscribeOnSatResult.broadcast`** — surface how far broadcasting actually got, instead of discarding it.

Non-breaking. Both defaults are unchanged.

## Why

Each of these cost a debugging round trip with a creator's BTC already committed, and each would cost the next consumer the same.

### `prevTxHex`

BIP-143 computes a SegWit v0 sighash from `witnessUtxo` alone, so the commit builder never attached the previous transaction — correct for the protocol. Signers require it anyway:

```
sign_transaction code 3: input 0 is missing non_witness_utxo for
SegWit v0 input; provide both witness_utxo and non_witness_utxo
```

That's Turnkey, but it isn't Turnkey-specific: hardware wallets have demanded the full previous transaction for years, because it is their only defence against being lied to about an input's value — the fee-inflation attack. Any consumer with a remote or hardware signer hits this, and the SDK gave them no way through it short of post-processing the PSBT themselves.

**It is verified, not trusted.** The bytes must hash to the UTXO's `txid`, and the output at `vout` must match its value and `scriptPubKey`. An unchecked `nonWitnessUtxo` is exactly what the attack substitutes — a transaction claiming a larger input, so the signer approves a far larger fee. A mismatch throws rather than reaching a signer.

Where the bytes come from stays the caller's business: it's deployment-specific, and in our case scoped to the user's own funding outputs rather than a general lookup.

### `broadcast`

`submitInscription` was already typed to return `'commit_broadcast' | 'reveal_broadcast'`, with the interface documenting exactly what each means. `inscribeOnSat` then did this:

```ts
await provider.submitInscription({...});   // typed return value, discarded
```

So a caller could not tell a completed pair from a commit-only broadcast whose reveal is persisted for rebroadcast. Both are successes — the commit-only case completes without re-signing — but only one means the inscription **exists**. Built on the missing distinction, our UI announced an inscription and linked to a reveal txid that returned 404 for the twenty minutes before the commit confirmed.

A provider that reports no status is treated as complete, which is what it has always meant, so existing implementations are unaffected.

## How

- `Utxo` gains `prevTxHex?: string`. The commit builder attaches `nonWitnessUtxo` only when it is present, after `verifiedPrevTx` proves it.
- `InscribeOnSatResult` gains `broadcast`, populated on both the `submitInscription` path and the two-broadcast fallback.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Test addition or improvement

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] I have updated JSDoc comments for any changed public APIs
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Testing

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing (describe steps)

SDK suite **3,385 tests / 0 fail**, landing **792 / 0 fail**, repo typecheck, lint and build all clean.

Ten new tests in `tests/unit/bitcoin/`. Both changes verified load-bearing — reverting them fails six:

```
(fail) reports commit_broadcast when only the commit did — the case that used to be invisible
(fail) supplying it attaches the whole previous transaction alongside witnessUtxo
(fail) refuses a transaction that hashes to a different txid
(fail) refuses a value that disagrees with the UTXO
(fail) refuses an output index the previous transaction does not have
(fail) refuses anything that is not raw transaction hex
```

The verification tests are the ones that matter: each substitutes a plausible-but-wrong previous transaction and asserts it is refused.

**Validated end to end on mainnet.** The landing app's equivalent of this shipped first and produced a real inscription — commit `b15bceae…` at height 963409, reveal `8ad88c2a…` at 963410. This PR moves that capability into the SDK so the next consumer doesn't rediscover it with money on the line.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
