### PR TITLE
fix(docs): point every install command at the tag that carries 3.x

### DIFF
--- a/.changeset/data-dir-is-fatal.md
+++ b/.changeset/data-dir-is-fatal.md
@@ -1,0 +1,5 @@
+---
+---
+
+Landing server only: a missing or unmounted `ORIGINALS_DATA_DIR` is now a hard
+startup failure on a deployed instance. No published package changed.

--- a/.changeset/dependency-audit-in-ci.md
+++ b/.changeset/dependency-audit-in-ci.md
@@ -1,0 +1,6 @@
+---
+---
+
+Repo tooling and docs: `bun audit` now runs in CI, root `overrides` clear every
+outstanding advisory (undici, js-yaml, brace-expansion, nanoid, postcss), and
+the two stale security docs are re-audited. No package source changed.

--- a/.changeset/install-commands-name-the-published-tag.md
+++ b/.changeset/install-commands-name-the-published-tag.md
@@ -1,0 +1,6 @@
+---
+---
+
+Docs and CI only: every published install command now names `@next`, and a new
+CI job asks the registry what those commands actually resolve to. No package
+code changed.

--- a/.changeset/readme-quick-starts-execute.md
+++ b/.changeset/readme-quick-starts-execute.md
@@ -1,0 +1,5 @@
+---
+---
+
+Docs and CI only: both README quick starts are now executable and are run
+against the built dist by a new CI gate. No package code changed.

--- a/.changeset/single-instance-guard.md
+++ b/.changeset/single-instance-guard.md
@@ -1,0 +1,6 @@
+---
+---
+
+Landing server only: replicas pinned to 1 and a boot-time guard that refuses to
+start if another process is writing to the data dir. No published package
+changed.

--- a/.changeset/verify-returns-a-report.md
+++ b/.changeset/verify-returns-a-report.md
@@ -1,0 +1,25 @@
+---
+"@originals/sdk": major
+---
+
+`asset.verify()` uses the SDK-configured `ordinalsProvider` and returns a
+`VerificationReport` instead of a bare boolean.
+
+**Breaking.** `asset.verify()` and `sdk.lifecycle.verifyAsset()` now resolve to
+`{ verified, code?, message?, details? }`. The report object is always truthy,
+so `if (await asset.verify())` silently becomes always-true — update call sites
+to check `.verified`.
+
+Two fixes behind one change:
+
+- Assets minted or loaded through `sdk.lifecycle` carry the configured
+  `ordinalsProvider`, so the documented create → publish → inscribe → verify
+  flow now ends `true`. It previously ended `false` for every inscribed asset
+  unless the caller re-passed a provider the SDK already held.
+- A failure now names a reason. In particular `ORDINALS_PROVIDER_REQUIRED`
+  distinguishes "the Bitcoin witness proof was not checked" from "the proof does
+  not hold" — a distinction a boolean could not express, and the one that
+  matters most for a provenance product.
+
+`checkGenesisResourceBinding` is now total: a resource whose hash is not sha256
+hex is simply not a match, where it previously threw.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,35 @@ jobs:
       - name: Typecheck, test and build the landing app against the built SDK
         run: bun run landing:check
 
+  audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.22
+
+      # --frozen-lockfile here specifically: an audit of a tree that drifted
+      # from the committed lockfile is an audit of something we do not ship.
+      - name: Install dependencies (bun)
+        run: bun install --frozen-lockfile
+
+      # --prod first and separately, because these are the advisories that
+      # reach EVERY consumer of the published packages: `npm audit` fires on
+      # their install, against dependencies they did not choose. A dev-only
+      # advisory is a smaller problem than a shipped one, and conflating them
+      # is how the shipped one sat unnoticed (undici 5.29.0, 10 highs, through
+      # jsonld).
+      - name: Audit production dependencies
+        run: bun audit --prod
+
+      - name: Audit all dependencies (including dev)
+        run: bun audit
+
   install-docs:
     name: Documented install commands resolve to this major
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,13 @@ jobs:
       - name: Verify browser-facing entry points have no eager Node builtins
         run: node scripts/check-browser-safety.mjs
 
+      # The quick starts are the first code an adopter runs. The root README's
+      # threw NO_CUSTODY on its happy path against this very dist and nothing
+      # noticed, because nothing had ever executed it. Runs here rather than in
+      # the package suites because it needs the BUILD.
+      - name: Execute the documented README snippets against the built dist
+        run: node scripts/check-readme-snippets.mjs
+
   landing:
     name: Landing app typechecks, tests and builds
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,27 @@ jobs:
       - name: Typecheck, test and build the landing app against the built SDK
         run: bun run landing:check
 
+  install-docs:
+    name: Documented install commands resolve to this major
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "20.10.0"
+
+      # Reads the LIVE registry: every `npm install @originals/*` in the shipped
+      # markdown must resolve to the major this repo documents. The launch-review
+      # bug (docs describing 3.x while `latest` served 2.1.0) is registry state,
+      # so no amount of source review catches it — only asking npm does.
+      # A registry failure fails this job rather than skipping it: a gate that
+      # passes when it could not check is how the bug shipped.
+      - name: Check install commands against the registry
+        run: node scripts/check-install-docs.mjs
+
   changeset:
     name: Changeset present
     # Only on PRs, and skip the "Version Packages" PR (which intentionally has no

--- a/README.md
+++ b/README.md
@@ -29,15 +29,31 @@ npm install @originals/sdk@next
 
 ## Quick Start
 
+This snippet runs as-is (`scripts/check-readme-snippets.mjs` executes it against
+the built `dist` in CI, so it cannot silently rot).
+
+<!-- readme:run -->
 ```typescript
 import { OriginalsSDK } from '@originals/sdk';
 import { OrdMockProvider } from '@originals/sdk/testing';
+
+// Custody first: createAsset mints an Ed25519 controller key, and the SDK
+// refuses to mint (NO_CUSTODY) if it has nowhere to keep it — an asset whose
+// key was dropped can never author another event. This Map is the smallest
+// thing that satisfies the contract; use a real keyStore, or a `signer` for
+// Turnkey/KMS/HSM custody, for anything you intend to keep.
+const keys = new Map<string, string>();
+const keyStore = {
+  getPrivateKey: async (id: string) => keys.get(id) ?? null,
+  setPrivateKey: async (id: string, privateKey: string) => { keys.set(id, privateKey); }
+};
 
 // For testing/development - use mock provider
 const originals = OriginalsSDK.create({
   network: 'regtest',
   enableLogging: true,
-  ordinalsProvider: new OrdMockProvider()
+  ordinalsProvider: new OrdMockProvider(),
+  keyStore
 });
 
 // Create a digital asset

--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ const published = await originals.lifecycle.publish(draft, 'did:webvh:my-domain.
 // Inscribe on Bitcoin for permanent ownership (mints did:btco:<sat>)
 const inscribed = await originals.lifecycle.inscribe(published);
 
+// Verify the whole signed chain. No argument needed: verify() uses the
+// ordinalsProvider from the SDK config, so the Bitcoin witness proof is
+// actually checked. On failure the report names a reason — `report.code` tells
+// a proof that does not hold apart from a check that could not run.
+const report = await inscribed.verify();
+console.log(report.verified, report.code ?? '');
+
 // Transfer ownership: a pure Bitcoin sat move. Ownership IS live sat control,
 // so this writes NOTHING to the CEL — read the owner back with getCurrentOwner().
 // await originals.lifecycle.transfer(inscribed, 'bc1q...newowner');

--- a/README.md
+++ b/README.md
@@ -18,8 +18,14 @@ Assets migrate unidirectionally through these layers, with economic gravity dete
 ## Installation
 
 ```bash
-npm install @originals/sdk
+npm install @originals/sdk@next
 ```
+
+> **Why `@next`:** 3.x is still a prerelease, so npm's `latest` tag deliberately
+> stays on the last stable release (2.1.0). Everything documented here — `did:cel`
+> genesis, the CEL event log, custody-required signers, the `./testing` subpath —
+> is 3.x only, so a bare `npm install @originals/sdk` would hand you a different
+> SDK than this README describes. Drop the tag once 3.0.0 ships to `latest`.
 
 ## Quick Start
 

--- a/apps/landing/DEPLOY.md
+++ b/apps/landing/DEPLOY.md
@@ -25,7 +25,15 @@ state, so the checklist below is the only place they are written down.
 ## Environment contract
 
 `apps/landing/server/config.ts` validates this at boot and reports every
-violation by name. It is **warn-only** unless `CONFIG_STRICT=1`. See
+violation by name. It is **warn-only** unless `CONFIG_STRICT=1`, with one
+exception: **the durable data directory is always fatal on a deploy.**
+
+`ORIGINALS_DATA_DIR` unset, unwritable, or writable-but-not-a-mounted-volume
+**refuses the boot regardless of `CONFIG_STRICT`.** That path holds the only
+copies of signed reveal transactions, so booting past it means accepting a
+stranger's Bitcoin while writing the one artifact that could recover it to
+storage a redeploy deletes. A service that is down is recoverable in minutes;
+that data is not recoverable at all. Every other rule is unchanged — see
 "Turning on strict mode" before you set that flag.
 
 ### Server, read at runtime
@@ -59,9 +67,13 @@ real-money action; a mismatch is reported in both directions.
 Run one deploy with the code as-is and read the boot log. Do not proceed while
 any of these is outstanding.
 
-1. **Volume attached and mounted.** The log must not say the data directory is
-   writable but not a mounted volume. Writability alone passes on exactly the
-   ephemeral path this check exists to catch.
+1. **Volume attached and mounted.** Enforced at boot: the server now refuses
+   to start if the data directory is unset, unwritable, or writable but not a
+   mounted volume — regardless of `CONFIG_STRICT`. Writability alone passes on
+   exactly the ephemeral path this check exists to catch, which is why the
+   mount check and not the write probe is the gate. If the deploy is crash-
+   looping with `[fatal] ORIGINALS_DATA_DIR`, the volume is the problem; attach
+   it and point `ORIGINALS_DATA_DIR` at its mount path.
 2. **Scheduled backup enabled.** Railway backups are opt-in and there is no
    published durability SLA. Record the schedule and who enabled it in the log
    at the bottom of this file — the setting is dashboard-only and cannot
@@ -97,9 +109,13 @@ any of these is outstanding.
 
 ## Turning on strict mode
 
-`CONFIG_STRICT=1` turns every contract violation into a refusal to start.
-`/railway.json` caps restarts at 5, so flipping it against an environment that
-does not satisfy the contract takes the site down rather than degrading it.
+`CONFIG_STRICT=1` turns every remaining contract violation into a refusal to
+start. `/railway.json` caps restarts at 5, so flipping it against an environment
+that does not satisfy the contract takes the site down rather than degrading it.
+
+It does **not** govern the data directory: those violations are fatal either
+way (see "Environment contract"), so unsetting `CONFIG_STRICT` is not a way to
+boot past a missing volume, and was never meant to be.
 
 Deploy warn-only first, read the boot log, and fix everything it names —
 `NODE_ENV` and `TRUSTED_PROXY_HOPS` in particular are ones Railway does not

--- a/apps/landing/DEPLOY.md
+++ b/apps/landing/DEPLOY.md
@@ -18,9 +18,34 @@ inscription path is live it strands real money.
 | Start command | `bun run apps/landing/serve.ts` |
 | Persistent volume | required, mounted, with `ORIGINALS_DATA_DIR` pointing at it |
 
-`/railway.json` at the repo root carries the build and start commands. It does
-**not** declare the volume or any environment variable — those are dashboard
-state, so the checklist below is the only place they are written down.
+`/railway.json` at the repo root carries the build and start commands, and pins
+**`numReplicas: 1`**. It does **not** declare the volume or any environment
+variable — those are dashboard state, so the checklist below is the only place
+they are written down.
+
+### Why one replica, and why the process now enforces it
+
+`numReplicas: 1` is load-bearing, not a cost setting. Everything on the money
+path coordinates through in-process state: the double-spend guard is a promise
+chain keyed by JWT sub, every rate limiter is an in-memory Map, the deposit
+sweep walks a process-local cursor, and both file stores serialize their
+read-modify-write on the single-threaded event loop. Each is correct for
+exactly one writer.
+
+Two writers is not a degraded version of that. Two replicas polling the same
+user's inscription both see the same funding outpoint as unspent, both build a
+commit against it, and the loser's reveal is stranded on a double-spent commit
+— a creator's BTC committed to an inscription that can never land.
+
+JSON has no comments, so the reason lives here. And because a dashboard click or
+an autoscale rule can override the pin regardless, the process no longer trusts
+it: on boot it claims a heartbeat lock file in the data directory
+(`.instance.lock`) and **refuses to start if another live process already holds
+it**, logging the holder's pid and host. A crashed holder is detected by PID on
+the same host, or after 60 quiet seconds across a restart, and the next start
+takes over. If you ever need to clear one by hand, delete
+`$ORIGINALS_DATA_DIR/.instance.lock` — but only once you are certain no other
+instance is running.
 
 ## Environment contract
 
@@ -78,11 +103,15 @@ any of these is outstanding.
    published durability SLA. Record the schedule and who enabled it in the log
    at the bottom of this file — the setting is dashboard-only and cannot
    appear in a commit, so that line is the only evidence it happened.
-3. **`TRUSTED_PROXY_HOPS` set** (Railway edge = `1`). Until it is, the
+3. **One replica.** `railway.json` pins `numReplicas: 1` and the boot log must
+   read `sole writer to that dir`. If a deploy is refusing to start with
+   "another process is already writing", the service is scaled above one —
+   scale it back rather than deleting the lock.
+4. **`TRUSTED_PROXY_HOPS` set** (Railway edge = `1`). Until it is, the
    per-client rate limits are inert and everyone shares one bucket. Confirm it
    from the `[landing] proxy sample:` line the server logs once per process:
    the resolved identity must be your address, not the proxy's.
-4. **`QUICKNODE_ENDPOINT` reaches a mainnet node with the Ordinals & Runes
+5. **`QUICKNODE_ENDPOINT` reaches a mainnet node with the Ordinals & Runes
    add-on.** Without the add-on, sat lookup returns `SAT_INDEX_UNAVAILABLE`
    and inscription is impossible. `bun scripts/check:ordinals` — i.e.
    `bun scripts/check-quicknode-ordinals.ts` — is the pre-deploy probe; it
@@ -94,7 +123,7 @@ any of these is outstanding.
    blocked at the edge, and the Ordinals add-on maps outpoint→address and
    sat→address only), so deposit polling costs no QuickNode quota and lives
    behind `BTC_INDEXER_API` instead.
-5. **One live Turnkey OTP verification.** Outstanding since PR #356. This
+6. **One live Turnkey OTP verification.** Outstanding since PR #356. This
    check earned its place twice over: the login path was broken the entire time
    it went unrun, in two independent ways, and neither was reachable from any
    test. It first sent a DER signature where OTP_LOGIN wants raw IEEE-P1363
@@ -104,7 +133,7 @@ any of these is outstanding.
    credential being installed cannot already exist. It now runs STAMP_LOGIN
    with the attested stamp, which is what `@turnkey/core` does. The only thing
    that proves it works is running it against a real org.
-6. **One complete mainnet inscription by a human**, from a cold browser,
+7. **One complete mainnet inscription by a human**, from a cold browser,
    before anyone else is invited.
 
 ## Turning on strict mode

--- a/apps/landing/serve.ts
+++ b/apps/landing/serve.ts
@@ -43,7 +43,12 @@ import { checkConfig, isStrictConfig, resolveDataDir } from './server/config';
 
 // The configuration contract (R10/R23), FIRST: a deployed instance missing or
 // malforming a required value says so by name here, before a single request is
-// served. Warn-only until CONFIG_STRICT=1 — see server/config.ts for why.
+// served. Warn-only until CONFIG_STRICT=1 — see server/config.ts for why —
+// EXCEPT the durable data directory, which THROWS here on a deployed instance
+// no matter what CONFIG_STRICT says. That directory holds the only copies of
+// signed reveal transactions; a process that boots without it takes strangers'
+// Bitcoin and writes the one artifact that could recover it to storage a
+// redeploy deletes. Crash-looping is the better failure.
 const configIssues = checkConfig();
 
 const DIST = new URL('./dist/', import.meta.url).pathname;

--- a/apps/landing/serve.ts
+++ b/apps/landing/serve.ts
@@ -40,6 +40,7 @@ import { createOriginalsStore } from './server/originals-store';
 import { createInscriptionsStore } from './server/inscriptions-store';
 import { createOriginalsRoutes, type OriginalsRoutes } from './server/originals-routes';
 import { checkConfig, isStrictConfig, resolveDataDir } from './server/config';
+import { acquireInstanceLock, releaseOnExit } from './server/instance-lock';
 
 // The configuration contract (R10/R23), FIRST: a deployed instance missing or
 // malforming a required value says so by name here, before a single request is
@@ -62,6 +63,15 @@ const hostStore = createWebvhHostStore();
 // deploy that dir is ephemeral and every redeploy silently wipes signed-in
 // users' Originals (checkConfig() above reports exactly that, by name).
 const { path: originalsDataDir, explicit: originalsDataDirIsExplicit } = resolveDataDir(process.env);
+// Single-instance enforcement, BEFORE any store opens the directory. This
+// process is single-instance by construction — the double-spend guard, every
+// rate limiter and both file stores coordinate through in-process state — and
+// railway.json pins numReplicas to 1, but a dashboard click or an autoscale
+// rule can still put a second writer on this volume. Refuse rather than let two
+// commits go live against one funding set. Throws MultipleInstanceError.
+const instanceLock = acquireInstanceLock(originalsDataDir, { log: (m) => console.warn(m) });
+releaseOnExit(instanceLock);
+
 const originalsStore = createOriginalsStore({ dataDir: originalsDataDir });
 // In-flight commit+reveal pairs persist next to the Originals (same data dir,
 // same JWT-sub namespacing) so a dead tab can never strand committed funds.
@@ -209,6 +219,9 @@ console.log(
 );
 console.log(
   `[landing] durable Originals dir: ${originalsDataDir}${originalsDataDirIsExplicit ? '' : ' (default — NOT set via ORIGINALS_DATA_DIR)'}`
+);
+console.log(
+  `[landing] sole writer to that dir (instance lock ${instanceLock.path}, owner ${instanceLock.record.owner})`
 );
 
 // Monitoring sweep (stranger-safe checklist): any inscription still holding

--- a/apps/landing/server/config.ts
+++ b/apps/landing/server/config.ts
@@ -14,6 +14,18 @@
  * CONFIG_STRICT=1. Rollback is unsetting that one variable — no redeploy of
  * code.
  *
+ * ONE exception, and it is deliberately not on that ladder: the durable data
+ * directory. `ORIGINALS_DATA_DIR` holds the only copy of signed reveal
+ * transactions — the single artifact standing between a dead browser tab and a
+ * creator's permanently committed BTC. A deployed instance that boots without a
+ * real volume there accepts money it cannot let anyone recover, and it does so
+ * silently, because a warning on a platform where nobody reads boot logs is
+ * indistinguishable from silence. Those issues are `fatal`: they refuse the
+ * boot on a deployed instance regardless of CONFIG_STRICT. A service that is
+ * down is recoverable in minutes. Reveal hex written to a tmpfs that a redeploy
+ * wipes is not recoverable at all. Locally they stay warnings — CONFIG_STRICT's
+ * meaning is unchanged for every other rule.
+ *
  * Every rule is a pure function over an env snapshot plus a data-dir probe, so
  * "writable but not a mounted volume" is testable without a container.
  */
@@ -22,7 +34,17 @@ import { join, isAbsolute } from 'node:path';
 import { isLikelyDeployed } from './deploy-env';
 import { isBitcoinConfigured, serverBtcNetwork } from './bitcoin';
 
-export type ConfigSeverity = 'error' | 'warn';
+/**
+ * - `warn`  — degrading as configured; never fatal.
+ * - `error` — a deployed instance is misconfigured; fatal only under CONFIG_STRICT.
+ * - `fatal` — fatal on a deployed instance NO MATTER WHAT CONFIG_STRICT says.
+ *
+ * `fatal` exists for exactly one class of misconfiguration: the one where
+ * booting anyway destroys something that cannot be recovered. Everything else
+ * stays on the warn-then-strict ladder the module header describes, and
+ * CONFIG_STRICT keeps its meaning for all of it.
+ */
+export type ConfigSeverity = 'error' | 'warn' | 'fatal';
 
 export interface ConfigIssue {
   /** The env var at fault. Always named — a report you cannot act on is noise. */
@@ -268,23 +290,39 @@ export function validateConfig(input: ConfigInput): ConfigIssue[] {
     );
   }
 
-  // Durable data. Only signed-in users have any, so this follows the auth surface.
+  // Durable data. Only signed-in users have any, so this follows the auth
+  // surface. On a DEPLOYED instance every one of these is `fatal`, not `error`:
+  // see the module header. Each is the same failure — this process is about to
+  // accept a stranger's Bitcoin and write the only copy of the signed reveal
+  // somewhere that does not survive — and none of them is a judgement call an
+  // operator should be able to defer by leaving CONFIG_STRICT unset.
   if (authIntended(env)) {
+    const dataDirSeverity: ConfigSeverity = deployed ? 'fatal' : 'warn';
+    const reportDataDir = (message: string) =>
+      issues.push({ key: 'ORIGINALS_DATA_DIR', severity: dataDirSeverity, message });
+    const RECOVERY_STAKES =
+      'This path holds the only copies of signed reveal transactions — the one thing standing between a ' +
+      'dead browser tab and a creator\'s permanently committed BTC.';
+
     const { explicit } = resolveDataDir(env);
     if (!explicit) {
-      report(
-        'ORIGINALS_DATA_DIR',
-        `ORIGINALS_DATA_DIR is not set — durable Originals fall back to ${DEFAULT_DATA_DIR}, which a redeploy wipes.`
+      reportDataDir(
+        `ORIGINALS_DATA_DIR is not set — durable Originals fall back to ${DEFAULT_DATA_DIR}, which is inside ` +
+          `the container and which every redeploy wipes. ${RECOVERY_STAKES} Attach a persistent volume and set ` +
+          `ORIGINALS_DATA_DIR to its mount path.`
       );
     }
     const probe = input.dataDir;
     if (probe) {
       if (!probe.writable) {
-        report('ORIGINALS_DATA_DIR', `ORIGINALS_DATA_DIR (${probe.path}) is not writable.`);
+        reportDataDir(
+          `ORIGINALS_DATA_DIR (${probe.path}) is not writable — nothing can be persisted at all. ${RECOVERY_STAKES}`
+        );
       } else if (deployed && explicit && !isMountedVolume(probe.path, probe.mountPoints)) {
-        report(
-          'ORIGINALS_DATA_DIR',
-          `ORIGINALS_DATA_DIR (${probe.path}) is writable but is not a mounted volume — attach a persistent volume and point it at the mount path. Writability alone survives nothing: a redeploy deletes this path, and it holds the only copies of signed reveal transactions.`
+        reportDataDir(
+          `ORIGINALS_DATA_DIR (${probe.path}) is writable but is not a mounted volume — attach a persistent ` +
+            `volume and point it at the mount path. Writability alone survives nothing: a redeploy deletes this ` +
+            `path. ${RECOVERY_STAKES}`
         );
       }
     }
@@ -343,9 +381,9 @@ export function isStrictConfig(env: Record<string, string | undefined> = process
   return v === '1' || v === 'true';
 }
 
-export function formatConfigReport(issues: ConfigIssue[], strict: boolean): string {
+export function formatConfigReport(issues: ConfigIssue[], refusing: boolean): string {
   const errors = issues.filter((i) => i.severity === 'error');
-  const head = strict
+  const head = refusing
     ? 'Refusing to start — the configuration contract is not met:'
     : errors.length > 0
       ? 'Configuration contract NOT met (warn-only: set CONFIG_STRICT=1 to make this fatal):'
@@ -355,8 +393,14 @@ export function formatConfigReport(issues: ConfigIssue[], strict: boolean): stri
 }
 
 /**
- * Report the issues, and in strict mode throw on the first deployed-environment
- * error. Pure over its `log` sink so a test never writes to the console.
+ * Report the issues, and refuse the boot when they include either a `fatal`
+ * issue (always) or, under CONFIG_STRICT, a deployed-environment `error`. Pure
+ * over its `log` sink so a test never writes to the console.
+ *
+ * `strict` does NOT gate `fatal`. That is the whole point of the severity: a
+ * missing data volume is not a policy question, and leaving CONFIG_STRICT unset
+ * must not be a way to boot past it. CONFIG_STRICT's meaning for `error` is
+ * exactly what it was.
  */
 export function enforceConfig(
   issues: ConfigIssue[],
@@ -365,9 +409,11 @@ export function enforceConfig(
   if (issues.length === 0) return;
   const strict = opts.strict ?? isStrictConfig();
   const log = opts.log ?? ((m: string) => console.warn(m));
+  const fatal = issues.filter((i) => i.severity === 'fatal');
   const errors = issues.filter((i) => i.severity === 'error');
-  const message = formatConfigReport(issues, strict && errors.length > 0);
-  if (strict && errors.length > 0) throw new Error(message);
+  const refusing = fatal.length > 0 || (strict && errors.length > 0);
+  const message = formatConfigReport(issues, refusing);
+  if (refusing) throw new Error(message);
   log(message);
 }
 

--- a/apps/landing/server/instance-lock.ts
+++ b/apps/landing/server/instance-lock.ts
@@ -1,0 +1,296 @@
+/**
+ * Single-instance enforcement for the data directory.
+ *
+ * Everything on the money path assumes one process. The double-spend guard is
+ * an in-process promise chain keyed by JWT sub (`subLocks` in bitcoin.ts), every
+ * rate limiter is an in-memory Map, the deposit sweep walks a process-local
+ * cursor, and both file stores serialize their read-modify-write with nothing
+ * but the single-threaded event loop. Each of those is correct — and documented
+ * as such — for exactly one writer.
+ *
+ * Two writers is not a degraded version of that. Two replicas polling the same
+ * user's inscription both see the same funding outpoint as unspent, both build
+ * a commit against it, and the loser's reveal is stranded on a double-spent
+ * commit: a creator's BTC committed to an inscription that can never land. The
+ * platform makes that one dashboard click (or one autoscale rule) away, and
+ * nothing in the process would notice.
+ *
+ * So the process asks the volume — the one thing every writer shares — whether
+ * anyone else is already writing to it, and refuses to start if so.
+ *
+ * The mechanism is a heartbeat lock file, with `O_EXCL` create as the atomic
+ * primitive. Whether a lock may be TAKEN depends on what we can actually
+ * observe (see `isAbandoned`):
+ *
+ *   - Same host: the PID probe is authoritative in both directions. A dead pid
+ *     frees the lock instantly (a crashed dev server costs no wait), and a live
+ *     one holds it however stale the heartbeat — a wedged process is still a
+ *     writer.
+ *   - Another host: we cannot see its processes, so a heartbeat that has gone
+ *     quiet longer than STALE_AFTER_MS is the only evidence of death. This is
+ *     the container case: a crashed container never releases its lock, and a
+ *     restart arrives with a fresh hostname and PID.
+ */
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  unlinkSync,
+  writeSync,
+} from 'node:fs';
+import { hostname } from 'node:os';
+import { join } from 'node:path';
+
+export const LOCK_FILENAME = '.instance.lock';
+
+/** How often the holder proves it is still alive. */
+export const HEARTBEAT_MS = 10_000;
+/**
+ * How quiet a lock must go before another process may claim it. Six missed
+ * heartbeats: long enough that a GC pause, a slow fsync or a busy event loop
+ * never looks like death, short enough that a crash-restart is not left
+ * waiting minutes for a volume it already owns.
+ */
+export const STALE_AFTER_MS = 60_000;
+
+export interface LockRecord {
+  /** Unique per acquisition — this is what proves WE won a contested write. */
+  owner: string;
+  pid: number;
+  hostname: string;
+  startedAt: string;
+  heartbeatAt: string;
+}
+
+export interface InstanceLock {
+  /** The record this process wrote. */
+  record: LockRecord;
+  path: string;
+  /** Stop heartbeating and remove the lock. Idempotent. */
+  release(): void;
+}
+
+export class MultipleInstanceError extends Error {
+  constructor(
+    message: string,
+    readonly holder: LockRecord
+  ) {
+    super(message);
+    this.name = 'MultipleInstanceError';
+  }
+}
+
+/** Injectable clock/identity/process seams so the whole policy is testable. */
+export interface LockEnvironment {
+  now(): number;
+  pid: number;
+  host: string;
+  /** True when a process with this pid exists. Only meaningful on this host. */
+  isProcessAlive(pid: number): boolean;
+  newOwnerId(): string;
+}
+
+export const systemEnvironment: LockEnvironment = {
+  now: () => Date.now(),
+  pid: process.pid,
+  host: hostname(),
+  isProcessAlive: (pid) => {
+    try {
+      // Signal 0 performs the permission/existence check without delivering.
+      process.kill(pid, 0);
+      return true;
+    } catch (err) {
+      // EPERM means it EXISTS but belongs to another user — alive, not absent.
+      return (err as NodeJS.ErrnoException)?.code === 'EPERM';
+    }
+  },
+  newOwnerId: () => `${process.pid}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`,
+};
+
+function readLock(path: string): LockRecord | null {
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as Partial<LockRecord>;
+    if (
+      typeof parsed?.owner !== 'string' ||
+      typeof parsed?.pid !== 'number' ||
+      typeof parsed?.hostname !== 'string' ||
+      typeof parsed?.heartbeatAt !== 'string'
+    ) {
+      return null;
+    }
+    return parsed as LockRecord;
+  } catch {
+    // Missing, truncated or garbage. A lock we cannot read cannot be honoured;
+    // treat it as absent rather than deadlocking the service on a bad byte.
+    return null;
+  }
+}
+
+/**
+ * Is `holder` abandoned — safe for us to take over?
+ *
+ * Same host: a PID probe is authoritative and instant. Different host: we can
+ * only wait out the heartbeat, because we cannot see that machine's processes
+ * and must assume a live replica until proven otherwise.
+ */
+export function isAbandoned(holder: LockRecord, env: LockEnvironment): boolean {
+  if (holder.hostname === env.host) {
+    // We can see this host's processes, so liveness is authoritative in BOTH
+    // directions — and staleness must not override it. A process that is
+    // running but has stopped heartbeating (wedged event loop, a disk that is
+    // failing our heartbeat writes) is still a writer, and taking its lock
+    // would create exactly the two-writer condition this guard exists to
+    // prevent. Refusing costs availability; taking it costs a creator's BTC.
+    //
+    // The cost of that choice is PID reuse: after a same-host crash, an
+    // unrelated process may inherit the pid and hold this lock indefinitely.
+    // That is a wedged deploy with a loud message and a one-line manual
+    // remedy (delete the lock file), which is the cheaper failure. On a
+    // container platform a restart brings a new hostname anyway, so that path
+    // falls to the staleness rule below.
+    return !env.isProcessAlive(holder.pid);
+  }
+  // Another machine: we cannot probe it, so a fresh heartbeat is the whole of
+  // the evidence and must be believed until it goes quiet.
+  const beat = Date.parse(holder.heartbeatAt);
+  const quietFor = Number.isFinite(beat) ? env.now() - beat : Infinity;
+  return quietFor > STALE_AFTER_MS;
+}
+
+function writeRecord(path: string, record: LockRecord, exclusive: boolean): boolean {
+  let fd: number;
+  try {
+    fd = openSync(path, exclusive ? 'wx' : 'w');
+  } catch (err) {
+    if (exclusive && (err as NodeJS.ErrnoException)?.code === 'EEXIST') return false;
+    throw err;
+  }
+  try {
+    writeSync(fd, JSON.stringify(record));
+  } finally {
+    closeSync(fd);
+  }
+  return true;
+}
+
+function describe(holder: LockRecord): string {
+  return `pid ${holder.pid} on host ${holder.hostname} (started ${holder.startedAt}, last heartbeat ${holder.heartbeatAt})`;
+}
+
+/**
+ * Claim the data directory, or throw {@link MultipleInstanceError}.
+ *
+ * @param setInterval - injected so tests do not leave a live timer behind.
+ */
+export function acquireInstanceLock(
+  dataDir: string,
+  opts: {
+    env?: LockEnvironment;
+    log?: (message: string) => void;
+    setInterval?: (fn: () => void, ms: number) => { unref?: () => void };
+    clearInterval?: (handle: unknown) => void;
+  } = {}
+): InstanceLock {
+  const env = opts.env ?? systemEnvironment;
+  const log = opts.log ?? ((m: string) => console.warn(m));
+  const path = join(dataDir, LOCK_FILENAME);
+
+  mkdirSync(dataDir, { recursive: true });
+
+  const stamp = () => new Date(env.now()).toISOString();
+  const record: LockRecord = {
+    owner: env.newOwnerId(),
+    pid: env.pid,
+    hostname: env.host,
+    startedAt: stamp(),
+    heartbeatAt: stamp(),
+  };
+
+  if (!writeRecord(path, record, true)) {
+    const holder = readLock(path);
+    if (holder && !isAbandoned(holder, env)) {
+      throw new MultipleInstanceError(
+        `[landing] Refusing to start: another process is already writing to ${dataDir} — ${describe(holder)}.\n` +
+          `  This service is single-instance by construction. The double-spend guard, every rate limiter and both\n` +
+          `  file stores coordinate through in-process state, so a second writer can build a second commit against\n` +
+          `  a funding outpoint the first already spent — stranding a creator's committed BTC on a reveal that can\n` +
+          `  never land.\n` +
+          `  If you scaled this service up, scale it back to ONE replica (railway.json pins numReplicas: 1).\n` +
+          `  If that process is genuinely gone, its lock goes stale ${STALE_AFTER_MS / 1000}s after its last\n` +
+          `  heartbeat and the next start will take over; you can also delete ${path} by hand once you are sure.`,
+        holder
+      );
+    }
+    if (holder) {
+      log(
+        `[landing] taking over an abandoned instance lock at ${path} — previous holder ${describe(holder)}.`
+      );
+    } else {
+      log(`[landing] replacing an unreadable instance lock at ${path}.`);
+    }
+    writeRecord(path, record, false);
+
+    // Two processes can both find the lock abandoned and both rewrite it. The
+    // exclusive create cannot arbitrate that, so the owner id does: re-read,
+    // and whoever is not in the file steps aside. One of them always is.
+    const settled = readLock(path);
+    if (!settled || settled.owner !== record.owner) {
+      throw new MultipleInstanceError(
+        `[landing] Refusing to start: lost a race for the instance lock at ${path} — ` +
+          `${settled ? describe(settled) : 'another process'} claimed it. This is the correct outcome; ` +
+          `only one process may write to ${dataDir}.`,
+        settled ?? record
+      );
+    }
+  }
+
+  const schedule = opts.setInterval ?? ((fn, ms) => setInterval(fn, ms));
+  const cancel = opts.clearInterval ?? ((h) => clearInterval(h as ReturnType<typeof setInterval>));
+
+  const timer = schedule(() => {
+    record.heartbeatAt = stamp();
+    try {
+      writeRecord(path, record, false);
+    } catch (err) {
+      // A failed heartbeat is not worth killing a running service over: the
+      // lock simply ages toward stale, and the volume problem behind it will
+      // surface far more loudly on the next real write.
+      log(`[landing] instance-lock heartbeat failed: ${(err as Error)?.message}`);
+    }
+  }, HEARTBEAT_MS);
+  // Never hold the event loop open for the heartbeat alone.
+  timer.unref?.();
+
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
+    cancel(timer);
+    try {
+      // Only remove a lock that is still OURS — a takeover after a stale
+      // window must not have its lock deleted by the process it replaced.
+      if (existsSync(path) && readLock(path)?.owner === record.owner) unlinkSync(path);
+    } catch {
+      // Best effort: a lock left behind goes stale on its own.
+    }
+  };
+
+  return { record, path, release };
+}
+
+/**
+ * Wire `release()` to the ways this process ends, so an orderly shutdown frees
+ * the volume immediately instead of making the next start wait out staleness.
+ */
+export function releaseOnExit(lock: InstanceLock): void {
+  const off = () => lock.release();
+  process.once('exit', off);
+  for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP'] as const) {
+    process.once(signal, () => {
+      off();
+      process.exit(0);
+    });
+  }
+}

--- a/apps/landing/server/tests/config.test.ts
+++ b/apps/landing/server/tests/config.test.ts
@@ -31,6 +31,12 @@ const GOOD = {
 const mounted: DataDirProbe = { path: '/data', writable: true, mountPoints: ['/data'] };
 
 const errors = (issues: ConfigIssue[]) => issues.filter((i) => i.severity === 'error');
+/**
+ * Data-dir issues are `fatal` on a deployed instance, not `error`: they refuse
+ * the boot regardless of CONFIG_STRICT, because booting past a missing volume
+ * destroys the only copy of signed reveal hex. See config.ts's header.
+ */
+const fatals = (issues: ConfigIssue[]) => issues.filter((i) => i.severity === 'fatal');
 const keys = (issues: ConfigIssue[]) => issues.map((i) => i.key);
 const without = (env: Record<string, string | undefined>, key: string) => {
   const next = { ...env };
@@ -114,23 +120,23 @@ describe('validateConfig — deployed environment', () => {
     expect(keys(issues)).toContain('QUICKNODE_ENDPOINT');
   });
 
-  test('a missing ORIGINALS_DATA_DIR is reported', () => {
-    const issues = errors(
+  test('a missing ORIGINALS_DATA_DIR is FATAL', () => {
+    const issues = fatals(
       validateConfig({ env: without(GOOD, 'ORIGINALS_DATA_DIR'), dataDir: null })
     );
     expect(keys(issues)).toContain('ORIGINALS_DATA_DIR');
   });
 
-  test('an unwritable data directory is reported', () => {
-    const issues = errors(
+  test('an unwritable data directory is FATAL', () => {
+    const issues = fatals(
       validateConfig({ env: GOOD, dataDir: { ...mounted, writable: false } })
     );
     expect(keys(issues)).toEqual(['ORIGINALS_DATA_DIR']);
     expect(issues[0].message).toMatch(/writ/i);
   });
 
-  test('a path that is writable but not a mounted volume fails', () => {
-    const issues = errors(
+  test('a path that is writable but not a mounted volume is FATAL', () => {
+    const issues = fatals(
       validateConfig({
         env: { ...GOOD, ORIGINALS_DATA_DIR: '/app/.originals-data', RAILWAY_VOLUME_MOUNT_PATH: '/data' },
         dataDir: { path: '/app/.originals-data', writable: true, mountPoints: ['/data'] },
@@ -138,6 +144,16 @@ describe('validateConfig — deployed environment', () => {
     );
     expect(keys(issues)).toEqual(['ORIGINALS_DATA_DIR']);
     expect(issues[0].message).toMatch(/volume|mount/i);
+  });
+
+  test('every data-dir message names what is actually at stake', () => {
+    for (const input of [
+      { env: without(GOOD, 'ORIGINALS_DATA_DIR'), dataDir: null },
+      { env: GOOD, dataDir: { ...mounted, writable: false } },
+    ]) {
+      const [issue] = fatals(validateConfig(input));
+      expect(issue.message).toMatch(/signed reveal/i);
+    }
   });
 
   test('an absent trusted-proxy hop count is reported naming it', () => {
@@ -197,7 +213,7 @@ describe('validateConfig — local environment', () => {
     expect(validateConfig({ env: { NODE_ENV: 'development' }, dataDir: null })).toEqual([]);
   });
 
-  test('locally a missing ORIGINALS_DATA_DIR warns rather than erroring', () => {
+  test('locally a missing ORIGINALS_DATA_DIR warns rather than erroring or being fatal', () => {
     const env = {
       JWT_SECRET: 'x'.repeat(32),
       TURNKEY_API_PUBLIC_KEY: 'pub',
@@ -206,6 +222,7 @@ describe('validateConfig — local environment', () => {
     };
     const issues = validateConfig({ env, dataDir: null });
     expect(errors(issues)).toEqual([]);
+    expect(fatals(issues)).toEqual([]);
     expect(keys(issues)).toContain('ORIGINALS_DATA_DIR');
   });
 
@@ -330,6 +347,36 @@ describe('strict mode', () => {
     });
     expect(() => enforceConfig(issues, { strict: true, log: () => {} })).toThrow(/JWT_SECRET/);
     expect(() => enforceConfig(issues, { strict: true, log: () => {} })).toThrow(/TRUSTED_PROXY_HOPS/);
+  });
+
+  test('a FATAL issue refuses the boot even with CONFIG_STRICT off', () => {
+    // The whole point of the severity: an operator who has not opted into
+    // strict mode must not thereby boot past a missing data volume.
+    const fatal: ConfigIssue[] = [
+      { key: 'ORIGINALS_DATA_DIR', severity: 'fatal', message: 'not a mounted volume' },
+    ];
+    expect(() => enforceConfig(fatal, { strict: false, log: () => {} })).toThrow(/ORIGINALS_DATA_DIR/);
+    expect(() => enforceConfig(fatal, { strict: true, log: () => {} })).toThrow(/ORIGINALS_DATA_DIR/);
+  });
+
+  test('a deployed instance with no volume refuses to boot with CONFIG_STRICT unset', () => {
+    // End to end through validateConfig, which is how serve.ts reaches it.
+    const issues = validateConfig({
+      env: { ...GOOD, ORIGINALS_DATA_DIR: '/app/.originals-data' },
+      dataDir: { path: '/app/.originals-data', writable: true, mountPoints: ['/data'] },
+    });
+    expect(() => enforceConfig(issues, { strict: false, log: () => {} })).toThrow(/ORIGINALS_DATA_DIR/);
+  });
+
+  test('CONFIG_STRICT keeps its exact meaning for everything that is not fatal', () => {
+    // No fatal issue present: warn-only still boots, strict still refuses.
+    // Introducing `fatal` changed nothing about this ladder.
+    const nonFatal: ConfigIssue[] = [
+      { key: 'JWT_SECRET', severity: 'error', message: 'too short' },
+      { key: 'BTC_INDEXER_API', severity: 'warn', message: 'public tier' },
+    ];
+    expect(() => enforceConfig(nonFatal, { strict: false, log: () => {} })).not.toThrow();
+    expect(() => enforceConfig(nonFatal, { strict: true, log: () => {} })).toThrow(/JWT_SECRET/);
   });
 
   test('warn-only mode reports the same violations without throwing', () => {

--- a/apps/landing/server/tests/instance-lock.test.ts
+++ b/apps/landing/server/tests/instance-lock.test.ts
@@ -1,0 +1,232 @@
+/**
+ * The single-instance guard.
+ *
+ * The failure it exists to prevent: two replicas sharing the volume, both
+ * seeing the same funding outpoint as unspent, both building a commit against
+ * it — and the loser's reveal stranded on a double-spent commit, which is a
+ * creator's BTC committed to an inscription that can never land. Everything on
+ * the money path coordinates through in-process state, so nothing downstream
+ * would notice.
+ *
+ * Every test drives the real filesystem through a tmp dir, with the clock,
+ * pid, hostname and liveness probe injected so the staleness policy is
+ * exercised without sleeping.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  acquireInstanceLock,
+  isAbandoned,
+  MultipleInstanceError,
+  LOCK_FILENAME,
+  STALE_AFTER_MS,
+  type LockEnvironment,
+  type LockRecord,
+} from '../instance-lock';
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'instance-lock-'));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** A controllable process identity. `alive` is the set of live pids on this host. */
+function makeEnv(over: Partial<LockEnvironment> & { alive?: Set<number> } = {}): LockEnvironment {
+  const alive = over.alive ?? new Set<number>();
+  let seq = 0;
+  return {
+    now: over.now ?? (() => 1_700_000_000_000),
+    pid: over.pid ?? 100,
+    host: over.host ?? 'host-a',
+    isProcessAlive: over.isProcessAlive ?? ((pid) => alive.has(pid)),
+    newOwnerId: over.newOwnerId ?? (() => `owner-${over.pid ?? 100}-${seq++}`),
+  };
+}
+
+/** No real timers in tests: the heartbeat is scheduled through this. */
+const noTimers = {
+  setInterval: () => ({ unref: () => {} }),
+  clearInterval: () => {},
+};
+
+const lockPath = () => join(dir, LOCK_FILENAME);
+const readRecord = (): LockRecord => JSON.parse(readFileSync(lockPath(), 'utf8'));
+
+describe('acquiring the lock on a free directory', () => {
+  test('writes a record naming this process and returns a releasable handle', () => {
+    const lock = acquireInstanceLock(dir, { env: makeEnv(), log: () => {}, ...noTimers });
+    const record = readRecord();
+    expect(record.pid).toBe(100);
+    expect(record.hostname).toBe('host-a');
+    expect(record.owner).toBe(lock.record.owner);
+
+    lock.release();
+    expect(() => readFileSync(lockPath(), 'utf8')).toThrow();
+  });
+
+  test('release is idempotent', () => {
+    const lock = acquireInstanceLock(dir, { env: makeEnv(), log: () => {}, ...noTimers });
+    lock.release();
+    expect(() => lock.release()).not.toThrow();
+  });
+});
+
+describe('a second live writer is refused', () => {
+  test('a fresh lock held by a live process on THIS host blocks the start', () => {
+    const first = makeEnv({ pid: 100, alive: new Set([100]) });
+    acquireInstanceLock(dir, { env: first, log: () => {}, ...noTimers });
+
+    const second = makeEnv({ pid: 200, alive: new Set([100, 200]) });
+    expect(() => acquireInstanceLock(dir, { env: second, log: () => {}, ...noTimers })).toThrow(
+      MultipleInstanceError
+    );
+  });
+
+  test('a fresh lock held by ANOTHER host blocks the start — the replica case', () => {
+    // The real scenario: scaling to 2 replicas. We cannot probe that
+    // container's processes, so a fresh heartbeat is the whole of the evidence
+    // and it must be believed.
+    const other: LockRecord = {
+      owner: 'replica-1',
+      pid: 7,
+      hostname: 'railway-replica-1',
+      startedAt: new Date(1_700_000_000_000).toISOString(),
+      heartbeatAt: new Date(1_700_000_000_000).toISOString(),
+    };
+    writeFileSync(lockPath(), JSON.stringify(other));
+
+    const env = makeEnv({ host: 'railway-replica-2', pid: 9 });
+    let thrown: unknown;
+    try {
+      acquireInstanceLock(dir, { env, log: () => {}, ...noTimers });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(MultipleInstanceError);
+    // The message has to tell an operator what to actually do.
+    expect((thrown as Error).message).toContain('railway-replica-1');
+    expect((thrown as Error).message).toMatch(/numReplicas/);
+  });
+
+  test('the refusal leaves the incumbent lock untouched', () => {
+    const first = makeEnv({ pid: 100, alive: new Set([100]) });
+    const lock = acquireInstanceLock(dir, { env: first, log: () => {}, ...noTimers });
+
+    const second = makeEnv({ pid: 200, alive: new Set([100, 200]) });
+    expect(() => acquireInstanceLock(dir, { env: second, log: () => {}, ...noTimers })).toThrow();
+    expect(readRecord().owner).toBe(lock.record.owner);
+  });
+});
+
+describe('an abandoned lock is taken over', () => {
+  test('same host, dead pid: taken over immediately, without waiting out staleness', () => {
+    // A crashed local dev server must not cost the next start a 60s wait.
+    const first = makeEnv({ pid: 100, alive: new Set([100]) });
+    acquireInstanceLock(dir, { env: first, log: () => {}, ...noTimers });
+
+    const second = makeEnv({ pid: 200, alive: new Set([200]) }); // 100 is gone
+    const lines: string[] = [];
+    const lock = acquireInstanceLock(dir, { env: second, log: (m) => lines.push(m), ...noTimers });
+    expect(readRecord().owner).toBe(lock.record.owner);
+    expect(lines.join('\n')).toContain('abandoned');
+  });
+
+  test('different host, heartbeat gone quiet past the window: taken over', () => {
+    const t0 = 1_700_000_000_000;
+    writeFileSync(
+      lockPath(),
+      JSON.stringify({
+        owner: 'dead-container',
+        pid: 7,
+        hostname: 'old-container',
+        startedAt: new Date(t0).toISOString(),
+        heartbeatAt: new Date(t0).toISOString(),
+      })
+    );
+    const env = makeEnv({ host: 'new-container', pid: 9, now: () => t0 + STALE_AFTER_MS + 1 });
+    const lock = acquireInstanceLock(dir, { env, log: () => {}, ...noTimers });
+    expect(readRecord().owner).toBe(lock.record.owner);
+  });
+
+  test('one second inside the window is still held — the boundary is not rounded away', () => {
+    const t0 = 1_700_000_000_000;
+    writeFileSync(
+      lockPath(),
+      JSON.stringify({
+        owner: 'live-container',
+        pid: 7,
+        hostname: 'other-container',
+        startedAt: new Date(t0).toISOString(),
+        heartbeatAt: new Date(t0).toISOString(),
+      })
+    );
+    const env = makeEnv({ host: 'new-container', pid: 9, now: () => t0 + STALE_AFTER_MS - 1000 });
+    expect(() => acquireInstanceLock(dir, { env, log: () => {}, ...noTimers })).toThrow(
+      MultipleInstanceError
+    );
+  });
+
+  test('an unreadable lock does not deadlock the service', () => {
+    writeFileSync(lockPath(), 'not json at all');
+    const lines: string[] = [];
+    const lock = acquireInstanceLock(dir, { env: makeEnv(), log: (m) => lines.push(m), ...noTimers });
+    expect(readRecord().owner).toBe(lock.record.owner);
+    expect(lines.join('\n')).toContain('unreadable');
+  });
+});
+
+describe('release only removes a lock we still hold', () => {
+  test('a process whose lock was taken over does not delete the new holder’s lock', () => {
+    // The sequence that would otherwise disarm the guard: A goes quiet, B takes
+    // over, then A's shutdown handler finally runs. If A unlinked here, the
+    // volume would be left unguarded with B still writing to it.
+    const a = makeEnv({ pid: 100, alive: new Set([100]) });
+    const lockA = acquireInstanceLock(dir, { env: a, log: () => {}, ...noTimers });
+
+    const b = makeEnv({ pid: 200, alive: new Set([200]) });
+    const lockB = acquireInstanceLock(dir, { env: b, log: () => {}, ...noTimers });
+
+    lockA.release();
+    expect(readRecord().owner).toBe(lockB.record.owner);
+  });
+});
+
+describe('isAbandoned', () => {
+  const holder = (over: Partial<LockRecord> = {}): LockRecord => ({
+    owner: 'o',
+    pid: 42,
+    hostname: 'host-a',
+    startedAt: new Date(0).toISOString(),
+    heartbeatAt: new Date(1_700_000_000_000).toISOString(),
+    ...over,
+  });
+
+  test('a live pid on this host is never abandoned, however old the heartbeat', () => {
+    const env = makeEnv({ host: 'host-a', alive: new Set([42]), now: () => 2_000_000_000_000 });
+    // Deliberately far past the stale window. A process we can SEE running is
+    // running, whatever its heartbeat says — a wedged writer is still a writer,
+    // and staleness must not be a way to take the lock out from under it.
+    expect(isAbandoned(holder(), env)).toBe(false);
+  });
+
+  test('a dead pid on this host is abandoned even with a fresh heartbeat', () => {
+    const env = makeEnv({ host: 'host-a', alive: new Set(), now: () => 1_700_000_000_000 });
+    expect(isAbandoned(holder(), env)).toBe(true);
+  });
+
+  test('on another host only the heartbeat can settle it', () => {
+    const t0 = 1_700_000_000_000;
+    const env = (now: number) => makeEnv({ host: 'elsewhere', alive: new Set([42]), now: () => now });
+    expect(isAbandoned(holder(), env(t0 + STALE_AFTER_MS - 1))).toBe(false);
+    expect(isAbandoned(holder(), env(t0 + STALE_AFTER_MS + 1))).toBe(true);
+  });
+
+  test('an unparseable heartbeat counts as abandoned rather than locking us out forever', () => {
+    const env = makeEnv({ host: 'other', alive: new Set([42]) });
+    expect(isAbandoned(holder({ heartbeatAt: 'nonsense' }), env)).toBe(true);
+  });
+});

--- a/apps/landing/src/sdk/engine.edit-flow.test.ts
+++ b/apps/landing/src/sdk/engine.edit-flow.test.ts
@@ -59,7 +59,7 @@ describe('editing an Original by its title', () => {
 
     // Genesis plus two edits, each edit touching artwork + metadata.
     expect(third.celLog.filter((e) => e.type === 'update')).toHaveLength(4);
-    expect(await engine.asset!.verify()).toBe(true);
+    expect((await engine.asset!.verify()).verified).toBe(true);
   });
 
   test('typing the title back to what was committed produces no new version', async () => {

--- a/apps/landing/src/sdk/engine.update.test.ts
+++ b/apps/landing/src/sdk/engine.update.test.ts
@@ -129,7 +129,7 @@ describe('revise a created asset', () => {
     const engine = new DemoEngine();
     await engine.create('One', 'Artwork', SVG);
     await engine.update('Two', 'Artwork', SVG_V2);
-    expect(await engine.asset!.verify()).toBe(true);
+    expect((await engine.asset!.verify()).verified).toBe(true);
   });
 
   test('a PUBLISHED asset is still revisable, and the new bytes are hosted', async () => {

--- a/bun.lock
+++ b/bun.lock
@@ -139,7 +139,12 @@
     },
   },
   "overrides": {
+    "brace-expansion": "^5.0.8",
     "human-id": "4.1.1",
+    "js-yaml": "^4.3.1",
+    "nanoid": "^3.3.16",
+    "postcss": "^8.5.23",
+    "undici": "^6.28.0",
   },
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
@@ -247,8 +252,6 @@
     "@eslint/object-schema": ["@eslint/object-schema@3.0.5", "", {}, "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
-
-    "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
     "@fontsource-variable/inter": ["@fontsource-variable/inter@5.2.8", "", {}, "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ=="],
 
@@ -556,7 +559,7 @@
 
     "borsh": ["borsh@2.0.0", "", {}, "sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg=="],
 
-    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -641,8 +644,6 @@
     "eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
     "espree": ["espree@11.2.0", "", { "dependencies": { "acorn": "^8.16.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.1" } }, "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw=="],
-
-    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
     "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
 
@@ -748,7 +749,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
+    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
@@ -842,7 +843,7 @@
 
     "mylas": ["mylas@2.1.14", "", {}, "sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog=="],
 
-    "nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
@@ -894,7 +895,7 @@
 
     "plimit-lit": ["plimit-lit@1.6.1", "", { "dependencies": { "queue-lit": "^1.5.1" } }, "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA=="],
 
-    "postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
+    "postcss": ["postcss@8.5.26", "", { "dependencies": { "nanoid": "^3.3.17", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
@@ -962,8 +963,6 @@
 
     "spawndamnit": ["spawndamnit@3.0.1", "", { "dependencies": { "cross-spawn": "^7.0.5", "signal-exit": "^4.0.1" } }, "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg=="],
 
-    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
-
     "string-width": ["string-width@8.2.2", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -998,7 +997,7 @@
 
     "typescript-eslint": ["typescript-eslint@8.63.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.63.0", "@typescript-eslint/parser": "8.63.0", "@typescript-eslint/typescript-estree": "8.63.0", "@typescript-eslint/utils": "8.63.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ=="],
 
-    "undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
+    "undici": ["undici@6.28.0", "", {}, "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
@@ -1116,8 +1115,6 @@
 
     "path-scurry/lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
 
-    "read-yaml-file/js-yaml": ["js-yaml@3.15.0", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog=="],
-
     "readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
@@ -1147,8 +1144,6 @@
     "micro-ordinals/@scure/btc-signer/@noble/curves": ["@noble/curves@1.9.0", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-7YDlXiNMdO1YZeH6t/kvopHHbIZzlxrCV9WLqCY6QhcXOoXiNCMDqJIglZ9Yjx5+w7Dz30TITFrlTjnRg7sKEg=="],
 
     "micro-ordinals/@scure/btc-signer/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
-    "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@6.3.0", "", {}, "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ=="],
 

--- a/docs/BITCOIN_INTEGRATION_GUIDE.md
+++ b/docs/BITCOIN_INTEGRATION_GUIDE.md
@@ -65,19 +65,19 @@ AWS_KMS_KEY_ID=your_kms_key_id
 ### Using npm
 
 ```bash
-npm install @originals/sdk
+npm install @originals/sdk@next
 ```
 
 ### Using yarn
 
 ```bash
-yarn add @originals/sdk
+yarn add @originals/sdk@next
 ```
 
 ### Using bun
 
 ```bash
-bun add @originals/sdk
+bun add @originals/sdk@next
 ```
 
 ### TypeScript Configuration

--- a/docs/BITCOIN_MIGRATION_GUIDE.md
+++ b/docs/BITCOIN_MIGRATION_GUIDE.md
@@ -501,7 +501,7 @@ interface BitcoinTransaction {
 
 ### During Migration
 
-- [ ] Install Originals SDK: `npm install @originals/sdk`
+- [ ] Install Originals SDK: `npm install @originals/sdk@next`
 - [ ] Set up test environment with regtest or signet network
 - [ ] Configure `OrdinalsProvider` (use `OrdMockProvider` for testing)
 - [ ] Replace UTXO selection with SDK functions

--- a/docs/DEPENDENCY_AUDIT.md
+++ b/docs/DEPENDENCY_AUDIT.md
@@ -1,125 +1,100 @@
-# Dependency Audit — @originals/sdk v1.9.0
+# Dependency audit
 
-**Date:** 2026-03-06
-**Runtime:** Bun 1.3.5
-**Lockfile:** bun.lock (v1)
+**Last reviewed:** 2026-08-24, against `@originals/sdk` 3.0.0-next.1,
+`@originals/cel` 0.2.0-next.1, `@originals/auth` 3.0.0-next.0.
 
----
+## The live answer is CI, not this file
 
-## Production Dependencies
+`bun audit --prod` and `bun audit` run as a **required CI job** on every push and
+pull request (`.github/workflows/ci.yml`, job `audit`). A new advisory against
+anything in the tree turns the build red on the next commit.
 
-| Package | Version | Purpose | Vulnerability |
-|---------|---------|---------|---------------|
-| `@noble/curves` | ^1.6.0 | Elliptic curve crypto | None |
-| `@noble/ed25519` | ^2.0.0 | Ed25519 signatures | None |
-| `@noble/hashes` | ^2.0.1 | SHA-256, SHA-512 | None |
-| `@noble/secp256k1` | ^2.0.0 | Bitcoin/secp256k1 | None |
-| `@scure/base` | ^1.1.6 | Base encoding | None |
-| `@scure/bip32` | ^2.0.0 | HD key derivation | None |
-| `@scure/btc-signer` | ^1.8.0 | Bitcoin tx signing | None |
-| `@stablelib/ed25519` | ^2.0.2 | Ed25519 (legacy) | None |
-| `b58` | ^4.0.3 | Base58 encoding | None |
-| `bitcoinjs-lib` | ^6.1.0 | Bitcoin address validation | None |
-| `cbor-js` | ^0.1.0 | CBOR encoding | None |
-| `didwebvh-ts` | ^2.5.5 | did:webvh implementation | **Transitive: minimatch, brace-expansion** |
-| `jsonld` | ^8.3.3 | JSON-LD processing | **Transitive: undici** |
-| `micro-ordinals` | ^0.2.2 | Ordinals inscription | None |
-| `multiformats` | ^12.0.0 | Multicodec/multibase | None |
-| `uuid` | ^13.0.0 | UUID generation | None |
+That job — not this page — is the source of truth. This page exists to record the
+things a tool cannot tell you: which advisories we have deliberately overridden,
+and why. Do not read a package table here as current; the previous version of
+this file listed `@scure/bip32`, `cbor-js`, `multiformats`, noble v1.x and
+`@semantic-release/*` long after all of them had left the tree, which made it
+actively misleading.
 
-### Production Vulnerability Summary
+**Current state: `bun audit` reports no vulnerabilities.**
 
-Only **2 production deps** have transitive vulnerabilities, both in deep dependencies:
+## Why `--prod` runs separately
 
-1. **`didwebvh-ts` → minimatch <3.1.3, @isaacs/brace-expansion <=5.0.0** (High: ReDoS)
-   - Impact: Low — these are used for glob matching in build/tooling context, not user-facing input processing
-   - Mitigation: Wait for upstream update or pin override
+Production advisories reach every consumer of the published packages: `npm audit`
+fires on *their* install, against dependencies they did not choose and cannot
+easily replace. A dev-only advisory is our problem; a production one is
+everybody's. The CI job runs `bun audit --prod` as its own step so the two can
+never be conflated in a summary count — which is exactly how a shipped one went
+unnoticed (see undici below).
 
-2. **`jsonld` → undici <6.23.0** (Moderate: unbounded decompression)
-   - Impact: Low — jsonld uses undici for fetching JSON-LD contexts, which are fetched from trusted URLs
-   - Mitigation: Wait for upstream update
+## Standing overrides
 
-### Crypto Library Assessment
+These live in the root `package.json` under `overrides`. Each forces a
+transitive dependency to a patched version its own parent has not yet moved to.
+Every one of them is a **bug in someone else's dependency range**, so each should
+be deleted as soon as the parent catches up.
 
-The `@noble/*` and `@scure/*` families are audited, well-maintained cryptographic libraries by Paul Miller. All are at current stable versions with no known vulnerabilities. These are the correct choices for a Bitcoin/DID SDK.
+| Override | Forced to | Why | Remove when |
+|---|---|---|---|
+| `undici` | `^6.28.0` | **Shipped to every SDK consumer.** `jsonld@8` → `@digitalbazaar/http-client@3.4.1` → `undici@^5.21.2`, which resolved to 5.29.0: ten high advisories (unbounded WebSocket memory, request smuggling, CRLF injection, response-queue poisoning). The whole 5.x line and 6.x up to 6.27.0 are affected, so no in-range version is clean. | `jsonld@9` is adopted — it depends on `http-client@4`, whose own range is already `^6.28.0`. See the note below on why that upgrade is not this change. |
+| `js-yaml` | `^4.3.1` | Quadratic CPU consumption in `!!omap` resolution (GHSA-5p4m-2wfm-xmqj) affects 3.x and 4.x below 4.3.1. Reached through `didwebvh-ts` (production) and through `changesets`/`commitlint` (dev). | `didwebvh-ts`, `read-yaml-file` and `cosmiconfig` all require ≥4.3.1. |
+| `brace-expansion` | `^5.0.8` | Two DoS advisories below 5.0.8 (unbounded expansion length; unbounded intermediate arrays bypassing the earlier mitigation). Dev-only — reaches us through `eslint` and `typescript-eslint`. | eslint's tree moves past 5.0.7. |
+| `nanoid` | `^3.3.16` | Non-secure generators can loop indefinitely on negative or zero size. Dev-only, via `vite`. | vite's tree moves past 3.3.15. |
+| `postcss` | `^8.5.23` | Path traversal via `sourceMappingURL` auto-loading discloses arbitrary `.map` files. Dev-only, via `vite`. | vite's tree moves past 8.5.22. |
+| `human-id` | `4.1.1` | Pre-existing; pins changesets' branch-name generator. | — |
 
----
+Forcing `js-yaml` to 4.x collapses the two copies in the tree onto one. That is
+a real behaviour change for `read-yaml-file` and `cosmiconfig`, which sat on
+3.15.0 — both were checked by running `bunx changeset status` and `commitlint`
+against the overridden tree, and both work (v4's `load` is the API they use;
+only the removed `safeLoad`/`safeDump` would have broken them).
 
-## Dev Dependencies
+### Why not simply upgrade `jsonld` to 9?
 
-| Package | Version | Status |
-|---------|---------|--------|
-| `@babel/core` | ^7.28.4 | Current |
-| `@babel/preset-env` | ^7.28.3 | Current |
-| `@types/bun` | ^1.3.0 | Current |
-| `@types/node` | ^20.19.17 | Current |
-| `@typescript-eslint/eslint-plugin` | ^6.0.0 | **Outdated** — v8 available |
-| `@typescript-eslint/parser` | ^6.0.0 | **Outdated** — v8 available |
-| `bun-types` | ^1.3.1 | Current |
-| `eslint` | ^8.0.0 | **Outdated** — v9 available |
-| `prettier` | ^3.0.0 | Current |
-| `tsc-alias` | ^1.8.16 | Current |
-| `typedoc` | ^0.28.17 | Current |
-| `typescript` | ^5.0.0 | Current |
+It is the obvious fix and it does not work yet. `jsonld@9.0.0` pulls
+`rdf-canonize@5` and a stricter safe mode; against it, eight tests fail — the
+whole BBS+ `bbs-2023` selective-disclosure round-trip, plus safe-mode
+canonicalization in `CredentialManager`. That is the canonicalization step
+underneath every signature this SDK produces, so it is not a dependency bump to
+land inside a packaging fix. The override closes the advisory today; the
+upgrade needs its own change with the BBS+ suite green.
 
-### Dev Vulnerability Summary
+## Production dependency surface
 
-Most dev vulnerabilities come from `eslint` v8 and its transitive dependency tree (`minimatch`, `ajv`). The `eslint` v8 → v9 migration would resolve these. The `@semantic-release/*` packages at the root monorepo have minor patch updates available.
+Enumerated so the shape is legible, not to be maintained as a version table —
+read `package.json` for versions and `bun audit` for advisories.
 
----
+- **`@originals/sdk`** — `@noble/*` and `@scure/*` (curves, ed25519, hashes,
+  secp256k1, base, btc-signer), `@digitalbazaar/bbs-signatures`, `@originals/cel`,
+  `b58`, `bitcoinjs-lib`, `didwebvh-ts`, `fflate`, `jsonld`, `micro-ordinals`,
+  `uuid`.
+- **`@originals/cel`** — `@noble/curves`, `@noble/ed25519`, `@noble/hashes`,
+  `@scure/base`, `cborg`. Deliberately minimal: no Bitcoin stack, no `jsonld`,
+  no Node builtins (enforced by `scripts/check-browser-safety.mjs`).
+- **`@originals/auth`** — `@noble/*`, `@originals/sdk`, `@turnkey/*`,
+  `jsonwebtoken`.
 
-## Vulnerability Report (14 total)
+The `@noble/*` and `@scure/*` families are the audited, minimal-dependency
+crypto libraries this SDK is built on. They pull nothing transitively, which is
+why none of the advisories above ever touch the signing path.
 
-### High Severity (12)
+`jsonld` is the one heavyweight, and it is used only for JSON-LD
+canonicalization and BBS+ selective disclosure. It is lazy-imported
+(`src/crypto/signingInput.ts`, `src/vc/utils/jsonld.ts`) so it never lands in a
+consumer's bundle unless they sign or verify a credential — but it is a hard
+`dependencies` entry, so its advisories still fire on every adopter's `npm
+install`. That is the whole reason the `undici` override exists.
 
-| CVE/Advisory | Package | Affected | Type | Production? |
-|-------------|---------|----------|------|-------------|
-| GHSA-3ppc-4f35-3m26 | minimatch <3.1.3 | eslint, typedoc, didwebvh-ts | ReDoS | Transitive via didwebvh-ts |
-| GHSA-7r86-cg39-jmmj | minimatch <3.1.3 | Same | ReDoS (GLOBSTAR) | Transitive via didwebvh-ts |
-| GHSA-23c5-xmqv-rm74 | minimatch <3.1.3 | Same | ReDoS (extglobs) | Transitive via didwebvh-ts |
-| GHSA-83g3-92jg-28cx | tar <7.5.8 | @semantic-release/npm | File traversal | No (dev only) |
-| GHSA-qffp-2rhf-9h96 | tar <7.5.8 | @semantic-release/npm | Path traversal | No (dev only) |
-| GHSA-7h2j-956f-4vf2 | @isaacs/brace-expansion <=5.0.0 | eslint, typedoc, didwebvh-ts | Resource consumption | Transitive via didwebvh-ts |
+## Version pinning strategy
 
-### Moderate Severity (2)
+Caret ranges in every `package.json`, exact versions in `bun.lock`. Consumers
+resolve against their own lockfile; the `overrides` block is the only place we
+override that, and only for the advisories above.
 
-| CVE/Advisory | Package | Affected | Type | Production? |
-|-------------|---------|----------|------|-------------|
-| GHSA-2g4f-4pwh-qvx6 | ajv <6.14.0 | eslint, @commitlint | ReDoS | No (dev only) |
-| GHSA-g9mf-h72j-4rw9 | undici <6.23.0 | @semantic-release/github, jsonld | Decompression DoS | Transitive via jsonld |
-
----
+CI installs with `--frozen-lockfile` in the audit job: auditing a tree that has
+drifted from the committed lockfile is auditing something we do not ship.
 
 ## Automation
 
-### Dependabot (already configured)
-
-`.github/dependabot.yml` is in place with:
-- Weekly checks on Mondays
-- Grouped updates for `@noble/*` / `@scure/*` (crypto) and dev tools
-- GitHub Actions ecosystem also tracked
-- 10 PR limit
-
-### Recommendations
-
-1. **No immediate action required** — all high-severity vulns are in transitive deps of dev tools or used in non-user-facing contexts
-2. **Pin versions in lockfile** — `bun.lock` already pins all transitive deps (confirmed)
-3. **Update dev tools when ready:**
-   - `eslint` v8 → v9 (breaking: flat config migration)
-   - `@typescript-eslint/*` v6 → v8 (breaking: requires eslint v9)
-   - `@semantic-release/*` patch updates (non-breaking)
-4. **Monitor upstream:**
-   - `didwebvh-ts` for minimatch fix
-   - `jsonld` for undici update
-5. **Consider overrides** if upstream is slow — Bun supports `"overrides"` in package.json to force transitive dep versions
-
----
-
-## Version Pinning Strategy
-
-Current approach: **caret ranges** (`^`) for all deps. This is appropriate for an SDK because:
-- Lockfile (`bun.lock`) pins exact versions for reproducible builds
-- Caret ranges allow Dependabot to propose compatible updates
-- Production consumers get their own lockfile resolution
-
-No changes recommended to version strategy.
+`.github/dependabot.yml` runs weekly with grouped updates for the crypto
+families and dev tooling. Dependabot proposes; the `audit` job is what blocks.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -18,13 +18,13 @@ By the end of this tutorial, you'll have:
 ## Step 1: Install the SDK
 
 ```bash
-npm install @originals/sdk
+npm install @originals/sdk@next
 ```
 
 Or with Bun:
 
 ```bash
-bun add @originals/sdk
+bun add @originals/sdk@next
 ```
 
 ## Step 2: Initialize the SDK

--- a/docs/LLM_AGENT_GUIDE.md
+++ b/docs/LLM_AGENT_GUIDE.md
@@ -820,11 +820,22 @@ await asset.verify(deps?: {
   didManager?: DIDManager;
   credentialManager?: CredentialManager;
   fetch?: (url: string) => Promise<Response>;
-  ordinalsProvider?: OrdinalsProvider;  // Required to verify inscribed (did:btco) assets
-}): Promise<boolean>
+  // Defaults to the SDK-configured provider for assets minted or loaded
+  // through sdk.lifecycle — pass one only to override it.
+  ordinalsProvider?: OrdinalsProvider;
+}): Promise<VerificationReport>
+
+interface VerificationReport {
+  verified: boolean;
+  code?: VerificationFailureCode;   // absent when verified
+  message?: string;                 // absent when verified
+  details?: Record<string, unknown>;
+}
 ```
 
-> Inscribed assets carry a Bitcoin witness proof in their CEL log; verifying one **requires** passing `{ ordinalsProvider }`, or verification fails closed.
+> **Check `.verified`, never the report's truthiness** — the report object is always truthy.
+>
+> Inscribed assets carry a Bitcoin witness proof in their CEL log, which fails closed without an ordinals provider. `verify()` uses the one from the SDK config, so `create → publish → inscribe → verify` needs no argument. When no provider is available from either source the report is `{ verified: false, code: 'ORDINALS_PROVIDER_REQUIRED' }` — that is "the proof was not checked", **not** "the proof does not hold". Branch on `code`, not on `verified` alone.
 
 ### ProvenanceChain Structure
 

--- a/docs/LLM_QUICK_REFERENCE.md
+++ b/docs/LLM_QUICK_REFERENCE.md
@@ -244,7 +244,7 @@ await sdk.did.createDIDWebVH({
 
 ## Critical Rules
 
-1. **Bitcoin ops need `ordinalsProvider`** - Always configure for inscribe/transfer; also pass it to `asset.verify({ ordinalsProvider })` to verify inscribed (did:btco) assets
+1. **Bitcoin ops need `ordinalsProvider`** - Always configure for inscribe/transfer. `asset.verify()` then uses it automatically for inscribed (did:btco) assets; it returns a `VerificationReport` — check `.verified`, and read `.code` on failure (`ORDINALS_PROVIDER_REQUIRED` means the proof was never checked, not that it failed)
 2. **Keys are Multikey, not JWK** - Use `multikey.encode*()` functions
 3. **Migration is one-way** - did:cel → webvh → btco only (no fallback once on btco)
 4. **Max fee rate: 10,000 sat/vB** - Prevents accidental fund loss

--- a/docs/ORIGINALS_CEL_GUIDE.md
+++ b/docs/ORIGINALS_CEL_GUIDE.md
@@ -25,9 +25,9 @@ Get up and running with Originals CEL in 5 minutes.
 ### Installation
 
 ```bash
-npm install @originals/sdk
+npm install @originals/sdk@next
 # or
-bun add @originals/sdk
+bun add @originals/sdk@next
 ```
 
 ### Create Your First Asset
@@ -518,7 +518,7 @@ The `originals-cel` CLI provides command-line access to CEL operations.
 
 ```bash
 # Via npm/bun (global)
-npm install -g @originals/sdk
+npm install -g @originals/sdk@next
 
 # Or run directly via npx
 npx originals-cel --help
@@ -1044,7 +1044,7 @@ Check that proofs have all required fields:
 Ensure the SDK is installed in your project:
 
 ```bash
-npm install @originals/sdk
+npm install @originals/sdk@next
 ```
 
 For Convex actions using Node.js, add `"use node";` at the top of the file.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -38,6 +38,52 @@ is.
   publish while the registry propagates, even though the tarball is already
   live. Re-check before assuming the publish failed.
 
+## Dist-tags: what a consumer actually installs
+
+`changeset publish` picks the tag; nobody checks the result. That gap shipped a
+launch-blocking bug: every doc described 3.x while `npm install @originals/sdk`
+returned **2.1.0**, a major behind, with a different lifecycle API and no
+`./testing` subpath. `bun run check:install-docs` (a CI job) now asks the
+registry what each shipped install command resolves to and fails if it is not
+the major this repo documents.
+
+**The standing decision: a prerelease never goes on `latest`.** 3.0.0-next.N is
+not the build we want a stranger installing by default — it is a prerelease, and
+`latest` is the tag that means "the supported release". So `latest` stays on
+2.1.0 and every install command in the docs and on the site names `@next`. When
+3.0.0 is ready, `bunx changeset pre exit` ships it to `latest` and the `@next`
+tags come back out of the docs (the honesty tests in
+`apps/landing/src/components/install-line-honesty.test.ts` say the same thing).
+
+### The first-publish trap
+
+A package with no prior normal release publishes to `latest` even in prerelease
+mode, and npm additionally forces `latest` on the very first publish of any
+package. `@originals/cel` hit both: `0.2.0-next.0` went out as the first publish
+(so npm set `latest` **and** `next`), then `0.2.0-next.1` went to `latest` by the
+no-prior-normal-release rule — leaving `next` pointing at the **older** build.
+
+That is registry state, not repo state, so no merge fixes it. Correct it with a
+token that can publish:
+
+```bash
+# @originals/cel: move `next` forward off the stale 0.2.0-next.0.
+npm dist-tag add @originals/cel@0.2.0-next.1 next
+
+# Confirm both packages afterwards.
+npm view @originals/cel dist-tags
+npm view @originals/sdk dist-tags   # expect latest=2.1.0 (stable), next=3.0.0-next.1
+npm view @originals/auth dist-tags  # expect latest=2.0.0 (stable), next=3.0.0-next.0
+```
+
+`@originals/cel` has no stable release at all, so its `latest` stays on a
+prerelease until 0.2.0 ships — there is nothing better to point it at, and it is
+a transitive dependency resolved by the range in `packages/sdk/package.json`, not
+something the docs tell anyone to install directly.
+
+After any dist-tag change, run `bun run check:install-docs` locally: it is the
+same check CI runs, and it reads the live registry.
+
 ## Credentials
 
 Publishing uses the repo secret `NPM_TOKEN`. See

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -1,8 +1,20 @@
 # Originals SDK — Security Audit & Threat Model
 
-**Date:** 2026-03-06
-**Scope:** @originals/sdk v1.9.0 — crypto operations, key handling, input validation, Bitcoin transactions
-**Overall Risk:** MEDIUM — solid fundamentals, recommended hardening items below
+**Last re-audited:** 2026-08-24, against `@originals/sdk` 3.0.0-next.1.
+**Previous audit:** 2026-03-06 against v1.9.0.
+**Scope:** crypto operations, key handling, input validation, Bitcoin transactions.
+**Overall Risk:** MEDIUM — solid fundamentals; the open items below are the honest remainder.
+
+> **Every status in this document was re-checked against the code at the date
+> above, not carried forward.** Rows that had drifted are corrected below, and
+> one finding (the old T13/F11, "EdDSA proof hash collision via missing domain
+> separation", carried as an open **High**) was a **false positive** and has been
+> withdrawn — see "Withdrawn findings" for the reasoning, which is recorded
+> rather than deleted so nobody re-files it.
+>
+> A public threat model carrying a stale open High is worse than no threat
+> model: it misdirects a reader's attention and misrepresents the code. If you
+> change security-relevant code, update the row here in the same change.
 
 ---
 
@@ -25,7 +37,7 @@ External signers  ───→  Interface contract   ───→  Credential is
 
 | # | Threat | Component | Severity | Status |
 |---|--------|-----------|----------|--------|
-| T1 | Malformed Bitcoin address causes fund loss | `commit.ts`, `transfer.ts` | High | Partially mitigated — see F1 |
+| T1 | Malformed Bitcoin address causes fund loss | `commit.ts`, `transfer.ts` | High | **Mitigated (2026-08)** — `validateBitcoinAddress()` now runs at both entry points (`transfer.ts:98,102`, `commit.ts:219`) |
 | T2 | Fee rate manipulation drains wallet | `BitcoinManager`, `fee-calculation.ts` | High | Mitigated — max fee rate enforced in BitcoinManager |
 | T3 | UTXO double-spend via concurrent selection | `utxo-selection.ts` | High | Known limitation — wallet-level locking required |
 | T4 | Private key leakage via logging/errors | `Signer.ts`, `commit.ts`, `eddsa.ts` | Medium | Mitigated — no keys in logs/errors currently |
@@ -35,15 +47,15 @@ External signers  ───→  Interface contract   ───→  Credential is
 | T8 | DID document injection | `DIDManager`, `validation.ts` | Low | Partially mitigated — see F5 |
 | T9 | Memory storage in production | `MemoryStorageAdapter.ts` | Low | Dev-only adapter, no production guard |
 | T10 | Dust output creation | `commit.ts`, `utxo-selection.ts` | Medium | Mitigated — dust added to fee, 546 sat minimum |
-| T11 | SSRF via malicious inscription URL | `BtcoDidResolver.ts` | Medium | Not mitigated — see F9 |
-| T12 | Silent multi-proof bypass | `Verifier.ts` | Low | Not mitigated — see F10 |
-| T13 | EdDSA proof hash collision via missing domain separation | `eddsa.ts` | High | Not mitigated — see F11 |
-| T14 | Incorrect multibase encoding in Ed25519Verifier | `Ed25519Verifier.ts` | Medium | Not mitigated — see F12 |
-| T15 | Malicious external signer injecting invalid proofs | `WebVHManager.ts` | Medium | Not mitigated — see F13 |
-| T16 | Silent signature corruption via format fallback | `Signer.ts` | Medium | Not mitigated — see F14 |
-| T17 | Provider MiTM via HTTP (no HTTPS enforcement) | `OrdHttpProvider.ts` | High | Not mitigated — see F15 |
-| T18 | No inscription data size limit | `BitcoinManager.ts` | Medium | Not mitigated — see F16 |
-| T19 | Provider retry storm (no backoff/circuit breaker) | `OrdinalsProvider.ts` | Medium | Not mitigated — see F17 |
+| T11 | SSRF via malicious inscription URL | `BtcoDidResolver.ts` | Medium | **Partially mitigated (2026-08)** — see F9 |
+| T12 | Silent multi-proof bypass | `Verifier.ts` | Low | **Open (re-confirmed 2026-08)** — see F10 |
+| ~~T13~~ | ~~EdDSA proof hash collision via missing domain separation~~ | `eddsa.ts` | — | **Withdrawn (2026-08): false positive.** See "Withdrawn findings" |
+| ~~T14~~ | ~~Incorrect multibase encoding in Ed25519Verifier~~ | `Ed25519Verifier.ts` | — | **Fixed (2026-08)** — uses `multikey.encodePublicKey()`, plus a 32-byte length guard |
+| ~~T15~~ | ~~Malicious external signer injecting invalid proofs~~ | `WebVHManager.ts` | — | **Fixed (2026-08)** — an `externalVerifier` is REQUIRED when the signer has no `verify()` (`WebVHManager.ts:404-413`) |
+| T16 | Silent signature corruption via format fallback | `Signer.ts` | Medium | **Open (re-confirmed 2026-08)** — see F14 |
+| T17 | Provider MiTM via HTTP (no HTTPS enforcement) | `OrdHttpProvider.ts` | High | **Partially mitigated (2026-08)** — see F15 |
+| T18 | No inscription data size limit | `BitcoinManager.ts` | Medium | **Open (re-confirmed 2026-08)** — see F16 |
+| T19 | Provider retry storm (no backoff/circuit breaker) | `OrdinalsProvider.ts` | Medium | **Largely mitigated (2026-08)** — see F17 |
 
 ---
 
@@ -51,11 +63,12 @@ External signers  ───→  Interface contract   ───→  Credential is
 
 ### High Priority
 
-**F1 — Missing address validation in transfer/commit paths**
-- **Files:** `src/bitcoin/transfer.ts:27`, `src/bitcoin/transactions/commit.ts:184-186`
-- **Issue:** Change address and recipient address checked for presence but not format validity. `validateBitcoinAddress()` exists but isn't called in these paths.
-- **Impact:** Invalid addresses would fail at `addOutputAddress()` with unclear errors instead of early validation.
-- **Recommendation:** Add `validateBitcoinAddress(address, network)` calls at function entry points.
+**F1 — Missing address validation in transfer/commit paths — RESOLVED (2026-08)**
+- **Files:** `src/bitcoin/transfer.ts`, `src/bitcoin/transactions/commit.ts`
+- **Was:** Change and recipient addresses were checked for presence but not format.
+- **Now:** `validateBitcoinAddress(address, network)` runs at both entry points
+  (`transfer.ts:98` recipient, `transfer.ts:102` change, `commit.ts:219`
+  destination), network-aware, with `signet`/`regtest` mapped explicitly.
 
 **F2 — No maximum transaction input limit**
 - **File:** `src/bitcoin/utxo-selection.ts`
@@ -89,59 +102,88 @@ External signers  ───→  Interface contract   ───→  Credential is
 - **Issue:** `calculateFee()` doesn't validate the `feeRate` parameter. Protection exists in `BitcoinManager` (max 10,000 sat/vB) but not in the utility function.
 - **Recommendation:** Add bounds checking in `calculateFee()` for defense-in-depth.
 
-**F9 — SSRF via unvalidated inscription content URL**
-- **File:** `src/did/BtcoDidResolver.ts:126-134`
-- **Issue:** When resolving a `did:btco`, the resolver fetches `inscription.content_url` without validating the URL scheme or destination. A malicious inscription could set `content_url` to `file:///etc/passwd` or `http://169.254.169.254/...` (cloud metadata).
-- **Impact:** Server-side request forgery — an attacker could probe internal networks or read local files via a crafted inscription.
-- **Recommendation:** Validate URL scheme (allow only `https://`), reject private IP ranges and localhost before fetching.
+**F9 — SSRF via unvalidated inscription content URL — PARTIALLY MITIGATED (2026-08)**
+- **Files:** `src/did/BtcoDidResolver.ts:150`, `src/adapters/providers/OrdHttpProvider.ts:42-53`
+- **Mitigated:** `OrdHttpProvider.assertSameOrigin()` rejects any `content_url`
+  whose origin differs from the configured `baseUrl`, which closes the
+  attacker-controlled-destination vector (`http://169.254.169.254/…`,
+  `file:///…`) for the shipped HTTP provider. The fetch also carries a 10s
+  timeout covering the body read.
+- **Still open:** the guard lives in the provider, not in the resolver.
+  `BtcoDidResolver` fetches whatever `content_url` its provider hands it, so a
+  custom `OrdinalsProvider` reintroduces the vector. And **the response body is
+  unbounded** — `await response.text()` has no size cap, so a hostile or broken
+  content host can drive a resolver into memory exhaustion. The timeout does not
+  bound a fast, large response.
+- **Recommendation:** move a scheme/private-IP check into the resolver so it does
+  not depend on provider behaviour, and cap the read (stream with a byte budget,
+  or reject on `content-length` above a limit).
 
 **F10 — Silent multi-proof bypass in credential verification**
 - **File:** `src/vc/Verifier.ts:21,45`
 - **Issue:** When a credential has multiple proofs, only the first is verified: `Array.isArray(proofValue) ? proofValue[0] : proofValue`. Additional proofs are silently ignored.
 - **Impact:** Low — an attacker cannot exploit this to bypass verification, but valid additional proofs go unverified.
+- **Status (2026-08):** re-confirmed open. Still `proofValue[0]` at
+  `Verifier.ts:121` (credentials) and `Verifier.ts:613` (presentations).
 - **Recommendation:** Document single-proof-only behavior or implement multi-proof verification.
 
-**F11 — EdDSA proof hash concatenation without domain separation**
-- **File:** `src/vc/cryptosuites/eddsa.ts:83`
-- **Issue:** The proof hash is created by concatenating `proofConfigHash` (32 bytes) and `documentHash` (32 bytes) directly: `new Uint8Array([...proofConfigHash, ...documentHash])`. No length prefix or domain separator is used. This creates a theoretical risk of collision attacks where different (proofConfig, document) pairs could produce the same 64-byte concatenation.
-- **Impact:** Theoretical collision risk in credential proof verification. Practical exploitation is difficult but violates cryptographic best practice.
-- **Recommendation:** Add domain separation tag or length prefix before each hash component.
+**F12 — Incorrect multibase encoding in Ed25519Verifier — RESOLVED (2026-08)**
+- **File:** `src/did/Ed25519Verifier.ts:63-73`
+- **Was:** base64 behind a `z` prefix, which per multibase means base58-btc.
+- **Now:** `multikey.encodePublicKey(this.publicKey, 'Ed25519')`, with an explicit
+  32-byte length guard that throws rather than silently slicing a wrong-length key
+  into a well-formed-looking but wrong multikey (issue #352).
 
-**F12 — Incorrect multibase encoding in Ed25519Verifier**
-- **File:** `src/did/Ed25519Verifier.ts:65`
-- **Issue:** `getPublicKeyMultibase()` encodes the public key as base64 with a `z` prefix (`z<base64>`), but the `z` prefix per multibase standard means base58-btc. This is inconsistent with the rest of the SDK which correctly uses base58-btc with `z`.
-- **Impact:** Keys from Ed25519Verifier are non-standard multibase and would fail interoperability with correct multibase decoders.
-- **Recommendation:** Use `multikey.encodePublicKey(this.publicKey, 'Ed25519')` from `src/crypto/Multikey.ts`.
-
-**F13 — External signer proofValue not validated after signing**
-- **File:** `src/did/WebVHManager.ts:199-213`
-- **Issue:** When using an external signer, the returned `proofValue` is accepted without verifying it is a valid signature. A compromised or malicious external signer could return arbitrary proof values that would be stored as valid.
-- **Impact:** Invalid credentials could be created if the external signer is compromised.
-- **Recommendation:** Always verify the returned signature against the document, even for external signers. Validate that `proofValue` decodes as valid multibase.
+**F13 — External signer proofValue not validated after signing — RESOLVED (2026-08)**
+- **File:** `src/did/WebVHManager.ts:404-413`
+- **Was:** an external signer's `proofValue` was stored without ever being checked.
+- **Now:** the signer is only accepted as a verifier if it actually implements
+  `verify()`; otherwise an `externalVerifier` is **required** and its absence
+  throws at construction. Silently casting a signer to a verifier is no longer
+  possible.
 
 **F14 — Signature format detection with silent fallback**
 - **File:** `src/crypto/Signer.ts:40-50`
 - **Issue:** When noble crypto returns an unrecognized signature format, the code falls back to `new Uint8Array(sigAny)` which could produce a corrupted signature without error.
 - **Impact:** If noble changes its return type, signatures could silently become invalid rather than throwing.
+- **Status (2026-08):** re-confirmed open. `Signer.ts:65-71` still ends its
+  format ladder in `new Uint8Array(sigAny)`.
 - **Recommendation:** Throw an explicit error if the signature format is unrecognized instead of silent conversion.
 
 **F15 — Provider MiTM via HTTP (no HTTPS enforcement)**
 - **File:** `src/adapters/providers/OrdHttpProvider.ts:13-21`
 - **Issue:** `OrdHttpProvider` fetches from `baseUrl` using `globalThis.fetch()` without enforcing HTTPS. Provider responses (inscription data, satoshi info) are trusted without independent verification.
 - **Impact:** A network attacker could intercept HTTP provider responses to return false inscription ownership, potentially enabling theft during transfers.
-- **Recommendation:** Enforce HTTPS for provider URLs at construction time. Consider certificate pinning for high-value operations.
+- **Status (2026-08):** partially mitigated. `assertSameOrigin()` now pins every
+  candidate URL to `baseUrl`'s origin, so a compromised response cannot redirect
+  the client elsewhere. **`baseUrl` itself is still not required to be
+  `https://`**, so a plaintext-configured provider remains interceptable.
+- **Recommendation:** reject a non-`https:` `baseUrl` at construction (with an
+  explicit escape for localhost/regtest development).
 
 **F16 — No inscription data size limit**
 - **File:** `src/bitcoin/BitcoinManager.ts:99-107`
 - **Issue:** `inscribeData()` accepts any data with only a non-null check. No size limit is enforced before serialization.
 - **Impact:** DoS via resource exhaustion — caller could attempt to inscribe gigabytes, consuming memory before the provider rejects it.
+- **Status (2026-08):** re-confirmed open. `BitcoinManager` bounds the fee rate
+  (`MAX_REASONABLE_FEE_RATE`) but nothing bounds the payload. Note the separate
+  10MB-per-resource cap does apply on the `LifecycleManager` path; `inscribeData()`
+  called directly has no cap.
 - **Recommendation:** Add configurable max inscription size (e.g., 4MB default).
 
 **F17 — Provider retry storm (no backoff or circuit breaker)**
 - **File:** `src/bitcoin/providers/OrdinalsProvider.ts:14-55`
-- **Issue:** All provider calls use `withRetry()` with `isRetriable: () => true`, meaning any error triggers retries. No exponential backoff or circuit breaker pattern.
-- **Impact:** Could hammer a provider with repeated requests for permanent errors. DoS risk against provider infrastructure.
-- **Recommendation:** Implement exponential backoff, distinguish retriable (network) vs permanent (404) errors, add circuit breaker.
+- **Issue:** All provider calls use `withRetry()` with `isRetriable: () => true`, meaning any error triggers retries.
+- **Status (2026-08):** the backoff half of this is **wrong and is corrected
+  here**: `src/utils/retry.ts` does exponential backoff (base 300ms, factor 2,
+  10s ceiling) with ±10% jitter, and caps at 2–3 attempts. There is no retry
+  storm. What remains true is narrower: `isRetriable: () => true` still retries
+  **permanent** errors (a 404 is retried like a timeout), and there is no
+  circuit breaker.
+- **Impact (revised):** wasted latency and a few redundant calls on permanent
+  errors. Not a DoS vector against provider infrastructure.
+- **Recommendation:** distinguish retriable (network/5xx) from permanent (4xx)
+  errors. A circuit breaker is optional at these retry counts.
 
 ### Low Priority
 
@@ -154,6 +196,47 @@ External signers  ───→  Interface contract   ───→  Credential is
 - **File:** `src/storage/MemoryStorageAdapter.ts`
 - **Issue:** No warning when used outside test/dev context.
 - **Recommendation:** Log a warning if `network === 'mainnet'` and storage is `MemoryStorageAdapter`.
+
+---
+
+## Withdrawn findings
+
+Recorded rather than deleted, so the same analysis is not re-filed.
+
+### T13 / F11 — "EdDSA proof hash collision via missing domain separation" (was High)
+
+**Withdrawn 2026-08-24: false positive.**
+
+The finding claimed that concatenating `proofConfigHash` and `documentHash`
+without a domain separator or length prefix admits a collision, because
+different `(proofConfig, document)` pairs might produce the same 64-byte
+preimage.
+
+That reasoning applies to concatenating **variable-length** values, where
+`a‖b` is genuinely ambiguous. It does not apply here. The current preimage is
+built in `src/crypto/signingInput.ts` (`signingInput.credential`):
+
+```
+sha256(RDFC(proofConfig)) ‖ sha256(RDFC(document))
+```
+
+Both halves are SHA-256 outputs, so both are **exactly 32 bytes**. The 64-byte
+result therefore has exactly one parse — split at offset 32 — and no
+`(proofConfig, document)` pair can be reinterpreted as another. Producing a
+collision would require colliding SHA-256 itself on one half, which is the
+hash function's own security assumption, not a framing weakness. A domain
+separator would add nothing.
+
+This is also precisely what the W3C `eddsa-rdfc-2022` cryptosuite specifies for
+its hashing step (proof-configuration hash first, transformed-document hash
+second), so changing it would break interoperability while improving nothing.
+
+Verified against `src/crypto/signingInput.ts` and
+`src/vc/cryptosuites/eddsa.ts` (the sign and verify paths call the same helper,
+so the two sides cannot drift).
+
+**Do not re-open without a concrete collision argument that survives the
+fixed-length observation above.**
 
 ---
 
@@ -209,33 +292,32 @@ The SDK demonstrates strong security practices in several areas:
 
 ## Recommended Actions
 
-### Immediate (before v1.0 release)
-1. Add `validateBitcoinAddress()` in `transfer.ts` and `commit.ts` entry points
-2. Set default `maxInputs: 100` in UTXO selection
-3. Document UTXO locking requirement for production integrators
-4. Validate inscription content URLs in `BtcoDidResolver` — whitelist `https://`, reject private IPs
-5. Fix Ed25519Verifier multibase encoding — use `multikey.encodePublicKey()` instead of base64 with `z` prefix
-6. Add domain separation to EdDSA proof hash concatenation in `eddsa.ts`
-7. Replace silent signature format fallback in `Signer.ts` with explicit error
-8. Enforce HTTPS for `OrdHttpProvider` base URLs
-9. Add configurable max inscription data size (e.g., 4MB default)
+Re-derived 2026-08-24 from the verified statuses above. Items 1, 5, 6, 7 and 15
+of the previous list are gone because they are done or were never real.
 
-### Short-term
-10. Minimize private key string conversions in `eddsa.ts` and `commit.ts`
-11. Call `validateDIDDocument()` in DID creation paths
-12. Add fee rate validation in `calculateFee()`
-13. Add production warning for `MemoryStorageAdapter` on mainnet
-14. Document or implement multi-proof credential verification
-15. Verify external signer proofValue after signing in `WebVHManager`
-16. Add exponential backoff and circuit breaker to provider retry logic
+### Open, worth doing before a wider launch
+1. **Bound the inscription content read** (F9) — `await response.text()` in
+   `BtcoDidResolver` is unbounded; a hostile content host can exhaust memory
+   despite the timeout.
+2. **Move the SSRF check into the resolver** (F9) — today it lives in
+   `OrdHttpProvider`, so a custom provider reintroduces the vector.
+3. **Require `https://` for `OrdHttpProvider` base URLs** (F15), with an
+   explicit localhost/regtest escape.
+4. **Replace the silent signature-format fallback** in `Signer.ts` with an
+   explicit throw (F14).
+5. **Cap inscription data size** in `inscribeData()` (F16) — the 10MB
+   per-resource limit does not cover direct callers.
 
-### Medium-term
-17. Replace `any` assertions in `Signer.ts` with typed noble wrappers
-18. Consider UTXO locking API for wallet-level integrations
-19. Add key rotation test suite
-20. Expand security test suite (see gaps below)
-
----
+### Open, lower priority
+6. Distinguish retriable from permanent provider errors (F17) — backoff already
+   exists; only the `isRetriable: () => true` predicate is left.
+7. Document or implement multi-proof credential verification (F10).
+8. Call `validateDIDDocument()` in DID creation paths (F5).
+9. Add fee-rate bounds inside `calculateFee()` for defence in depth (F6).
+10. Warn when `MemoryStorageAdapter` is used with `network === 'mainnet'` (F8).
+11. Replace `any` assertions in `Signer.ts` with typed noble wrappers (F7).
+12. Default `maxInputs` in UTXO selection (F2); document the wallet-level UTXO
+    locking requirement for integrators (F3).
 
 ## Security Test Gaps
 
@@ -248,4 +330,4 @@ Areas not yet covered by `tests/security/bitcoin-penetration-tests.test.ts`:
 | Large inscription DoS | No tests for oversized inscription data | Medium |
 | Provider retry exhaustion | No tests for retry storm behavior | Medium |
 | Inscription ownership | No tests for unauthorized transfer attempts | Medium |
-| Multibase encoding | No tests for Ed25519Verifier encoding correctness | Medium |
+| Multibase encoding | Covered as of 2026-08 (`tests/unit/did/Ed25519Verifier.test.ts`) | — |

--- a/docs/api-reference/media/BITCOIN_INTEGRATION_GUIDE.md
+++ b/docs/api-reference/media/BITCOIN_INTEGRATION_GUIDE.md
@@ -65,19 +65,19 @@ AWS_KMS_KEY_ID=your_kms_key_id
 ### Using npm
 
 ```bash
-npm install @originals/sdk
+npm install @originals/sdk@next
 ```
 
 ### Using yarn
 
 ```bash
-yarn add @originals/sdk
+yarn add @originals/sdk@next
 ```
 
 ### Using bun
 
 ```bash
-bun add @originals/sdk
+bun add @originals/sdk@next
 ```
 
 ### TypeScript Configuration

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "landing:ci": "bun apps/landing/scripts/ci.mjs",
     "landing:check": "turbo run build --filter='./packages/*' && cd apps/landing && bun run typecheck && bun run typecheck:server && bun test && bun run build",
     "verify:esm": "node scripts/verify-esm.mjs",
+    "check:install-docs": "node scripts/check-install-docs.mjs",
     "verify:browser": "node scripts/check-browser-safety.mjs",
     "test": "turbo run test --filter='./packages/*'",
     "typecheck": "turbo run typecheck --filter='./packages/*'",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "landing:check": "turbo run build --filter='./packages/*' && cd apps/landing && bun run typecheck && bun run typecheck:server && bun test && bun run build",
     "verify:esm": "node scripts/verify-esm.mjs",
     "check:install-docs": "node scripts/check-install-docs.mjs",
+    "check:readme": "turbo run build --filter='./packages/*' && node scripts/check-readme-snippets.mjs",
     "verify:browser": "node scripts/check-browser-safety.mjs",
     "test": "turbo run test --filter='./packages/*'",
     "typecheck": "turbo run typecheck --filter='./packages/*'",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,12 @@
     "turbo": "^2.3.3"
   },
   "overrides": {
-    "human-id": "4.1.1"
+    "human-id": "4.1.1",
+    "undici": "^6.28.0",
+    "brace-expansion": "^5.0.8",
+    "nanoid": "^3.3.16",
+    "postcss": "^8.5.23",
+    "js-yaml": "^4.3.1"
   },
   "engines": {
     "node": ">=20.10.0"

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -5,9 +5,9 @@ Turnkey-based authentication for the [Originals Protocol](https://github.com/oni
 ## Installation
 
 ```bash
-npm install @originals/auth
+npm install @originals/auth@next
 # or
-bun add @originals/auth
+bun add @originals/auth@next
 ```
 
 Requires Node.js `>=20.10.0` (or Bun). Published as ESM. `express` is an optional peer dependency for the server middleware.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -15,10 +15,14 @@ Ownership at the `did:btco` layer IS live Bitcoin sat control — never a creden
 ## Installation
 
 ```bash
-npm install @originals/sdk
+npm install @originals/sdk@next
 # or
-bun add @originals/sdk
+bun add @originals/sdk@next
 ```
+
+> **Why `@next`:** 3.x is still a prerelease, so npm's `latest` tag deliberately
+> stays on the last stable release (2.1.0). Everything below is 3.x only. Drop the
+> tag once 3.0.0 ships to `latest`.
 
 Requires Node.js `>=20.10.0` (or Bun). Published as ESM.
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -28,22 +28,40 @@ Requires Node.js `>=20.10.0` (or Bun). Published as ESM.
 
 ## Quick start
 
+This snippet runs as-is (`scripts/check-readme-snippets.mjs` executes it against
+the built `dist` in CI, so it cannot silently rot).
+
+<!-- readme:run -->
 ```typescript
 import { OriginalsSDK } from '@originals/sdk';
+import { OrdMockProvider } from '@originals/sdk/testing';
+
+// Custody is required to mint — see "Custody" below for why, and for the
+// remote-custody (`signer`) alternative. A Map is the smallest thing that
+// satisfies the contract; it is not durable, so use a real store for anything
+// you intend to keep.
+const keys = new Map<string, string>();
+const myKeyStore = {
+  getPrivateKey: async (id: string) => keys.get(id) ?? null,
+  setPrivateKey: async (id: string, privateKey: string) => { keys.set(id, privateKey); },
+};
 
 const sdk = OriginalsSDK.create({
-  network: 'mainnet',          // 'mainnet' | 'signet' | 'regtest'
+  network: 'regtest',          // 'mainnet' | 'signet' | 'regtest'
   defaultKeyType: 'ES256K',    // 'ES256K' | 'Ed25519' | 'ES256'
   keyStore: myKeyStore,        // custody: keyStore OR signer — see "Custody" below
+  ordinalsProvider: new OrdMockProvider(),  // real Bitcoin: OrdinalsClient
 });
 
 // 1. Create an asset privately (did:cel genesis — offline, free)
+//    `hash` is the sha256 hex of the content; this is the digest of the
+//    empty string, which is a real digest and keeps the snippet runnable.
 const asset = await sdk.lifecycle.createAsset([
   {
     id: 'artwork-1',
     type: 'image',
     contentType: 'image/png',
-    hash: '<sha256-hex-of-content>',
+    hash: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
   },
 ]);
 

--- a/packages/sdk/src/events/types.ts
+++ b/packages/sdk/src/events/types.ts
@@ -9,6 +9,7 @@
 
 import { LayerType } from '../types/index.js';
 import type { MigrationError } from '../migration/types.js';
+import type { VerificationFailureCode } from '../lifecycle/VerificationReport.js';
 
 /**
  * Base event interface that all events extend
@@ -149,6 +150,13 @@ export interface VerificationCompletedEvent extends BaseEvent {
     id: string;
   };
   result: boolean;
+  /**
+   * Why verification did not succeed — the `code` from the
+   * {@link VerificationReport}. Absent when `result` is true. A subscriber
+   * logging these can tell "the proof does not hold" from "no ordinals provider
+   * was configured, so it was never checked".
+   */
+  code?: VerificationFailureCode;
   checks?: {
     didDocument: boolean;
     resources: boolean;

--- a/packages/sdk/src/examples/basic-usage.ts
+++ b/packages/sdk/src/examples/basic-usage.ts
@@ -39,8 +39,8 @@ async function basicExample() {
     console.log('Provenance:', provenance);
     
     // Verify asset integrity
-    const isValid = await asset.verify();
-    console.log('Asset is valid:', isValid);
+    const verification = await asset.verify();
+    console.log('Asset is valid:', verification.verified, verification.code ?? '');
     
   } catch (error) {
     console.error('Error:', error);

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -21,6 +21,7 @@ export type { ReplayedProvenance } from './lifecycle/replayProvenance.js';
 export { ASSET_ENVELOPE_FORMAT, ASSET_ENVELOPE_VERSION } from './lifecycle/assetEnvelope.js';
 export type { AssetEnvelope } from './lifecycle/assetEnvelope.js';
 export { checkGenesisResourceBinding } from './lifecycle/genesisBinding.js';
+export type { VerificationReport, VerificationFailureCode } from './lifecycle/VerificationReport.js';
 
 // Type exports
 export * from './types/index.js';

--- a/packages/sdk/src/lifecycle/LifecycleManager.ts
+++ b/packages/sdk/src/lifecycle/LifecycleManager.ts
@@ -20,6 +20,7 @@ import type { CredentialManager } from '../vc/CredentialManager.js';
 import { OriginalsAsset, type ProvenanceChain } from './OriginalsAsset.js';
 import { replayProvenance } from './replayProvenance.js';
 import { checkGenesisResourceBinding } from './genesisBinding.js';
+import type { VerificationReport } from './VerificationReport.js';
 import {
   ASSET_ENVELOPE_FORMAT,
   ASSET_ENVELOPE_VERSION,
@@ -515,6 +516,9 @@ export class LifecycleManager {
     // stale inside it. Later appends take a signer per call, or `config.signer`.
     asset._bindCelAppender((type, data, opts) =>
       this.appendCelEventAndMaybeInscribe(asset, type, data, opts));
+    // So `asset.verify()` checks the Bitcoin witness proof instead of failing
+    // closed on a provider the SDK was handed at construction (launch review).
+    asset._bindVerificationDefaults({ ordinalsProvider: this.config.ordinalsProvider });
 
     // Persist the genesis CEL at the conventional cel/<suffix>.json key so
     // the did:cel resolves from storage immediately (best-effort, never gates).
@@ -930,6 +934,7 @@ export class LifecycleManager {
       { currentLayer: folded.currentLayer, bindings: folded.bindings, provenance }
     );
     asset._bindCelAppender((type, data, opts) => this.appendCelEventAndMaybeInscribe(asset, type, data, opts));
+    asset._bindVerificationDefaults({ ordinalsProvider: this.config.ordinalsProvider });
 
     // Repopulate captured DID docs so re-serializing a loaded asset is
     // lossless. Only for layers cross-checked against the fold in step 5
@@ -1289,7 +1294,7 @@ export class LifecycleManager {
   async verifyAsset(
     asset: OriginalsAsset,
     overrides?: { ordinalsProvider?: OrdinalsLookup }
-  ): Promise<boolean> {
+  ): Promise<VerificationReport> {
     return asset.verify({
       didManager: this.didManager,
       credentialManager: this.credentialManager,

--- a/packages/sdk/src/lifecycle/OriginalsAsset.ts
+++ b/packages/sdk/src/lifecycle/OriginalsAsset.ts
@@ -20,6 +20,11 @@ import { createDidManagerKeyResolver } from '@originals/cel';
 import { serializeEventLogJson, parseEventLogJson } from '@originals/cel';
 import { replayProvenance } from './replayProvenance.js';
 import { checkGenesisResourceBinding } from './genesisBinding.js';
+import {
+  VERIFIED,
+  verificationFailure,
+  type VerificationReport
+} from './VerificationReport.js';
 import type { AppendFailurePolicy } from '../types/common.js';
 import {
   ASSET_ENVELOPE_FORMAT,
@@ -79,6 +84,10 @@ export class OriginalsAsset {
   // Per-layer DID documents captured at operation time (publish/inscribe/rotate).
   // These are discarded by the live flow otherwise; serialize() needs them.
   #didDocuments: Map<'did:webvh' | 'did:btco', DIDDocument> = new Map();
+  // Verification dependencies the SDK is already configured with, bound by
+  // LifecycleManager at mint/load. Undefined for assets constructed directly,
+  // which is why verify() still accepts per-call overrides.
+  #verificationDefaults?: { ordinalsProvider?: OrdinalsLookup };
   // Injected by LifecycleManager (createAsset / loadAsset). Appends a signed CEL
   // event via the manager's degrade-aware path and returns the new head digest,
   // or null when the append was skipped (no keyStore / no signing key). Undefined
@@ -220,6 +229,15 @@ export class OriginalsAsset {
   /** The CEL event log backing this asset, if minted via createAsset. */
   get celLog(): EventLog | undefined {
     return this.#celLog;
+  }
+
+  /**
+   * @internal — verification dependencies the SDK already holds, bound at mint
+   * and at load so `verify()` does not make the caller re-thread configuration
+   * the SDK was constructed with.
+   */
+  _bindVerificationDefaults(defaults: { ordinalsProvider?: OrdinalsLookup }): void {
+    this.#verificationDefaults = defaults;
   }
 
   /**
@@ -433,27 +451,43 @@ export class OriginalsAsset {
     return this.provenance.migrations.find(m => m.inscriptionId === inscriptionId) || null;
   }
 
+  /**
+   * Verify this asset: the whole signed CEL chain, the genesis resource
+   * binding, the DID document, resource integrity and credentials.
+   *
+   * Returns a {@link VerificationReport}, never a bare boolean — check
+   * `.verified`, and read `.code` when it is false. `false` used to mean both
+   * "the proof does not hold" and "I could not check it", which for a proof
+   * product is the one ambiguity that must not exist.
+   *
+   * @param deps.ordinalsProvider - Overrides the provider bound from the SDK
+   *   config. Assets minted or loaded through `sdk.lifecycle` already carry the
+   *   configured one, so the documented create → publish → inscribe → verify
+   *   flow needs no argument here. Absent both ways, a btco-anchored log fails
+   *   closed with `ORDINALS_PROVIDER_REQUIRED`.
+   */
   async verify(deps?: {
     didManager?: DIDManager;
     credentialManager?: CredentialManager;
     fetch?: (url: string) => Promise<{ arrayBuffer: () => Promise<ArrayBuffer> }>;
     /**
      * Required to verify `bitcoin-ordinals-2024` witness proofs in the CEL log
-     * (btco-anchored assets). Without it, a log carrying a bitcoin witness
-     * proof fails closed — see VerifyOptions.ordinalsProvider.
+     * (btco-anchored assets). Defaults to the SDK-configured provider — see
+     * VerifyOptions.ordinalsProvider for the fail-closed contract.
      */
     ordinalsProvider?: OrdinalsLookup;
-  }): Promise<boolean> {
-    const result = await this.runVerificationChecks(deps);
+  }): Promise<VerificationReport> {
+    const report = await this.runVerificationChecks(deps);
     // 'verification:completed' is part of the public EventTypeMap and is
     // subscribed by EventLogger; it was declared but never emitted (issue #352).
     await this.eventEmitter.emit({
       type: 'verification:completed',
       timestamp: new Date().toISOString(),
       asset: { id: this.id },
-      result
+      result: report.verified,
+      ...(report.code ? { code: report.code } : {})
     });
-    return result;
+    return report;
   }
 
   private async runVerificationChecks(deps?: {
@@ -461,7 +495,11 @@ export class OriginalsAsset {
     credentialManager?: CredentialManager;
     fetch?: (url: string) => Promise<{ arrayBuffer: () => Promise<ArrayBuffer> }>;
     ordinalsProvider?: OrdinalsLookup;
-  }): Promise<boolean> {
+  }): Promise<VerificationReport> {
+    // A per-call provider wins; otherwise use the one the SDK is already
+    // configured with. Threading it by hand was the whole bug: the config held
+    // a provider, verify() ignored it, and every inscribed asset reported false.
+    const ordinalsProvider = deps?.ordinalsProvider ?? this.#verificationDefaults?.ordinalsProvider;
     try {
       // 0) GATING: whole-chain CEL verification. `expectedDid: this.id` is the
       // binding check for _replaceCelLog — a swapped-in foreign log (even one
@@ -471,14 +509,32 @@ export class OriginalsAsset {
         const celResult = await verifyEventLog(this.#celLog, {
           expectedDid: this.id,
           resolveKey: deps?.didManager ? createDidManagerKeyResolver(deps.didManager) : undefined,
-          ordinalsProvider: deps?.ordinalsProvider,
+          ordinalsProvider,
           // With a provider we can (and must) reject a truncated pre-rotation
           // log whose on-chain head betrays the omission (#366). No provider ⇒
           // the flag is a no-op (btco witnesses fail closed without one anyway).
-          checkHeadFreshness: deps?.ordinalsProvider !== undefined
+          checkHeadFreshness: ordinalsProvider !== undefined
         });
         if (!celResult.verified) {
-          return false;
+          // Separate "I could not look" from "the proof does not hold". The
+          // verifier reports the missing provider by name; matching it is
+          // narrow, but the alternative is reporting a configuration gap as a
+          // failed proof, which is the ambiguity this report exists to remove.
+          if (!ordinalsProvider && celResult.errors.some((e) => /ordinalsProvider/i.test(e))) {
+            return verificationFailure(
+              'ORDINALS_PROVIDER_REQUIRED',
+              'This asset is anchored on Bitcoin and its witness proof was NOT checked: no ordinals provider ' +
+                'was available. This is not a statement about the proof — configure `ordinalsProvider` on the ' +
+                'SDK (OrdMockProvider for tests, OrdinalsClient/QuickNodeProvider for real chains) or pass one ' +
+                'to verify(), then verify again.',
+              { errors: celResult.errors }
+            );
+          }
+          return verificationFailure(
+            'CEL_LOG_INVALID',
+            'The signed event log did not verify.',
+            { errors: celResult.errors }
+          );
         }
 
         // Bind the in-memory resources to the verified genesis: every resource
@@ -487,26 +543,40 @@ export class OriginalsAsset {
         // resources passes (the log verifies, the resources don't back it).
         // Shared with loadAsset via the extracted pure helper.
         if (!checkGenesisResourceBinding(this.#celLog, this.resources)) {
-          return false;
+          return verificationFailure(
+            'GENESIS_RESOURCE_BINDING',
+            'The event log verified, but this asset\'s resources do not match the digests recorded at genesis.'
+          );
         }
       }
 
       // 1) DID Document validation (structure + supported method via validateDID)
       if (!validateDIDDocument(this.did)) {
-        return false;
+        return verificationFailure(
+          'DID_DOCUMENT_INVALID',
+          `The DID document for ${this.id} is structurally invalid or uses an unsupported method.`
+        );
       }
 
       // 2) Resources integrity
       for (const res of this.resources) {
         if (!res || typeof res.id !== 'string' || typeof res.type !== 'string' || typeof res.contentType !== 'string') {
-          return false;
+          return verificationFailure(
+            'RESOURCE_INVALID',
+            'A resource is missing a string id, type or contentType.',
+            { resourceId: typeof res?.id === 'string' ? res.id : undefined }
+          );
         }
         // Anchored: the hash must be entirely hex. An unanchored test would
         // accept any string merely containing a hex character (e.g.
         // "not-a-real-hash"); this structural gate runs before the content/URL
         // integrity checks below.
         if (typeof res.hash !== 'string' || !/^[0-9a-f]+$/i.test(res.hash)) {
-          return false;
+          return verificationFailure(
+            'RESOURCE_INVALID',
+            `Resource "${res.id}" has no valid hex hash.`,
+            { resourceId: res.id }
+          );
         }
 
         // If inline content is present, verify by hashing it
@@ -515,7 +585,11 @@ export class OriginalsAsset {
           const computed = hashResource(data);
           const expected = (res.hash || '').toLowerCase();
           if (computed.toLowerCase() !== expected) {
-            return false;
+            return verificationFailure(
+              'RESOURCE_HASH_MISMATCH',
+              `Resource "${res.id}" has inline content that does not hash to its declared hash.`,
+              { resourceId: res.id, declared: expected, computed: computed.toLowerCase() }
+            );
           }
           continue;
         }
@@ -526,7 +600,12 @@ export class OriginalsAsset {
         if (typeof res.url === 'string') {
           // No fetcher → hosted content is unverifiable → fail closed.
           if (!deps?.fetch) {
-            return false;
+            return verificationFailure(
+              'RESOURCE_UNVERIFIABLE',
+              `Resource "${res.id}" is hosted at a URL and its bytes were NOT checked: verify() was given no ` +
+                `fetch implementation. Pass one to confirm hosted content, or attach the content inline.`,
+              { resourceId: res.id, url: res.url }
+            );
           }
           try {
             const response = await deps.fetch(res.url);
@@ -534,11 +613,19 @@ export class OriginalsAsset {
             const computed = hashResource(buf);
             const expected = (res.hash || '').toLowerCase();
             if (computed.toLowerCase() !== expected) {
-              return false;
+              return verificationFailure(
+                'RESOURCE_HASH_MISMATCH',
+                `Resource "${res.id}" was fetched but does not hash to its declared hash.`,
+                { resourceId: res.id, url: res.url, declared: expected, computed: computed.toLowerCase() }
+              );
             }
-          } catch {
+          } catch (err) {
             // Fetch error on a hosted resource → unverifiable → fail closed.
-            return false;
+            return verificationFailure(
+              'RESOURCE_UNVERIFIABLE',
+              `Resource "${res.id}" could not be fetched, so its integrity was NOT checked.`,
+              { resourceId: res.id, url: res.url, error: (err as Error)?.message }
+            );
           }
         }
       }
@@ -546,7 +633,11 @@ export class OriginalsAsset {
       // 3) Credentials validation
       for (const cred of this.credentials) {
         if (!validateCredential(cred)) {
-          return false;
+          return verificationFailure(
+            'CREDENTIAL_INVALID',
+            'A credential attached to this asset is structurally invalid.',
+            { credentialId: (cred as { id?: unknown }).id }
+          );
         }
       }
 
@@ -558,13 +649,23 @@ export class OriginalsAsset {
       if (deps?.credentialManager && typeof deps.credentialManager.verifyCredential === 'function' && deps?.didManager) {
         for (const cred of this.credentials) {
           const ok = await deps.credentialManager.verifyCredential(cred);
-          if (!ok) return false;
+          if (!ok) {
+            return verificationFailure(
+              'CREDENTIAL_UNVERIFIED',
+              'A credential attached to this asset did not verify cryptographically.',
+              { credentialId: (cred as { id?: unknown }).id }
+            );
+          }
         }
       }
 
-      return true;
-    } catch {
-      return false;
+      return VERIFIED;
+    } catch (err) {
+      return verificationFailure(
+        'VERIFICATION_ERROR',
+        `Verification threw: ${(err as Error)?.message ?? String(err)}`,
+        { error: (err as Error)?.message ?? String(err) }
+      );
     }
   }
 

--- a/packages/sdk/src/lifecycle/VerificationReport.ts
+++ b/packages/sdk/src/lifecycle/VerificationReport.ts
@@ -1,0 +1,65 @@
+/**
+ * What `asset.verify()` answers with.
+ *
+ * A bare `boolean` conflates two very different statements: "I checked, and the
+ * proof does not hold" and "I could not check". For a product whose entire
+ * claim is that the proof verifies, those must never look the same to a caller
+ * — `false` with no reason sent developers hunting for a forgery when the real
+ * answer was a missing ordinals provider (launch review, item 3).
+ *
+ * So every non-verified outcome names a machine-readable `code` and a message
+ * that says what to do about it.
+ */
+
+/**
+ * Why verification did not succeed. Stable identifiers — branch on these, not
+ * on `message`.
+ */
+export type VerificationFailureCode =
+  /**
+   * The btco-anchored log carries a Bitcoin witness proof and no ordinals
+   * provider was available to check it, so verification FAILED CLOSED without
+   * looking. This is a configuration answer, not a provenance answer: configure
+   * `ordinalsProvider` on the SDK, or pass one to `verify()`.
+   */
+  | 'ORDINALS_PROVIDER_REQUIRED'
+  /** The signed CEL chain itself did not verify. `details.errors` carries the verifier's own reasons. */
+  | 'CEL_LOG_INVALID'
+  /** The log verified, but the asset's current resources do not match the digests recorded at genesis. */
+  | 'GENESIS_RESOURCE_BINDING'
+  /** The DID document is structurally invalid or names an unsupported method. */
+  | 'DID_DOCUMENT_INVALID'
+  /** A resource is structurally invalid (missing/!string id, type, contentType, or a non-hex hash). */
+  | 'RESOURCE_INVALID'
+  /** Inline or fetched content does not hash to the resource's declared hash. */
+  | 'RESOURCE_HASH_MISMATCH'
+  /** A hosted (URL-only) resource could not be fetched and hashed, so its integrity is unconfirmed. Fails closed. */
+  | 'RESOURCE_UNVERIFIABLE'
+  /** A credential is structurally invalid. */
+  | 'CREDENTIAL_INVALID'
+  /** A credential's signature did not verify. */
+  | 'CREDENTIAL_UNVERIFIED'
+  /** Verification threw. `details.error` carries the message. */
+  | 'VERIFICATION_ERROR';
+
+export interface VerificationReport {
+  /** The answer. Check this, never the truthiness of the report itself. */
+  verified: boolean;
+  /** Absent when `verified`. */
+  code?: VerificationFailureCode;
+  /** Human-readable and actionable. Absent when `verified`. */
+  message?: string;
+  /** Whatever the failing check knew: the offending resource id, the CEL verifier's errors. */
+  details?: Record<string, unknown>;
+}
+
+/** The verified answer. A single shared shape so callers can compare cheaply. */
+export const VERIFIED: VerificationReport = Object.freeze({ verified: true });
+
+export function verificationFailure(
+  code: VerificationFailureCode,
+  message: string,
+  details?: Record<string, unknown>
+): VerificationReport {
+  return details ? { verified: false, code, message, details } : { verified: false, code, message };
+}

--- a/packages/sdk/src/lifecycle/genesisBinding.ts
+++ b/packages/sdk/src/lifecycle/genesisBinding.ts
@@ -22,7 +22,20 @@ export function checkGenesisResourceBinding(log: EventLog, resources: AssetResou
     // which predate this contract — skip the check.
     return typeof genesis?.did === 'string';
   }
-  const present = new Set(resources.map(r => hexSha256ToDigestMultibase(r.hash)));
+  // Total by construction: a resource whose hash is not a sha256 hex string
+  // cannot match any genesis digest, and `hexSha256ToDigestMultibase` THROWS on
+  // one. Letting that escape turned a plain "these resources don't back this
+  // log" into an exception — swallowed as a bare `false` by verify()'s catch,
+  // and escaping loadAsset as a raw error instead of its structured
+  // ASSET_LOAD_VERIFICATION_FAILED. A malformed hash is simply not a match.
+  const present = new Set<string>();
+  for (const r of resources) {
+    try {
+      present.add(hexSha256ToDigestMultibase(r.hash));
+    } catch {
+      // Not a usable digest — contributes nothing to the present set.
+    }
+  }
   for (const entry of genesisResources) {
     const dm = (entry as { digestMultibase?: unknown })?.digestMultibase;
     if (typeof dm !== 'string' || !present.has(dm)) {

--- a/packages/sdk/tests/integration/BtcoRoundTrip.test.ts
+++ b/packages/sdk/tests/integration/BtcoRoundTrip.test.ts
@@ -119,9 +119,11 @@ describe('inscribeOnBitcoin commits to the CEL head digest (#365)', () => {
     const anchored = await verifyEventLog(asset.celLog!, { expectedDid: asset.id, ordinalsProvider });
     expect(anchored.verified).toBe(true);
 
-    // asset.verify() delegates: gated without the provider dep, true with it.
-    expect(await asset.verify()).toBe(false);
-    expect(await asset.verify({ ordinalsProvider })).toBe(true);
+    // asset.verify() delegates, and reaches the chain through the provider the
+    // SDK was configured with — the documented create/publish/inscribe/verify
+    // flow ends `true`, not `false`, and needs no hand-threaded dependency.
+    expect((await asset.verify()).verified).toBe(true);
+    expect((await asset.verify({ ordinalsProvider })).verified).toBe(true);
   });
 
   test('keyStore-less inscribe degrades: cel:append-skipped, no #cel anchor, log untouched', async () => {

--- a/packages/sdk/tests/integration/CelConvergence.e2e.test.ts
+++ b/packages/sdk/tests/integration/CelConvergence.e2e.test.ts
@@ -97,9 +97,11 @@ describe('CEL convergence end-to-end (#Phase2 Task9)', () => {
     // The creator still holds the pen: their post-anchor entry is a CREATOR claim.
     expect(result.events[3].authorClass).toBe('creator');
     expect(result.holders).toEqual([]);
-    // Same guarantee via the asset façade, and fail-closed without the dep.
-    expect(await asset.verify({ ordinalsProvider })).toBe(true);
-    expect(await asset.verify()).toBe(false);
+    // Same guarantee via the asset façade. No argument needed: the asset was
+    // minted through an SDK configured with this provider, and verify() uses it
+    // rather than reporting `false` for a check it never ran.
+    expect((await asset.verify({ ordinalsProvider })).verified).toBe(true);
+    expect((await asset.verify()).verified).toBe(true);
 
     // ---- The pure fold agrees with the live in-memory caches. ----
     const folded = replayProvenance(log);

--- a/packages/sdk/tests/integration/CompleteLifecycle.e2e.test.ts
+++ b/packages/sdk/tests/integration/CompleteLifecycle.e2e.test.ts
@@ -346,18 +346,18 @@ describe('E2E Integration: Complete Lifecycle Flow', () => {
       const asset = await sdk.lifecycle.createAsset(resources);
       
       // Verify at each stage (structural only)
-      expect(await asset.verify()).toBe(true);
+      expect((await asset.verify()).verified).toBe(true);
 
       const webAsset = await sdk.lifecycle.publishToWeb(asset, 'integrity.test');
-      expect(await webAsset.verify()).toBe(true);
+      expect((await webAsset.verify()).verified).toBe(true);
 
       // Post-inscription the CEL log carries a bitcoin witness proof (#367):
       // verify() now gates on the chain, so the ordinals provider is required.
       const btcoAsset = await sdk.lifecycle.inscribeOnBitcoin(webAsset, 5);
-      expect(await btcoAsset.verify({ ordinalsProvider })).toBe(true);
+      expect((await btcoAsset.verify({ ordinalsProvider })).verified).toBe(true);
 
       await sdk.lifecycle.transferOwnership(btcoAsset, 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx');
-      expect(await btcoAsset.verify({ ordinalsProvider })).toBe(true);
+      expect((await btcoAsset.verify({ ordinalsProvider })).verified).toBe(true);
     });
   });
 

--- a/packages/sdk/tests/integration/RemoteSignerLifecycle.e2e.test.ts
+++ b/packages/sdk/tests/integration/RemoteSignerLifecycle.e2e.test.ts
@@ -104,7 +104,7 @@ describe('remote-custody lifecycle (MockRemoteSigner, no keyStore)', () => {
     // proof, with zero private keys ever leaving custody. ----
     const result = await verifyEventLog(asset.celLog!, { expectedDid: asset.id, ordinalsProvider });
     expect(result.verified).toBe(true);
-    expect(await asset.verify({ ordinalsProvider })).toBe(true);
+    expect((await asset.verify({ ordinalsProvider })).verified).toBe(true);
   });
 
   test('config-level signer: OriginalsSDK.create({ signer }) is the ambient authorship signer', async () => {
@@ -130,7 +130,7 @@ describe('remote-custody lifecycle (MockRemoteSigner, no keyStore)', () => {
     await sdk.lifecycle.publishToWeb(asset, 'example.com');
     expect(skipped).toHaveLength(0);
     expect(asset.celLog!.events.map(e => e.type)).toEqual(['create', 'update', 'migrate']);
-    expect(await asset.verify()).toBe(true);
+    expect((await asset.verify()).verified).toBe(true);
   });
 
   test('the minting signer is NOT retained — a later append with no signer degrades', async () => {
@@ -163,7 +163,7 @@ describe('remote-custody lifecycle (MockRemoteSigner, no keyStore)', () => {
     expect(asset.celLog!.events.map(e => e.type)).toEqual(['create', 'update']);
     expect(asset.celLog!.events[1].proof[0].verificationMethod)
       .toBe(canonicalDidKeyVm(remote.publicKeyMultibase));
-    expect(await asset.verify()).toBe(true);
+    expect((await asset.verify()).verified).toBe(true);
   });
 
   test('config.signer still serves later appends — explicit config, not carried state', async () => {
@@ -173,7 +173,7 @@ describe('remote-custody lifecycle (MockRemoteSigner, no keyStore)', () => {
 
     await asset.addResourceVersion('art', 'remote-art-v2', 'image/png');
     expect(asset.celLog!.events.map(e => e.type)).toEqual(['create', 'update']);
-    expect(await asset.verify()).toBe(true);
+    expect((await asset.verify()).verified).toBe(true);
   });
 
   test('a non-Ed25519 signer is rejected loudly at createAsset (CEL is Ed25519-only)', async () => {

--- a/packages/sdk/tests/integration/ResourceUpdateHandoff.e2e.test.ts
+++ b/packages/sdk/tests/integration/ResourceUpdateHandoff.e2e.test.ts
@@ -221,7 +221,7 @@ describe('Resource-update handoff (e2e)', () => {
     expect(asset.celLog!.events.some(e => e.type === 'update')).toBe(false);
 
     // The log is still verifiable — no unverifiable event was ever appended.
-    expect(await asset.verify()).toBe(true);
+    expect((await asset.verify()).verified).toBe(true);
     // But the envelope now carries UNPROVABLE in-memory v2/v3 (degraded, never
     // logged); a buyer must fail closed rather than restore unverifiable
     // versions (#401 post-genesis binding). The log soundness is proven above.
@@ -248,7 +248,7 @@ describe('Resource-update handoff (e2e)', () => {
     expect(contents).toContain('v2b');
 
     // The resulting chain verifies (genesis → v2a → v2b, correctly serialized).
-    expect(await asset.verify()).toBe(true);
+    expect((await asset.verify()).verified).toBe(true);
     const buyer = OriginalsSDK.create({ network: 'regtest', defaultKeyType: 'Ed25519', keyStore: new MockKeyStore() });
     const { verification } = await buyer.lifecycle.loadAsset(asset.serialize());
     expect(verification?.verified).toBe(true);
@@ -270,6 +270,6 @@ describe('Resource-update handoff (e2e)', () => {
     expect(updates.length).toBe(2);
     expect(asset.getResourceVersion('a', 2)?.content).toBe('a2');
     expect(asset.getResourceVersion('b', 2)?.content).toBe('b2');
-    expect(await asset.verify()).toBe(true);
+    expect((await asset.verify()).verified).toBe(true);
   });
 });

--- a/packages/sdk/tests/unit/events/ManagerEventMirroring.test.ts
+++ b/packages/sdk/tests/unit/events/ManagerEventMirroring.test.ts
@@ -100,9 +100,9 @@ describe("'verification:completed' is emitted by OriginalsAsset.verify (issue #3
     const events: VerificationCompletedEvent[] = [];
     asset.on('verification:completed', (e) => { events.push(e); });
 
-    const ok = await asset.verify();
+    const report = await asset.verify();
     expect(events.length).toBe(1);
-    expect(events[0].result).toBe(ok);
+    expect(events[0].result).toBe(report.verified);
     expect(events[0].asset.id).toBe(asset.id);
   });
 
@@ -113,10 +113,14 @@ describe("'verification:completed' is emitted by OriginalsAsset.verify (issue #3
     const events: VerificationCompletedEvent[] = [];
     asset.on('verification:completed', (e) => { events.push(e); });
 
-    const ok = await asset.verify();
-    expect(ok).toBe(false);
+    const report = await asset.verify();
+    expect(report.verified).toBe(false);
     expect(events.length).toBe(1);
     expect(events[0].result).toBe(false);
+    // The event carries the reason too, so a subscriber logging these can tell
+    // a failed proof from a check that never ran.
+    expect(events[0].code).toBe(report.code);
+    expect(report.code).toBe('GENESIS_RESOURCE_BINDING');
   });
 });
 

--- a/packages/sdk/tests/unit/lifecycle/LifecycleManager.appendRace.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/LifecycleManager.appendRace.test.ts
@@ -105,7 +105,7 @@ describe('#400: addResourceVersion vs lifecycle append race', () => {
 
     // The chain must still verify end-to-end (a clobbered/stale-chained append
     // would break continuity).
-    expect(await asset.verify()).toBe(true);
+    expect((await asset.verify()).verified).toBe(true);
   });
 
   // The end-to-end publish variant proves one op's wiring against a real clobber.

--- a/packages/sdk/tests/unit/lifecycle/LifecycleManager.celgenesis.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/LifecycleManager.celgenesis.test.ts
@@ -96,7 +96,7 @@ describe('verify() binds in-memory resources to the CEL genesis', () => {
       { id: 'res-1', type: 'data', contentType: 'text/plain', hash: 'ab'.repeat(32) }
     ]);
     // Baseline: genuine asset with the resource the genesis committed to.
-    expect(await asset.verify()).toBe(true);
+    expect((await asset.verify()).verified).toBe(true);
 
     // Same verified log + facade DID doc, but a DIFFERENT resource (different
     // hash). The genesis digest is no longer among the current resources → fail.
@@ -106,6 +106,6 @@ describe('verify() binds in-memory resources to the CEL genesis', () => {
       [],
       asset.celLog!
     );
-    expect(await swapped.verify()).toBe(false);
+    expect((await swapped.verify()).verified).toBe(false);
   });
 });

--- a/packages/sdk/tests/unit/lifecycle/LifecycleManager.rotateBtcoKeys.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/LifecycleManager.rotateBtcoKeys.test.ts
@@ -56,6 +56,6 @@ describe('rotateBtcoKeys (removed capability: lineage frozen at the anchor)', ()
 
     const newKey = multikey.encodePublicKey(new Uint8Array(32).fill(7), 'Ed25519');
     await expect(sdk.lifecycle.rotateBtcoKeys(asset, { publicKeyMultibase: newKey })).rejects.toThrow(/not permitted after the btco anchor/);
-    expect(await asset.verify({ ordinalsProvider: provider })).toBe(true);
+    expect((await asset.verify({ ordinalsProvider: provider })).verified).toBe(true);
   });
 });

--- a/packages/sdk/tests/unit/lifecycle/LifecycleManager.verifyAsset.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/LifecycleManager.verifyAsset.test.ts
@@ -20,7 +20,7 @@ describe('LifecycleManager.verifyAsset', () => {
     const asset = await sdk.lifecycle.createAsset([
       { id: 'r', type: 'data', contentType: 'text/plain', hash: '11'.repeat(32) }
     ]);
-    expect(await sdk.lifecycle.verifyAsset(asset)).toBe(true);
+    expect((await sdk.lifecycle.verifyAsset(asset)).verified).toBe(true);
   });
 
   test('verifies a btco-anchored asset WITHOUT hand-passing a provider (config.ordinalsProvider is threaded automatically)', async () => {
@@ -39,7 +39,7 @@ describe('LifecycleManager.verifyAsset', () => {
     // Bare call — no overrides. Bitcoin witness verification requires a
     // provider; asset.verify() called directly (with no deps) would fail
     // closed here. verifyAsset must supply config.ordinalsProvider itself.
-    expect(await sdk.lifecycle.verifyAsset(asset)).toBe(true);
+    expect((await sdk.lifecycle.verifyAsset(asset)).verified).toBe(true);
   });
 
   test('an explicit override provider takes priority over config.ordinalsProvider', async () => {
@@ -67,11 +67,11 @@ describe('LifecycleManager.verifyAsset', () => {
       getInscriptionsBySatoshi: (sat: string) => configProvider.getInscriptionsBySatoshi(sat),
       getAnchoringsForDidCel: (didCel: string) => configProvider.getAnchoringsForDidCel!(didCel)
     };
-    expect(await sdk.lifecycle.verifyAsset(asset, { ordinalsProvider: overrideProvider })).toBe(true);
+    expect((await sdk.lifecycle.verifyAsset(asset, { ordinalsProvider: overrideProvider })).verified).toBe(true);
     expect(calls).toBeGreaterThan(0);
   });
 
-  test('a btco-anchored asset fails closed with NO provider configured and none overridden', async () => {
+  test('a btco-anchored asset loaded by a provider-less SDK fails closed, and SAYS it did not look', async () => {
     const provider = new OrdMockProvider();
     const sdkWithProvider = OriginalsSDK.create({
       network: 'regtest',
@@ -84,8 +84,36 @@ describe('LifecycleManager.verifyAsset', () => {
     ]);
     await sdkWithProvider.lifecycle.inscribeOnBitcoin(asset);
 
-    // A SEPARATE manager configured with no ordinalsProvider at all.
+    // The stranger's position: someone else's envelope, an SDK with no
+    // ordinalsProvider at all. The Bitcoin witness proof CANNOT be checked, so
+    // this must not report success...
     const sdkNoProvider = OriginalsSDK.create({ keyStore: new MockKeyStore(), network: 'regtest', defaultKeyType: 'Ed25519' });
-    expect(await sdkNoProvider.lifecycle.verifyAsset(asset)).toBe(false);
+    const { asset: loaded } = await sdkNoProvider.lifecycle.loadAsset(asset.serialize(), { skipVerification: true });
+    const report = await sdkNoProvider.lifecycle.verifyAsset(loaded);
+    expect(report.verified).toBe(false);
+    // ...and must not let that be mistaken for a failed proof. This is the
+    // distinction the bare boolean could not make.
+    expect(report.code).toBe('ORDINALS_PROVIDER_REQUIRED');
+    expect(report.message).toContain('ordinals provider');
+  });
+
+  test('an asset minted through a configured SDK keeps that provider, so a bare verify() still checks the chain', async () => {
+    const provider = new OrdMockProvider();
+    const sdk = OriginalsSDK.create({
+      network: 'regtest',
+      defaultKeyType: 'Ed25519',
+      ordinalsProvider: provider,
+      keyStore: new MockKeyStore()
+    });
+    const asset = await sdk.lifecycle.createAsset([
+      { id: 'r', type: 'data', contentType: 'text/plain', hash: '55'.repeat(32) }
+    ]);
+    await sdk.lifecycle.inscribeOnBitcoin(asset);
+
+    // Not through verifyAsset — directly on the asset, with no arguments. This
+    // is the call the README documents and it used to answer `false`.
+    const report = await asset.verify();
+    expect(report.verified).toBe(true);
+    expect(report.code).toBeUndefined();
   });
 });

--- a/packages/sdk/tests/unit/lifecycle/OriginalsAsset.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/OriginalsAsset.test.ts
@@ -59,13 +59,13 @@ describe('OriginalsAsset', () => {
 
   test('verifies asset integrity (inline content hash match)', async () => {
     const asset = new OriginalsAsset(resources, buildDid('did:cel:xyz'), emptyCreds);
-    await expect(asset.verify()).resolves.toBe(true);
+    expect((await asset.verify()).verified).toBe(true);
   });
 
   test('verify returns false on invalid DID Document', async () => {
     const badDid: any = { '@context': ['https://www.w3.org/ns/did/v1'], id: 'did:cel:abc', controller: ['not-a-did'] };
     const asset = new OriginalsAsset(resources, badDid, emptyCreds as any);
-    await expect(asset.verify()).resolves.toBe(false);
+    expect((await asset.verify()).verified).toBe(false);
   });
 
   test('verify uses injected fetch if provided for URL resources', async () => {
@@ -78,7 +78,7 @@ describe('OriginalsAsset', () => {
     };
     const asset = new OriginalsAsset([resWithUrl], buildDid('did:cel:abc'), emptyCreds);
     const mockFetch = async () => ({ arrayBuffer: async () => new ArrayBuffer(0) }) as any;
-    await expect(asset.verify({ fetch: mockFetch })).resolves.toBe(true);
+    expect((await asset.verify({ fetch: mockFetch })).verified).toBe(true);
   });
 
   test('verify rejects a URL-only resource whose hash is not entirely hex', async () => {
@@ -95,13 +95,13 @@ describe('OriginalsAsset', () => {
     };
     const asset = new OriginalsAsset([resWithUrl], buildDid('did:cel:abc'), emptyCreds);
     // No fetch provided → structural check is the only gate.
-    await expect(asset.verify()).resolves.toBe(false);
+    expect((await asset.verify()).verified).toBe(false);
   });
 
   test('verify validates attached credentials structure and returns false on bad', async () => {
     const badVc: any = { '@context': ['https://example.com'], type: ['VerifiableCredential'], issuer: 'did:cel:x', issuanceDate: new Date().toISOString(), credentialSubject: {} };
     const asset = new OriginalsAsset(resources, buildDid('did:cel:xyz'), [badVc]);
-    await expect(asset.verify()).resolves.toBe(false);
+    expect((await asset.verify()).verified).toBe(false);
   });
 
   test('verify with credentialManager performs cryptographic verification', async () => {
@@ -119,7 +119,7 @@ describe('OriginalsAsset', () => {
     const didManager = new DIDManager({} as any);
     const cm = new CredentialManager({ defaultKeyType: 'ES256K', network: 'regtest' } as any, didManager);
     const spy = spyOn(cm, 'verifyCredential').mockResolvedValue(true);
-    await expect(asset.verify({ credentialManager: cm, didManager })).resolves.toBe(true);
+    expect((await asset.verify({ credentialManager: cm, didManager })).verified).toBe(true);
     spy.mockRestore();
   });
 
@@ -138,7 +138,7 @@ describe('OriginalsAsset', () => {
     const didManager = new DIDManager({} as any);
     const cm = new CredentialManager({ defaultKeyType: 'ES256K', network: 'regtest' } as any, didManager);
     const spy = spyOn(cm, 'verifyCredential').mockResolvedValue(false);
-    await expect(asset.verify({ credentialManager: cm, didManager })).resolves.toBe(false);
+    expect((await asset.verify({ credentialManager: cm, didManager })).verified).toBe(false);
     spy.mockRestore();
   });
 
@@ -149,7 +149,7 @@ describe('OriginalsAsset', () => {
     };
     const asset = new OriginalsAsset([resWithUrl], buildDid('did:cel:abc'), emptyCreds);
     const failingFetch = async () => { throw new Error('network'); };
-    await expect(asset.verify({ fetch: failingFetch as any })).resolves.toBe(false);
+    expect((await asset.verify({ fetch: failingFetch as any })).verified).toBe(false);
   });
 
   test('verify fails closed for a hosted (URL-only) resource when no fetcher is provided (#368)', async () => {
@@ -163,7 +163,7 @@ describe('OriginalsAsset', () => {
       hash: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' // valid hex, sha256 of empty
     };
     const asset = new OriginalsAsset([resWithUrl], buildDid('did:cel:abc'), emptyCreds);
-    await expect(asset.verify()).resolves.toBe(false);
+    expect((await asset.verify()).verified).toBe(false);
   });
 
   test('verify passes for a resource with BOTH inline content and url via the inline path, no fetcher (#368)', async () => {
@@ -177,19 +177,19 @@ describe('OriginalsAsset', () => {
       hash: '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'
     };
     const asset = new OriginalsAsset([resBoth], buildDid('did:cel:abc'), emptyCreds);
-    await expect(asset.verify()).resolves.toBe(true);
+    expect((await asset.verify()).verified).toBe(true);
   });
 
   test('verify returns false when resource has invalid id type', async () => {
     const badResource: any = { id: 123, type: 'text', contentType: 'text/plain', hash: 'abc' };
     const asset = new OriginalsAsset([badResource], buildDid('did:cel:abc'), emptyCreds);
-    await expect(asset.verify()).resolves.toBe(false);
+    expect((await asset.verify()).verified).toBe(false);
   });
 
   test('verify returns false when resource hash has non-hex characters', async () => {
     const badResource: AssetResource = { id: 'r', type: 'text', contentType: 'text/plain', hash: 'zzzz' };
     const asset = new OriginalsAsset([badResource], buildDid('did:cel:abc'), emptyCreds);
-    await expect(asset.verify()).resolves.toBe(false);
+    expect((await asset.verify()).verified).toBe(false);
   });
 
   test('verify returns false when inline content hash mismatch', async () => {
@@ -201,7 +201,7 @@ describe('OriginalsAsset', () => {
       hash: 'wrong0000000000000000000000000000000000000000000000000000000000'
     };
     const asset = new OriginalsAsset([badResource], buildDid('did:cel:abc'), emptyCreds);
-    await expect(asset.verify()).resolves.toBe(false);
+    expect((await asset.verify()).verified).toBe(false);
   });
 
   test('verify returns false when fetched URL content hash mismatch', async () => {
@@ -214,7 +214,7 @@ describe('OriginalsAsset', () => {
     };
     const asset = new OriginalsAsset([resWithUrl], buildDid('did:cel:abc'), emptyCreds);
     const mockFetch = async () => ({ arrayBuffer: async () => Buffer.from('test').buffer }) as any;
-    await expect(asset.verify({ fetch: mockFetch })).resolves.toBe(false);
+    expect((await asset.verify({ fetch: mockFetch })).verified).toBe(false);
   });
 
   test('verify catches and returns false on unexpected error', async () => {
@@ -224,7 +224,7 @@ describe('OriginalsAsset', () => {
     spyOn(require('../../../src/utils/validation'), 'validateDIDDocument').mockImplementationOnce(() => {
       throw new Error('unexpected');
     });
-    await expect(asset.verify()).resolves.toBe(false);
+    expect((await asset.verify()).verified).toBe(false);
   });
 
   test('constructor throws on unknown DID method (coverage for error path)', () => {
@@ -253,13 +253,13 @@ describe('verify() gates on whole-chain CEL verification (#Phase2 Task 8)', () =
   test('intact celLog: verify() is true', async () => {
     const asset = await makeCelAsset();
     expect(asset.celLog).toBeDefined();
-    await expect(asset.verify()).resolves.toBe(true);
+    expect((await asset.verify()).verified).toBe(true);
   });
 
   test('tampered log (event data mutated post-hoc) flips verify() to false', async () => {
     const asset = await makeCelAsset();
     (asset.celLog!.events[0].data as { name?: string }).name = 'tampered';
-    await expect(asset.verify()).resolves.toBe(false);
+    expect((await asset.verify()).verified).toBe(false);
   });
 
   test('a swapped-in FOREIGN log (individually valid) flips verify() to false — the _replaceCelLog binding check', async () => {
@@ -269,13 +269,13 @@ describe('verify() gates on whole-chain CEL verification (#Phase2 Task 8)', () =
     expect((await verifyEventLog(b.celLog!)).verified).toBe(true);
     // ...but it does not back A's DID, so verify() must reject the swap.
     a._replaceCelLog(b.celLog!);
-    await expect(a.verify()).resolves.toBe(false);
+    expect((await a.verify()).verified).toBe(false);
   });
 
   test('legacy asset without a celLog keeps its current verify behavior', async () => {
     const asset = new OriginalsAsset(resources, buildDid('did:cel:xyz'), emptyCreds);
     expect(asset.celLog).toBeUndefined();
-    await expect(asset.verify()).resolves.toBe(true);
+    expect((await asset.verify()).verified).toBe(true);
   });
 });
 

--- a/packages/sdk/tests/unit/lifecycle/addResourceVersion.webvhHosting.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/addResourceVersion.webvhHosting.test.ts
@@ -135,7 +135,7 @@ describe('addResourceVersion on a published (did:webvh) asset', () => {
     const storage = new MemoryStorageAdapter();
     const { asset } = await publishedAsset(storage);
     await asset.addResourceVersion('doc.txt', V2, 'text/plain');
-    expect(await asset.verify()).toBe(true);
+    expect((await asset.verify()).verified).toBe(true);
   });
 
   // Abort-before-mutate: hosting runs BEFORE the append, so a hosting failure

--- a/packages/sdk/tests/unit/lifecycle/authorCommitted.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/authorCommitted.test.ts
@@ -47,7 +47,7 @@ describe('post-anchor appends commit data.author', () => {
     expect(updates.length).toBe(1);
     expect((updates[0].data as { author?: string }).author).toBe(controllerDid);
     // The committed author binds to the actual signer — the log verifies.
-    expect(await asset.verify({ ordinalsProvider: provider })).toBe(true);
+    expect((await asset.verify({ ordinalsProvider: provider })).verified).toBe(true);
   });
 
   test('the reinscribed btco document announces the appending key the entry commits to', async () => {
@@ -77,7 +77,7 @@ describe('post-anchor appends commit data.author', () => {
     expect(asset.celLog!.events.map((e) => e.type)).toEqual(['create', 'migrate']);
     const head = asset.celLog!.events[1];
     expect(head.proof.some((p) => (p as { cryptosuite?: string }).cryptosuite === 'bitcoin-ordinals-2024')).toBe(true);
-    expect(await asset.verify({ ordinalsProvider: provider })).toBe(true);
+    expect((await asset.verify({ ordinalsProvider: provider })).verified).toBe(true);
   });
 
   test('a statement append commits its author and verifies (rotateKey is refused post-anchor)', async () => {
@@ -94,7 +94,7 @@ describe('post-anchor appends commit data.author', () => {
     await asset.appendStatement({ statement: 'still mine' });
     const head = asset.celLog!.events[asset.celLog!.events.length - 1];
     expect((head.data as { author?: string }).author).toBe(controllerDid);
-    expect(await asset.verify({ ordinalsProvider: provider })).toBe(true);
+    expect((await asset.verify({ ordinalsProvider: provider })).verified).toBe(true);
   });
 
   test('pre-anchor events carry NO author (key lineage governs before the anchor)', async () => {

--- a/packages/sdk/tests/unit/lifecycle/custody-required.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/custody-required.test.ts
@@ -59,7 +59,7 @@ describe('createAsset requires custody [plan 041]', () => {
     const asset = await sdk.lifecycle.createAsset(RES, { controller: 'ephemeral' });
     expect(asset.currentLayer).toBe('did:cel');
     // It still verifies — it simply can never gain another event.
-    expect(await asset.verify()).toBe(true);
+    expect((await asset.verify()).verified).toBe(true);
   });
 
   test('createDraft forwards custody rather than bypassing the requirement', async () => {

--- a/packages/sdk/tests/unit/lifecycle/inscribeOnBitcoin.satSelect.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/inscribeOnBitcoin.satSelect.test.ts
@@ -172,8 +172,8 @@ describe('inscribeOnBitcoin (sat-selected)', () => {
     expect(asset.bindings!['did:btco']).toBe('did:btco:reg:1777');
 
     // verify / replay fold from the log without blowing up (return, not throw).
-    const ok = await asset.verify({ ordinalsProvider: provider as any });
-    expect(typeof ok).toBe('boolean');
+    const report = await asset.verify({ ordinalsProvider: provider as any });
+    expect(typeof report.verified).toBe('boolean');
     expect(() => asset.getProvenance()).not.toThrow();
   });
 

--- a/packages/sdk/tests/unit/lifecycle/loadAsset.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/loadAsset.test.ts
@@ -85,7 +85,9 @@ describe('loadAsset — round-trip', () => {
     expect(lp.txid).toBe(oBtco.transactionId);
 
     // The loaded asset re-verifies on its own.
-    expect(await loaded.verify({ ordinalsProvider: (sdk as any).config?.ordinalsProvider })).toBe(true);
+    // No hand-threaded provider: loadAsset binds the manager's own, so a
+    // loaded asset re-verifies with a bare call.
+    expect((await loaded.verify()).verified).toBe(true);
   });
 
   test('genesis-only asset round-trips (currentLayer did:cel)', async () => {

--- a/packages/sdk/tests/unit/lifecycle/satGatedAppends.sdk.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/satGatedAppends.sdk.test.ts
@@ -57,7 +57,7 @@ describe('sat-gated appends (SDK write side)', () => {
     const captured = (asset.serialize().didDocuments as { 'did:btco'?: { verificationMethod?: Array<{ publicKeyMultibase?: string }> } })['did:btco'];
     expect(captured?.verificationMethod?.[0]?.publicKeyMultibase).toBe(holderKp.publicKey);
     // And the whole log verifies: the sat gate, not the key set, authorized it.
-    expect(await asset.verify({ ordinalsProvider: provider })).toBe(true);
+    expect((await asset.verify({ ordinalsProvider: provider })).verified).toBe(true);
   });
 
   test('a non-lineage signer with an authenticity field throws CEL_HOLDER_FIELD_NOT_PERMITTED before ANY inscription', async () => {

--- a/packages/sdk/tests/unit/lifecycle/verifyReport.test.ts
+++ b/packages/sdk/tests/unit/lifecycle/verifyReport.test.ts
@@ -1,0 +1,141 @@
+/**
+ * `asset.verify()` across the documented lifecycle, and what it says when it
+ * cannot answer.
+ *
+ * The launch-review regression: the create → publish → inscribe → verify flow
+ * that the README documents ended in `false`, because `verify()` ignored the
+ * `ordinalsProvider` the SDK config already held and the btco witness proof
+ * fails closed without one. The developer got a bare `false` and nothing to
+ * debug with — for a product whose claim is "the proof verifies", the worst
+ * possible default.
+ *
+ * Two properties are pinned here:
+ *   1. every layer of the documented flow verifies with a bare `verify()`;
+ *   2. when the proof genuinely cannot be checked, the report SAYS SO
+ *      (`ORDINALS_PROVIDER_REQUIRED`) rather than implying the proof failed.
+ */
+import { describe, test, expect } from 'bun:test';
+import { OriginalsSDK } from '../../../src';
+import { OrdMockProvider } from '../../../src/adapters/providers/OrdMockProvider';
+import { MockKeyStore } from '../../mocks/MockKeyStore';
+
+// A FACTORY, not a shared constant: some tests below mutate the asset's
+// resources in place, and createAsset holds the objects it was handed.
+const resources = () => [
+  { id: 'artwork-1', type: 'image', contentType: 'image/png', hash: 'ab'.repeat(32) }
+];
+
+function makeSdk(ordinalsProvider = new OrdMockProvider()) {
+  return OriginalsSDK.create({
+    network: 'regtest',
+    defaultKeyType: 'Ed25519',
+    ordinalsProvider,
+    keyStore: new MockKeyStore()
+  });
+}
+
+describe('asset.verify() across the documented lifecycle', () => {
+  test('did:cel genesis verifies', async () => {
+    const asset = await makeSdk().lifecycle.createAsset(resources());
+    expect(asset.currentLayer).toBe('did:cel');
+    const report = await asset.verify();
+    expect(report.verified).toBe(true);
+    expect(report.code).toBeUndefined();
+  });
+
+  test('did:webvh publication verifies', async () => {
+    const sdk = makeSdk();
+    const asset = await sdk.lifecycle.createAsset(resources());
+    await sdk.lifecycle.publishToWeb(asset, 'example.com');
+    expect(asset.currentLayer).toBe('did:webvh');
+    const report = await asset.verify();
+    expect(report.verified).toBe(true);
+    expect(report.code).toBeUndefined();
+  });
+
+  test('did:btco inscription verifies with NO argument — the regression this file exists for', async () => {
+    const sdk = makeSdk();
+    const asset = await sdk.lifecycle.createAsset(resources());
+    await sdk.lifecycle.publishToWeb(asset, 'example.com');
+    await sdk.lifecycle.inscribeOnBitcoin(asset);
+    expect(asset.currentLayer).toBe('did:btco');
+
+    // Before the fix this was `false`: the config held a provider, verify()
+    // did not use it, and the btco witness proof failed closed.
+    const report = await asset.verify();
+    expect(report.verified).toBe(true);
+    expect(report.code).toBeUndefined();
+  });
+
+  test('an explicitly passed provider still wins over the configured one', async () => {
+    const configProvider = new OrdMockProvider();
+    const sdk = makeSdk(configProvider);
+    const asset = await sdk.lifecycle.createAsset(resources());
+    await sdk.lifecycle.inscribeOnBitcoin(asset);
+
+    let calls = 0;
+    const override = {
+      getInscriptionById: (id: string) => { calls += 1; return configProvider.getInscriptionById(id); },
+      getInscriptionsBySatoshi: (sat: string) => configProvider.getInscriptionsBySatoshi(sat),
+      getAnchoringsForDidCel: (did: string) => configProvider.getAnchoringsForDidCel!(did)
+    };
+    expect((await asset.verify({ ordinalsProvider: override })).verified).toBe(true);
+    expect(calls).toBeGreaterThan(0);
+  });
+});
+
+describe('verify() distinguishes "the proof does not hold" from "I did not look"', () => {
+  test('a btco asset with no provider anywhere reports ORDINALS_PROVIDER_REQUIRED, not a bare false', async () => {
+    const sdk = makeSdk();
+    const asset = await sdk.lifecycle.createAsset(resources());
+    await sdk.lifecycle.inscribeOnBitcoin(asset);
+
+    // Loaded by an SDK that has no provider at all — the stranger's position.
+    const bare = OriginalsSDK.create({
+      network: 'regtest',
+      defaultKeyType: 'Ed25519',
+      keyStore: new MockKeyStore()
+    });
+    const { asset: loaded } = await bare.lifecycle.loadAsset(asset.serialize(), { skipVerification: true });
+
+    const report = await loaded.verify();
+    expect(report.verified).toBe(false);
+    expect(report.code).toBe('ORDINALS_PROVIDER_REQUIRED');
+    // The message has to name the fix, not just the symptom.
+    expect(report.message).toContain('ordinalsProvider');
+    expect(report.details?.errors).toBeDefined();
+  });
+
+  test('a swapped resource reports the binding failure, not the provider', async () => {
+    const sdk = makeSdk();
+    const asset = await sdk.lifecycle.createAsset(resources());
+    (asset.resources[0] as { hash: string }).hash = 'cd'.repeat(32);
+
+    const report = await asset.verify();
+    expect(report.verified).toBe(false);
+    expect(report.code).toBe('GENESIS_RESOURCE_BINDING');
+  });
+
+  test('a structurally invalid resource hash is reported, not thrown', async () => {
+    const sdk = makeSdk();
+    const asset = await sdk.lifecycle.createAsset(resources());
+    (asset.resources[0] as { hash: string }).hash = 'not-a-real-hash';
+
+    // `hexSha256ToDigestMultibase` throws on this; the report must still be a
+    // report. VERIFICATION_ERROR would mean the check crashed.
+    const report = await asset.verify();
+    expect(report.verified).toBe(false);
+    expect(report.code).toBe('GENESIS_RESOURCE_BINDING');
+  });
+
+  test('a hosted resource with no fetcher is reported as unverifiable, not as a failed proof', async () => {
+    const sdk = makeSdk();
+    const asset = await sdk.lifecycle.createAsset(resources());
+    (asset.resources[0] as { url?: string }).url = 'https://example.com/artwork.png';
+
+    const report = await asset.verify();
+    expect(report.verified).toBe(false);
+    expect(report.code).toBe('RESOURCE_UNVERIFIABLE');
+    expect(report.details?.resourceId).toBe('artwork-1');
+  });
+});

--- a/railway.json
+++ b/railway.json
@@ -6,6 +6,7 @@
   },
   "deploy": {
     "startCommand": "bun run apps/landing/serve.ts",
+    "numReplicas": 1,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 5
   }

--- a/scripts/check-install-docs.mjs
+++ b/scripts/check-install-docs.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+/**
+ * Gate: every install command we publish must resolve to the code we document.
+ *
+ * The failure this exists to prevent (launch review, item 1): the repo and every
+ * doc described 3.x while `npm install @originals/sdk` resolved to 2.1.0 — a
+ * major behind, with a different lifecycle API and no `./testing` subpath. An
+ * outside developer followed the quick start against an SDK that no longer
+ * existed and concluded the library was broken. Nothing in CI noticed, because
+ * nothing in CI had ever asked the registry what our own install line returns.
+ *
+ * So: scrape every install command out of the shipped markdown, ask the registry
+ * what each one actually resolves to, and require the answer to be on the same
+ * MAJOR line as the workspace package it documents.
+ *
+ * Why major-only rather than an exact match: between merging the Version PR and
+ * the publish job finishing, the workspace version is legitimately ahead of the
+ * registry. Requiring equality would make that window red for a non-problem.
+ * Major is the line where the API changes shape, which is exactly the breakage
+ * this gate is for.
+ *
+ * Network failures FAIL, they do not skip — a gate that silently passes when it
+ * could not check is the thing that let this ship in the first place. Same
+ * choice release.yml already makes for its registry probe.
+ *
+ * Usage: node scripts/check-install-docs.mjs
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const ROOT = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
+
+/**
+ * Directories that are not the shipped docs: historical planning material and
+ * vendored code. `legacy/` in particular documents an SDK that is gone.
+ */
+const SKIP_DIRS = new Set([
+  'node_modules', '.git', 'dist', 'coverage', 'legacy', 'plans', 'tasks',
+  'specs', 'migrations', '.changeset', '.turbo', 'viewer', 'badges',
+]);
+
+function markdownFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...markdownFiles(full));
+    else if (entry.endsWith('.md')) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Install commands inside FENCED SHELL BLOCKS only. Prose that quotes a bare
+ * `npm install @originals/sdk` to explain why you should not run it is not an
+ * instruction, and flagging it would push the docs into never naming the wrong
+ * command even to warn about it.
+ */
+const FENCE = /^```(bash|sh|shell|console|zsh)\s*$/;
+const INSTALL = /\b(?:npm\s+(?:install|i|add)|bun\s+add|yarn\s+add|pnpm\s+add)\s+(?:-g\s+|--global\s+)?(@originals\/[a-z0-9-]+(?:@[^\s`]+)?)/g;
+
+function installSpecs(file) {
+  const found = [];
+  let inFence = false;
+  const lines = readFileSync(file, 'utf8').split('\n');
+  for (const [i, line] of lines.entries()) {
+    if (line.startsWith('```')) {
+      // A fence closes whatever is open; otherwise it opens one only if it is a
+      // shell block. Non-shell blocks (typescript, json) still toggle correctly
+      // because the close fence is a bare ```.
+      inFence = inFence ? false : FENCE.test(line);
+      continue;
+    }
+    if (!inFence) continue;
+    for (const m of line.matchAll(INSTALL)) {
+      found.push({ spec: m[1], file, line: i + 1 });
+    }
+  }
+  return found;
+}
+
+/** Workspace packages, by name → local version. */
+function workspacePackages() {
+  const map = new Map();
+  for (const scope of ['packages', 'apps']) {
+    const base = join(ROOT, scope);
+    let entries = [];
+    try {
+      entries = readdirSync(base);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      try {
+        const pkg = JSON.parse(readFileSync(join(base, entry, 'package.json'), 'utf8'));
+        if (pkg.name && pkg.version) map.set(pkg.name, pkg.version);
+      } catch {
+        /* not a package */
+      }
+    }
+  }
+  return map;
+}
+
+const majorOf = (v) => String(v).split('.')[0];
+const isPrerelease = (v) => /-/.test(String(v));
+
+/**
+ * What `npm install <spec>` would give you today. Throws on any registry
+ * failure that is not a clean "this spec matches nothing".
+ */
+function resolve(spec) {
+  try {
+    const out = execFileSync('npm', ['view', spec, 'version', '--json'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+    if (!out) return null;
+    const parsed = JSON.parse(out);
+    // A range spec can match many versions; npm returns them oldest-first and
+    // installs the newest.
+    return Array.isArray(parsed) ? parsed[parsed.length - 1] : parsed;
+  } catch (err) {
+    const stderr = String(err.stderr ?? '');
+    if (/E404|code E404|is not in this registry|No matching version/i.test(stderr)) return null;
+    throw new Error(`registry lookup failed for "${spec}": ${stderr || err.message}`);
+  }
+}
+
+const specs = markdownFiles(ROOT).flatMap(installSpecs);
+if (specs.length === 0) {
+  console.error('check-install-docs: found no install commands to check — the scraper is broken.');
+  process.exit(1);
+}
+
+const local = workspacePackages();
+const failures = [];
+const checked = new Map();
+
+for (const { spec, file, line } of specs) {
+  const at = spec.lastIndexOf('@');
+  const name = at > 0 ? spec.slice(0, at) : spec;
+  const where = `${relative(ROOT, file)}:${line}`;
+
+  const localVersion = local.get(name);
+  if (!localVersion) {
+    failures.push(`${where}: "${spec}" names ${name}, which is not a package in this workspace.`);
+    continue;
+  }
+
+  if (!checked.has(spec)) checked.set(spec, resolve(spec));
+  const resolved = checked.get(spec);
+
+  if (resolved === null) {
+    failures.push(
+      `${where}: "${spec}" resolves to NOTHING on the registry — this command fails for anyone who runs it.`
+    );
+    continue;
+  }
+  if (majorOf(resolved) !== majorOf(localVersion)) {
+    failures.push(
+      `${where}: "${spec}" resolves to ${resolved}, but this repo documents ${name}@${localVersion}. ` +
+        `A reader following these docs would install a different major. ` +
+        `Either publish ${majorOf(localVersion)}.x to the tag this command names, or point the command at a tag that carries it.`
+    );
+    continue;
+  }
+  // Prerelease line documented, stable install line published: the reverse of
+  // the bug above and just as wrong — the docs would describe unreleased API.
+  if (isPrerelease(localVersion) && !isPrerelease(resolved) && !spec.includes('@next')) {
+    failures.push(
+      `${where}: "${spec}" resolves to the stable ${resolved} while this repo is on the prerelease ${localVersion}. ` +
+        `Point the command at @next until ${majorOf(localVersion)}.0.0 ships to latest.`
+    );
+  }
+}
+
+for (const [spec, resolved] of checked) {
+  console.log(`  ${spec} → ${resolved ?? 'NOTHING'}`);
+}
+
+if (failures.length > 0) {
+  console.error(`\ncheck-install-docs: ${failures.length} install command(s) do not match what this repo documents:\n`);
+  for (const f of failures) console.error(`  - ${f}`);
+  process.exit(1);
+}
+
+console.log(`\ncheck-install-docs: ${checked.size} distinct install command(s) across ${specs.length} site(s) all resolve to the documented major.`);

--- a/scripts/check-readme-snippets.mjs
+++ b/scripts/check-readme-snippets.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * Gate: the quick starts we ship must actually run.
+ *
+ * The failure this exists to prevent (launch review, item 2): the root README's
+ * quick start — the first code any adopter executes — threw `NO_CUSTODY` on the
+ * happy path, verbatim, against the built dist. Nothing caught it because
+ * nothing had ever run it. Prose rots silently; only execution notices.
+ *
+ * Every fenced block preceded by `<!-- readme:run -->` is extracted, pointed at
+ * the BUILT dist (not src — consumers get the dist, and a dist-only breakage is
+ * exactly the class of bug the ESM gate exists for), and executed. A non-zero
+ * exit fails this script with the snippet's own stderr.
+ *
+ * Marking is opt-in on purpose: most blocks in these files are illustrative
+ * fragments that were never meant to run standalone. A block that claims to be
+ * a quick start should carry the marker and earn it.
+ *
+ * Usage: bun run build && node scripts/check-readme-snippets.mjs
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const ROOT = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
+
+/** Files whose marked snippets are executed. */
+const DOCS = ['README.md', 'packages/sdk/README.md'];
+
+const MARKER = '<!-- readme:run -->';
+
+/** Built entry points a snippet's bare specifiers are rewritten to. */
+const DIST = {
+  '@originals/sdk/testing': join(ROOT, 'packages/sdk/dist/testing/index.js'),
+  '@originals/sdk/types': join(ROOT, 'packages/sdk/dist/types/index.js'),
+  '@originals/sdk/cel': join(ROOT, 'packages/sdk/dist/cel/index.js'),
+  '@originals/sdk': join(ROOT, 'packages/sdk/dist/index.js'),
+  '@originals/cel': join(ROOT, 'packages/cel/dist/index.js'),
+};
+
+for (const [spec, path] of Object.entries(DIST)) {
+  if (!existsSync(path)) {
+    console.error(
+      `check-readme-snippets: ${path} is missing — run \`bun run build\` first ` +
+        `(this gate runs against the built dist, which is what consumers get, not src).`
+    );
+    process.exit(1);
+  }
+}
+
+/** Marked fenced blocks, with the line the fence opens on for error messages. */
+function markedSnippets(file) {
+  const lines = readFileSync(join(ROOT, file), 'utf8').split('\n');
+  const out = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() !== MARKER) continue;
+    // The fence may be separated from the marker by blank lines.
+    let j = i + 1;
+    while (j < lines.length && lines[j].trim() === '') j++;
+    const open = lines[j] ?? '';
+    if (!/^```(ts|typescript|js|javascript)\s*$/.test(open.trim())) {
+      console.error(`check-readme-snippets: ${file}:${i + 1}: ${MARKER} is not followed by a ts/js code fence.`);
+      process.exit(1);
+    }
+    const body = [];
+    let k = j + 1;
+    for (; k < lines.length && !lines[k].startsWith('```'); k++) body.push(lines[k]);
+    if (k >= lines.length) {
+      console.error(`check-readme-snippets: ${file}:${j + 1}: unterminated code fence.`);
+      process.exit(1);
+    }
+    out.push({ file, line: j + 1, code: body.join('\n') });
+    i = k;
+  }
+  return out;
+}
+
+/**
+ * Point bare `@originals/*` specifiers at the built dist. Longest specifier
+ * first so `@originals/sdk/testing` is not eaten by the `@originals/sdk` rule.
+ */
+function rewriteImports(code) {
+  let out = code;
+  for (const [spec, path] of Object.entries(DIST)) {
+    out = out.replaceAll(`'${spec}'`, `'${path}'`).replaceAll(`"${spec}"`, `"${path}"`);
+  }
+  return out;
+}
+
+const snippets = DOCS.flatMap(markedSnippets);
+if (snippets.length === 0) {
+  console.error(`check-readme-snippets: no ${MARKER} blocks found — the quick starts lost their marker.`);
+  process.exit(1);
+}
+
+const dir = mkdtempSync(join(tmpdir(), 'readme-snippets-'));
+let failed = 0;
+try {
+  for (const { file, line, code } of snippets) {
+    const path = join(dir, `${file.replace(/[^a-z0-9]+/gi, '-')}-${line}.ts`);
+    writeFileSync(path, rewriteImports(code));
+    // Bun, not node: the snippets are TypeScript and use top-level await, which
+    // is exactly how a Bun/tsx consumer runs them.
+    const run = spawnSync('bun', ['run', path], { encoding: 'utf8', cwd: ROOT });
+    if (run.status === 0) {
+      console.log(`  ok   ${file}:${line}`);
+      continue;
+    }
+    failed++;
+    console.error(`  FAIL ${file}:${line} (exit ${run.status})`);
+    const detail = [run.stdout, run.stderr].filter(Boolean).join('\n').trimEnd();
+    console.error(detail.split('\n').map((l) => `       ${l}`).join('\n'));
+  }
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+if (failed > 0) {
+  console.error(
+    `\ncheck-readme-snippets: ${failed} of ${snippets.length} documented snippet(s) do not run. ` +
+      `This is the first code an adopter executes — fix the snippet or fix the API.`
+  );
+  process.exit(1);
+}
+console.log(`\ncheck-readme-snippets: ${snippets.length} documented snippet(s) run against the built dist.`);


### PR DESCRIPTION
npm's `latest` for @originals/sdk resolves to 2.1.0 while the repo and every
doc describe 3.0.0-next.1, so anyone following the quick start installed an API
that no longer exists: no did:cel, no CEL event log, no ./testing subpath.

The standing decision is recorded in docs/RELEASING.md: a prerelease never goes
on `latest`. 3.0.0-next.N is not what a stranger should get by default, so
`latest` stays on the stable 2.1.0 and every install command names `@next` —
matching what the landing site and its honesty tests already do.

@originals/cel's dist-tags are registry state that no merge can fix: its first
publish forced `latest`, and the no-prior-normal-release rule then sent
0.2.0-next.1 to `latest` too, leaving `next` on the older 0.2.0-next.0.
RELEASING.md now carries the exact `npm dist-tag` command to correct it.

Adds scripts/check-install-docs.mjs and a CI job behind it: it scrapes every
install command out of the shipped markdown, asks the live registry what each
one resolves to, and fails if that is not the major this repo documents. A
registry failure fails the job rather than skipping it — a gate that passes
when it could not check is how this shipped in the first place.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017RLuttJLFFMVRwFaGa7FAH