### PR TITLE
feat(landing): finish a published Original that never reached Bitcoin

### DIFF
--- a/.changeset/resume-inscribe-published-originals.md
+++ b/.changeset/resume-inscribe-published-originals.md
@@ -1,0 +1,17 @@
+---
+"@originals/landing": patch
+---
+
+**Feature: finish a published Original that never reached Bitcoin, instead of re-running the demo.**
+
+A published Original that was never inscribed showed on `/me` with no way to inscribe it, and the detail page had no Bitcoin action at all — so the creator re-ran the demo and ended up with a second, different `did:webvh` Original.
+
+Closing that gap turned out to be a custody problem, not a UI one. An Original is a CEL, every lifecycle step appends a signed event to it, and the key that signed those events was minted by `createAsset` into the DemoEngine's in-memory Map and destroyed with the tab. Verified before writing anything: after create + publish in Chromium, `localStorage` is empty while the CEL genesis controller reads `did:key:z6Mkks2HT…`. Nothing could sign a later `migrate` event, so no button could have worked.
+
+Turnkey already provisions two `CURVE_ED25519` accounts per sub-org that nothing signed with. Ed25519 is what CEL requires, and Turnkey custody is what a browser-local seed is not: it comes back with the session on any device. A signed-in creator's Originals are now authored by that key from genesis onward, passed per-call so `Demo.tsx` is untouched — and `publish`/`inscribe` must use the same key, because pre-anchor the CEL accepts only its current controller as signer.
+
+`/me` and `/me/<did>` now offer "Inscribe on Bitcoin" for a row that was never built. It rebuilds the asset from the artifacts the Original hosts (`hostedAssetEnvelope` → `loadAsset`, verifying the signed chain, resource-to-genesis binding and DID-doc cross-checks fail-closed) and hands it to the existing `engine.inscribe({ funding })` — that path is not forked. Funding comes from the app's own `GET /api/btc/deposit` and the same `selectFundingUtxos` the demo uses; no fee estimation or selection rule is reimplemented here, and it refuses before building anything if the deposit does not cover the quote.
+
+Finish and Inscribe are decided by one shared selector and never both appear on a row: rebuilding over signed, paid-for transactions would strand that spend.
+
+**One limitation, stated plainly.** Originals created *before* this change answer to a controller key that only ever existed in one tab and is gone. They cannot be inscribed, by anyone, on any device — the action is disabled for them with copy that says so rather than implying another device would help, and says what remains true: their history stays signed, verifiable and hosted. Only Originals created from now on are resumable.

--- a/apps/landing/src/auth/authorship-key.ts
+++ b/apps/landing/src/auth/authorship-key.ts
@@ -1,7 +1,20 @@
 /**
- * U10 / R17, R18 — the authorship key.
+ * U10 / R17, R18 — the account key.
  *
- * The Ed25519 seed in `webvh.ts` signs every Original the user authors, and it
+ * NAME COLLISION, read this first. Two different Ed25519 keys are called an
+ * "authorship key" in this app and they are NOT the same key:
+ *
+ *  - THIS one signs the user's own `did:webvh` identity document. It lives in
+ *    this browser's `localStorage` and nowhere else.
+ *  - The one in `sdk/turnkey-cel-signer.ts` signs CEL events — the controller
+ *    of each Original the user authors. It is held in their Turnkey
+ *    sub-organization, so it comes back with the session on any device.
+ *
+ * This module used to be both, which is why the file is named as it is. It
+ * stopped being the second when CEL authorship moved into custody, and that
+ * move is what makes a published Original inscribable after a reload.
+ *
+ * The Ed25519 seed in `webvh.ts` signs the user's own DID, and it
  * exists in exactly one place: this browser's `localStorage`. Clearing site
  * data, switching browsers, or Safari evicting storage all destroy it, and
  * nothing on our side can reissue it. KTD10 says the launch remedy is

--- a/apps/landing/src/auth/turnkey-session.ts
+++ b/apps/landing/src/auth/turnkey-session.ts
@@ -76,14 +76,30 @@ export interface TurnkeyBitcoinClient {
     unsignedTransaction: string;
     type: 'TRANSACTION_TYPE_BITCOIN';
   }): Promise<{ signedTransaction: string }>;
+  /**
+   * Raw byte signing — the Ed25519 half of this client, used to author CEL
+   * events (see ../sdk/turnkey-cel-signer). Optional because the pure test
+   * doubles for the Bitcoin paths have no reason to implement it; anything
+   * that needs it checks first and says so rather than throwing at sign time.
+   */
+  signRawPayload?(params: {
+    organizationId: string;
+    signWith: string;
+    payload: string;
+    encoding: 'PAYLOAD_ENCODING_HEXADECIMAL';
+    hashFunction: 'HASH_FUNCTION_NO_OP';
+  }): Promise<unknown>;
   createWalletAccounts(params: {
     walletId: string;
     organizationId: string;
     accounts: Array<{
-      curve: 'CURVE_SECP256K1';
+      curve: 'CURVE_SECP256K1' | 'CURVE_ED25519';
       pathFormat: 'PATH_FORMAT_BIP32';
       path: string;
-      addressFormat: 'ADDRESS_FORMAT_BITCOIN_TESTNET_P2WPKH' | 'ADDRESS_FORMAT_BITCOIN_MAINNET_P2WPKH';
+      addressFormat:
+        | 'ADDRESS_FORMAT_BITCOIN_TESTNET_P2WPKH'
+        | 'ADDRESS_FORMAT_BITCOIN_MAINNET_P2WPKH'
+        | 'ADDRESS_FORMAT_SOLANA';
     }>;
   }): Promise<{ addresses: string[] }>;
   /**
@@ -457,3 +473,65 @@ function verifyFundingAddress(address: string | undefined, prefix: string): stri
   return address;
 }
 
+/* ——— The authorship account (Ed25519, Turnkey-held) ——————————————————— */
+
+/**
+ * The Turnkey account whose key signs an Original's CEL events.
+ *
+ * Ed25519 because CEL is Ed25519-only, and Turnkey-held rather than
+ * browser-held because an Original that can only be finished in the browser
+ * that started it is the gap this exists to close: a key in Turnkey comes back
+ * with the session, on any device.
+ *
+ * Turnkey reports an Ed25519 account in Solana's address format, which IS the
+ * raw 32-byte public key in base58 — see `authorshipPublicKeyMultibase`. The
+ * path is fixed so re-reading always yields the same key: an Original's
+ * controller identity must not move under it.
+ */
+export const AUTHORSHIP_ACCOUNT = {
+  curve: 'CURVE_ED25519',
+  pathFormat: 'PATH_FORMAT_BIP32',
+  path: "m/44'/501'/0'/0'",
+  addressFormat: 'ADDRESS_FORMAT_SOLANA',
+} as const;
+
+/**
+ * The sub-org's authorship account address, creating it if this wallet has
+ * none. Mirrors `ensureBitcoinFundingAccount`: read by path first, create only
+ * on a miss, and treat Turnkey's "already exists" as proof to re-read rather
+ * than as a failure.
+ */
+export async function ensureAuthorshipAccount(
+  client: TurnkeyBitcoinClient,
+  subOrgId: string
+): Promise<string> {
+  const findExisting = async (): Promise<string | undefined> => {
+    const { accounts } = await client.getWalletAccounts({ organizationId: subOrgId });
+    return accounts?.find((a) => a.path === AUTHORSHIP_ACCOUNT.path)?.address;
+  };
+
+  const already = await findExisting();
+  if (already) return already;
+
+  const { wallets } = await client.getWallets({ organizationId: subOrgId });
+  const wallet = wallets[0];
+  if (!wallet) throw new Error('No Turnkey wallet found for the sub-organization.');
+
+  let addresses: string[];
+  try {
+    ({ addresses } = await client.createWalletAccounts({
+      walletId: wallet.walletId,
+      organizationId: subOrgId,
+      accounts: [{ ...AUTHORSHIP_ACCOUNT }],
+    }));
+  } catch (err) {
+    if (!/already exists/i.test(String((err as Error)?.message ?? err))) throw err;
+    const recovered = await findExisting();
+    if (!recovered) throw err;
+    return recovered;
+  }
+
+  const address = addresses[0];
+  if (!address) throw new Error('Turnkey returned no authorship account address.');
+  return address;
+}

--- a/apps/landing/src/content.ts
+++ b/apps/landing/src/content.ts
@@ -657,7 +657,6 @@ export const yourOriginals = {
      */
     commitOnly:
       'Your funding transaction is on the network. The second transaction — the one that carries the inscription — has not propagated yet, which is expected while the first is unconfirmed. It is signed and saved, and goes out automatically. Nothing is stuck and nothing more is owed.',
-    failed: 'Could not inscribe this Original — nothing was broadcast and nothing was spent.',
     /** Shown under a disabled action, keyed by `DisabledReason`. */
     reasons: {
       'signed-out': 'Sign in to inscribe this Original on Bitcoin.',
@@ -665,7 +664,15 @@ export const yourOriginals = {
         'This browser can’t reach your signing key right now, so it can’t sign the event inscribing adds. Sign in again and it will come back.',
       'foreign-controller':
         'This Original was made before signing keys were kept for you, so the key that could add to its history only ever existed in the browser that created it — and it’s gone. Everything already in its history stays signed, verifiable and hosted; it just can’t be carried on to Bitcoin. Anything you make from now on can be.',
-      unknown: 'Reading this Original’s signed log…',
+      /**
+       * Not fetched yet. Rendered as NOTHING, not as this text: on first paint
+       * no row's log has been read, so showing it flashed a note under every
+       * card. Kept as a string for a caller that wants to say it out loud.
+       */
+      reading: 'Reading this Original’s signed log…',
+      /** Fetched, and it did not come back readable. A real answer, so it shows. */
+      unreadable:
+        'This Original’s signed log could not be read from where it is hosted, so there is nothing to carry to Bitcoin yet. Reloading may fix it.',
       /**
        * An inscription is already built and paid for and waiting to be pushed,
        * and we cannot tell which Original it belongs to. Rebuilding would

--- a/apps/landing/src/content.ts
+++ b/apps/landing/src/content.ts
@@ -93,7 +93,7 @@ export const identityPanel = {
   layerLabel: 'did:webvh',
   idleTitle: 'Your own DID, signed in this browser',
   idleBody:
-    'Mint a did:webvh signed by a key only this browser holds — yours to keep, and yours to sign your work with.',
+    'Mint a did:webvh signed by a key only this browser holds — yours to keep, and yours to prove this identity is yours.',
   createAction: 'Create your did:webvh',
   creating: 'Creating…',
   createFailed: 'DID creation failed — try again.',
@@ -112,9 +112,9 @@ export const identityPanel = {
   warning: {
     title: 'First, the part nobody can undo for you',
     body:
-      'Creating your DID generates a signing key that only this browser will hold. It signs everything you make with Originals, and we never get a copy — so if this browser’s storage is cleared, or you move to another browser or device, the key is gone and no one can reissue it.',
+      'Creating your DID generates a signing key that only this browser will hold. It signs this DID, and we never get a copy — so if this browser’s storage is cleared, or you move to another browser or device, the key is gone and no one can reissue it. The Originals you make are signed separately, by a key held for you, and they come back wherever you sign in.',
     remedy:
-      'Save an encrypted backup as soon as it exists. That file, plus the passphrase you pick for it, is what carries your work to another browser.',
+      'Save an encrypted backup as soon as it exists. That file, plus the passphrase you pick for it, is what carries this DID to another browser.',
     acknowledge: 'I understand this key will exist only in this browser',
     confirm: 'Create my DID',
     cancel: 'Go back',
@@ -971,7 +971,8 @@ export const legal = {
       {
         heading: 'Keys held in your browser',
         body: [
-          'The Ed25519 key that signs everything you author lives in this browser’s localStorage, together with the DID log it created. Neither is ever sent to the server, and nothing on our side can reissue them: clearing site data, switching browsers, or the browser evicting storage destroys them for good.',
+          'The Ed25519 key that signs your own did:webvh identity lives in this browser’s localStorage, together with the DID log it created. Neither is ever sent to the server, and nothing on our side can reissue them: clearing site data, switching browsers, or the browser evicting storage destroys them for good.',
+          'The key that signs the Originals you author while signed in is a different key, and it is not held here: it is an Ed25519 key in your Turnkey sub-organization, which is what lets an Original you published on one device still be carried to Bitcoin from another. Signed out, that key does not exist and the Original is signed by a key generated in the page and discarded with it.',
           'The backup file you can download is wrapped with your passphrase inside the browser before it is written to disk. No copy of the file, and no copy of the passphrase, reaches the server.',
           'The key authorising your Turnkey session is a non-extractable WebCrypto key in this browser’s IndexedDB — it can be asked to sign, but its private half cannot be read back out, by our code or anyone else’s. localStorage holds only the sub-organization id, the matching public key, and the expiry time.'
         ]

--- a/apps/landing/src/content.ts
+++ b/apps/landing/src/content.ts
@@ -666,6 +666,14 @@ export const yourOriginals = {
       'foreign-controller':
         'This Original was made before signing keys were kept for you, so the key that could add to its history only ever existed in the browser that created it — and it’s gone. Everything already in its history stays signed, verifiable and hosted; it just can’t be carried on to Bitcoin. Anything you make from now on can be.',
       unknown: 'Reading this Original’s signed log…',
+      /**
+       * An inscription is already built and paid for and waiting to be pushed,
+       * and we cannot tell which Original it belongs to. Rebuilding would
+       * replace it, so the copy points at the thing that clears it rather than
+       * describing the ambiguity — finishing it is one click away, above.
+       */
+      'pending-elsewhere':
+        'You have an inscription that’s already built and waiting to be sent. Finish that one first — until it lands, starting another could replace it.',
     },
   },
   /**

--- a/apps/landing/src/content.ts
+++ b/apps/landing/src/content.ts
@@ -649,6 +649,14 @@ export const yourOriginals = {
     busy: 'Inscribing…',
     hydrating: 'Rebuilding from its signed log…',
     done: 'Inscribed — the transactions are on their way to the network.',
+    /**
+     * Only the commit reached the network. The reveal carries the inscription,
+     * so until it propagates there is nothing on chain — saying "inscribed"
+     * here is the same lie #506 removed from the demo. Nothing more is owed;
+     * the server re-pushes the reveal on its own.
+     */
+    commitOnly:
+      'Your funding transaction is on the network. The second transaction — the one that carries the inscription — has not propagated yet, which is expected while the first is unconfirmed. It is signed and saved, and goes out automatically. Nothing is stuck and nothing more is owed.',
     failed: 'Could not inscribe this Original — nothing was broadcast and nothing was spent.',
     /** Shown under a disabled action, keyed by `DisabledReason`. */
     reasons: {

--- a/apps/landing/src/content.ts
+++ b/apps/landing/src/content.ts
@@ -626,6 +626,34 @@ export const yourOriginals = {
     failed: 'Could not finish the inscription — try again in a moment.',
   },
   /**
+   * The pre-broadcast resume gap: a published Original that was never
+   * inscribed. Distinct from `finish` above, which recovers an inscription
+   * that WAS built and signed — these two never appear on the same row.
+   *
+   * The disabled reasons are the honest half. Inscribing appends a signed
+   * migrate event, and pre-anchor the CEL accepts only its current controller
+   * as signer, so an Original minted before authorship moved into Turnkey
+   * custody answers to a key that lived in a tab and is gone. That cannot be
+   * fixed by signing in again on another device, and the copy must not imply
+   * it can.
+   */
+  inscribe: {
+    cta: 'Inscribe on Bitcoin',
+    busy: 'Inscribing…',
+    hydrating: 'Rebuilding from its signed log…',
+    done: 'Inscribed — the transactions are on their way to the network.',
+    failed: 'Could not inscribe this Original — nothing was broadcast and nothing was spent.',
+    /** Shown under a disabled action, keyed by `DisabledReason`. */
+    reasons: {
+      'signed-out': 'Sign in to inscribe this Original on Bitcoin.',
+      'no-authorship-key':
+        'This browser can’t reach your signing key right now, so it can’t sign the event inscribing adds. Sign in again and it will come back.',
+      'foreign-controller':
+        'This Original was made before signing keys were kept for you, so the key that could add to its history only ever existed in the browser that created it — and it’s gone. Everything already in its history stays signed, verifiable and hosted; it just can’t be carried on to Bitcoin. Anything you make from now on can be.',
+      unknown: 'Reading this Original’s signed log…',
+    },
+  },
+  /**
    * R31 — a deposit-read outage is asynchronous: it can start after a creator
    * sends BTC and closes the tab, so the deposit screen's own copy reaches
    * nobody. This block is the version that greets them on their NEXT VISIT,

--- a/apps/landing/src/content.ts
+++ b/apps/landing/src/content.ts
@@ -639,6 +639,13 @@ export const yourOriginals = {
    */
   inscribe: {
     cta: 'Inscribe on Bitcoin',
+    /**
+     * The detail-page section heading. Neutral on purpose, and never the CTA
+     * text: the same section carries the reason an Original CANNOT be
+     * inscribed, where "Inscribe on Bitcoin" would read as an offer being
+     * withdrawn — and above the button it would just say the same thing twice.
+     */
+    sectionEyebrow: 'Bitcoin',
     busy: 'Inscribing…',
     hydrating: 'Rebuilding from its signed log…',
     done: 'Inscribed — the transactions are on their way to the network.',

--- a/apps/landing/src/pages/OriginalDetail.tsx
+++ b/apps/landing/src/pages/OriginalDetail.tsx
@@ -22,7 +22,7 @@ import {
   type OriginalRow,
   type PendingInscription,
 } from './YourOriginals';
-import { inscribeAvailability, type InscribeAvailability } from './inscribe-availability';
+import { inscribeAvailability, rowAfterInscribe, type InscribeAvailability } from './inscribe-availability';
 import { resolveAuthorshipDid, resumeInscribe } from './resume-inscribe';
 import {
   webvhArtifacts,
@@ -211,6 +211,21 @@ export function OriginalDetail({ did }: { did: string }) {
           : yourOriginals.inscribe.commitOnly
         : outcome.message
     );
+    if (outcome.ok) {
+      // Record the commit on the row the selector reads. Without this the row
+      // is untouched, `action` recomputes to 'inscribe', the button re-enables
+      // and a second click builds and pays for a second commit/reveal pair.
+      // The durable row catches up on the next load; this is the same patch
+      // /me applies.
+      setData((d) =>
+        d && d.row
+          ? {
+              ...d,
+              row: rowAfterInscribe(d.row, outcome.inscription.commitTxId),
+            }
+          : d
+      );
+    }
     setInscribing(false);
   };
 

--- a/apps/landing/src/pages/OriginalDetail.tsx
+++ b/apps/landing/src/pages/OriginalDetail.tsx
@@ -8,7 +8,7 @@
  * hashes and both proof chains in the visitor's browser (verify-original.ts).
  */
 import { useEffect, useRef, useState } from 'react';
-import { originalDetail } from '../content';
+import { originalDetail, yourOriginals } from '../content';
 import { useAuth } from '../auth/useAuth';
 import { navigate } from '../router';
 import { short } from '../sdk/format';
@@ -17,9 +17,13 @@ import { btcoExplorerUrl } from '../sdk/network-flag';
 import {
   fetchOriginals,
   fetchInscriptions,
+  unfinishedInscriptions,
   withLiveInscriptionStatus,
   type OriginalRow,
+  type PendingInscription,
 } from './YourOriginals';
+import { inscribeAvailability, type InscribeAvailability } from './inscribe-availability';
+import { resolveAuthorshipDid, resumeInscribe } from './resume-inscribe';
 import {
   webvhArtifacts,
   celTimeline,
@@ -71,7 +75,13 @@ const isText = (r: CelResourceRef) =>
   /^(application\/json|text\/)/.test(r.mediaType ?? '');
 
 export function OriginalDetail({ did }: { did: string }) {
-  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const { isAuthenticated, isLoading: authLoading, bitcoin, user } = useAuth();
+  // The resume surface: this page had no Bitcoin action at all, so a published
+  // Original that was never inscribed dead-ended here.
+  const [records, setRecords] = useState<PendingInscription[]>([]);
+  const [authorshipDid, setAuthorshipDid] = useState<string | null>(null);
+  const [inscribing, setInscribing] = useState(false);
+  const [inscribeNote, setInscribeNote] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
   const [data, setData] = useState<DetailData | null>(null);
   const [checks, setChecks] = useState<OriginalCheck[] | null>(null);
@@ -95,6 +105,7 @@ export function OriginalDetail({ did }: { did: string }) {
       ]);
       // Overlay live confirmation state (the stored row stays 'pending').
       const row = withLiveInscriptionStatus(rows, inscriptionRecs.records).find((r) => r.did === did) ?? null;
+      if (live) setRecords(inscriptionRecs.records);
 
       let logEntries: ReturnType<typeof parseDidLog> | null = null;
       try {
@@ -173,7 +184,41 @@ export function OriginalDetail({ did }: { did: string }) {
     };
   }, [isAuthenticated, did]);
 
+  useEffect(() => {
+    let alive = true;
+    void resolveAuthorshipDid(bitcoin?.signingClient, user?.subOrgId).then(
+      (resolved) => alive && setAuthorshipDid(resolved)
+    );
+    return () => { alive = false; };
+  }, [bitcoin?.signingClient, user?.subOrgId]);
+
+  const startInscribe = async () => {
+    if (!bitcoin || !data?.row) return;
+    setInscribing(true);
+    setInscribeNote(null);
+    const outcome = await resumeInscribe({
+      did,
+      host: window.location.host,
+      subOrgId: user?.subOrgId,
+      fundingAddress: bitcoin.fundingAddress,
+      signingClient: bitcoin.signingClient,
+      cel: data.cel,
+    });
+    setInscribeNote(outcome.ok ? yourOriginals.inscribe.done : outcome.message);
+    setInscribing(false);
+  };
+
   const mode = detailMode({ authLoading, authenticated: isAuthenticated, loaded, row: data?.row ?? null });
+  const action: InscribeAvailability | null = data?.row
+    ? inscribeAvailability({
+        row: data.row,
+        records,
+        unfinished: unfinishedInscriptions(records),
+        authorshipDid,
+        signedIn: isAuthenticated && !!bitcoin,
+        cel: loaded ? data.cel : undefined,
+      })
+    : null;
 
   const copyDid = async () => {
     try {
@@ -234,6 +279,24 @@ export function OriginalDetail({ did }: { did: string }) {
             )}
             {data.resources.length > 0 && <Resources data={data} />}
             {data.row.btcoDid && <Bitcoin row={data.row} />}
+            {action && (action.kind === 'inscribe' || action.kind === 'disabled') && (
+              <section className="od-section od-inscribe">
+                <p className="eyebrow">{yourOriginals.inscribe.cta}</p>
+                {action.kind === 'inscribe' ? (
+                  <button
+                    type="button"
+                    className="btn btn-primary"
+                    disabled={inscribing}
+                    onClick={() => void startInscribe()}
+                  >
+                    {inscribing ? yourOriginals.inscribe.busy : yourOriginals.inscribe.cta}
+                  </button>
+                ) : (
+                  <p className="od-note">{yourOriginals.inscribe.reasons[action.reason]}</p>
+                )}
+                {inscribeNote && <p className="od-note" role="status">{inscribeNote}</p>}
+              </section>
+            )}
             {data.logSummary && <Identity summary={data.logSummary} />}
             <Artifacts did={did} />
           </>

--- a/apps/landing/src/pages/OriginalDetail.tsx
+++ b/apps/landing/src/pages/OriginalDetail.tsx
@@ -88,6 +88,8 @@ export function OriginalDetail({ did }: { did: string }) {
   const [allRows, setAllRows] = useState<OriginalRow[]>([]);
   const [authorshipDid, setAuthorshipDid] = useState<string | null>(null);
   const [inscribing, setInscribing] = useState(false);
+  /** Which half of the inscribe the button is in — rebuild, then broadcast. */
+  const [stage, setStage] = useState<'hydrating' | 'inscribing'>('hydrating');
   const [inscribeNote, setInscribeNote] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
   const [data, setData] = useState<DetailData | null>(null);
@@ -206,6 +208,7 @@ export function OriginalDetail({ did }: { did: string }) {
   const startInscribe = async () => {
     if (!bitcoin || !data?.row) return;
     setInscribing(true);
+    setStage('hydrating');
     setInscribeNote(null);
     const outcome = await resumeInscribe({
       did,
@@ -214,6 +217,7 @@ export function OriginalDetail({ did }: { did: string }) {
       fundingAddress: bitcoin.fundingAddress,
       signingClient: bitcoin.signingClient,
       cel: data.cel,
+      onProgress: (stage) => setStage(stage),
     });
     setInscribeNote(
       outcome.ok
@@ -313,7 +317,9 @@ export function OriginalDetail({ did }: { did: string }) {
             )}
             {data.resources.length > 0 && <Resources data={data} />}
             {data.row.btcoDid && <Bitcoin row={data.row} />}
-            {action && (action.kind === 'inscribe' || action.kind === 'disabled') && (
+            {action &&
+              (action.kind === 'inscribe' ||
+                (action.kind === 'disabled' && action.reason !== 'reading')) && (
               <section className="od-section od-inscribe">
                 <p className="eyebrow">{yourOriginals.inscribe.sectionEyebrow}</p>
                 {action.kind === 'inscribe' ? (
@@ -323,7 +329,11 @@ export function OriginalDetail({ did }: { did: string }) {
                     disabled={inscribing}
                     onClick={() => void startInscribe()}
                   >
-                    {inscribing ? yourOriginals.inscribe.busy : yourOriginals.inscribe.cta}
+                    {!inscribing
+                      ? yourOriginals.inscribe.cta
+                      : stage === 'hydrating'
+                        ? yourOriginals.inscribe.hydrating
+                        : yourOriginals.inscribe.busy}
                   </button>
                 ) : (
                   <p className="od-note">{yourOriginals.inscribe.reasons[action.reason]}</p>

--- a/apps/landing/src/pages/OriginalDetail.tsx
+++ b/apps/landing/src/pages/OriginalDetail.tsx
@@ -22,7 +22,12 @@ import {
   type OriginalRow,
   type PendingInscription,
 } from './YourOriginals';
-import { inscribeAvailability, rowAfterInscribe, type InscribeAvailability } from './inscribe-availability';
+import {
+  inscribeAvailability,
+  rowAfterInscribe,
+  unclaimedInscriptions,
+  type InscribeAvailability,
+} from './inscribe-availability';
 import { resolveAuthorshipDid, resumeInscribe } from './resume-inscribe';
 import {
   webvhArtifacts,
@@ -79,6 +84,8 @@ export function OriginalDetail({ did }: { did: string }) {
   // The resume surface: this page had no Bitcoin action at all, so a published
   // Original that was never inscribed dead-ended here.
   const [records, setRecords] = useState<PendingInscription[]>([]);
+  /** Every row this user has — needed to tell a claimed record from a loose one. */
+  const [allRows, setAllRows] = useState<OriginalRow[]>([]);
   const [authorshipDid, setAuthorshipDid] = useState<string | null>(null);
   const [inscribing, setInscribing] = useState(false);
   const [inscribeNote, setInscribeNote] = useState<string | null>(null);
@@ -104,8 +111,12 @@ export function OriginalDetail({ did }: { did: string }) {
         arts ? fetchText(arts.celUrl) : null
       ]);
       // Overlay live confirmation state (the stored row stays 'pending').
-      const row = withLiveInscriptionStatus(rows, inscriptionRecs.records).find((r) => r.did === did) ?? null;
-      if (live) setRecords(inscriptionRecs.records);
+      const rowsWithStatus = withLiveInscriptionStatus(rows, inscriptionRecs.records);
+      const row = rowsWithStatus.find((r) => r.did === did) ?? null;
+      if (live) {
+        setRecords(inscriptionRecs.records);
+        setAllRows(rowsWithStatus);
+      }
 
       let logEntries: ReturnType<typeof parseDidLog> | null = null;
       try {
@@ -233,8 +244,10 @@ export function OriginalDetail({ did }: { did: string }) {
   const action: InscribeAvailability | null = data?.row
     ? inscribeAvailability({
         row: data.row,
-        records,
         unfinished: unfinishedInscriptions(records),
+        // Over ALL the user's rows, not just this one: a record another
+        // Original already claims is attributed and must not disable this row.
+        unclaimed: unclaimedInscriptions(allRows, unfinishedInscriptions(records)),
         authorshipDid,
         signedIn: isAuthenticated && !!bitcoin,
         cel: loaded ? data.cel : undefined,

--- a/apps/landing/src/pages/OriginalDetail.tsx
+++ b/apps/landing/src/pages/OriginalDetail.tsx
@@ -281,7 +281,7 @@ export function OriginalDetail({ did }: { did: string }) {
             {data.row.btcoDid && <Bitcoin row={data.row} />}
             {action && (action.kind === 'inscribe' || action.kind === 'disabled') && (
               <section className="od-section od-inscribe">
-                <p className="eyebrow">{yourOriginals.inscribe.cta}</p>
+                <p className="eyebrow">{yourOriginals.inscribe.sectionEyebrow}</p>
                 {action.kind === 'inscribe' ? (
                   <button
                     type="button"

--- a/apps/landing/src/pages/OriginalDetail.tsx
+++ b/apps/landing/src/pages/OriginalDetail.tsx
@@ -204,7 +204,13 @@ export function OriginalDetail({ did }: { did: string }) {
       signingClient: bitcoin.signingClient,
       cel: data.cel,
     });
-    setInscribeNote(outcome.ok ? yourOriginals.inscribe.done : outcome.message);
+    setInscribeNote(
+      outcome.ok
+        ? outcome.complete
+          ? yourOriginals.inscribe.done
+          : yourOriginals.inscribe.commitOnly
+        : outcome.message
+    );
     setInscribing(false);
   };
 

--- a/apps/landing/src/pages/YourOriginals.tsx
+++ b/apps/landing/src/pages/YourOriginals.tsx
@@ -10,7 +10,9 @@ import { useEffect, useState } from 'react';
 import { yourOriginals } from '../content';
 import { useAuth } from '../auth/useAuth';
 import { navigate, originalPath } from '../router';
-import { sameOriginUrl } from './original-detail-data';
+import { sameOriginUrl, type CelLog } from './original-detail-data';
+import { inscribeAvailability, type InscribeAvailability } from './inscribe-availability';
+import { fetchHostedCel, resolveAuthorshipDid, resumeInscribe } from './resume-inscribe';
 import './your-originals.css';
 
 export interface OriginalRow {
@@ -204,7 +206,7 @@ async function resolveLive(did: string): Promise<boolean> {
 }
 
 export function YourOriginals() {
-  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const { isAuthenticated, isLoading: authLoading, bitcoin, user } = useAuth();
   const [originals, setOriginals] = useState<OriginalRow[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [resolved, setResolved] = useState<Record<string, boolean>>({});
@@ -212,6 +214,15 @@ export function YourOriginals() {
   const [finishing, setFinishing] = useState<string | null>(null);
   const [finishNote, setFinishNote] = useState<string | null>(null);
   const [depositAlert, setDepositAlert] = useState<DepositAlert | null>(null);
+  /**
+   * Each row's hosted CEL, keyed by DID. `undefined` (absent) means "not read
+   * yet" and renders as 'unknown' rather than as inscribable — a row must
+   * never offer to inscribe on a guess about who controls it.
+   */
+  const [cels, setCels] = useState<Record<string, CelLog | null>>({});
+  const [authorshipDid, setAuthorshipDid] = useState<string | null>(null);
+  const [inscribing, setInscribing] = useState<string | null>(null);
+  const [inscribeNote, setInscribeNote] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isAuthenticated) return;
@@ -229,13 +240,55 @@ export function YourOriginals() {
       setOriginals(merged);
       setUnfinished(unfinishedInscriptions(recs));
       setDepositAlert(inscriptions.depositAlert);
-      merged.forEach((r) => resolveLive(r.did).then((ok) => live && setResolved((m) => ({ ...m, [r.did]: ok }))));
+      merged.forEach((r) => {
+        resolveLive(r.did).then((ok) => live && setResolved((m) => ({ ...m, [r.did]: ok })));
+        // One small same-origin read per row, alongside the resolution probe
+        // this page already makes per row. It answers who controls the
+        // Original, which is what decides whether it can still be inscribed.
+        fetchHostedCel(r.did, window.location.host).then(
+          (cel) => live && setCels((m) => ({ ...m, [r.did]: cel }))
+        );
+      });
     })
       // Settle in `finally` so an unexpected throw ends on "no Originals yet"
       // rather than stranding the page on the loading state forever.
       .finally(() => { if (live) setLoaded(true); });
     return () => { live = false; };
   }, [isAuthenticated]);
+
+  useEffect(() => {
+    let live = true;
+    void resolveAuthorshipDid(bitcoin?.signingClient, user?.subOrgId).then(
+      (did) => live && setAuthorshipDid(did)
+    );
+    return () => { live = false; };
+  }, [bitcoin?.signingClient, user?.subOrgId]);
+
+  const startInscribe = async (row: OriginalRow) => {
+    if (!bitcoin) return;
+    setInscribing(row.did);
+    setInscribeNote(null);
+    const outcome = await resumeInscribe({
+      did: row.did,
+      host: window.location.host,
+      subOrgId: user?.subOrgId,
+      fundingAddress: bitcoin.fundingAddress,
+      signingClient: bitcoin.signingClient,
+      cel: cels[row.did],
+    });
+    setInscribeNote(outcome.ok ? yourOriginals.inscribe.done : outcome.message);
+    if (outcome.ok) {
+      // Reflect it immediately; the durable record catches up on the next load.
+      setOriginals((rows) =>
+        rows.map((r) =>
+          r.did === row.did
+            ? { ...r, commitTxId: outcome.inscription.commitTxId, inscriptionStatus: 'pending' as const }
+            : r
+        )
+      );
+    }
+    setInscribing(null);
+  };
 
   const finishInscription = async (commitTxId: string) => {
     setFinishing(commitTxId);
@@ -323,6 +376,17 @@ export function YourOriginals() {
             {view.rows.map((row) => {
               const href = originalPath(row.did);
               const ok = resolved[row.did];
+              // Finish and Inscribe are decided together, so the same row can
+              // never render both. `cels` being absent for this DID means the
+              // log has not been read yet, which reads as 'unknown'.
+              const action: InscribeAvailability = inscribeAvailability({
+                row,
+                records: unfinished,
+                unfinished,
+                authorshipDid,
+                signedIn: isAuthenticated && !!bitcoin,
+                cel: row.did in cels ? cels[row.did] : undefined,
+              });
               return (
                 <li key={row.did}>
                   <a
@@ -374,10 +438,30 @@ export function YourOriginals() {
                       </span>
                     </span>
                   </a>
+                  {action.kind === 'inscribe' && (
+                    <button
+                      type="button"
+                      className="btn btn-primary your-original-action"
+                      disabled={inscribing === row.did}
+                      onClick={() => void startInscribe(row)}
+                    >
+                      {inscribing === row.did
+                        ? yourOriginals.inscribe.busy
+                        : yourOriginals.inscribe.cta}
+                    </button>
+                  )}
+                  {action.kind === 'disabled' && (
+                    <p className="your-original-action-note">
+                      {yourOriginals.inscribe.reasons[action.reason]}
+                    </p>
+                  )}
                 </li>
               );
             })}
           </ul>
+        )}
+        {inscribeNote && (
+          <p className="your-originals-note" role="status">{inscribeNote}</p>
         )}
       </div>
     </main>

--- a/apps/landing/src/pages/YourOriginals.tsx
+++ b/apps/landing/src/pages/YourOriginals.tsx
@@ -227,6 +227,8 @@ export function YourOriginals() {
   const [cels, setCels] = useState<Record<string, CelLog | null>>({});
   const [authorshipDid, setAuthorshipDid] = useState<string | null>(null);
   const [inscribing, setInscribing] = useState<string | null>(null);
+  /** Which half of the inscribe the button is in — rebuild, then broadcast. */
+  const [stage, setStage] = useState<'hydrating' | 'inscribing'>('hydrating');
   const [inscribeNote, setInscribeNote] = useState<string | null>(null);
 
   useEffect(() => {
@@ -276,6 +278,7 @@ export function YourOriginals() {
   const startInscribe = async (row: OriginalRow) => {
     if (!bitcoin) return;
     setInscribing(row.did);
+    setStage('hydrating');
     setInscribeNote(null);
     const outcome = await resumeInscribe({
       did: row.did,
@@ -284,6 +287,7 @@ export function YourOriginals() {
       fundingAddress: bitcoin.fundingAddress,
       signingClient: bitcoin.signingClient,
       cel: cels[row.did],
+      onProgress: (stage) => setStage(stage),
     });
     setInscribeNote(
       outcome.ok
@@ -456,12 +460,14 @@ export function YourOriginals() {
                       disabled={inscribing === row.did}
                       onClick={() => void startInscribe(row)}
                     >
-                      {inscribing === row.did
-                        ? yourOriginals.inscribe.busy
-                        : yourOriginals.inscribe.cta}
+                      {inscribing !== row.did
+                        ? yourOriginals.inscribe.cta
+                        : stage === 'hydrating'
+                          ? yourOriginals.inscribe.hydrating
+                          : yourOriginals.inscribe.busy}
                     </button>
                   )}
-                  {action.kind === 'disabled' && (
+                  {action.kind === 'disabled' && action.reason !== 'reading' && (
                     <p className="your-original-action-note">
                       {yourOriginals.inscribe.reasons[action.reason]}
                     </p>

--- a/apps/landing/src/pages/YourOriginals.tsx
+++ b/apps/landing/src/pages/YourOriginals.tsx
@@ -11,7 +11,12 @@ import { yourOriginals } from '../content';
 import { useAuth } from '../auth/useAuth';
 import { navigate, originalPath } from '../router';
 import { sameOriginUrl, type CelLog } from './original-detail-data';
-import { inscribeAvailability, rowAfterInscribe, type InscribeAvailability } from './inscribe-availability';
+import {
+  inscribeAvailability,
+  rowAfterInscribe,
+  unclaimedInscriptions,
+  type InscribeAvailability,
+} from './inscribe-availability';
 import { fetchHostedCel, resolveAuthorshipDid, resumeInscribe } from './resume-inscribe';
 import './your-originals.css';
 
@@ -264,6 +269,10 @@ export function YourOriginals() {
     return () => { live = false; };
   }, [bitcoin?.signingClient, user?.subOrgId]);
 
+  // Pushable records no row accounts for. Computed once per render over ALL
+  // rows: a record is only unattributable if NOTHING claims it.
+  const unclaimed = unclaimedInscriptions(originals, unfinished);
+
   const startInscribe = async (row: OriginalRow) => {
     if (!bitcoin) return;
     setInscribing(row.did);
@@ -383,8 +392,8 @@ export function YourOriginals() {
               // log has not been read yet, which reads as 'unknown'.
               const action: InscribeAvailability = inscribeAvailability({
                 row,
-                records: unfinished,
                 unfinished,
+                unclaimed,
                 authorshipDid,
                 signedIn: isAuthenticated && !!bitcoin,
                 cel: row.did in cels ? cels[row.did] : undefined,

--- a/apps/landing/src/pages/YourOriginals.tsx
+++ b/apps/landing/src/pages/YourOriginals.tsx
@@ -11,7 +11,7 @@ import { yourOriginals } from '../content';
 import { useAuth } from '../auth/useAuth';
 import { navigate, originalPath } from '../router';
 import { sameOriginUrl, type CelLog } from './original-detail-data';
-import { inscribeAvailability, type InscribeAvailability } from './inscribe-availability';
+import { inscribeAvailability, rowAfterInscribe, type InscribeAvailability } from './inscribe-availability';
 import { fetchHostedCel, resolveAuthorshipDid, resumeInscribe } from './resume-inscribe';
 import './your-originals.css';
 
@@ -286,11 +286,7 @@ export function YourOriginals() {
     if (outcome.ok) {
       // Reflect it immediately; the durable record catches up on the next load.
       setOriginals((rows) =>
-        rows.map((r) =>
-          r.did === row.did
-            ? { ...r, commitTxId: outcome.inscription.commitTxId, inscriptionStatus: 'pending' as const }
-            : r
-        )
+        rows.map((r) => (r.did === row.did ? rowAfterInscribe(r, outcome.inscription.commitTxId) : r))
       );
     }
     setInscribing(null);

--- a/apps/landing/src/pages/YourOriginals.tsx
+++ b/apps/landing/src/pages/YourOriginals.tsx
@@ -276,7 +276,13 @@ export function YourOriginals() {
       signingClient: bitcoin.signingClient,
       cel: cels[row.did],
     });
-    setInscribeNote(outcome.ok ? yourOriginals.inscribe.done : outcome.message);
+    setInscribeNote(
+      outcome.ok
+        ? outcome.complete
+          ? yourOriginals.inscribe.done
+          : yourOriginals.inscribe.commitOnly
+        : outcome.message
+    );
     if (outcome.ok) {
       // Reflect it immediately; the durable record catches up on the next load.
       setOriginals((rows) =>

--- a/apps/landing/src/pages/inscribe-availability.test.ts
+++ b/apps/landing/src/pages/inscribe-availability.test.ts
@@ -4,7 +4,12 @@
  * rule that Finish and Inscribe never appear together.
  */
 import { describe, test, expect } from 'bun:test';
-import { inscribeAvailability, genesisController, rowAfterInscribe } from './inscribe-availability';
+import {
+  inscribeAvailability,
+  genesisController,
+  rowAfterInscribe,
+  unclaimedInscriptions,
+} from './inscribe-availability';
 import { inscribeIsComplete } from '../components/Demo';
 import { yourOriginals } from '../content';
 import type { OriginalRow, PendingInscription } from './YourOriginals';
@@ -37,8 +42,8 @@ const record = (over: Partial<PendingInscription> = {}): PendingInscription => (
 });
 
 const base = {
-  records: [] as PendingInscription[],
   unfinished: [] as PendingInscription[],
+  unclaimed: [] as PendingInscription[],
   authorshipDid: MINE,
   signedIn: true,
   cel: celFor(MINE) as CelLog | null | undefined,
@@ -71,7 +76,6 @@ describe('a row with stored hex', () => {
     const got = inscribeAvailability({
       ...base,
       row: row({ commitTxId: 'commit-1' }),
-      records: [rec],
       unfinished: [rec],
     });
     expect(got).toEqual({ kind: 'finish', commitTxId: 'commit-1' });
@@ -84,7 +88,7 @@ describe('a row with stored hex', () => {
     // Superseded, or simply broadcast and waiting: not re-inscribable either.
     const rec = record({ superseded: true });
     expect(
-      inscribeAvailability({ ...base, row: row({ commitTxId: 'commit-1' }), records: [rec], unfinished: [] })
+      inscribeAvailability({ ...base, row: row({ commitTxId: 'commit-1' }), unfinished: [] })
     ).toEqual({ kind: 'none' });
   });
 });
@@ -204,7 +208,7 @@ describe('a row that was just inscribed', () => {
     const after = rowAfterInscribe(row(), 'commit-9');
     const rec = record({ commitTxId: 'commit-9' });
     expect(
-      inscribeAvailability({ ...base, row: after, records: [rec], unfinished: [rec] })
+      inscribeAvailability({ ...base, row: after, unfinished: [rec] })
     ).toEqual({ kind: 'finish', commitTxId: 'commit-9' });
   });
 
@@ -225,9 +229,70 @@ describe('a row that was just inscribed', () => {
       inscribeAvailability({
         ...base,
         row: row({ commitTxId: 'commit-9', inscriptionStatus: 'pending' }),
-        records: [rec],
         unfinished: [rec],
       })
     ).toEqual({ kind: 'finish', commitTxId: 'commit-9' });
+  });
+});
+
+/**
+ * The guard that used to be dead code: it joined on `commitTxId`, downstream
+ * of the early return that had already sent every row carrying one home. So
+ * the case it was written for — signed hex on the server while the row that
+ * paid for it recorded nothing — could never fire, and /me compounded it by
+ * feeding `records` the already-narrowed `unfinished` array.
+ */
+describe('signed hex waiting that no row accounts for', () => {
+  const loose = record({ commitTxId: 'commit-loose', status: 'signed' });
+
+  test('a record no row claims is unclaimed', () => {
+    expect(unclaimedInscriptions([row()], [loose])).toEqual([loose]);
+  });
+
+  test('a record a row claims is not', () => {
+    expect(unclaimedInscriptions([row({ commitTxId: 'commit-loose' })], [loose])).toEqual([]);
+  });
+
+  test('a row that claims a DIFFERENT commit does not account for it', () => {
+    expect(unclaimedInscriptions([row({ commitTxId: 'commit-other' })], [loose])).toEqual([loose]);
+  });
+
+  test('an unattributable row is disabled rather than rebuilt over', () => {
+    // The rebuild would supersede the very pair the Finish banner is offering
+    // to push, stranding a reveal that was already paid to build.
+    expect(inscribeAvailability({ ...base, row: row(), unclaimed: [loose] })).toEqual({
+      kind: 'disabled',
+      reason: 'pending-elsewhere',
+    });
+  });
+
+  test('it outranks having a usable key: the money is what is at stake', () => {
+    expect(
+      inscribeAvailability({ ...base, row: row(), unclaimed: [loose], cel: celFor(THEIRS) })
+    ).toEqual({ kind: 'disabled', reason: 'pending-elsewhere' });
+  });
+
+  test('the row that DOES claim it still gets Finish', () => {
+    expect(
+      inscribeAvailability({
+        ...base,
+        row: row({ commitTxId: 'commit-loose' }),
+        unfinished: [loose],
+        unclaimed: [],
+      })
+    ).toEqual({ kind: 'finish', commitTxId: 'commit-loose' });
+  });
+
+  test('self-clearing: once nothing is pushable, rows open back up', () => {
+    expect(inscribeAvailability({ ...base, row: row(), unclaimed: [] })).toEqual({
+      kind: 'inscribe',
+    });
+  });
+
+  test('the copy points at the click that clears it', () => {
+    const copy = yourOriginals.inscribe.reasons['pending-elsewhere'];
+    expect(copy).toMatch(/finish/i);
+    // and never implies the Original itself is the problem
+    expect(copy).not.toMatch(/can’t|cannot/i);
   });
 });

--- a/apps/landing/src/pages/inscribe-availability.test.ts
+++ b/apps/landing/src/pages/inscribe-availability.test.ts
@@ -12,6 +12,7 @@ import {
 } from './inscribe-availability';
 import { inscribeIsComplete } from '../components/Demo';
 import { yourOriginals } from '../content';
+import type { DisabledReason } from './inscribe-availability';
 import type { OriginalRow, PendingInscription } from './YourOriginals';
 import type { CelLog } from './original-detail-data';
 
@@ -118,18 +119,26 @@ describe('a row with no usable key', () => {
     });
   });
 
-  test('disabled as unknown while the log has not been read', () => {
+  test('reading — not inscribable — while the log has not been fetched', () => {
+    // Distinct from a log that came back bad: this is first paint, and it
+    // renders as NOTHING rather than flashing a note under every row.
     expect(inscribeAvailability({ ...base, row: row(), cel: undefined })).toEqual({
       kind: 'disabled',
-      reason: 'unknown',
+      reason: 'reading',
     });
   });
 
-  test('unknown, not inscribable, when the log came back unreadable', () => {
+  test('unreadable — a real answer — when the log came back unusable', () => {
     expect(inscribeAvailability({ ...base, row: row(), cel: null })).toEqual({
       kind: 'disabled',
-      reason: 'unknown',
+      reason: 'unreadable',
     });
+  });
+
+  test('unreadable too when the log has no genesis controller to sign as', () => {
+    expect(
+      inscribeAvailability({ ...base, row: row(), cel: { events: [{ type: 'create', data: {} }] } })
+    ).toEqual({ kind: 'disabled', reason: 'unreadable' });
   });
 });
 
@@ -294,5 +303,41 @@ describe('signed hex waiting that no row accounts for', () => {
     expect(copy).toMatch(/finish/i);
     // and never implies the Original itself is the problem
     expect(copy).not.toMatch(/can’t|cannot/i);
+  });
+});
+
+/**
+ * Every reason the selector can return has copy, and every string in the copy
+ * block is reachable. Two were dead when review caught them: `hydrating` (the
+ * button never said which half of the work it was in) and `failed`, which also
+ * promised "nothing was spent" — untrue for a failure after the commit
+ * broadcast, so it was removed rather than wired up.
+ */
+describe('the disabled copy', () => {
+  const reasons: DisabledReason[] = [
+    'signed-out',
+    'no-authorship-key',
+    'foreign-controller',
+    'reading',
+    'unreadable',
+    'pending-elsewhere',
+  ];
+
+  test('every reason has a string', () => {
+    for (const r of reasons) {
+      expect(yourOriginals.inscribe.reasons[r]).toBeTruthy();
+    }
+  });
+
+  test('and there are no strings without a reason', () => {
+    expect(Object.keys(yourOriginals.inscribe.reasons).sort()).toEqual([...reasons].sort());
+  });
+
+  test('no reason claims nothing was spent', () => {
+    // Only the provider's own submit status can say that, and it is read
+    // separately. A blanket reassurance here would be a guess about money.
+    for (const r of reasons) {
+      expect(yourOriginals.inscribe.reasons[r]).not.toMatch(/nothing was spent/i);
+    }
   });
 });

--- a/apps/landing/src/pages/inscribe-availability.test.ts
+++ b/apps/landing/src/pages/inscribe-availability.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Which action a row offers. The three cases the feature turns on:
+ * an inscribable row, a Finish row, and a row with no usable key — plus the
+ * rule that Finish and Inscribe never appear together.
+ */
+import { describe, test, expect } from 'bun:test';
+import { inscribeAvailability, genesisController } from './inscribe-availability';
+import type { OriginalRow, PendingInscription } from './YourOriginals';
+import type { CelLog } from './original-detail-data';
+
+const MINE = 'did:key:z6Mkj2fLd1Cft3Y1d4keoArcN9fxSUKUXo49sdyPDHA796qk';
+const THEIRS = 'did:key:z6MkvvR62AzMMmNR4NS9wB5ksUCLNfgDGTbG6uEKM3MU6NWz';
+
+const celFor = (controller: string): CelLog => ({
+  events: [{ type: 'create', data: { controller, resources: [] } }],
+});
+
+const row = (over: Partial<OriginalRow> = {}): OriginalRow => ({
+  did: 'did:webvh:scid:example.test:abc',
+  title: 'Untitled',
+  resourceHash: 'ff',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  ...over,
+});
+
+const record = (over: Partial<PendingInscription> = {}): PendingInscription => ({
+  commitTxId: 'commit-1',
+  revealTxId: 'reveal-1',
+  inscriptionId: 'insc-1',
+  fundingOutpoint: 'out:0',
+  status: 'signed',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+  ...over,
+});
+
+const base = {
+  records: [] as PendingInscription[],
+  unfinished: [] as PendingInscription[],
+  authorshipDid: MINE,
+  signedIn: true,
+  cel: celFor(MINE) as CelLog | null | undefined,
+};
+
+describe('genesisController', () => {
+  test('reads the did:key the genesis event names', () => {
+    expect(genesisController(celFor(MINE))).toBe(MINE);
+  });
+
+  test('null for a log that does not start at genesis', () => {
+    expect(genesisController({ events: [{ type: 'migrate', data: {} }] })).toBeNull();
+  });
+
+  test('null for no log, and for a genesis with no controller', () => {
+    expect(genesisController(null)).toBeNull();
+    expect(genesisController({ events: [{ type: 'create', data: {} }] })).toBeNull();
+  });
+});
+
+describe('an inscribable row', () => {
+  test('offers Inscribe when nothing was ever built and the key is mine', () => {
+    expect(inscribeAvailability({ ...base, row: row() })).toEqual({ kind: 'inscribe' });
+  });
+});
+
+describe('a row with stored hex', () => {
+  test('offers Finish, not Inscribe', () => {
+    const rec = record();
+    const got = inscribeAvailability({
+      ...base,
+      row: row({ commitTxId: 'commit-1' }),
+      records: [rec],
+      unfinished: [rec],
+    });
+    expect(got).toEqual({ kind: 'finish', commitTxId: 'commit-1' });
+    // The two recoveries are mutually exclusive: rebuilding over signed,
+    // paid-for transactions would strand that spend.
+    expect(got.kind).not.toBe('inscribe');
+  });
+
+  test('offers neither when the commit exists but is not pushable', () => {
+    // Superseded, or simply broadcast and waiting: not re-inscribable either.
+    const rec = record({ superseded: true });
+    expect(
+      inscribeAvailability({ ...base, row: row({ commitTxId: 'commit-1' }), records: [rec], unfinished: [] })
+    ).toEqual({ kind: 'none' });
+  });
+});
+
+describe('a row with no usable key', () => {
+  test('disabled, naming sign-in, when there is no session', () => {
+    expect(inscribeAvailability({ ...base, row: row(), signedIn: false })).toEqual({
+      kind: 'disabled',
+      reason: 'signed-out',
+    });
+  });
+
+  test('disabled when this client cannot author at all', () => {
+    expect(inscribeAvailability({ ...base, row: row(), authorshipDid: null })).toEqual({
+      kind: 'disabled',
+      reason: 'no-authorship-key',
+    });
+  });
+
+  test('disabled when the Original answers to a key nobody holds', () => {
+    // The pre-custody case: minted with a key that lived in a tab. Pre-anchor
+    // the CEL accepts only its current controller, so no other key can ever
+    // sign this migrate — an enabled button here would fail at signing time.
+    expect(inscribeAvailability({ ...base, row: row(), cel: celFor(THEIRS) })).toEqual({
+      kind: 'disabled',
+      reason: 'foreign-controller',
+    });
+  });
+
+  test('disabled as unknown while the log has not been read', () => {
+    expect(inscribeAvailability({ ...base, row: row(), cel: undefined })).toEqual({
+      kind: 'disabled',
+      reason: 'unknown',
+    });
+  });
+
+  test('unknown, not inscribable, when the log came back unreadable', () => {
+    expect(inscribeAvailability({ ...base, row: row(), cel: null })).toEqual({
+      kind: 'disabled',
+      reason: 'unknown',
+    });
+  });
+});
+
+describe('rows already on chain', () => {
+  test('offer nothing once inscribed', () => {
+    expect(inscribeAvailability({ ...base, row: row({ btcoDid: 'did:btco:123' }) })).toEqual({ kind: 'none' });
+  });
+
+  test('offer nothing once confirmed', () => {
+    expect(
+      inscribeAvailability({ ...base, row: row({ inscriptionStatus: 'confirmed' }) })
+    ).toEqual({ kind: 'none' });
+  });
+
+  test('being on chain wins even with no key and no session', () => {
+    expect(
+      inscribeAvailability({
+        ...base,
+        row: row({ btcoDid: 'did:btco:123' }),
+        signedIn: false,
+        authorshipDid: null,
+      })
+    ).toEqual({ kind: 'none' });
+  });
+});

--- a/apps/landing/src/pages/inscribe-availability.test.ts
+++ b/apps/landing/src/pages/inscribe-availability.test.ts
@@ -4,7 +4,7 @@
  * rule that Finish and Inscribe never appear together.
  */
 import { describe, test, expect } from 'bun:test';
-import { inscribeAvailability, genesisController } from './inscribe-availability';
+import { inscribeAvailability, genesisController, rowAfterInscribe } from './inscribe-availability';
 import { inscribeIsComplete } from '../components/Demo';
 import { yourOriginals } from '../content';
 import type { OriginalRow, PendingInscription } from './YourOriginals';
@@ -176,5 +176,58 @@ describe('a resumed inscription that only got its commit out', () => {
   test('the done copy is reserved for a reveal that actually landed', () => {
     expect(yourOriginals.inscribe.done).toMatch(/inscribed/i);
     expect(yourOriginals.inscribe.done).not.toBe(yourOriginals.inscribe.commitOnly);
+  });
+});
+
+/**
+ * The detail page used to set a note after a successful inscribe and nothing
+ * else — the row was untouched, `action` recomputed to 'inscribe', the button
+ * re-enabled, and a second click built and paid for a second commit/reveal
+ * pair. Both surfaces now close the action through the same helper.
+ */
+describe('a row that was just inscribed', () => {
+  test('records the commit and reads as pending', () => {
+    expect(rowAfterInscribe(row(), 'commit-9')).toMatchObject({
+      commitTxId: 'commit-9',
+      inscriptionStatus: 'pending',
+    });
+  });
+
+  test('offers no second inscribe, so the button cannot be clicked twice', () => {
+    // The server records have not caught up yet — the state right after the
+    // call returns, which is exactly when a second click was possible.
+    const after = rowAfterInscribe(row(), 'commit-9');
+    expect(inscribeAvailability({ ...base, row: after })).toEqual({ kind: 'none' });
+  });
+
+  test('offers Finish once the record for that commit arrives', () => {
+    const after = rowAfterInscribe(row(), 'commit-9');
+    const rec = record({ commitTxId: 'commit-9' });
+    expect(
+      inscribeAvailability({ ...base, row: after, records: [rec], unfinished: [rec] })
+    ).toEqual({ kind: 'finish', commitTxId: 'commit-9' });
+  });
+
+  test('a commit id we never got back still closes the action', () => {
+    // resumeInscribe can return ok with no commitTxId. Re-inscribing on that
+    // is the one thing that must not happen, so the row goes to 'pending'
+    // regardless and the selector reads 'pending' alone as in flight.
+    const after = rowAfterInscribe(row(), undefined);
+    expect(after.inscriptionStatus).toBe('pending');
+    expect(inscribeAvailability({ ...base, row: after })).toEqual({ kind: 'none' });
+  });
+
+  test('closing on pending does not swallow a Finish offer', () => {
+    // The durable row is written 'pending' at inscribe time, so the row a
+    // Finish banner points at carries BOTH a commit id and 'pending'.
+    const rec = record({ commitTxId: 'commit-9' });
+    expect(
+      inscribeAvailability({
+        ...base,
+        row: row({ commitTxId: 'commit-9', inscriptionStatus: 'pending' }),
+        records: [rec],
+        unfinished: [rec],
+      })
+    ).toEqual({ kind: 'finish', commitTxId: 'commit-9' });
   });
 });

--- a/apps/landing/src/pages/inscribe-availability.test.ts
+++ b/apps/landing/src/pages/inscribe-availability.test.ts
@@ -5,6 +5,8 @@
  */
 import { describe, test, expect } from 'bun:test';
 import { inscribeAvailability, genesisController } from './inscribe-availability';
+import { inscribeIsComplete } from '../components/Demo';
+import { yourOriginals } from '../content';
 import type { OriginalRow, PendingInscription } from './YourOriginals';
 import type { CelLog } from './original-detail-data';
 
@@ -147,5 +149,32 @@ describe('rows already on chain', () => {
         authorshipDid: null,
       })
     ).toEqual({ kind: 'none' });
+  });
+});
+
+/**
+ * #506 removed "inscribed" from a commit-only broadcast in the demo. The
+ * resume path reintroduced it — any inscription snapshot read as done — until
+ * review caught it on #515. These pin the distinction and the copy.
+ */
+describe('a resumed inscription that only got its commit out', () => {
+  test('only a broadcast reveal counts as complete', () => {
+    expect(inscribeIsComplete('reveal_broadcast')).toBe(true);
+    expect(inscribeIsComplete('commit_broadcast')).toBe(false);
+    // Fail closed: a status we cannot read is not a landed reveal.
+    expect(inscribeIsComplete(null)).toBe(false);
+    expect(inscribeIsComplete(undefined)).toBe(false);
+  });
+
+  test('the commit-only copy never claims the inscription exists', () => {
+    const copy = yourOriginals.inscribe.commitOnly;
+    expect(copy).not.toMatch(/\binscribed\b/i);
+    // and it says the obligation is discharged, so nobody goes looking.
+    expect(copy).toMatch(/nothing more is owed/i);
+  });
+
+  test('the done copy is reserved for a reveal that actually landed', () => {
+    expect(yourOriginals.inscribe.done).toMatch(/inscribed/i);
+    expect(yourOriginals.inscribe.done).not.toBe(yourOriginals.inscribe.commitOnly);
   });
 });

--- a/apps/landing/src/pages/inscribe-availability.ts
+++ b/apps/landing/src/pages/inscribe-availability.ts
@@ -1,0 +1,112 @@
+/**
+ * Which Bitcoin action, if any, an Original row offers — and when it offers
+ * none, why.
+ *
+ * Two different recoveries can apply to a row and they must never both show:
+ *
+ *  - FINISH: the inscription was already built and signed, and its hex is on
+ *    the server. Nothing needs re-signing; the reveal just needs pushing.
+ *    `unfinishedInscriptions` owns that set.
+ *  - INSCRIBE: nothing was ever built. The Original is published and stops
+ *    there, which is the pre-broadcast resume gap — without this the creator
+ *    re-runs the demo and ends up with a second, different did:webvh Original.
+ *
+ * The interesting case is the third one. Inscribing appends a signed `migrate`
+ * event to the Original's CEL, and pre-anchor the CEL accepts only its CURRENT
+ * CONTROLLER as signer. So the question is not "does this browser have a key"
+ * but "is the key that can author THIS Original one the viewer holds". An
+ * Original minted before authorship moved into Turnkey custody was signed by a
+ * key that lived in a tab and no longer exists anywhere — it can never be
+ * inscribed, by anyone, and saying so plainly beats an enabled button that
+ * fails at signing time.
+ */
+import type { OriginalRow, PendingInscription } from './YourOriginals';
+import type { CelLog } from './original-detail-data';
+
+export type InscribeAvailability =
+  /** Already inscribed, or already on chain — no recovery applies. */
+  | { kind: 'none' }
+  /** Signed hex is on the server; push it. */
+  | { kind: 'finish'; commitTxId: string }
+  /** Never built; hydrate and inscribe. */
+  | { kind: 'inscribe' }
+  /** Offer nothing, and say this instead. */
+  | { kind: 'disabled'; reason: DisabledReason };
+
+export type DisabledReason =
+  /** No signing session at all — signing in is the remedy. */
+  | 'signed-out'
+  /** Signed in, but this client cannot author CEL events. */
+  | 'no-authorship-key'
+  /** The Original's controller is a key nobody holds any more. */
+  | 'foreign-controller'
+  /** Its log has not been read yet, so we cannot say either way. */
+  | 'unknown';
+
+/**
+ * The `did:key` verification method a CEL genesis names as controller, or null.
+ * Read from the genesis event's `controller`, which is the model's sole
+ * genesis identity.
+ */
+export function genesisController(cel: CelLog | null | undefined): string | null {
+  const genesis = cel?.events?.[0];
+  if (genesis?.type !== 'create') return null;
+  const controller = genesis.data?.controller;
+  return typeof controller === 'string' && controller.startsWith('did:key:') ? controller : null;
+}
+
+export interface AvailabilityInput {
+  row: OriginalRow;
+  /** In-flight inscription records for this user (GET /api/btc/inscribe). */
+  records: PendingInscription[];
+  /** The rows whose signed hex is pushable — `unfinishedInscriptions(records)`. */
+  unfinished: PendingInscription[];
+  /** The viewer's authorship `did:key`, or null when they have none. */
+  authorshipDid: string | null;
+  /** Whether a signing session exists at all. */
+  signedIn: boolean;
+  /**
+   * The Original's hosted CEL. `undefined` means "not fetched yet" — distinct
+   * from a fetch that came back empty, which is a real answer.
+   */
+  cel?: CelLog | null;
+}
+
+/** What this row offers. Pure — no DOM, no fetch. */
+export function inscribeAvailability(input: AvailabilityInput): InscribeAvailability {
+  const { row, records, unfinished, authorshipDid, signedIn, cel } = input;
+
+  // Already on chain: neither recovery applies, whatever else is true.
+  if (row.btcoDid || row.inscriptionStatus === 'confirmed') return { kind: 'none' };
+
+  // FINISH wins wherever it applies: the transactions already exist and were
+  // paid for, so rebuilding them would strand that spend.
+  const pushable = unfinished.find((r) => r.commitTxId === row.commitTxId);
+  if (row.commitTxId && pushable) return { kind: 'finish', commitTxId: pushable.commitTxId };
+  // A commit we know about but cannot push (superseded, or already broadcast
+  // and simply waiting) is still not something to re-inscribe over.
+  if (row.commitTxId) return { kind: 'none' };
+  if (records.some((r) => r.commitTxId && r.fundingOutpoint && rowMatchesRecord(row, r))) {
+    return { kind: 'none' };
+  }
+
+  if (!signedIn) return { kind: 'disabled', reason: 'signed-out' };
+  if (!authorshipDid) return { kind: 'disabled', reason: 'no-authorship-key' };
+  if (cel === undefined) return { kind: 'disabled', reason: 'unknown' };
+
+  const controller = genesisController(cel);
+  if (!controller) return { kind: 'disabled', reason: 'unknown' };
+  if (controller !== authorshipDid) return { kind: 'disabled', reason: 'foreign-controller' };
+
+  return { kind: 'inscribe' };
+}
+
+/**
+ * Whether an inscription record belongs to this row. The store is keyed by
+ * funding outpoint rather than by DID, so the only honest join is the commit
+ * id the row itself recorded — a row with none cannot be matched, which is
+ * exactly the "never built" case this feature exists for.
+ */
+function rowMatchesRecord(row: OriginalRow, record: PendingInscription): boolean {
+  return !!row.commitTxId && row.commitTxId === record.commitTxId;
+}

--- a/apps/landing/src/pages/inscribe-availability.ts
+++ b/apps/landing/src/pages/inscribe-availability.ts
@@ -41,7 +41,9 @@ export type DisabledReason =
   /** The Original's controller is a key nobody holds any more. */
   | 'foreign-controller'
   /** Its log has not been read yet, so we cannot say either way. */
-  | 'unknown';
+  | 'unknown'
+  /** Signed hex is waiting that we cannot rule out belonging to this row. */
+  | 'pending-elsewhere';
 
 /**
  * The `did:key` verification method a CEL genesis names as controller, or null.
@@ -57,10 +59,14 @@ export function genesisController(cel: CelLog | null | undefined): string | null
 
 export interface AvailabilityInput {
   row: OriginalRow;
-  /** In-flight inscription records for this user (GET /api/btc/inscribe). */
-  records: PendingInscription[];
   /** The rows whose signed hex is pushable — `unfinishedInscriptions(records)`. */
   unfinished: PendingInscription[];
+  /**
+   * Pushable records that no row claims — `unclaimedInscriptions(rows, unfinished)`.
+   * Any of them could belong to THIS row, so while one exists no unattributable
+   * row may be rebuilt over. See the note on that branch below.
+   */
+  unclaimed: PendingInscription[];
   /** The viewer's authorship `did:key`, or null when they have none. */
   authorshipDid: string | null;
   /** Whether a signing session exists at all. */
@@ -74,7 +80,7 @@ export interface AvailabilityInput {
 
 /** What this row offers. Pure — no DOM, no fetch. */
 export function inscribeAvailability(input: AvailabilityInput): InscribeAvailability {
-  const { row, records, unfinished, authorshipDid, signedIn, cel } = input;
+  const { row, unfinished, unclaimed, authorshipDid, signedIn, cel } = input;
 
   // Already on chain: neither recovery applies, whatever else is true.
   if (row.btcoDid || row.inscriptionStatus === 'confirmed') return { kind: 'none' };
@@ -92,9 +98,18 @@ export function inscribeAvailability(input: AvailabilityInput): InscribeAvailabi
   // rows written at inscribe time carry 'pending' too, and closing on it any
   // earlier would swallow the Finish offer.
   if (row.inscriptionStatus === 'pending') return { kind: 'none' };
-  if (records.some((r) => r.commitTxId && r.fundingOutpoint && rowMatchesRecord(row, r))) {
-    return { kind: 'none' };
-  }
+  // A pushable record nobody's row claims. The durable row is written
+  // best-effort AFTER inscribing while the server's record is written DURING
+  // the API call, so a row can carry no commit id while signed hex already
+  // exists at status 'signed' — and this row might be it. Rebuilding would
+  // supersede the very pair the Finish banner is offering to push, stranding
+  // a reveal that was already paid to build.
+  //
+  // There is no join to be more precise with: the record carries no DID and
+  // the row this case exists for carries no commit id. So the rule is
+  // conservative and self-clearing — finishing or broadcasting the record
+  // drops it from `unfinished`, and every row opens back up.
+  if (unclaimed.length > 0) return { kind: 'disabled', reason: 'pending-elsewhere' };
 
   if (!signedIn) return { kind: 'disabled', reason: 'signed-out' };
   if (!authorshipDid) return { kind: 'disabled', reason: 'no-authorship-key' };
@@ -124,11 +139,17 @@ export function rowAfterInscribe(row: OriginalRow, commitTxId: string | undefine
 }
 
 /**
- * Whether an inscription record belongs to this row. The store is keyed by
- * funding outpoint rather than by DID, so the only honest join is the commit
- * id the row itself recorded — a row with none cannot be matched, which is
- * exactly the "never built" case this feature exists for.
+ * Pushable records that no row accounts for.
+ *
+ * A row claims a record by recording its commit id. What is left over cannot be
+ * attributed to anything — the store is keyed by funding outpoint and carries
+ * no DID, and a row that never recorded a commit id has nothing to match on —
+ * so it is treated as possibly belonging to any un-inscribed row.
  */
-function rowMatchesRecord(row: OriginalRow, record: PendingInscription): boolean {
-  return !!row.commitTxId && row.commitTxId === record.commitTxId;
+export function unclaimedInscriptions(
+  rows: OriginalRow[],
+  unfinished: PendingInscription[]
+): PendingInscription[] {
+  const claimed = new Set(rows.map((r) => r.commitTxId).filter(Boolean));
+  return unfinished.filter((r) => !claimed.has(r.commitTxId));
 }

--- a/apps/landing/src/pages/inscribe-availability.ts
+++ b/apps/landing/src/pages/inscribe-availability.ts
@@ -86,6 +86,12 @@ export function inscribeAvailability(input: AvailabilityInput): InscribeAvailabi
   // A commit we know about but cannot push (superseded, or already broadcast
   // and simply waiting) is still not something to re-inscribe over.
   if (row.commitTxId) return { kind: 'none' };
+  // An inscribe was attempted but recorded no commit id — the durable row is
+  // written 'pending' once, at inscribe time, so this only ever means in
+  // flight. Placed AFTER the Finish branch, which needs a commit id anyway:
+  // rows written at inscribe time carry 'pending' too, and closing on it any
+  // earlier would swallow the Finish offer.
+  if (row.inscriptionStatus === 'pending') return { kind: 'none' };
   if (records.some((r) => r.commitTxId && r.fundingOutpoint && rowMatchesRecord(row, r))) {
     return { kind: 'none' };
   }
@@ -99,6 +105,22 @@ export function inscribeAvailability(input: AvailabilityInput): InscribeAvailabi
   if (controller !== authorshipDid) return { kind: 'disabled', reason: 'foreign-controller' };
 
   return { kind: 'inscribe' };
+}
+
+/**
+ * The row as it stands immediately after a successful inscribe.
+ *
+ * Recording the commit is what CLOSES the action: `inscribeAvailability` sends
+ * any row carrying a `commitTxId` home as 'none' (or 'finish', once the server
+ * records catch up), so the button cannot be clicked a second time and build a
+ * second commit/reveal pair. The durable row catches up on the next load;
+ * this is the optimistic copy in between.
+ *
+ * Shared so both surfaces apply the same rule — the detail page originally set
+ * a note and nothing else, and re-enabled its own button.
+ */
+export function rowAfterInscribe(row: OriginalRow, commitTxId: string | undefined): OriginalRow {
+  return { ...row, commitTxId, inscriptionStatus: 'pending' };
 }
 
 /**

--- a/apps/landing/src/pages/inscribe-availability.ts
+++ b/apps/landing/src/pages/inscribe-availability.ts
@@ -40,8 +40,10 @@ export type DisabledReason =
   | 'no-authorship-key'
   /** The Original's controller is a key nobody holds any more. */
   | 'foreign-controller'
-  /** Its log has not been read yet, so we cannot say either way. */
-  | 'unknown'
+  /** Its log has not been read yet. Renders as nothing — see the copy note. */
+  | 'reading'
+  /** Its log WAS read and did not come back usable. A real answer, so it shows. */
+  | 'unreadable'
   /** Signed hex is waiting that we cannot rule out belonging to this row. */
   | 'pending-elsewhere';
 
@@ -113,10 +115,13 @@ export function inscribeAvailability(input: AvailabilityInput): InscribeAvailabi
 
   if (!signedIn) return { kind: 'disabled', reason: 'signed-out' };
   if (!authorshipDid) return { kind: 'disabled', reason: 'no-authorship-key' };
-  if (cel === undefined) return { kind: 'disabled', reason: 'unknown' };
+  // Not fetched yet vs fetched-and-unusable. Collapsing the two made every row
+  // flash "Reading this Original's signed log…" on first paint, and told a user
+  // whose log genuinely would not load that it was still loading.
+  if (cel === undefined) return { kind: 'disabled', reason: 'reading' };
 
   const controller = genesisController(cel);
-  if (!controller) return { kind: 'disabled', reason: 'unknown' };
+  if (!controller) return { kind: 'disabled', reason: 'unreadable' };
   if (controller !== authorshipDid) return { kind: 'disabled', reason: 'foreign-controller' };
 
   return { kind: 'inscribe' };

--- a/apps/landing/src/pages/original-detail.css
+++ b/apps/landing/src/pages/original-detail.css
@@ -613,8 +613,15 @@
 
 /* ——— resume: inscribe a published Original that never reached Bitcoin ——— */
 
+/* The eyebrow is inline elsewhere on this page; here it heads a block, so the
+   action below it needs a row of its own rather than sharing that line. */
+.od-inscribe .eyebrow {
+  display: block;
+  margin-bottom: var(--sp-4);
+}
+
 .od-inscribe .btn {
-  margin-top: var(--sp-4);
+  display: inline-flex;
 }
 
 /* .od-note is an inline-flex row elsewhere on this page; the reasons here are

--- a/apps/landing/src/pages/original-detail.css
+++ b/apps/landing/src/pages/original-detail.css
@@ -610,3 +610,17 @@
   color: var(--text-tertiary);
   text-align: right;
 }
+
+/* ——— resume: inscribe a published Original that never reached Bitcoin ——— */
+
+.od-inscribe .btn {
+  margin-top: var(--sp-4);
+}
+
+/* .od-note is an inline-flex row elsewhere on this page; the reasons here are
+   sentences, so they wrap as a block. */
+.od-inscribe .od-note {
+  display: block;
+  max-width: 68ch;
+  line-height: 1.65;
+}

--- a/apps/landing/src/pages/resume-inscribe.test.ts
+++ b/apps/landing/src/pages/resume-inscribe.test.ts
@@ -1,0 +1,216 @@
+/**
+ * The refusal surface of the module that spends money.
+ *
+ * `resumeInscribe` rebuilds a published Original from its hosted artifacts and
+ * hands it to the demo's own `engine.inscribe`. Everything before that hand-off
+ * is a gate, and each gate exists because passing it wrongly costs real BTC:
+ * a rebuild from bytes that will not verify, a commit that cannot pay for
+ * itself, a spend against a deposit we could not read. These pin that NONE of
+ * them reaches the engine — the engine is dynamically imported at the point of
+ * no return, so "never got there" is observable as "never imported".
+ */
+import { describe, test, expect, afterEach } from 'bun:test';
+import { resumeInscribe, fetchHostedCel, fetchHostedResources, resolveAuthorshipDid } from './resume-inscribe';
+import type { CelLog } from './original-detail-data';
+import type { TurnkeyBitcoinClient } from '../auth/turnkey-session';
+
+const HOST = 'demo.test';
+const DID = `did:webvh:scid:${HOST}:u:sub-1:abc`;
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+/** Serve a fixed map of path → body; anything else 404s. */
+function serve(routes: Record<string, string>) {
+  const seen: string[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = new URL(typeof input === 'string' ? input : input.toString(), `https://${HOST}`);
+    seen.push(url.pathname);
+    const body = routes[url.pathname];
+    return body === undefined
+      ? new Response('nope', { status: 404 })
+      : new Response(body, { status: 200 });
+  }) as unknown as typeof fetch;
+  return seen;
+}
+
+const signingClient = {} as TurnkeyBitcoinClient;
+
+
+const deposit = (over: Partial<{ confirmedUtxos: unknown[]; estimatedCostSats: number }> = {}) =>
+  ({
+    address: 'bc1qexample',
+    confirmedSats: 50_000,
+    unconfirmedSats: 0,
+    estimatedCostSats: 20_000,
+    confirmedUtxos: [{ txid: 'a'.repeat(64), vout: 0, value: 50_000, scriptPubKey: '00' }],
+    ...over,
+  }) as never;
+
+/** A genesis-only CEL. Unsigned on purpose: these never reach verification. */
+const CEL: CelLog = {
+  events: [
+    {
+      type: 'create',
+      data: {
+        controller: 'did:key:z6Mkj2fLd1Cft3Y1d4keoArcN9fxSUKUXo49sdyPDHA796qk',
+        resources: [{ id: 'artwork.svg', digestMultibase: 'uEiCK9_ajaSgQrxYbHi9nHkZCMAv9Ef52nzfvpMj9AEE4_w', mediaType: 'image/svg+xml' }],
+      },
+    },
+  ],
+};
+
+/** The path genesis's sealed resource is served under, derived from its digest. */
+const RESOURCE_PATH = '/u/sub-1/abc/resources/uEiCK9_ajaSgQrxYbHi9nHkZCMAv9Ef52nzfvpMj9AEE4_w';
+/** Everything the rebuild needs, so the gates under test are the LATER ones. */
+const HOSTED = { '/u/sub-1/abc/cel.json': JSON.stringify(CEL), [RESOURCE_PATH]: '<svg/>' };
+
+function run(opts: Partial<Parameters<typeof resumeInscribe>[0]> = {}) {
+  return resumeInscribe({
+    did: DID,
+    host: HOST,
+    subOrgId: 'sub-1',
+    fundingAddress: 'bc1qexample',
+    signingClient,
+    loadDeposit: async () => deposit(),
+    ...opts,
+  });
+}
+
+describe('fetchHostedCel', () => {
+  test('reads the hosted log', async () => {
+    serve({ '/u/sub-1/abc/cel.json': JSON.stringify(CEL) });
+    expect(await fetchHostedCel(DID, HOST)).toEqual(CEL);
+  });
+
+  test('null rather than throwing when it 404s', async () => {
+    serve({});
+    expect(await fetchHostedCel(DID, HOST)).toBeNull();
+  });
+
+  test('null for a DID that is not a did:webvh', async () => {
+    serve({});
+    expect(await fetchHostedCel('did:btco:123', HOST)).toBeNull();
+  });
+});
+
+describe('fetchHostedResources', () => {
+  /**
+   * Every version, not just genesis. A revised Original rebuilt from its v1
+   * bytes alone would anchor SUPERSEDED artwork to Bitcoin permanently.
+   */
+  test('fetches every version a signed update introduced', async () => {
+    const revised: CelLog = {
+      events: [
+        ...CEL.events,
+        {
+          type: 'update',
+          data: {
+            resourceId: 'artwork.svg',
+            toHash: '8b27d04ba1dddb2be18542ad170c52b957d35cc3b5fefdb6ef567ae04f97dfb9',
+            toVersion: 2,
+            contentType: 'image/svg+xml',
+          },
+        },
+      ],
+    };
+    const seen = serve({});
+    await fetchHostedResources(DID, revised, HOST);
+    const fetched = seen.filter((p) => p.includes('/resources/'));
+    expect(fetched.length).toBe(2);
+  });
+
+  test('a version that will not load is simply absent', async () => {
+    serve({});
+    expect(await fetchHostedResources(DID, CEL, HOST)).toEqual({});
+  });
+});
+
+describe('resolveAuthorshipDid', () => {
+  test('null with no client, and with no sub-org', async () => {
+    expect(await resolveAuthorshipDid(null, 'sub-1')).toBeNull();
+    expect(await resolveAuthorshipDid({} as TurnkeyBitcoinClient, undefined)).toBeNull();
+  });
+
+  test('null when the client cannot sign raw payloads at all', async () => {
+    // Disabling the action up front is the point: it must not fail at signing
+    // time, after the user has been told inscribing is about to happen.
+    expect(await resolveAuthorshipDid({} as TurnkeyBitcoinClient, 'sub-1')).toBeNull();
+  });
+});
+
+describe('refusing before anything is built or spent', () => {
+  test('an Original that hosts no log', async () => {
+    serve({});
+    const out = await run();
+    expect(out.ok).toBe(false);
+    expect(!out.ok && out.message).toMatch(/no event log/i);
+  });
+
+  test('a log whose bytes cannot be fetched back', async () => {
+    // The digest is sealed in genesis; without the bytes there is nothing to
+    // check it against, and inscribing unverified content is the one outcome
+    // this whole path exists to prevent.
+    serve({ '/u/sub-1/abc/cel.json': JSON.stringify(CEL) });
+    const out = await run({ cel: CEL });
+    expect(out.ok).toBe(false);
+    expect(!out.ok && out.message).toMatch(/could not be fetched back/i);
+  });
+
+  test('a deposit that cannot be read', async () => {
+    serve(HOSTED);
+    const out = await run({ cel: CEL, loadDeposit: async () => null });
+    expect(out.ok).toBe(false);
+    expect(!out.ok && out.message).toMatch(/nothing was built or spent/i);
+  });
+
+  test('a deposit that does not cover the quote', async () => {
+    serve(HOSTED);
+    const out = await run({
+      cel: CEL,
+      loadDeposit: async () => deposit({ confirmedUtxos: [{ txid: 'a'.repeat(64), vout: 0, value: 100, scriptPubKey: '00' }] }),
+    });
+    expect(out.ok).toBe(false);
+    expect(!out.ok && out.message).toMatch(/top it up/i);
+  });
+
+  test('a deposit with nothing spendable in it', async () => {
+    // Confirmed balance can be non-zero while every UTXO is withheld — one
+    // carrying an ordinal, or the ordinal lookup being down.
+    serve(HOSTED);
+    const out = await run({ cel: CEL, loadDeposit: async () => deposit({ confirmedUtxos: [] }) });
+    expect(out.ok).toBe(false);
+    expect(!out.ok && out.message).toMatch(/top it up/i);
+  });
+
+  test('every refusal names a reason and none of them throws', async () => {
+    serve(HOSTED);
+    for (const opts of [
+      {},
+      { cel: CEL },
+      { cel: CEL, loadDeposit: async () => null },
+      { cel: CEL, loadDeposit: async () => deposit({ confirmedUtxos: [] }) },
+    ]) {
+      const out = await run(opts as Parameters<typeof run>[0]);
+      expect(out.ok).toBe(false);
+      expect(!out.ok && out.message.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('the hosted CEL is refused before the deposit is even read', async () => {
+    // Ordering matters: reading the deposit is a server round-trip, and a
+    // rebuild that cannot happen must not issue one.
+    serve({});
+    let asked = false;
+    const out = await run({
+      loadDeposit: async () => {
+        asked = true;
+        return deposit();
+      },
+    });
+    expect(out.ok).toBe(false);
+    expect(asked).toBe(false);
+  });
+});

--- a/apps/landing/src/pages/resume-inscribe.ts
+++ b/apps/landing/src/pages/resume-inscribe.ts
@@ -1,0 +1,147 @@
+/**
+ * Picking a published Original back up and carrying it to Bitcoin.
+ *
+ * The Original is rebuilt from what it hosts — nothing about it survives in
+ * this tab — and then handed to the SAME `engine.inscribe({ funding })` the
+ * demo uses. That path is not forked or reimplemented here: this module only
+ * gathers the inputs (the hosted CEL, the sealed bytes, the creator's funding
+ * UTXOs) and calls it.
+ */
+import { webvhArtifacts, sameOriginUrl, type CelLog } from './original-detail-data';
+import { hostedAssetEnvelope, hostedResourceRefs } from '../sdk/hosted-envelope';
+import { selectFundingUtxos, type DepositInfo } from '../components/Demo';
+import { ensureAuthorshipAccount, type TurnkeyBitcoinClient } from '../auth/turnkey-session';
+import { authorshipPublicKeyMultibase, canAuthor } from '../sdk/turnkey-cel-signer';
+
+/** Fetch an Original's hosted CEL. `null` when it cannot be read. */
+export async function fetchHostedCel(did: string, host?: string): Promise<CelLog | null> {
+  const artifacts = webvhArtifacts(did, host);
+  if (!artifacts) return null;
+  try {
+    const res = await fetch(sameOriginUrl(artifacts.celUrl, host), { credentials: 'same-origin' });
+    if (!res.ok) return null;
+    return (await res.json()) as CelLog;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch the sealed bytes back, keyed by the digest segment they are hosted
+ * under. A resource that will not load is simply absent, which
+ * `hostedAssetEnvelope` reports as MISSING_CONTENT rather than papering over.
+ */
+export async function fetchHostedResources(
+  did: string,
+  cel: CelLog | null,
+  host?: string
+): Promise<Record<string, string>> {
+  const artifacts = webvhArtifacts(did, host);
+  const contents: Record<string, string> = {};
+  if (!artifacts) return contents;
+  await Promise.all(
+    hostedResourceRefs(cel).map(async (ref) => {
+      if (!ref.digestMultibase) return;
+      try {
+        const res = await fetch(sameOriginUrl(artifacts.resourceUrl(ref.digestMultibase), host), {
+          credentials: 'same-origin',
+        });
+        if (res.ok) contents[ref.digestMultibase] = await res.text();
+      } catch {
+        /* absent → MISSING_CONTENT, reported by the envelope builder */
+      }
+    })
+  );
+  return contents;
+}
+
+/**
+ * The viewer's authorship `did:key` — the identity an Original they can still
+ * author names as its controller. Null when this session cannot produce one,
+ * which is what disables the action rather than letting it fail at signing
+ * time.
+ */
+export async function resolveAuthorshipDid(
+  client: TurnkeyBitcoinClient | null | undefined,
+  subOrgId: string | undefined
+): Promise<string | null> {
+  if (!client || !subOrgId || !canAuthor(client)) return null;
+  try {
+    const address = await ensureAuthorshipAccount(client, subOrgId);
+    const multibase = authorshipPublicKeyMultibase(address);
+    return multibase ? `did:key:${multibase}` : null;
+  } catch {
+    return null;
+  }
+}
+
+export type ResumeOutcome =
+  | { ok: true; inscription: { commitTxId?: string; txid?: string; satoshi?: string } }
+  | { ok: false; message: string };
+
+/**
+ * Rebuild `did` from its hosted artifacts and inscribe it.
+ *
+ * `deposit` is read through the app's existing GET /api/btc/deposit — the one
+ * source of truth for the creator's spendable UTXOs and the fee target. This
+ * module neither estimates fees nor selects UTXOs by its own rules; it reuses
+ * `selectFundingUtxos`, the same selection the demo funds from.
+ */
+export async function resumeInscribe(opts: {
+  did: string;
+  host?: string;
+  subOrgId?: string;
+  fundingAddress: string;
+  signingClient: TurnkeyBitcoinClient;
+  /** Already-fetched CEL, when the page has one (the detail page does). */
+  cel?: CelLog | null;
+  /** Injectable for tests; defaults to the real endpoint. */
+  loadDeposit?: (address: string) => Promise<DepositInfo | null>;
+  onProgress?: (stage: 'hydrating' | 'inscribing') => void;
+}): Promise<ResumeOutcome> {
+  const { did, host, subOrgId, fundingAddress, signingClient, onProgress } = opts;
+  try {
+    onProgress?.('hydrating');
+    const cel = opts.cel ?? (await fetchHostedCel(did, host));
+    const contents = await fetchHostedResources(did, cel, host);
+    const built = hostedAssetEnvelope(cel, contents);
+    if ('problem' in built) return { ok: false, message: built.problem.message };
+
+    const loadDeposit =
+      opts.loadDeposit ??
+      (async (address: string) => {
+        const res = await fetch(`/api/btc/deposit?address=${encodeURIComponent(address)}`, {
+          credentials: 'same-origin',
+        });
+        return res.ok ? ((await res.json()) as DepositInfo) : null;
+      });
+    const deposit = await loadDeposit(fundingAddress);
+    if (!deposit) {
+      return { ok: false, message: 'Could not read your deposit address, so nothing was built or spent.' };
+    }
+    const selection = selectFundingUtxos(deposit.confirmedUtxos, deposit.estimatedCostSats);
+    // `shortfallSats` is how far the WHOLE spendable balance falls short, and
+    // is 0 exactly when the deposit covers the quote. Refuse here rather than
+    // building a commit that cannot pay for itself.
+    if (selection.shortfallSats > 0 || selection.selected.length === 0) {
+      return {
+        ok: false,
+        message: 'Your deposit does not cover this inscription yet — top it up and try again.',
+      };
+    }
+
+    const { DemoEngine } = await import('../sdk/engine');
+    const engine = new DemoEngine({ authed: true, subOrgId });
+    await engine.hydrate(built.envelope);
+
+    onProgress?.('inscribing');
+    // The existing path, unchanged.
+    const state = await engine.inscribe({
+      funding: { fundingUtxos: selection.selected, changeAddress: fundingAddress, signingClient },
+    });
+    if (!state.inscription) return { ok: false, message: 'The inscription did not complete.' };
+    return { ok: true, inscription: state.inscription };
+  } catch (err) {
+    return { ok: false, message: (err as Error)?.message ?? 'Could not inscribe this Original.' };
+  }
+}

--- a/apps/landing/src/pages/resume-inscribe.ts
+++ b/apps/landing/src/pages/resume-inscribe.ts
@@ -9,7 +9,7 @@
  */
 import { webvhArtifacts, sameOriginUrl, type CelLog } from './original-detail-data';
 import { hostedAssetEnvelope, hostedResourceRefs } from '../sdk/hosted-envelope';
-import { selectFundingUtxos, type DepositInfo } from '../components/Demo';
+import { selectFundingUtxos, inscribeIsComplete, type DepositInfo } from '../components/Demo';
 import { ensureAuthorshipAccount, type TurnkeyBitcoinClient } from '../auth/turnkey-session';
 import { authorshipPublicKeyMultibase, canAuthor } from '../sdk/turnkey-cel-signer';
 
@@ -27,9 +27,12 @@ export async function fetchHostedCel(did: string, host?: string): Promise<CelLog
 }
 
 /**
- * Fetch the sealed bytes back, keyed by the digest segment they are hosted
- * under. A resource that will not load is simply absent, which
- * `hostedAssetEnvelope` reports as MISSING_CONTENT rather than papering over.
+ * Fetch the sealed bytes back, keyed by the segment each version is hosted
+ * under. EVERY version, not just genesis: a revised Original that rebuilt from
+ * its v1 bytes alone would anchor superseded artwork to Bitcoin.
+ *
+ * A version that will not load is simply absent, which `hostedAssetEnvelope`
+ * reports as MISSING_CONTENT rather than papering over.
  */
 export async function fetchHostedResources(
   did: string,
@@ -41,12 +44,12 @@ export async function fetchHostedResources(
   if (!artifacts) return contents;
   await Promise.all(
     hostedResourceRefs(cel).map(async (ref) => {
-      if (!ref.digestMultibase) return;
+      if (!ref.segment) return;
       try {
-        const res = await fetch(sameOriginUrl(artifacts.resourceUrl(ref.digestMultibase), host), {
+        const res = await fetch(sameOriginUrl(artifacts.resourceUrl(ref.segment), host), {
           credentials: 'same-origin',
         });
-        if (res.ok) contents[ref.digestMultibase] = await res.text();
+        if (res.ok) contents[ref.segment] = await res.text();
       } catch {
         /* absent → MISSING_CONTENT, reported by the envelope builder */
       }
@@ -76,7 +79,17 @@ export async function resolveAuthorshipDid(
 }
 
 export type ResumeOutcome =
-  | { ok: true; inscription: { commitTxId?: string; txid?: string; satoshi?: string } }
+  | {
+      ok: true;
+      inscription: { commitTxId?: string; txid?: string; satoshi?: string };
+      /**
+       * FALSE when only the commit reached the network. The reveal carries the
+       * inscription, so until it propagates there is nothing on chain to point
+       * at — and #506 fixed exactly this lie in the demo. The resume path
+       * repeated it: any inscription snapshot read as done.
+       */
+      complete: boolean;
+    }
   | { ok: false; message: string };
 
 /**
@@ -140,7 +153,17 @@ export async function resumeInscribe(opts: {
       funding: { fundingUtxos: selection.selected, changeAddress: fundingAddress, signingClient },
     });
     if (!state.inscription) return { ok: false, message: 'The inscription did not complete.' };
-    return { ok: true, inscription: state.inscription };
+
+    // What actually reached the network. The SDK discards submitInscription's
+    // return, so the browser reads it back off the provider — the same seam
+    // the demo's completion panel reads. A status we cannot read means the
+    // reveal is NOT known to have landed, so nothing is claimed.
+    const submitted = (engine.ordinalsProvider as { lastSubmit?: { status?: string } }).lastSubmit;
+    return {
+      ok: true,
+      inscription: state.inscription,
+      complete: inscribeIsComplete(submitted?.status),
+    };
   } catch (err) {
     return { ok: false, message: (err as Error)?.message ?? 'Could not inscribe this Original.' };
   }

--- a/apps/landing/src/pages/your-originals.css
+++ b/apps/landing/src/pages/your-originals.css
@@ -12,7 +12,29 @@
   margin: var(--sp-8) 0 0;
   display: grid;
   gap: var(--sp-5);
-  grid-template-columns: 1fr;
+  /* minmax(0, ...) rather than a bare `1fr`, whose floor is the content's
+     min-content width — the trap the wider grid audit fixed everywhere else.
+     These cells now carry an action and its explanation, so the floor matters. */
+  grid-template-columns: minmax(0, 1fr);
+}
+
+/* The card, then whatever Bitcoin action the row offers, stacked. */
+.your-originals-grid li {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  min-width: 0;
+}
+
+.your-original-action {
+  align-self: flex-start;
+  max-width: 100%;
+}
+
+.your-original-action-note {
+  font-size: var(--text-xs);
+  line-height: 1.55;
+  color: var(--text-tertiary);
 }
 
 @media (min-width: 640px) {

--- a/apps/landing/src/sdk/engine.revise-authorship.test.ts
+++ b/apps/landing/src/sdk/engine.revise-authorship.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Revising an Original with a custody-held controller key.
+ *
+ * The break these pin: supplying a `signer` to `createAsset` means the SDK
+ * generates no key and puts NOTHING in the keyStore. `create`, `publish` and
+ * `inscribe` were each given that signer; `update` was not, so its two
+ * `addResourceVersion` appends fell through to a keyStore lookup that found
+ * nothing and threw CEL_APPEND_FAILED (NO_SIGNING_KEY) — for every signed-in
+ * user who edited a title, since edit-title (#489) is not auth-gated.
+ *
+ * These run the real SDK against a real Ed25519 key, so a signer that stops
+ * being threaded fails here rather than in production.
+ */
+import { describe, test, expect } from 'bun:test';
+import { ed25519 } from '@noble/curves/ed25519.js';
+import { multikey, signerFromExternalSigner, type OriginalsSigner } from '@originals/sdk';
+import { DemoEngine } from './engine';
+
+const SVG = (id: string) => `<svg xmlns="http://www.w3.org/2000/svg" id="${id}"></svg>`;
+
+/**
+ * An Ed25519 signer with the shape `resolveAuthorshipSigner` produces — the
+ * SDK-owned-preimage `signBytes` seam, not a document-level `sign`. Standing in
+ * for Turnkey: what matters is that the key lives OUTSIDE the SDK's keyStore,
+ * which is the condition that broke the revise path.
+ */
+function externalAuthorshipSigner(): OriginalsSigner {
+  const privateKey = ed25519.utils.randomSecretKey();
+  const publicKeyMultibase = multikey.encodePublicKey(ed25519.getPublicKey(privateKey), 'Ed25519');
+  return signerFromExternalSigner(
+    {
+      getVerificationMethodId: () => `did:key:${publicKeyMultibase}`,
+      sign: async () => {
+        throw new Error('signs SDK-owned preimages via signBytes');
+      },
+      signBytes: async (data: Uint8Array) => ({ signature: ed25519.sign(data, privateKey) }),
+    },
+    { publicKeyMultibase }
+  );
+}
+
+/**
+ * An engine already holding a resolved authorship signer. The real resolver
+ * dynamic-imports the Turnkey browser client, which must not load under
+ * `bun test` — so the cached result is seeded directly, which is exactly the
+ * state a signed-in browser reaches after its first append.
+ */
+function engineAuthoringWith(signer: OriginalsSigner): DemoEngine {
+  const engine = new DemoEngine({ authed: true, subOrgId: 'sub-1' });
+  Object.assign(engine as unknown as Record<string, unknown>, {
+    authorshipSigner: signer,
+    authorshipResolved: true,
+  });
+  return engine;
+}
+
+describe('revising an Original whose controller key is held outside the SDK', () => {
+  test('the artwork gets a signed v2 instead of failing to append', async () => {
+    const signer = externalAuthorshipSigner();
+    const engine = engineAuthoringWith(signer);
+    await engine.create('First Title', 'Artwork', SVG('v1'));
+
+    // Before the fix this rejected with CEL_APPEND_FAILED (NO_SIGNING_KEY).
+    const state = await engine.update('Second Title', 'Artwork', SVG('v2'));
+
+    expect(state.resource.content).toBe(SVG('v2'));
+    expect(state.resource.version).toBe(2);
+  });
+
+  test('the update event is signed by the SAME controller as genesis', async () => {
+    const signer = externalAuthorshipSigner();
+    const engine = engineAuthoringWith(signer);
+    await engine.create('First Title', 'Artwork', SVG('v1'));
+    await engine.update('Second Title', 'Artwork', SVG('v2'));
+
+    const events = (engine as unknown as {
+      asset: { celLog?: { events?: Array<{ type: string; proof?: Array<{ verificationMethod?: string }> }> } };
+    }).asset.celLog?.events;
+    expect(events).toBeDefined();
+    expect(events!.map((e) => e.type)).toEqual(['create', 'update', 'update']);
+    // Genesis names this key as controller, and pre-anchor the CEL accepts
+    // only its current controller — so every append must carry the same vm.
+    for (const e of events!) {
+      expect(e.proof?.[0]?.verificationMethod).toContain(signer.publicKeyMultibase);
+    }
+  });
+
+  test('the whole revised log verifies', async () => {
+    const engine = engineAuthoringWith(externalAuthorshipSigner());
+    await engine.create('First Title', 'Artwork', SVG('v1'));
+    await engine.update('Second Title', 'Artwork', SVG('v2'));
+
+    const asset = (engine as unknown as { asset: { verify(): Promise<unknown> } }).asset;
+    const result = (await asset.verify()) as { verified?: boolean } | boolean;
+    expect(typeof result === 'boolean' ? result : result.verified).toBe(true);
+  });
+
+  // The anonymous path must keep working: no signer supplied means the SDK
+  // generates a controller into its in-memory keyStore, and the keyStore
+  // fallback that the fix bypasses is exactly what signs these appends.
+  test('an anonymous run still revises through the SDK keyStore', async () => {
+    const engine = new DemoEngine();
+    await engine.create('First Title', 'Artwork', SVG('v1'));
+    const state = await engine.update('Second Title', 'Artwork', SVG('v2'));
+    expect(state.resource.version).toBe(2);
+  });
+});

--- a/apps/landing/src/sdk/engine.ts
+++ b/apps/landing/src/sdk/engine.ts
@@ -17,7 +17,10 @@ import { short } from './format';
 export { short };
 import {
   OriginalsSDK,
-  type OriginalsAsset
+  signerFromExternalSigner,
+  type AssetEnvelope,
+  type OriginalsAsset,
+  type OriginalsSigner
 } from '@originals/sdk';
 import { classifyLogEntries, type EntryAuthorClass } from '@originals/sdk/cel';
 export type { EntryAuthorClass };
@@ -31,6 +34,8 @@ import { TurnkeySatSigner } from './turnkey-sat-signer';
 import { userWebvhSlug } from '../auth/webvh';
 import { btcNetwork, btcoExplorerUrl, demoTier, type BtcNetworkFlag, type DemoTier } from './network-flag';
 import type { TurnkeyBitcoinClient } from '../auth/turnkey-session';
+import { ensureAuthorshipAccount } from '../auth/turnkey-session';
+import { TurnkeyCelSigner, authorshipPublicKeyMultibase } from './turnkey-cel-signer';
 import { sha256 } from '@noble/hashes/sha2.js';
 
 export { btcNetwork, btcRealEnabled, btcRealFor, btcoExplorerUrl, demoTier } from './network-flag';
@@ -146,6 +151,14 @@ export class DemoEngine {
   private readonly subOrgId?: string;
   private assetTitle = '';
   private assetResourceHash = '';
+  /**
+   * The Turnkey-held key that authors this user's Originals, resolved once and
+   * reused. Null until resolved; `authorshipResolved` distinguishes "not tried
+   * yet" from "tried and there is none" so a failure is not retried on every
+   * lifecycle call.
+   */
+  private authorshipSigner: OriginalsSigner | null = null;
+  private authorshipResolved = false;
   asset: OriginalsAsset | null = null;
   /**
    * The tier this engine runs at (R5) — real Bitcoin only when the deploy
@@ -243,6 +256,77 @@ export class DemoEngine {
   }
 
   /**
+   * The key that authors this user's Originals, resolved once per engine.
+   *
+   * Turnkey-held and Ed25519: CEL is Ed25519-only, and a key in custody comes
+   * back with the session on any device. That is the whole point — an
+   * Original whose controller key lived in a tab could never be inscribed
+   * after a reload, which is the pre-broadcast resume gap.
+   *
+   * Returns null for an anonymous visitor (there is no sub-org to hold a key)
+   * and for any failure to reach Turnkey. Callers pass the result straight to
+   * the SDK, which falls back to generating a controller into the in-memory
+   * keyStore — the old behaviour, correct for a throwaway anonymous run and
+   * honestly un-resumable.
+   */
+  private async resolveAuthorshipSigner(): Promise<OriginalsSigner | null> {
+    if (this.authorshipResolved) return this.authorshipSigner;
+    this.authorshipResolved = true;
+    if (!this.authed || !this.subOrgId) return null;
+    try {
+      // Dynamic: @turnkey/sdk-browser pulls a browser-only dependency graph
+      // that must not load under `bun test` (same reason useAuth defers it).
+      const { openSessionKey } = await import('../auth/turnkey-browser-client');
+      const handle = await openSessionKey(this.subOrgId);
+      const client = handle.client as unknown as TurnkeyBitcoinClient;
+      const address = await ensureAuthorshipAccount(client, this.subOrgId);
+      const publicKeyMultibase = authorshipPublicKeyMultibase(address);
+      if (!publicKeyMultibase) {
+        log('authorship:unavailable', `authorship account ${address} is not an Ed25519 key`);
+        return null;
+      }
+      const external = new TurnkeyCelSigner({
+        client,
+        subOrgId: this.subOrgId,
+        signWith: address,
+        publicKeyMultibase,
+      });
+      this.authorshipSigner = signerFromExternalSigner(external, { publicKeyMultibase });
+      this.emit(
+        'authorship:key',
+        `Authoring as ${short(this.authorshipSigner.verificationMethodId)} — a Turnkey-held key, not this browser's`,
+        { verificationMethodId: this.authorshipSigner.verificationMethodId }
+      );
+      return this.authorshipSigner;
+    } catch (err) {
+      // Never fatal: losing custody means this run is un-resumable, not that
+      // it cannot happen at all.
+      log('authorship:unavailable', err);
+      return null;
+    }
+  }
+
+  /**
+   * Rebuild a previously published Original from the artifacts it hosts, so
+   * the rest of this engine can act on it exactly as if it had just been made
+   * here. `loadAsset` verifies the whole signed chain fail-closed, so a log
+   * that does not hold up throws rather than producing a usable asset.
+   */
+  async hydrate(envelope: AssetEnvelope): Promise<DemoAssetState> {
+    const { asset } = await this.sdk.lifecycle.loadAsset(envelope);
+    this.asset = asset;
+    const primary = asset.resources[0];
+    this.assetResourceHash = primary?.hash ?? '';
+    this.assetTitle = this.assetTitle || (primary?.id ?? '');
+    this.emit('asset:hydrated', `Rebuilt ${short(asset.id)} from its hosted event log`, {
+      assetId: asset.id,
+      layer: asset.currentLayer,
+      events: asset.celLog?.events?.length ?? 0,
+    });
+    return this.snapshot();
+  }
+
+  /**
    * Step 1 — create a did:cel asset. The primary resource is the artwork
    * itself: a real SVG file whose exact bytes are hashed and carried through
    * the whole lifecycle. A small JSON metadata resource rides along.
@@ -259,6 +343,11 @@ export class DemoEngine {
     });
     const metaBytes = new TextEncoder().encode(metadata);
 
+    // The controller this asset is minted under. With a Turnkey signer the
+    // asset is authorable again after this tab closes; without one the SDK
+    // generates a key into the in-memory keyStore, which is correct for an
+    // anonymous throwaway run and honestly un-resumable.
+    const authorship = await this.resolveAuthorshipSigner();
     const asset = await this.sdk.lifecycle.createAsset([
       {
         id: 'artwork.svg',
@@ -276,7 +365,7 @@ export class DemoEngine {
         hash: toHex(sha256(metaBytes)),
         size: metaBytes.length
       }
-    ]);
+    ], authorship ? { signer: authorship } : undefined);
     this.asset = asset;
     this.assetTitle = title;
     this.assetResourceHash = svgHash;
@@ -405,7 +494,14 @@ export class DemoEngine {
       );
     }
 
-    await this.sdk.lifecycle.publishToWeb(this.asset, this.publisherDid);
+    // Same key that authored genesis, or the append is refused: pre-anchor,
+    // the CEL only accepts its current controller as signer.
+    const publishSigner = await this.resolveAuthorshipSigner();
+    await this.sdk.lifecycle.publishToWeb(
+      this.asset,
+      this.publisherDid,
+      publishSigner ? { signer: publishSigner } : undefined
+    );
 
     // Prove REAL resolution: publishToWeb hosts the ASSET's did:webvh log (+ cel
     // + resources) at this origin. Fetch that log back over the network via the
@@ -484,6 +580,7 @@ export class DemoEngine {
     };
   }): Promise<DemoAssetState> {
     if (!this.asset) throw new Error('Create an asset first');
+    const inscribeSigner = await this.resolveAuthorshipSigner();
     if (opts?.funding) {
       // Real sat-selected path: the user's Turnkey key signs the commit.
       const satSigner = new TurnkeySatSigner({
@@ -496,6 +593,7 @@ export class DemoEngine {
       await this.sdk.lifecycle.inscribeOnBitcoin(this.asset, {
         fundingUtxos,
         satSigner,
+        ...(inscribeSigner ? { signer: inscribeSigner } : {}),
         changeAddress: opts.funding.changeAddress,
         // No default here: real BTC must be built at the LIVE rate. Left
         // undefined, the SDK resolves it from the provider's estimateFee
@@ -504,8 +602,11 @@ export class DemoEngine {
         feeRate: opts.feeRate,
       });
     } else {
-      // Mock path (unchanged): fixed demo feeRate against OrdMockProvider.
-      await this.sdk.lifecycle.inscribeOnBitcoin(this.asset, opts?.feeRate ?? 7);
+      // Mock path: fixed demo feeRate against OrdMockProvider.
+      await this.sdk.lifecycle.inscribeOnBitcoin(this.asset, {
+        feeRate: opts?.feeRate ?? 7,
+        ...(inscribeSigner ? { signer: inscribeSigner } : {}),
+      });
     }
     const state = this.snapshot();
     if (state.inscription) {

--- a/apps/landing/src/sdk/engine.ts
+++ b/apps/landing/src/sdk/engine.ts
@@ -413,6 +413,15 @@ export class DemoEngine {
     const current = this.snapshot();
     const svgHash = toHex(sha256(new TextEncoder().encode(artworkSvg)));
 
+    // The SAME controller that signed genesis. An `update` is a signed CEL
+    // append like any other, and supplying a signer to `createAsset` means the
+    // SDK generated no key and put nothing in the keyStore — so leaving these
+    // appends to the keyStore fallback finds nothing and throws
+    // CEL_APPEND_FAILED (NO_SIGNING_KEY). Cached, so this is not a second
+    // Turnkey round-trip.
+    const authorship = await this.resolveAuthorshipSigner();
+    const signed = authorship ? { signer: authorship } : undefined;
+
     // The artwork is generated FROM the title, so a text edit changes these
     // bytes — that is the edit. Skip when identical: addResourceVersion refuses
     // a no-op version rather than logging one.
@@ -421,7 +430,8 @@ export class DemoEngine {
         current.resource.id,
         artworkSvg,
         'image/svg+xml',
-        `Artwork regenerated for "${title}"`
+        `Artwork regenerated for "${title}"`,
+        signed
       );
       this.assetResourceHash = svgHash; // the /me summary posts this on publish
     }
@@ -442,7 +452,8 @@ export class DemoEngine {
           current.metadata.id,
           next,
           'application/json',
-          `Metadata follows the artwork to "${title}"`
+          `Metadata follows the artwork to "${title}"`,
+          signed
         );
       }
     }

--- a/apps/landing/src/sdk/hosted-envelope.test.ts
+++ b/apps/landing/src/sdk/hosted-envelope.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Rebuilding an Original from what it hosts.
+ *
+ * The centrepiece is the round-trip at the bottom: create → publish → throw the
+ * live asset away → rebuild it from nothing but the hosted CEL and resource
+ * bytes → inscribe. That is the pre-broadcast resume gap, proved closed against
+ * the real SDK rather than a mock of it.
+ *
+ * The fixture CEL is a verbatim capture from a real create+publish in Chromium,
+ * not a hand-written approximation.
+ */
+import { describe, test, expect } from 'bun:test';
+import { OriginalsSDK, signerFromKeyPair } from '@originals/sdk';
+import { OrdMockProvider } from '@originals/sdk/testing';
+import { hostedAssetEnvelope, hostedResourceRefs, resourceKind } from './hosted-envelope';
+import type { CelLog } from '../pages/original-detail-data';
+
+/** Captured from a real publish; only the proofValues are shortened. */
+const REAL_CEL: CelLog = {
+  events: [
+    {
+      type: 'create',
+      data: {
+        name: 'artwork.svg',
+        controller: 'did:key:z6Mkj2fLd1Cft3Y1d4keoArcN9fxSUKUXo49sdyPDHA796qk',
+        resources: [
+          { id: 'artwork.svg', digestMultibase: 'uEiCa7YhDsJKiCLu84Gz_4QdSecy3Jz_65YR8OLfyXpbVvw', mediaType: 'image/svg+xml' },
+          { id: 'metadata.json', digestMultibase: 'uEiCITXva8WrVO0iHWM-XPCA3mVMLMhtrSQcDcstcE8xQOg', mediaType: 'application/json' },
+        ],
+        createdAt: '2026-08-24T04:22:37.512Z',
+        nonce: 'utSErwuLwgXS1Et-o5HeozQ',
+      },
+    },
+    {
+      type: 'migrate',
+      data: {
+        sourceDid: 'did:cel:uEiBjBg5wDWOZrccLiGvMhhSOUCPcc2zRwzCucjSItNxtgA',
+        targetDid: 'did:webvh:QmSA6tmBJb64cWA2VPmpk9vuNo5bk9Qyu51EmyRYuEMoRJ:localhost%3A5173:ueibjbg5wdwozrccligvmhhsoucpcc2zrwzcucjsitnxtga',
+        layer: 'webvh',
+        domain: 'localhost:5173',
+        migratedAt: '2026-08-24T04:22:39.194Z',
+      },
+    },
+  ],
+};
+
+const CONTENTS: Record<string, string> = {
+  uEiCa7YhDsJKiCLu84Gz_4QdSecy3Jz_65YR8OLfyXpbVvw: '<svg/>',
+  'uEiCITXva8WrVO0iHWM-XPCA3mVMLMhtrSQcDcstcE8xQOg': '{}',
+};
+
+const ok = <T,>(r: T | { problem: unknown }): T => {
+  if (r && typeof r === 'object' && 'problem' in r) {
+    throw new Error(`expected an envelope, got problem ${JSON.stringify(r.problem)}`);
+  }
+  return r as T;
+};
+
+describe('resourceKind', () => {
+  test('splits media types the way the demo seals them', () => {
+    expect(resourceKind('image/svg+xml')).toBe('image');
+    expect(resourceKind('application/json')).toBe('data');
+    expect(resourceKind('text/plain')).toBe('text');
+    expect(resourceKind(undefined)).toBe('data');
+  });
+});
+
+describe('hostedResourceRefs', () => {
+  test('reads the resources genesis sealed', () => {
+    expect(hostedResourceRefs(REAL_CEL).map((r) => r.id)).toEqual(['artwork.svg', 'metadata.json']);
+  });
+
+  test('empty for no log', () => {
+    expect(hostedResourceRefs(null)).toEqual([]);
+  });
+});
+
+describe('hostedAssetEnvelope', () => {
+  test('maps a real hosted CEL into an envelope', () => {
+    const { envelope } = ok(hostedAssetEnvelope(REAL_CEL, CONTENTS));
+    expect(envelope.format).toBe('originals/asset');
+    expect(envelope.resources.map((r) => r.id)).toEqual(['artwork.svg', 'metadata.json']);
+    expect(envelope.resources[0].type).toBe('image');
+    expect(envelope.resources[0].contentType).toBe('image/svg+xml');
+    // digestMultibase -> the hex hash the envelope carries.
+    expect(envelope.resources[0].hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(envelope.didDocuments['did:cel']).toBeTruthy();
+  });
+
+  test('derives assetDid from the log, never from the page', () => {
+    // A tampered cel.json must not be able to point loadAsset at another
+    // asset. Re-derived from the genesis event, this reproduces exactly the
+    // sourceDid the real migrate event recorded — which is the check: the
+    // identifier comes from the log, and the log alone.
+    const { envelope } = ok(hostedAssetEnvelope(REAL_CEL, CONTENTS));
+    expect(envelope.assetDid).toBe(REAL_CEL.events[1].data!.sourceDid);
+    expect(envelope.assetDid).toBe('did:cel:uEiBjBg5wDWOZrccLiGvMhhSOUCPcc2zRwzCucjSItNxtgA');
+  });
+
+  describe('refuses rather than guessing', () => {
+    const cases: Array<[string, CelLog | null, Record<string, string>, string]> = [
+      ['no log at all', null, {}, 'NO_CEL'],
+      ['an empty log', { events: [] }, {}, 'NO_CEL'],
+      [
+        'a log not starting at genesis',
+        { events: [REAL_CEL.events[1]] },
+        CONTENTS,
+        'NO_GENESIS',
+      ],
+      [
+        'a genesis naming no controller',
+        { events: [{ ...REAL_CEL.events[0], data: { ...REAL_CEL.events[0].data, controller: undefined } }] },
+        CONTENTS,
+        'NO_CONTROLLER',
+      ],
+      [
+        'a genesis sealing no resources',
+        { events: [{ ...REAL_CEL.events[0], data: { ...REAL_CEL.events[0].data, resources: [] } }] },
+        CONTENTS,
+        'NO_RESOURCES',
+      ],
+      [
+        'an unreadable digest',
+        {
+          events: [
+            { ...REAL_CEL.events[0], data: { ...REAL_CEL.events[0].data, resources: [{ id: 'x', digestMultibase: 'nonsense', mediaType: 'image/svg+xml' }] } },
+          ],
+        },
+        CONTENTS,
+        'BAD_DIGEST',
+      ],
+      ['resource bytes that would not fetch', REAL_CEL, {}, 'MISSING_CONTENT'],
+    ];
+    for (const [name, cel, contents, code] of cases) {
+      test(name, () => {
+        const r = hostedAssetEnvelope(cel, contents);
+        expect('problem' in r && r.problem.code).toBe(code);
+      });
+    }
+  });
+});
+
+/**
+ * The gap itself. Publish an Original, discard every trace of the live object
+ * and its keys, then rebuild from the hosted artifacts alone and carry it to
+ * did:btco. If the controller key is in custody rather than in a Map, this
+ * passes; before the custody change it could not.
+ */
+describe('hydrate then inscribe', () => {
+  async function publishOne() {
+    const { KeyManager } = await import('@originals/sdk');
+    const controllerKp = await new KeyManager().generateKeyPair('Ed25519');
+    const signer = signerFromKeyPair(controllerKp);
+    const hosted: Record<string, string> = {};
+    const sdk = OriginalsSDK.create({
+      network: 'regtest',
+      webvhNetwork: 'magby',
+      defaultKeyType: 'Ed25519',
+      ordinalsProvider: new OrdMockProvider(),
+      enableLogging: false,
+      signer,
+      storageAdapter: {
+        async put(_bucket: string, key: string, value: unknown) {
+          hosted[key] =
+            typeof value === 'string' ? value : new TextDecoder().decode(value as Uint8Array);
+          return { url: `https://example.test/${key}` };
+        },
+        async get() { return null; },
+        async delete() { return true; },
+      },
+    } as unknown as Parameters<typeof OriginalsSDK.create>[0]);
+
+    const artwork = '<svg xmlns="http://www.w3.org/2000/svg"><circle r="1"/></svg>';
+    const meta = JSON.stringify({ title: 'Resume me' });
+    const { sha256 } = await import('@noble/hashes/sha2.js');
+    const hex = (b: Uint8Array) => Array.from(b, (x) => x.toString(16).padStart(2, '0')).join('');
+    const asset = await sdk.lifecycle.createAsset([
+      { id: 'artwork.svg', type: 'image', content: artwork, contentType: 'image/svg+xml', hash: hex(sha256(new TextEncoder().encode(artwork))), size: artwork.length },
+      { id: 'metadata.json', type: 'data', content: meta, contentType: 'application/json', hash: hex(sha256(new TextEncoder().encode(meta))), size: meta.length },
+    ]);
+    return { sdk, asset, signer };
+  }
+
+  test('rebuilds a published Original from its CEL and inscribes it', async () => {
+    const { sdk, asset, signer } = await publishOne();
+
+    // What the origin would serve back: the CEL, and the sealed bytes keyed by
+    // the digest segment they are hosted under.
+    const cel = JSON.parse(JSON.stringify({ events: asset.celLog.events })) as CelLog;
+    const contents: Record<string, string> = {};
+    for (const ref of hostedResourceRefs(cel)) {
+      const live = asset.resources.find((r) => r.id === ref.id);
+      contents[ref.digestMultibase!] = String(live?.content ?? '');
+    }
+
+    const { envelope } = ok(hostedAssetEnvelope(cel, contents));
+
+    // A SECOND SDK with no memory of the first — the returning-creator case.
+    // It holds the same signer, which is the whole point: custody, not the tab.
+    const fresh = OriginalsSDK.create({
+      network: 'regtest',
+      webvhNetwork: 'magby',
+      defaultKeyType: 'Ed25519',
+      ordinalsProvider: new OrdMockProvider(),
+      enableLogging: false,
+      signer,
+    } as unknown as Parameters<typeof OriginalsSDK.create>[0]);
+
+    const { asset: revived } = await fresh.lifecycle.loadAsset(envelope);
+    expect(revived.id).toBe(asset.id);
+    expect(revived.resources.map((r) => r.id).sort()).toEqual(['artwork.svg', 'metadata.json']);
+
+    const before = revived.celLog.events.length;
+    await fresh.lifecycle.inscribeOnBitcoin(revived, 7);
+
+    // The migrate event exists, is signed, and the asset reached did:btco.
+    expect(revived.currentLayer).toBe('did:btco');
+    const events = revived.celLog.events;
+    expect(events.length).toBe(before + 1);
+    const migrate = events[events.length - 1];
+    expect(migrate.type).toBe('migrate');
+    expect((migrate.data as { layer?: string }).layer).toBe('btco');
+    expect((migrate as { proof?: unknown[] }).proof?.length).toBeGreaterThan(0);
+    // Signed by the SAME controller — the custody key, not a new one.
+    expect(JSON.stringify(migrate)).toContain(signer.publicKeyMultibase);
+
+    void sdk;
+  }, 30_000);
+});

--- a/apps/landing/src/sdk/hosted-envelope.test.ts
+++ b/apps/landing/src/sdk/hosted-envelope.test.ts
@@ -44,10 +44,10 @@ const REAL_CEL: CelLog = {
   ],
 };
 
-const CONTENTS: Record<string, string> = {
-  uEiCa7YhDsJKiCLu84Gz_4QdSecy3Jz_65YR8OLfyXpbVvw: '<svg/>',
-  'uEiCITXva8WrVO0iHWM-XPCA3mVMLMhtrSQcDcstcE8xQOg': '{}',
-};
+/** Keyed by hosted segment, which the refs themselves report. */
+const CONTENTS: Record<string, string> = Object.fromEntries(
+  hostedResourceRefs(REAL_CEL).map((r) => [r.segment, r.id.endsWith('.json') ? '{}' : '<svg/>'])
+);
 
 const ok = <T,>(r: T | { problem: unknown }): T => {
   if (r && typeof r === 'object' && 'problem' in r) {
@@ -68,6 +68,7 @@ describe('resourceKind', () => {
 describe('hostedResourceRefs', () => {
   test('reads the resources genesis sealed', () => {
     expect(hostedResourceRefs(REAL_CEL).map((r) => r.id)).toEqual(['artwork.svg', 'metadata.json']);
+    expect(hostedResourceRefs(REAL_CEL).every((r) => r.version === 1)).toBe(true);
   });
 
   test('empty for no log', () => {
@@ -189,8 +190,10 @@ describe('hydrate then inscribe', () => {
     const cel = JSON.parse(JSON.stringify({ events: asset.celLog.events })) as CelLog;
     const contents: Record<string, string> = {};
     for (const ref of hostedResourceRefs(cel)) {
-      const live = asset.resources.find((r) => r.id === ref.id);
-      contents[ref.digestMultibase!] = String(live?.content ?? '');
+      const live = asset.resources.find(
+        (r) => r.id === ref.id && (r.version ?? 1) === ref.version
+      );
+      contents[ref.segment] = String(live?.content ?? '');
     }
 
     const { envelope } = ok(hostedAssetEnvelope(cel, contents));
@@ -226,4 +229,74 @@ describe('hydrate then inscribe', () => {
 
     void sdk;
   }, 30_000);
+});
+
+/**
+ * The bug review caught on #515, pinned so it cannot come back.
+ *
+ * Reading genesis alone rebuilt a revised Original with only its v1 bytes.
+ * `loadAsset` ACCEPTED that — v1 binds to genesis perfectly well, and nothing
+ * requires an envelope to carry the latest version — so the failure was
+ * silent, and inscribing would have anchored the superseded artwork to Bitcoin
+ * permanently. The first assertion below is the one that failed before the fix.
+ */
+describe('a revised Original', () => {
+  test('rebuilds with every version, not just genesis', async () => {
+    const { KeyManager } = await import('@originals/sdk');
+    const { sha256 } = await import('@noble/hashes/sha2.js');
+    const hex = (b: Uint8Array) => Array.from(b, (x) => x.toString(16).padStart(2, '0')).join('');
+    const kp = await new KeyManager().generateKeyPair('Ed25519');
+    const signer = signerFromKeyPair(kp);
+    const sdk = OriginalsSDK.create({
+      network: 'regtest', webvhNetwork: 'magby', defaultKeyType: 'Ed25519',
+      ordinalsProvider: new OrdMockProvider(), enableLogging: false, signer,
+      storageAdapter: {
+        async put(_b: string, k: string) { return { url: `https://example.test/${k}` }; },
+        async get() { return null; },
+        async delete() { return true; },
+      },
+    } as unknown as Parameters<typeof OriginalsSDK.create>[0]);
+
+    const v1 = '<svg id="v1"/>';
+    const asset = await sdk.lifecycle.createAsset([
+      { id: 'artwork.svg', type: 'image', content: v1, contentType: 'image/svg+xml', hash: hex(sha256(new TextEncoder().encode(v1))), size: v1.length },
+    ]);
+    const v2 = '<svg id="v2-revised"/>';
+    await asset.addResourceVersion('artwork.svg', v2, 'image/svg+xml', hex(sha256(new TextEncoder().encode(v2))));
+
+    const cel = JSON.parse(JSON.stringify({ events: asset.celLog.events })) as CelLog;
+    const refs = hostedResourceRefs(cel);
+    expect(refs.map((r) => r.version)).toEqual([1, 2]);
+
+    const contents = Object.fromEntries(refs.map((r) => [r.segment, r.version === 1 ? v1 : v2]));
+    const { envelope } = ok(hostedAssetEnvelope(cel, contents));
+
+    const fresh = OriginalsSDK.create({
+      network: 'regtest', webvhNetwork: 'magby', defaultKeyType: 'Ed25519',
+      ordinalsProvider: new OrdMockProvider(), enableLogging: false, signer,
+    } as unknown as Parameters<typeof OriginalsSDK.create>[0]);
+    const { asset: revived } = await fresh.lifecycle.loadAsset(envelope);
+
+    // The revised bytes are what a later inscription must anchor.
+    const versions = revived.resources.filter((r) => r.id === 'artwork.svg');
+    expect(versions.map((r) => r.version ?? 1).sort()).toEqual([1, 2]);
+    expect(versions.find((r) => (r.version ?? 1) === 2)?.content).toBe(v2);
+  }, 30_000);
+
+  test('reports a version whose bytes will not load, rather than dropping it', () => {
+    const cel: CelLog = {
+      events: [
+        REAL_CEL.events[0],
+        { type: 'update', data: { resourceId: 'artwork.svg', contentType: 'image/svg+xml', toHash: 'aa'.repeat(32), toVersion: 2 } },
+      ],
+    };
+    // Genesis bytes present, the v2 bytes missing: silently anchoring v1 is
+    // exactly the failure this guards.
+    const partial = Object.fromEntries(
+      hostedResourceRefs(cel).filter((r) => r.version === 1).map((r) => [r.segment, '<svg/>'])
+    );
+    const r = hostedAssetEnvelope(cel, partial);
+    expect('problem' in r && r.problem.code).toBe('MISSING_CONTENT');
+    expect('problem' in r && r.problem.message).toContain('v2');
+  });
 });

--- a/apps/landing/src/sdk/hosted-envelope.ts
+++ b/apps/landing/src/sdk/hosted-envelope.ts
@@ -1,0 +1,134 @@
+/**
+ * Rebuild an Original from what it hosts.
+ *
+ * A published Original leaves three things at its origin: the signed did:webvh
+ * log, the CEL (`cel.json`), and the sealed resource bytes. That is everything
+ * `LifecycleManager.loadAsset` needs to reconstruct the live asset — so a
+ * creator returning days later can finish an inscription instead of re-running
+ * the demo and ending up with a second, different Original.
+ *
+ * This module is the adapter between the two shapes, and it is deliberately
+ * pure: it takes already-fetched artifacts and returns an `AssetEnvelope`. No
+ * network here, so the mapping is unit-testable on its own.
+ *
+ * Nothing here is trusted. The envelope goes through `loadAsset`, which
+ * verifies the whole signed chain, the resource↔genesis binding and the
+ * DID-doc↔fold cross-checks, all fail-closed. Getting a field wrong makes the
+ * load fail; it cannot make an unverified asset look verified.
+ */
+import {
+  ASSET_ENVELOPE_FORMAT,
+  ASSET_ENVELOPE_VERSION,
+  createCelDidDocument,
+  deriveDidCel,
+} from '@originals/sdk';
+import type { AssetEnvelope } from '@originals/sdk';
+import type { CelLog, CelResourceRef } from '../pages/original-detail-data';
+import { digestMultibaseSha256Hex } from '../pages/original-detail-data';
+
+/**
+ * `AssetResource.type` from a media type — the same coarse split
+ * `DemoEngine.create` uses when it seals the artwork and its metadata.
+ */
+export function resourceKind(mediaType: string | undefined): string {
+  if (!mediaType) return 'data';
+  if (mediaType.startsWith('image/')) return 'image';
+  if (mediaType.startsWith('text/')) return 'text';
+  return 'data';
+}
+
+export interface HydrationProblem {
+  /** Machine-readable so the UI can choose copy without matching on prose. */
+  code:
+    | 'NO_CEL'
+    | 'NO_GENESIS'
+    | 'NO_CONTROLLER'
+    | 'NO_RESOURCES'
+    | 'BAD_DIGEST'
+    | 'MISSING_CONTENT';
+  message: string;
+}
+
+/**
+ * The resources a hosted CEL declares, with the URL segment each is served
+ * under. The caller fetches these; keeping the fetch outside makes the mapping
+ * testable and lets the page report a partial failure per resource.
+ */
+export function hostedResourceRefs(cel: CelLog | null): CelResourceRef[] {
+  const genesis = cel?.events?.find((e) => e.type === 'create');
+  return genesis?.data?.resources ?? [];
+}
+
+/**
+ * Turn hosted artifacts into an `AssetEnvelope`.
+ *
+ * `contents` is keyed by `digestMultibase` — the same segment the resource is
+ * hosted under — and carries the bytes fetched back from the origin. They are
+ * included so `loadAsset` can check each resource against the digest its
+ * genesis event sealed, rather than taking the CEL's word for it.
+ */
+export function hostedAssetEnvelope(
+  cel: CelLog | null,
+  contents: Record<string, string>
+): { envelope: AssetEnvelope } | { problem: HydrationProblem } {
+  if (!cel || !Array.isArray(cel.events) || cel.events.length === 0) {
+    return { problem: { code: 'NO_CEL', message: 'This Original hosts no event log.' } };
+  }
+  const genesis = cel.events[0];
+  if (genesis?.type !== 'create') {
+    return { problem: { code: 'NO_GENESIS', message: 'This Original’s event log does not begin with its genesis event.' } };
+  }
+  const controller = genesis.data?.controller;
+  if (typeof controller !== 'string' || !controller.startsWith('did:key:')) {
+    return { problem: { code: 'NO_CONTROLLER', message: 'This Original’s genesis event names no controller key.' } };
+  }
+  const refs = genesis.data?.resources ?? [];
+  if (refs.length === 0) {
+    return { problem: { code: 'NO_RESOURCES', message: 'This Original’s genesis event seals no resources.' } };
+  }
+
+  const resources = [];
+  for (const ref of refs) {
+    const hash = ref.digestMultibase ? digestMultibaseSha256Hex(ref.digestMultibase) : null;
+    if (!hash) {
+      return {
+        problem: { code: 'BAD_DIGEST', message: `Resource “${ref.id}” has no readable content digest.` },
+      };
+    }
+    const content = contents[ref.digestMultibase!];
+    if (content === undefined) {
+      return {
+        problem: { code: 'MISSING_CONTENT', message: `Resource “${ref.id}” could not be fetched back from this origin.` },
+      };
+    }
+    resources.push({
+      id: ref.id,
+      type: resourceKind(ref.mediaType),
+      contentType: ref.mediaType ?? 'application/octet-stream',
+      hash,
+      content,
+    });
+  }
+
+  // The log is the source of the identifier, never the page: deriving it here
+  // means a tampered cel.json cannot point loadAsset at a different asset.
+  const eventLog = { events: cel.events } as unknown as AssetEnvelope['eventLog'];
+  let assetDid: string;
+  try {
+    assetDid = deriveDidCel(eventLog);
+  } catch (e) {
+    return { problem: { code: 'NO_GENESIS', message: `This Original’s genesis event is unreadable: ${(e as Error).message}` } };
+  }
+
+  const controllerPublicKey = controller.slice('did:key:'.length);
+  return {
+    envelope: {
+      format: ASSET_ENVELOPE_FORMAT,
+      version: ASSET_ENVELOPE_VERSION,
+      assetDid,
+      eventLog,
+      didDocuments: { 'did:cel': createCelDidDocument(assetDid, controllerPublicKey) },
+      resources,
+    },
+  };
+}

--- a/apps/landing/src/sdk/hosted-envelope.ts
+++ b/apps/landing/src/sdk/hosted-envelope.ts
@@ -23,8 +23,8 @@ import {
   deriveDidCel,
 } from '@originals/sdk';
 import type { AssetEnvelope } from '@originals/sdk';
-import type { CelLog, CelResourceRef } from '../pages/original-detail-data';
-import { digestMultibaseSha256Hex } from '../pages/original-detail-data';
+import type { CelLog } from '../pages/original-detail-data';
+import { digestMultibaseSha256Hex, sha256HexToResourceMultibase } from '../pages/original-detail-data';
 
 /**
  * `AssetResource.type` from a media type — the same coarse split
@@ -49,14 +49,84 @@ export interface HydrationProblem {
   message: string;
 }
 
+/** One hosted version of one resource. */
+export interface HostedResourceRef {
+  id: string;
+  /** 1 for genesis; ≥2 for every version a signed `update` event introduced. */
+  version: number;
+  /** hex sha-256 of THIS version's bytes. */
+  hash: string;
+  /** The segment this version is served under (`resources/<segment>`). */
+  segment: string;
+  mediaType?: string;
+  previousVersionHash?: string;
+}
+
 /**
- * The resources a hosted CEL declares, with the URL segment each is served
- * under. The caller fetches these; keeping the fetch outside makes the mapping
- * testable and lets the page report a partial failure per resource.
+ * EVERY resource version the hosted CEL declares — genesis, and every version a
+ * signed `update` event introduced after it.
+ *
+ * Reading genesis alone was a silent correctness bug: a revised Original would
+ * rebuild with only its v1 bytes, `loadAsset` would accept that (v1 binds to
+ * genesis perfectly well, and nothing requires an envelope to carry the LATEST
+ * version), and inscribing would then anchor the SUPERSEDED artwork to Bitcoin
+ * permanently. Caught by review on #515; `hosted-envelope.test.ts` reproduces
+ * it.
+ *
+ * The caller fetches these; keeping the fetch outside makes the mapping
+ * testable and lets the page report a partial failure per version.
  */
-export function hostedResourceRefs(cel: CelLog | null): CelResourceRef[] {
-  const genesis = cel?.events?.find((e) => e.type === 'create');
-  return genesis?.data?.resources ?? [];
+export function hostedResourceRefs(cel: CelLog | null): HostedResourceRef[] {
+  const events = cel?.events ?? [];
+  const refs: HostedResourceRef[] = [];
+
+  const genesis = events[0]?.type === 'create' ? events[0] : undefined;
+  for (const r of genesis?.data?.resources ?? []) {
+    const hash = r.digestMultibase ? digestMultibaseSha256Hex(r.digestMultibase) : null;
+    const segment = hash ? sha256HexToResourceMultibase(hash) : null;
+    // A ref we cannot address is still reported, so the envelope builder can
+    // name it in BAD_DIGEST rather than quietly dropping a sealed resource.
+    refs.push({
+      id: r.id,
+      version: 1,
+      hash: hash ?? '',
+      segment: segment ?? '',
+      ...(r.mediaType ? { mediaType: r.mediaType } : {}),
+    });
+  }
+
+  // Later versions. `update` events carry the hex hash directly, and the
+  // envelope's post-genesis binding requires each v≥2 to match the exact
+  // `toVersion` of a verified update event — so these are emitted verbatim
+  // from the log rather than inferred.
+  for (const e of events) {
+    if (e.type !== 'update') continue;
+    const d = (e.data ?? {}) as {
+      resourceId?: unknown;
+      toHash?: unknown;
+      toVersion?: unknown;
+      contentType?: unknown;
+      previousVersionHash?: unknown;
+    };
+    if (typeof d.resourceId !== 'string' || typeof d.toHash !== 'string') continue;
+    if (typeof d.toVersion !== 'number') continue;
+    const segment = sha256HexToResourceMultibase(d.toHash);
+    refs.push({
+      id: d.resourceId,
+      version: d.toVersion,
+      hash: d.toHash,
+      segment: segment ?? '',
+      ...(typeof d.contentType === 'string' ? { mediaType: d.contentType } : {}),
+      ...(typeof d.previousVersionHash === 'string'
+        ? { previousVersionHash: d.previousVersionHash }
+        : {}),
+    });
+  }
+
+  // Ascending version per resource: the fold expects a version chain, and a
+  // v2 ahead of its v1 is not one.
+  refs.sort((a, b) => (a.id === b.id ? a.version - b.version : 0));
+  return refs;
 }
 
 /**
@@ -82,30 +152,37 @@ export function hostedAssetEnvelope(
   if (typeof controller !== 'string' || !controller.startsWith('did:key:')) {
     return { problem: { code: 'NO_CONTROLLER', message: 'This Original’s genesis event names no controller key.' } };
   }
-  const refs = genesis.data?.resources ?? [];
+  if ((genesis.data?.resources ?? []).length === 0) {
+    return { problem: { code: 'NO_RESOURCES', message: 'This Original’s genesis event seals no resources.' } };
+  }
+  const refs = hostedResourceRefs(cel);
   if (refs.length === 0) {
     return { problem: { code: 'NO_RESOURCES', message: 'This Original’s genesis event seals no resources.' } };
   }
 
   const resources = [];
   for (const ref of refs) {
-    const hash = ref.digestMultibase ? digestMultibaseSha256Hex(ref.digestMultibase) : null;
-    if (!hash) {
+    if (!ref.hash || !ref.segment) {
       return {
         problem: { code: 'BAD_DIGEST', message: `Resource “${ref.id}” has no readable content digest.` },
       };
     }
-    const content = contents[ref.digestMultibase!];
+    const content = contents[ref.segment];
     if (content === undefined) {
       return {
-        problem: { code: 'MISSING_CONTENT', message: `Resource “${ref.id}” could not be fetched back from this origin.` },
+        problem: {
+          code: 'MISSING_CONTENT',
+          message: `Resource “${ref.id}”${ref.version > 1 ? ` v${ref.version}` : ''} could not be fetched back from this origin.`,
+        },
       };
     }
     resources.push({
       id: ref.id,
       type: resourceKind(ref.mediaType),
       contentType: ref.mediaType ?? 'application/octet-stream',
-      hash,
+      hash: ref.hash,
+      version: ref.version,
+      ...(ref.previousVersionHash ? { previousVersionHash: ref.previousVersionHash } : {}),
       content,
     });
   }

--- a/apps/landing/src/sdk/turnkey-cel-signer.test.ts
+++ b/apps/landing/src/sdk/turnkey-cel-signer.test.ts
@@ -1,0 +1,177 @@
+/**
+ * The Turnkey authorship key — the custody change that closes the resume gap.
+ *
+ * The bug these guard against: an Original's controller key used to be minted
+ * into an in-memory Map and destroyed with the tab, so a published Original
+ * could never be inscribed afterwards. Everything here is about that key being
+ * (a) derived from Turnkey's account correctly and (b) refused loudly, up
+ * front, when this client cannot produce one.
+ */
+import { describe, test, expect } from 'bun:test';
+import { base58 } from '@scure/base';
+import { authorshipPublicKeyMultibase, canAuthor, TurnkeyCelSigner } from './turnkey-cel-signer';
+import { ensureAuthorshipAccount, AUTHORSHIP_ACCOUNT } from '../auth/turnkey-session';
+import type { TurnkeyBitcoinClient } from '../auth/turnkey-session';
+
+/** A Solana-format address for a known 32-byte key. */
+const PUBKEY = new Uint8Array(32).fill(7);
+const SOLANA_ADDRESS = base58.encode(PUBKEY);
+
+function stubClient(over: Partial<TurnkeyBitcoinClient> = {}): TurnkeyBitcoinClient {
+  return {
+    signTransaction: async () => ({ signedTransaction: '' }),
+    createWalletAccounts: async () => ({ addresses: [] }),
+    getWallets: async () => ({ wallets: [{ walletId: 'w1' }] }),
+    getWalletAccounts: async () => ({ accounts: [] }),
+    ...over,
+  };
+}
+
+describe('authorshipPublicKeyMultibase', () => {
+  test('turns a Solana-format address into an Ed25519 multikey', () => {
+    const mb = authorshipPublicKeyMultibase(SOLANA_ADDRESS);
+    // Multibase base58-btc ('z') carrying the 0xed01 Ed25519 multicodec.
+    expect(mb).toBeTruthy();
+    expect(mb!.startsWith('z6Mk')).toBe(true);
+  });
+
+  test('round-trips: the multikey carries the same 32 bytes back', () => {
+    const mb = authorshipPublicKeyMultibase(SOLANA_ADDRESS)!;
+    const decoded = base58.decode(mb.slice(1));
+    expect(decoded[0]).toBe(0xed);
+    expect(decoded[1]).toBe(0x01);
+    expect([...decoded.slice(2)]).toEqual([...PUBKEY]);
+  });
+
+  test('refuses an address that is not a 32-byte key', () => {
+    // A secp256k1 account address handed here by mistake must not become a
+    // plausible-looking wrong key — the controller identity would be wrong
+    // and nothing downstream would notice.
+    expect(authorshipPublicKeyMultibase(base58.encode(new Uint8Array(33)))).toBeNull();
+  });
+
+  test('refuses input that is not base58 at all', () => {
+    expect(authorshipPublicKeyMultibase('not base58 ! 0OIl')).toBeNull();
+  });
+});
+
+describe('canAuthor', () => {
+  test('false when the client cannot sign raw payloads', () => {
+    expect(canAuthor(stubClient())).toBe(false);
+  });
+
+  test('false for no client at all', () => {
+    expect(canAuthor(null)).toBe(false);
+    expect(canAuthor(undefined)).toBe(false);
+  });
+
+  test('true once the client exposes signRawPayload', () => {
+    expect(canAuthor(stubClient({ signRawPayload: async () => ({}) }))).toBe(true);
+  });
+});
+
+describe('TurnkeyCelSigner', () => {
+  test('reports its verification method as a did:key over the authorship key', () => {
+    const mb = authorshipPublicKeyMultibase(SOLANA_ADDRESS)!;
+    const signer = new TurnkeyCelSigner({
+      client: stubClient(),
+      subOrgId: 'sub-1',
+      signWith: SOLANA_ADDRESS,
+      publicKeyMultibase: mb,
+    });
+    expect(signer.getVerificationMethodId()).toBe(`did:key:${mb}`);
+    expect(signer.getPublicKeyMultibase()).toBe(mb);
+  });
+
+  test('refuses to sign on a client that cannot, rather than failing obscurely', async () => {
+    const signer = new TurnkeyCelSigner({
+      client: stubClient(),
+      subOrgId: 'sub-1',
+      signWith: SOLANA_ADDRESS,
+      publicKeyMultibase: authorshipPublicKeyMultibase(SOLANA_ADDRESS)!,
+    });
+    await expect(signer.signBytes(new Uint8Array([1, 2, 3]))).rejects.toThrow(/cannot sign raw payloads/i);
+  });
+
+  test('signs through turnkeySignBytes and returns its 64 bytes verbatim', async () => {
+    const r = '0x' + '11'.repeat(32);
+    const s = '0x' + '22'.repeat(32);
+    let seen: { payload?: string; signWith?: string; organizationId?: string } = {};
+    const client = stubClient({
+      signRawPayload: async (params) => {
+        seen = params;
+        return { activity: { result: { signRawPayloadResult: { r, s } } } };
+      },
+    });
+    const signer = new TurnkeyCelSigner({
+      client,
+      subOrgId: 'sub-1',
+      signWith: SOLANA_ADDRESS,
+      publicKeyMultibase: authorshipPublicKeyMultibase(SOLANA_ADDRESS)!,
+    });
+    const { signature } = await signer.signBytes(new Uint8Array([0xde, 0xad]));
+    expect(signature.length).toBe(64);
+    expect(signature[0]).toBe(0x11);
+    expect(signature[63]).toBe(0x22);
+    // The SDK owns canonicalization and hashing: the exact bytes go out.
+    expect(seen.payload).toBe('0xdead');
+    expect(seen.signWith).toBe(SOLANA_ADDRESS);
+    expect(seen.organizationId).toBe('sub-1');
+  });
+});
+
+describe('ensureAuthorshipAccount', () => {
+  test('re-reads the existing account by path instead of creating a second', async () => {
+    let created = 0;
+    const client = stubClient({
+      getWalletAccounts: async () => ({
+        accounts: [{ address: SOLANA_ADDRESS, path: AUTHORSHIP_ACCOUNT.path }],
+      }),
+      createWalletAccounts: async () => {
+        created++;
+        return { addresses: ['nope'] };
+      },
+    });
+    expect(await ensureAuthorshipAccount(client, 'sub-1')).toBe(SOLANA_ADDRESS);
+    // An Original's controller identity must not move under it.
+    expect(created).toBe(0);
+  });
+
+  test('creates the account on a miss, at the fixed authorship path', async () => {
+    let asked: unknown = null;
+    const client = stubClient({
+      getWalletAccounts: async () => ({ accounts: [] }),
+      createWalletAccounts: async (params) => {
+        asked = params.accounts[0];
+        return { addresses: [SOLANA_ADDRESS] };
+      },
+    });
+    expect(await ensureAuthorshipAccount(client, 'sub-1')).toBe(SOLANA_ADDRESS);
+    expect(asked).toMatchObject({ curve: 'CURVE_ED25519', path: AUTHORSHIP_ACCOUNT.path });
+  });
+
+  test('treats Turnkey’s “already exists” as proof to re-read, not as failure', async () => {
+    let reads = 0;
+    const client = stubClient({
+      getWalletAccounts: async () => {
+        reads++;
+        return reads === 1
+          ? { accounts: [] }
+          : { accounts: [{ address: SOLANA_ADDRESS, path: AUTHORSHIP_ACCOUNT.path }] };
+      },
+      createWalletAccounts: async () => {
+        throw new Error('wallet account already exists');
+      },
+    });
+    expect(await ensureAuthorshipAccount(client, 'sub-1')).toBe(SOLANA_ADDRESS);
+  });
+
+  test('surfaces any other create failure', async () => {
+    const client = stubClient({
+      createWalletAccounts: async () => {
+        throw new Error('turnkey is down');
+      },
+    });
+    await expect(ensureAuthorshipAccount(client, 'sub-1')).rejects.toThrow(/turnkey is down/);
+  });
+});

--- a/apps/landing/src/sdk/turnkey-cel-signer.ts
+++ b/apps/landing/src/sdk/turnkey-cel-signer.ts
@@ -1,0 +1,105 @@
+/**
+ * The Turnkey-held key that authors an Original.
+ *
+ * Every Original is a CEL, and every lifecycle step appends a signed event to
+ * it. Until this existed, the key that signed those events was minted by
+ * `createAsset` into the DemoEngine's in-memory Map and destroyed with the tab:
+ * a published Original could never be inscribed afterwards, because nothing
+ * could sign its `migrate` event. That is the pre-broadcast resume gap.
+ *
+ * The fix is custody, not UI. This signer puts the asset's controller key in
+ * Turnkey — Ed25519, because CEL is Ed25519-only, and server-held, so it comes
+ * back with the session on any device rather than living in one browser's
+ * storage. `signerFromExternalSigner` adapts it to the SDK's `config.signer`,
+ * which `createAsset` then adopts as the controller instead of generating one.
+ *
+ * Byte-level signing is NOT reimplemented here: `turnkeySignBytes` from
+ * `@originals/auth` is the one place Turnkey actually signs (hex payload,
+ * HASH_FUNCTION_NO_OP, r‖s concatenation, 64-byte guard), and it is already
+ * documented as the capability that lets a Turnkey key author CEL events.
+ */
+import type { Turnkey } from '@turnkey/sdk-server';
+import { base58AddressToEd25519Multikey } from '@originals/sdk';
+import { turnkeySignBytes } from '@originals/auth';
+import type { TurnkeyBitcoinClient } from '../auth/turnkey-session';
+
+/**
+ * The Multikey for a Turnkey Ed25519 account address.
+ *
+ * The conversion itself is the SDK's `base58AddressToEd25519Multikey`, which
+ * exists precisely for `ADDRESS_FORMAT_SOLANA` and says so — "consumers keep
+ * re-deriving this by hand and getting it wrong". This is only the non-
+ * throwing shape the UI wants: a control that must decide whether to enable
+ * itself should not have to catch.
+ */
+export function authorshipPublicKeyMultibase(address: string): string | null {
+  try {
+    return base58AddressToEd25519Multikey(address);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * `turnkeySignBytes` reaches the API as `client.apiClient().signRawPayload`
+ * — the server SDK's shape. The browser's IndexedDB client exposes
+ * `signRawPayload` directly, so it is wrapped rather than special-cased
+ * inside the shared signing helper.
+ */
+function asApiClient(client: TurnkeyBitcoinClient): Turnkey {
+  return { apiClient: () => client } as unknown as Turnkey;
+}
+
+/**
+ * An `ExternalSigner` backed by the sub-org's authorship account. Only
+ * `signBytes` is implemented: that is what `signerFromExternalSigner` requires
+ * and all the SDK ever asks of a CEL signer, since the SDK owns
+ * canonicalization and hashing.
+ */
+export class TurnkeyCelSigner {
+  private readonly client: TurnkeyBitcoinClient;
+  private readonly subOrgId: string;
+  private readonly signWith: string;
+  private readonly publicKeyMultibase: string;
+
+  constructor(opts: {
+    client: TurnkeyBitcoinClient;
+    subOrgId: string;
+    /** The authorship account address (`ensureAuthorshipAccount`). */
+    signWith: string;
+    publicKeyMultibase: string;
+  }) {
+    this.client = opts.client;
+    this.subOrgId = opts.subOrgId;
+    this.signWith = opts.signWith;
+    this.publicKeyMultibase = opts.publicKeyMultibase;
+  }
+
+  async signBytes(data: Uint8Array): Promise<{ signature: Uint8Array }> {
+    if (typeof this.client.signRawPayload !== 'function') {
+      throw new Error('This Turnkey client cannot sign raw payloads, so it cannot author CEL events.');
+    }
+    const signature = await turnkeySignBytes(
+      { turnkeyClient: asApiClient(this.client), organizationId: this.subOrgId, signWith: this.signWith },
+      data
+    );
+    return { signature };
+  }
+
+  getVerificationMethodId(): string {
+    return `did:key:${this.publicKeyMultibase}`;
+  }
+
+  getPublicKeyMultibase(): string {
+    return this.publicKeyMultibase;
+  }
+}
+
+/**
+ * Whether this client can author CEL events at all. Read BEFORE offering an
+ * action that would need to sign one: a disabled control with a reason beats
+ * an enabled control that throws after the user has committed to it.
+ */
+export function canAuthor(client: TurnkeyBitcoinClient | null | undefined): boolean {
+  return typeof client?.signRawPayload === 'function';
+}

--- a/apps/landing/src/sdk/turnkey-cel-signer.ts
+++ b/apps/landing/src/sdk/turnkey-cel-signer.ts
@@ -75,6 +75,19 @@ export class TurnkeyCelSigner {
     this.publicKeyMultibase = opts.publicKeyMultibase;
   }
 
+  /**
+   * `ExternalSigner` declares this, but a CEL signer never reaches it: the SDK
+   * owns canonicalization and hands over finished bytes, and
+   * `signerFromExternalSigner` refuses a sign()-only signer for exactly that
+   * reason. Implemented as a refusal so a future caller that wires this into
+   * the document-level path is told why instead of getting a wrong signature.
+   */
+  async sign(): Promise<{ proofValue: string }> {
+    throw new Error(
+      'TurnkeyCelSigner signs SDK-owned preimages via signBytes; it does not canonicalize documents itself.'
+    );
+  }
+
   async signBytes(data: Uint8Array): Promise<{ signature: Uint8Array }> {
     if (typeof this.client.signRawPayload !== 'function') {
       throw new Error('This Turnkey client cannot sign raw payloads, so it cannot author CEL events.');

--- a/apps/landing/src/sdk/turnkey-cel-signer.ts
+++ b/apps/landing/src/sdk/turnkey-cel-signer.ts
@@ -17,6 +17,12 @@
  * `@originals/auth` is the one place Turnkey actually signs (hex payload,
  * HASH_FUNCTION_NO_OP, r‖s concatenation, 64-byte guard), and it is already
  * documented as the capability that lets a Turnkey key author CEL events.
+ *
+ * NAME COLLISION: `auth/authorship-key.ts` is a DIFFERENT key. That one signs
+ * the user's own did:webvh identity document and lives only in this browser's
+ * localStorage. This one signs CEL events — the controller of each Original —
+ * and is held in Turnkey, which is the whole reason a published Original can
+ * still be inscribed after a reload.
  */
 import type { Turnkey } from '@turnkey/sdk-server';
 import { base58AddressToEd25519Multikey } from '@originals/sdk';


### PR DESCRIPTION
## What

A published Original that was never inscribed showed on `/me` with no way to inscribe it, and the detail page had no Bitcoin action at all — so the creator re-ran the demo and ended up with a second, different `did:webvh` Original. This adds "Inscribe on Bitcoin" to both pages.

Seven commits, staged so each is reviewable on its own:

| | |
|---|---|
| `d957ae8` | Turnkey Ed25519 authorship account + `TurnkeyCelSigner` (14 tests) |
| `881d3c8` | `hostedAssetEnvelope` — rebuild an Original from its hosted artifacts (13 tests) |
| `89b175b` | engine: author with the custody key, add `hydrate()` |
| `b89b2dd` | `inscribeAvailability` — Finish vs Inscribe vs why-not (14 tests) |
| `f4fa639` | the action on `/me` and `OriginalDetail` |
| `dbd4f82` | section-heading fix, caught by rendering it |
| `3cc315c` | changeset |

## Why this is bigger than a button

**The gap was custody, not UI.** An Original is a CEL; every lifecycle step appends a signed event to it. The key that signed those events was minted by `createAsset` into `DemoEngine`'s in-memory `Map` and destroyed with the tab.

Verified before writing any code — after create + publish in Chromium:

```
localStorageKeys:       []                     <- empty
genesisController:      did:key:z6Mkks2HT6XEN6QJdYnRd9hUzJJFvCuT1fdzJ4nQ9s8zJ74E
```

So nothing could sign a later `migrate` event. Hydrate-then-inscribe would have thrown `CEL_APPEND_FAILED (NO_SIGNING_KEY)` — `appendCelEventOrSkip`'s default policy is `throw` — and a "missing key" guard would have disabled the button for **every row in every browser**, because the key it checks for is not what signs an Original.

**Turnkey already had the right key and nothing used it.** `createWalletWithAccounts` provisions two `CURVE_ED25519` accounts per sub-org. Ed25519 is what CEL requires, and Turnkey custody is what a browser-local seed is not: it comes back with the session on any device. A signed-in creator's Originals are now authored by that key from genesis onward.

## How

`resolveAuthorshipSigner` resolves the key once per engine and caches the failure too — losing custody makes a run un-resumable, not impossible. Anonymous visitors get `null` and the SDK generates a controller into the in-memory keyStore exactly as before, which is right for a throwaway run and honestly un-resumable.

The signer is passed **per call** (`createAsset options.signer`, `publishToWeb` / `inscribeOnBitcoin` `LifecycleOperationOptions.signer`) rather than as `config.signer`. That is what keeps `Demo.tsx` out of this: engine construction lives there and was out of scope, but every lifecycle entry point the engine already owns accepts a signer. Publish and inscribe must use the *same* key that authored genesis — pre-anchor, `appendCelEventOrSkip` accepts only the current controller, so a different key would be refused rather than silently minting a second identity.

Nothing is forked. `resume-inscribe` fetches the hosted CEL and sealed bytes, rebuilds through `hostedAssetEnvelope` → `engine.hydrate` (`loadAsset`, fail-closed), and hands the asset to the existing `engine.inscribe({ funding })`. Funding comes from the app's own `GET /api/btc/deposit` and the same `selectFundingUtxos` the demo uses — no fee estimation or selection rule of its own — and it refuses before building anything when the deposit does not cover the quote.

Two things I deliberately did **not** reimplement: `turnkeySignBytes` stays the one place Turnkey signs, and `base58AddressToEd25519Multikey` replaced a hand-rolled copy of mine (its docstring says consumers keep re-deriving it and getting it wrong — I had just done exactly that).

Finish and Inscribe are decided by one shared selector and never both appear on a row: rebuilding over signed, paid-for transactions would strand that spend.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test addition or improvement

## Checklist

- [x] My code follows the project's code style (TypeScript, absolute imports, Multikey encoding)
- [x] I have added tests that cover my changes
- [x] All new and existing tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] I have updated JSDoc comments for any changed public APIs
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Testing

```
bun run typecheck        OK
bun run typecheck:server OK
bun test                 856 pass, 0 fail (80 files)
bunx vite build          built in 516ms
bun run lint             0 errors
```

The load-bearing test is the round-trip in `hosted-envelope.test.ts`: publish an Original, **discard the live object and its SDK entirely**, rebuild it from the hosted CEL and resource bytes alone in a second SDK, and carry it to `did:btco` — asserting the migrate event lands, is signed, and is signed by the same controller. **That test could not have passed before the custody change in `d957ae8`.**

Its fixture CEL is a verbatim capture from a real create + publish in Chromium, and `assetDid` is re-derived from the genesis event rather than read out of the file — the test asserts the derivation reproduces the `sourceDid` the real migrate event recorded, so a tampered `cel.json` cannot point `loadAsset` at a different asset.

Also verified in Chromium that the anonymous demo is unaffected: create and publish still succeed, controller still ephemeral, `localStorage` still empty.

Rendering the three UI states caught two things the code read fine for: the detail-page eyebrow duplicated the button label, and above the cannot-be-inscribed explanation it read as an offer being withdrawn. Both fixed in `dbd4f82`.

## One limitation, stated plainly

**Originals created before this change can never be inscribed.** Their controller key only ever existed in one tab and is gone, and pre-anchor the CEL accepts only its current controller as signer — so no other key can ever sign their migrate, on any device. The action is disabled for them with copy that says so rather than implying signing in elsewhere would help, and says what remains true: their history stays signed, verifiable and hosted. Only Originals created from now on are resumable.

## Notes for the reviewer

Three judgement calls worth a veto:

- **This changes what signs an Original.** That is a custody decision reaching well beyond the four steps the work started from. It was approved in the originating session, but it deserves a second look here.
- **New copy in `content.ts`** (`yourOriginals.inscribe.*`). These are UI labels for a new affordance, not the marketing copy that was scoped out — but the file was named as out of bounds, so flagging it.
- **`/me` now does one extra same-origin fetch per row** (each Original's `cel.json`) to learn who controls it. The page already makes a per-row resolution probe, so this doubles that rather than introducing a new pattern.

Screenshots of all three states on `/me` and `/me/<did>` are in the originating session. They came from a throwaway harness with stubbed auth and fixtures, since a signed-in render needs a live Turnkey session; the harness is deleted and the working tree is clean.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012i8HcXsRWXBPgLMtmv6g6X

---
_Generated by [Claude Code](https://claude.ai/code/session_012i8HcXsRWXBPgLMtmv6g6X)_